### PR TITLE
Airtable webhook support

### DIFF
--- a/apps/webapp/app/models/workflowListPresenter.server.ts
+++ b/apps/webapp/app/models/workflowListPresenter.server.ts
@@ -2,7 +2,7 @@ import type { SchedulerSource } from ".prisma/client";
 import { ScheduleSourceSchema } from "@trigger.dev/common-schemas";
 import cronstrue from "cronstrue";
 import type { DisplayProperties } from "internal-integrations";
-import { github } from "internal-integrations";
+import { airtable, github } from "internal-integrations";
 import invariant from "tiny-invariant";
 import { triggerLabel } from "~/components/triggers/triggerLabel";
 import type { PrismaClient } from "~/db.server";
@@ -139,6 +139,11 @@ function triggerProperties(
       switch (externalSource.service) {
         case "github":
           displayProperties = github.webhooks.displayProperties(
+            externalSource.source
+          );
+          break;
+        case "airtable":
+          displayProperties = airtable.webhooks.displayProperties(
             externalSource.source
           );
           break;

--- a/apps/webapp/app/services/externalSources/handleExternalSource.server.ts
+++ b/apps/webapp/app/services/externalSources/handleExternalSource.server.ts
@@ -130,14 +130,15 @@ export class HandleExternalSource {
         });
       }
       case "airtable": {
-        const latestTriggerEvent = this.#prismaClient.triggerEvent.findFirst({
-          where: {
-            key: request.body.base.id,
-          },
-          orderBy: {
-            createdAt: "desc",
-          },
-        });
+        const latestTriggerEvent =
+          await this.#prismaClient.triggerEvent.findFirst({
+            where: {
+              key: request.body.base.id,
+            },
+            orderBy: {
+              createdAt: "desc",
+            },
+          });
 
         return await airtable.webhooks.handleWebhookRequest({
           accessInfo,

--- a/apps/webapp/app/services/externalSources/handleExternalSource.server.ts
+++ b/apps/webapp/app/services/externalSources/handleExternalSource.server.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient } from "~/db.server";
 import { prisma } from "~/db.server";
-import { github } from "internal-integrations";
+import { airtable, github } from "internal-integrations";
 import type { ExternalSourceWithConnection } from "~/models/externalSource.server";
 import type { NormalizedRequest } from "internal-integrations";
 import { IngestEvent } from "../events/ingest.server";
@@ -126,6 +126,12 @@ export class HandleExternalSource {
     switch (serviceIdentifier) {
       case "github": {
         return github.webhooks.handleWebhookRequest({
+          request,
+          secret: externalSource.secret ?? undefined,
+        });
+      }
+      case "airtable": {
+        return airtable.webhooks.handleWebhookRequest({
           request,
           secret: externalSource.secret ?? undefined,
         });

--- a/apps/webapp/app/services/externalSources/registerExternalSource.server.ts
+++ b/apps/webapp/app/services/externalSources/registerExternalSource.server.ts
@@ -1,5 +1,5 @@
 import type { APIConnection, ExternalSource } from ".prisma/client";
-import type { AccessInfo } from "internal-integrations";
+import { AccessInfo, airtable } from "internal-integrations";
 import { github } from "internal-integrations";
 import crypto from "node:crypto";
 import type { PrismaClient } from "~/db.server";
@@ -123,6 +123,16 @@ export class RegisterExternalSource {
     switch (serviceIdentifier) {
       case "github": {
         return github.webhooks.registerWebhook(
+          {
+            callbackUrl,
+            secret,
+            accessInfo,
+          },
+          data
+        );
+      }
+      case "airtable": {
+        return airtable.webhooks.registerWebhook(
           {
             callbackUrl,
             secret,

--- a/apps/webapp/app/services/workflows/registerWorkflow.server.ts
+++ b/apps/webapp/app/services/workflows/registerWorkflow.server.ts
@@ -1,4 +1,4 @@
-import { github } from "internal-integrations";
+import { github, airtable } from "internal-integrations";
 import type { WorkflowMetadata } from "internal-platform";
 import { WorkflowMetadataSchema } from "internal-platform";
 import type { PrismaClient } from "~/db.server";
@@ -240,6 +240,9 @@ export class RegisterWorkflow {
       switch (payload.trigger.service) {
         case "github": {
           return github.webhooks.keyForSource(payload.trigger.source);
+        }
+        case "airtable": {
+          return airtable.webhooks.keyForSource(payload.trigger.source);
         }
         default: {
           return payload.trigger.service;

--- a/apps/webapp/prisma/migrations/20230123020201_triggerevent_added_key/migration.sql
+++ b/apps/webapp/prisma/migrations/20230123020201_triggerevent_added_key/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "TriggerEvent" ADD COLUMN     "key" TEXT;

--- a/apps/webapp/prisma/schema.prisma
+++ b/apps/webapp/prisma/schema.prisma
@@ -358,6 +358,7 @@ model TriggerEvent {
   timestamp DateTime    @default(now())
   payload   Json
   context   Json?
+  key       String?
 
   organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   organizationId String?

--- a/examples/airtable/package.json
+++ b/examples/airtable/package.json
@@ -1,0 +1,19 @@
+{
+  "private": true,
+  "name": "@examples/airtable",
+  "version": "0.0.1",
+  "description": "Example trigger.dev workflow that uses the Airtable integration",
+  "dependencies": {
+    "@trigger.dev/integrations": "workspace:*",
+    "@trigger.dev/sdk": "workspace:*",
+    "zod": "^3.20.2"
+  },
+  "devDependencies": {
+    "@trigger.dev/tsconfig": "workspace:*",
+    "@types/node": "16",
+    "tsx": "^3.12.0"
+  },
+  "scripts": {
+    "dev": "tsx src/index.ts"
+  }
+}

--- a/examples/airtable/src/index.ts
+++ b/examples/airtable/src/index.ts
@@ -1,0 +1,17 @@
+import { Trigger } from "@trigger.dev/sdk";
+import { airtable } from "@trigger.dev/integrations";
+
+new Trigger({
+  id: "airtable-webhook-1",
+  name: "Airtable webhook: appBlf3KsalIQeMUo",
+  apiKey: "trigger_dev_zC25mKNn6c0q",
+  endpoint: "ws://localhost:8889/ws",
+  logLevel: "debug",
+  on: airtable.events.all({
+    baseId: "appBlf3KsalIQeMUo",
+  }),
+  run: async (event, ctx) => {
+    await ctx.logger.info(`Received webhook!`);
+    return event;
+  },
+}).listen();

--- a/examples/airtable/tsconfig.json
+++ b/examples/airtable/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@trigger.dev/tsconfig/examples.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "**/*.test.*"]
+}

--- a/packages/internal-integrations/package.json
+++ b/packages/internal-integrations/package.json
@@ -6,10 +6,10 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "devDependencies": {
+    "@trigger.dev/providers": "workspace:*",
     "@trigger.dev/tsconfig": "workspace:*",
     "@types/debug": "^4.1.7",
     "@types/node": "16",
-    "@trigger.dev/providers": "workspace:*",
     "typescript": "^4.9.4"
   },
   "scripts": {},
@@ -20,6 +20,7 @@
     "@urql/core": "^3.1.1",
     "debug": "^4.3.4",
     "graphql": "^16.6.0",
+    "ulid": "^2.3.0",
     "urql": "^3.0.3",
     "zod": "^3.20.2"
   },

--- a/packages/internal-integrations/src/airtable/index.ts
+++ b/packages/internal-integrations/src/airtable/index.ts
@@ -25,6 +25,7 @@ export class AirtableWebhookIntegration implements WebhookIntegration {
   async handleWebhookRequest(options: HandleWebhookOptions) {
     const contentHash = options.request.headers["x-airtable-content-mac"];
 
+    //todo pass in raw body
     //todo – add webhook verification
     // if (options.secret && contentHash) {
     //   //Extract Signature header

--- a/packages/internal-integrations/src/airtable/index.ts
+++ b/packages/internal-integrations/src/airtable/index.ts
@@ -59,8 +59,8 @@ export class AirtableWebhookIntegration implements WebhookIntegration {
       "accept-encoding",
     ]);
 
-    const baseId = options.request.body.baseId;
-    const webhookId = options.request.body.webhookId;
+    const baseId = options.request.body.base.id;
+    const webhookId = options.request.body.webhook.id;
     const accessToken = getAccessToken(options.accessInfo);
     const latestTriggerEvent = options.options?.latestTriggerEvent;
     const payloads = await getPayloads({
@@ -79,12 +79,6 @@ export class AirtableWebhookIntegration implements WebhookIntegration {
       payloads: payloads ?? [],
     };
 
-    const id = triggerEventId({
-      baseId,
-      webhookId,
-      cursor: Math.max(...payloads.map((p) => p.baseTransactionNumber), 0) + 1,
-    });
-
     return {
       status: "ok" as const,
       data: payloads.map((p) => ({
@@ -93,7 +87,12 @@ export class AirtableWebhookIntegration implements WebhookIntegration {
           webhookId,
           cursor: p.baseTransactionNumber,
         }),
-        payload: p,
+        payload: {
+          base: {
+            id: baseId,
+          },
+          ...p,
+        },
         event: "all",
         context,
       })),

--- a/packages/internal-integrations/src/airtable/index.ts
+++ b/packages/internal-integrations/src/airtable/index.ts
@@ -1,0 +1,166 @@
+import { ulid } from "ulid";
+import {
+  DisplayProperty,
+  HandleWebhookOptions,
+  WebhookConfig,
+  WebhookIntegration,
+} from "../types";
+import { z } from "zod";
+import { airtable } from "@trigger.dev/providers";
+import { getAccessToken } from "../accessInfo";
+import crypto from "crypto";
+
+export class AirtableWebhookIntegration implements WebhookIntegration {
+  keyForSource(source: unknown): string {
+    const airtableSource = parseWebhookSource(source);
+    return `base.${airtableSource.baseId}.${airtableSource.events.join(".")}`;
+  }
+
+  registerWebhook(config: WebhookConfig, source: unknown) {
+    const airtableSource = parseWebhookSource(source);
+    return registerWebhook(config, airtableSource);
+  }
+
+  handleWebhookRequest(options: HandleWebhookOptions) {
+    const contentHash = options.request.headers["x-airtable-content-mac"];
+
+    //todo – add webhook verification
+    // if (options.secret && contentHash) {
+    //   //Extract Signature header
+    //   const sig = Buffer.from(contentHash || "", "utf8");
+
+    //   //Calculate HMAC
+    //   const hmac = crypto.createHmac("sha256", options.secret);
+    //   //create raw body from javascript object options.request.body
+
+    //   const rawBody = Buffer.from(
+    //     JSON.stringify(options.request.body)
+    //   ).toString("utf8");
+    //   const digest = Buffer.from(hmac.update(rawBody).digest("hex"), "utf8");
+
+    //   //Compare HMACs
+    //   if (
+    //     sig.length !== digest.length ||
+    //     !crypto.timingSafeEqual(digest, sig)
+    //   ) {
+    //     return {
+    //       status: "error" as const,
+    //       error: `AirtableWebhookIntegration: Could not verify webhook payload, invalid signature or secret`,
+    //     };
+    //   }
+    // }
+
+    const context = omit(options.request.headers, [
+      "x-airtable-content-mac",
+      "content-type",
+      "content-length",
+      "accept",
+      "accept-encoding",
+    ]);
+
+    return {
+      status: "ok" as const,
+      data: {
+        id: ulid(),
+        payload: options.request.body,
+        event: "all",
+        context,
+      },
+    };
+  }
+
+  displayProperties(source: unknown) {
+    const airtableSource = parseWebhookSource(source);
+
+    const title = `Airtable`;
+    let properties: DisplayProperty[] = [];
+
+    return { title, properties };
+  }
+}
+
+export const webhooks = new AirtableWebhookIntegration();
+
+async function registerWebhook(
+  config: WebhookConfig,
+  source: z.infer<typeof airtable.schemas.WebhookSourceSchema>
+) {
+  const response = await fetch(
+    `https://api.airtable.com/v0/bases/${source.baseId}/webhooks`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${getAccessToken(config.accessInfo)}`,
+      },
+      body: JSON.stringify({
+        notificationUrl: config.callbackUrl,
+        specification: {
+          options: {
+            filters: {
+              dataTypes: ["tableData", "tableFields", "tableMetadata"],
+            },
+            includes: {
+              includePreviousCellValues: true,
+              includePreviousFieldDefinitions: true,
+            },
+          },
+        },
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw new Error(
+        `Failed to register webhook: Airtable base ${source.baseId} not found`
+      );
+    }
+
+    const existingWebhooksList = await fetch(
+      `https://api.airtable.com/v0/bases/${source.baseId}/webhooks`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${getAccessToken(config.accessInfo)}`,
+        },
+      }
+    );
+
+    if (existingWebhooksList.ok) {
+      const existingJson = await existingWebhooksList.json();
+
+      if (existingJson.webhooks.length >= 2) {
+        throw new Error(
+          `Failed to register webhook: Airtable base ${source.baseId} already has ${existingJson.webhooks.length} webhooks`
+        );
+      }
+    }
+
+    throw new Error(`Failed to register webhook: ${response.statusText}`);
+  }
+
+  const webhook = await response.json();
+
+  return webhook;
+}
+
+function parseWebhookSource(source: unknown) {
+  return airtable.schemas.WebhookSourceSchema.parse(source);
+}
+
+function omit<T extends Record<string, unknown>, K extends keyof T>(
+  obj: T,
+  keys: K[]
+): Omit<T, K> {
+  const result: any = {};
+
+  for (const key of Object.keys(obj)) {
+    if (!keys.includes(key as K)) {
+      result[key] = obj[key];
+    }
+  }
+
+  return result;
+}

--- a/packages/internal-integrations/src/github/index.ts
+++ b/packages/internal-integrations/src/github/index.ts
@@ -1,4 +1,5 @@
 import {
+  AccessInfo,
   DisplayProperty,
   HandleWebhookOptions,
   WebhookConfig,
@@ -34,7 +35,10 @@ export class GitHubWebhookIntegration implements WebhookIntegration {
     }
   }
 
-  handleWebhookRequest(options: HandleWebhookOptions) {
+  async handleWebhookRequest(
+    accessInfo: AccessInfo,
+    options: HandleWebhookOptions
+  ) {
     const deliveryId = options.request.headers["x-github-delivery"];
 
     const signature = options.request.headers["x-hub-signature-256"];

--- a/packages/internal-integrations/src/github/index.ts
+++ b/packages/internal-integrations/src/github/index.ts
@@ -35,10 +35,7 @@ export class GitHubWebhookIntegration implements WebhookIntegration {
     }
   }
 
-  async handleWebhookRequest(
-    accessInfo: AccessInfo,
-    options: HandleWebhookOptions
-  ) {
+  async handleWebhookRequest(options: HandleWebhookOptions) {
     const deliveryId = options.request.headers["x-github-delivery"];
 
     const signature = options.request.headers["x-hub-signature-256"];
@@ -76,7 +73,7 @@ export class GitHubWebhookIntegration implements WebhookIntegration {
 
     return {
       status: "ok" as const,
-      data: { id: deliveryId, payload: options.request.body, event, context },
+      data: [{ id: deliveryId, payload: options.request.body, event, context }],
     };
   }
 

--- a/packages/internal-integrations/src/index.ts
+++ b/packages/internal-integrations/src/index.ts
@@ -1,3 +1,4 @@
+export * as airtable from "./airtable";
 export * as github from "./github";
 export * as slack from "./slack";
 export * as shopify from "./shopify";

--- a/packages/internal-integrations/src/types.ts
+++ b/packages/internal-integrations/src/types.ts
@@ -67,11 +67,13 @@ export interface WebhookIntegration {
   keyForSource: (source: unknown) => string;
   registerWebhook: (config: WebhookConfig, source: unknown) => Promise<any>;
   handleWebhookRequest: (
+    accessInfo: AccessInfo,
     options: HandleWebhookOptions
-  ) =>
+  ) => Promise<
     | { status: "ok"; data: ReceivedWebhook }
     | { status: "ignored"; reason: string }
-    | { status: "error"; error: string };
+    | { status: "error"; error: string }
+  >;
   displayProperties: (source: unknown) => DisplayProperties;
 }
 

--- a/packages/internal-integrations/src/types.ts
+++ b/packages/internal-integrations/src/types.ts
@@ -24,9 +24,26 @@ export interface NormalizedResponse {
 }
 
 export interface HandleWebhookOptions {
+  accessInfo: AccessInfo;
   request: NormalizedRequest;
   secret?: string;
+  options?: Record<string, any>;
 }
+
+export type IgnoredEventResponse = {
+  status: "ignored";
+  reason: string;
+};
+
+export type ErrorEventResponse = {
+  status: "error";
+  error: string;
+};
+
+export type TriggeredEventResponse = {
+  status: "ok";
+  data: ReceivedWebhook[];
+};
 
 export interface ReceivedWebhook {
   id: string;
@@ -63,17 +80,17 @@ export interface RequestIntegration {
   displayProperties: (endpoint: string, params: any) => DisplayProperties;
 }
 
+export type HandledExternalEventResponse =
+  | TriggeredEventResponse
+  | IgnoredEventResponse
+  | ErrorEventResponse;
+
 export interface WebhookIntegration {
   keyForSource: (source: unknown) => string;
   registerWebhook: (config: WebhookConfig, source: unknown) => Promise<any>;
   handleWebhookRequest: (
-    accessInfo: AccessInfo,
     options: HandleWebhookOptions
-  ) => Promise<
-    | { status: "ok"; data: ReceivedWebhook }
-    | { status: "ignored"; reason: string }
-    | { status: "error"; error: string }
-  >;
+  ) => Promise<HandledExternalEventResponse>;
   displayProperties: (source: unknown) => DisplayProperties;
 }
 

--- a/packages/internal-integrations/src/types.ts
+++ b/packages/internal-integrations/src/types.ts
@@ -43,6 +43,7 @@ export type ErrorEventResponse = {
 export type TriggeredEventResponse = {
   status: "ok";
   data: ReceivedWebhook[];
+  lastDelivery: any;
 };
 
 export interface ReceivedWebhook {

--- a/packages/trigger-integrations/src/index.ts
+++ b/packages/trigger-integrations/src/index.ts
@@ -1,5 +1,6 @@
+import * as airtable from "./integrations/airtable";
 import * as github from "./integrations/github";
-import * as slack from "./integrations/slack";
 import * as shopify from "./integrations/shopify";
+import * as slack from "./integrations/slack";
 
-export { github, slack, shopify };
+export { airtable, github, slack, shopify };

--- a/packages/trigger-integrations/src/integrations/airtable/events.ts
+++ b/packages/trigger-integrations/src/integrations/airtable/events.ts
@@ -1,0 +1,37 @@
+import { TriggerEvent } from "@trigger.dev/sdk";
+import { airtable } from "@trigger.dev/providers";
+
+export function all(params: {
+  baseId: string;
+}): TriggerEvent<typeof airtable.schemas.allEvent> {
+  return {
+    metadata: {
+      type: "WEBHOOK",
+      service: "airtable",
+      name: "all",
+      filter: {
+        service: ["airtable"],
+        payload: {
+          base: {
+            id: [params.baseId],
+          },
+        },
+        event: ["all"],
+      },
+      source: airtable.schemas.WebhookSourceSchema.parse({
+        baseId: params.baseId,
+        scopes: [
+          "data.records:read",
+          "data.records:write",
+          "data.recordComments:read",
+          "data.recordComments:write",
+          "schema.bases:read",
+          "schema.bases:write",
+          "webhook:manage",
+        ],
+        events: ["all"],
+      }),
+    },
+    schema: airtable.schemas.allEvent,
+  };
+}

--- a/packages/trigger-integrations/src/integrations/airtable/events.ts
+++ b/packages/trigger-integrations/src/integrations/airtable/events.ts
@@ -3,7 +3,7 @@ import { airtable } from "@trigger.dev/providers";
 
 export function all(params: {
   baseId: string;
-}): TriggerEvent<typeof airtable.schemas.allEvent> {
+}): TriggerEvent<typeof airtable.schemas.allEventSchema> {
   return {
     metadata: {
       type: "WEBHOOK",
@@ -32,6 +32,6 @@ export function all(params: {
         events: ["all"],
       }),
     },
-    schema: airtable.schemas.allEvent,
+    schema: airtable.schemas.allEventSchema,
   };
 }

--- a/packages/trigger-integrations/src/integrations/airtable/index.ts
+++ b/packages/trigger-integrations/src/integrations/airtable/index.ts
@@ -1,0 +1,3 @@
+import * as events from "./events";
+
+export { events };

--- a/packages/trigger-providers/src/providers/airtable/index.ts
+++ b/packages/trigger-providers/src/providers/airtable/index.ts
@@ -1,3 +1,5 @@
+import * as schemas from "./schemas";
+
 export const airtable = {
   name: "Airtable",
   slug: "airtable",
@@ -15,5 +17,5 @@ export const airtable = {
       "webhook:manage",
     ],
   },
-  schemas: {},
+  schemas,
 };

--- a/packages/trigger-providers/src/providers/airtable/schemas/index.ts
+++ b/packages/trigger-providers/src/providers/airtable/schemas/index.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const WebhookSourceSchema = z.object({
+  baseId: z.string(),
+  scopes: z.array(z.string()),
+  events: z.array(z.string()),
+});
+
+export const allEvent = z.any();

--- a/packages/trigger-providers/src/providers/airtable/schemas/index.ts
+++ b/packages/trigger-providers/src/providers/airtable/schemas/index.ts
@@ -200,22 +200,24 @@ export const payloadSchema = z.object({
         .optional(),
       destroyedFieldIds: z.array(z.string()).optional(),
       destroyedRecordIds: z.array(z.string()).optional(),
-      changedViewsById: z.record(
-        z.object({
-          createdRecordsById: z
-            .record(
-              z.object({
-                cellValuesByFieldId: z.record(cellValueSchema),
-                createdTime: z.string(),
-              })
-            )
-            .optional(),
-          changedRecordsById: z
-            .record(currentPreviousUnchangedSchema)
-            .optional(),
-          destroyedRecordIds: z.array(z.string()).optional(),
-        })
-      ),
+      changedViewsById: z
+        .record(
+          z.object({
+            createdRecordsById: z
+              .record(
+                z.object({
+                  cellValuesByFieldId: z.record(cellValueSchema),
+                  createdTime: z.string(),
+                })
+              )
+              .optional(),
+            changedRecordsById: z
+              .record(currentPreviousUnchangedSchema)
+              .optional(),
+            destroyedRecordIds: z.array(z.string()).optional(),
+          })
+        )
+        .optional(),
     })
   ),
 });

--- a/packages/trigger-providers/src/providers/airtable/schemas/index.ts
+++ b/packages/trigger-providers/src/providers/airtable/schemas/index.ts
@@ -6,9 +6,229 @@ export const WebhookSourceSchema = z.object({
   events: z.array(z.string()),
 });
 
-export const allEvent = z.object({
+const fieldTypeSchema = z.union([
+  z.literal("singleLineText"),
+  z.literal("email"),
+  z.literal("url"),
+  z.literal("multilineText"),
+  z.literal("number"),
+  z.literal("percent"),
+  z.literal("currency"),
+  z.literal("singleSelect"),
+  z.literal("multipleSelects"),
+  z.literal("singleCollaborator"),
+  z.literal("multipleCollaborators"),
+  z.literal("multipleRecordLinks"),
+  z.literal("date"),
+  z.literal("dateTime"),
+  z.literal("phoneNumber"),
+  z.literal("multipleAttachments"),
+  z.literal("checkbox"),
+  z.literal("formula"),
+  z.literal("createdTime"),
+  z.literal("rollup"),
+  z.literal("count"),
+  z.literal("lookup"),
+  z.literal("multipleLookupValues"),
+  z.literal("autoNumber"),
+  z.literal("barcode"),
+  z.literal("rating"),
+  z.literal("richText"),
+  z.literal("duration"),
+  z.literal("lastModifiedTime"),
+  z.literal("button"),
+  z.literal("createdBy"),
+  z.literal("lastModifiedBy"),
+  z.literal("externalSyncSource"),
+  z.string(),
+]);
+
+const userSchema = z.object({
+  id: z.string(),
+  name: z.string().optional(),
+  email: z.string(),
+  profilePicUrl: z.string().optional(),
+  permissionLevel: z.union([
+    z.literal("none"),
+    z.literal("read"),
+    z.literal("comment"),
+    z.literal("edit"),
+    z.literal("create"),
+  ]),
+});
+
+const actionMetadataSchema = z.discriminatedUnion("source", [
+  z.object({
+    source: z.literal("client"),
+    sourceMetadata: z.object({
+      user: userSchema,
+    }),
+  }),
+  z.object({
+    source: z.literal("publicApi"),
+    sourceMetadata: z.object({
+      user: userSchema,
+    }),
+  }),
+  z.object({
+    source: z.literal("formSubmission"),
+    sourceMetadata: z.object({
+      viewId: z.string(),
+    }),
+  }),
+  z.object({
+    source: z.literal("automation"),
+    sourceMetadata: z.object({
+      automationId: z.string(),
+    }),
+  }),
+  z.object({
+    source: z.literal("system"),
+  }),
+  z.object({
+    source: z.literal("sync"),
+  }),
+  z.object({
+    source: z.literal("anonymousUser"),
+  }),
+]);
+
+const thumbnailSchema = z.object({
+  url: z.string(),
+  width: z.number(),
+  height: z.number(),
+});
+
+const attachmentSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  filename: z.string(),
+  size: z.number(),
+  type: z.string(),
+  thumbnails: z
+    .object({
+      small: thumbnailSchema,
+      large: thumbnailSchema,
+      full: thumbnailSchema,
+    })
+    .optional(),
+});
+
+const collaboratorSchema = z.object({
+  id: z.string(),
+  email: z.string(),
+  name: z.string(),
+});
+
+const cellValueSchema = z.union([
+  z.string(),
+  z.array(z.string()),
+  z.number(),
+  z.boolean(),
+  z.null(),
+  z.array(attachmentSchema),
+  collaboratorSchema,
+  z.array(collaboratorSchema),
+  z.unknown(),
+]);
+
+const cellValueByFieldIdSchema = z.object({
+  cellValuesByFieldId: z.record(cellValueSchema),
+});
+
+const currentPreviousUnchangedSchema = z.object({
+  current: cellValueByFieldIdSchema,
+  previous: cellValueByFieldIdSchema.optional(),
+  unchanged: cellValueByFieldIdSchema.optional(),
+});
+
+export const payloadSchema = z.object({
+  timestamp: z.string(),
+  actionMetadata: actionMetadataSchema,
+  baseTransactionNumber: z.number(),
+  payloadFormat: z.literal("v0"),
+  changedTablesById: z.record(
+    z.object({
+      createdRecordsById: z
+        .record(
+          z.object({
+            createdTime: z.string(),
+            cellValuesByFieldId: cellValueSchema,
+          })
+        )
+        .optional(),
+      changedRecordsById: z.record(currentPreviousUnchangedSchema).optional(),
+      createdFieldsById: z
+        .record(
+          z.object({
+            name: z.string(),
+            type: z.string(),
+          })
+        )
+        .optional(),
+      changedFieldsById: z
+        .record(
+          z.object({
+            current: z.object({
+              type: fieldTypeSchema.optional(),
+              name: z.string().optional(),
+            }),
+            previous: z
+              .object({
+                type: fieldTypeSchema.optional(),
+                name: z.string().optional(),
+              })
+              .optional(),
+          })
+        )
+        .optional(),
+      changedMetadata: z
+        .record(
+          z.object({
+            current: z.object({
+              name: z.string().optional(),
+              description: z.string().optional().nullable(),
+            }),
+            previous: z
+              .object({
+                name: z.string().optional(),
+                description: z.string().optional().nullable(),
+              })
+              .optional(),
+          })
+        )
+        .optional(),
+      destroyedFieldIds: z.array(z.string()).optional(),
+      destroyedRecordIds: z.array(z.string()).optional(),
+      changedViewsById: z.record(
+        z.object({
+          createdRecordsById: z
+            .record(
+              z.object({
+                cellValuesByFieldId: z.record(cellValueSchema),
+                createdTime: z.string(),
+              })
+            )
+            .optional(),
+          changedRecordsById: z
+            .record(currentPreviousUnchangedSchema)
+            .optional(),
+          destroyedRecordIds: z.array(z.string()).optional(),
+        })
+      ),
+    })
+  ),
+});
+
+export const WebhookPayloadListSchema = z.object({
+  cursor: z.number(),
+  mightHaveMore: z.boolean(),
+  payloads: z.array(payloadSchema),
+});
+
+export const allEventSchema = z.object({
   base: z.object({
     id: z.string(),
   }),
-  payloads: z.array(z.any()),
+  payloads: z.array(payloadSchema),
 });

--- a/packages/trigger-providers/src/providers/airtable/schemas/index.ts
+++ b/packages/trigger-providers/src/providers/airtable/schemas/index.ts
@@ -6,4 +6,9 @@ export const WebhookSourceSchema = z.object({
   events: z.array(z.string()),
 });
 
-export const allEvent = z.any();
+export const allEvent = z.object({
+  base: z.object({
+    id: z.string(),
+  }),
+  payloads: z.array(z.any()),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -657,6 +657,7 @@ importers:
       debug: ^4.3.4
       graphql: ^16.6.0
       typescript: ^4.9.4
+      ulid: ^2.3.0
       urql: ^3.0.3
       zod: ^3.20.2
     dependencies:
@@ -666,7 +667,8 @@ importers:
       '@urql/core': 3.1.1_graphql@16.6.0
       debug: 4.3.4
       graphql: 16.6.0
-      urql: 3.0.3_graphql@16.6.0
+      ulid: 2.3.0
+      urql: 3.0.3_onqnqwb3ubg5opvemcqf7c2qhy
       zod: 3.20.2
     devDependencies:
       '@trigger.dev/providers': link:../trigger-providers
@@ -15958,7 +15960,7 @@ packages:
       prepend-http: 2.0.0
     dev: true
 
-  /urql/3.0.3_graphql@16.6.0:
+  /urql/3.0.3_onqnqwb3ubg5opvemcqf7c2qhy:
     resolution: {integrity: sha512-aVUAMRLdc5AOk239DxgXt6ZxTl/fEmjr7oyU5OGo8uvpqu42FkeJErzd2qBzhAQ3DyusoZIbqbBLPlnKo/yy2A==}
     peerDependencies:
       graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -15966,6 +15968,7 @@ packages:
     dependencies:
       '@urql/core': 3.1.1_graphql@16.6.0
       graphql: 16.6.0
+      react: 18.2.0
       wonka: 6.1.2
     dev: false
 


### PR DESCRIPTION
# Todo

- [ ] Remove `key` column from `TriggerEvent`
- [ ] Add `lastDelivery` and `version` columns to ExternalSource
- [ ] Use a cursor for getting Airtable payloads
- [ ] Verify the Airtable webhook using the raw body
- [ ] Amalgamate changes into a structure that's good for users
- [ ] Create convenient functions so user's can convert between fieldIds and names in their workflows

# Desired payload format

```ts
const payload = {
  recordId: "dsfgh",
  type: "update",
  fields: {
    Author: {
      fieldId: "dfg6y464hg43",
      previous: "123",
      current: "456",
    },
  },
};
```

# Workflow usage

```ts
const orgChart = airtable.tableSchema({
  dfg6y464hg43: {
    name: "Last contacted",
    type: airtable.CollaboratorSchema
  },
});

new Trigger({
  id: "airtable-webhook-9",
  name: "Airtable table change",
  apiKey: "trigger_dev_zC25mKNn6c0q",
  on: airtable.events.tableEvent({
    baseId: "appX9X9X9X9X9X9X9",
    tableId: "tblX9X9X9X9X9X9X9",
    tableSchema: orgChart,
  }),
  run: async (event, ctx) => {
    
    const lastContactedField = orgChart.f("Last contacted");
    const lastContactedValue = event.fields[lastContactedField]).current;

    return {};
  },
}).listen();
```
