### PR TITLE
Fix storybook root alias by removing trailing slashes

### DIFF
--- a/apps/webapp/.storybook/main.ts
+++ b/apps/webapp/.storybook/main.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from "@storybook/react-webpack5";
 import path from "path";
 
-const root = path.resolve(__dirname, "../app/");
+const root = path.resolve(__dirname, "../app");
 console.log("storybook root", root);
 
 const config: StorybookConfig = {
@@ -12,7 +12,7 @@ const config: StorybookConfig = {
         ...config.resolve,
         alias: {
           ...(config.resolve?.alias ?? {}),
-          "~/": root,
+          "~": root,
         },
         extensions: [
           ...(config.resolve?.extensions ?? []),


### PR DESCRIPTION
Fix storybook root alias by removing trailing slashes. Relevant Slack thread: https://mirrorful-internal.slack.com/archives/C052XABLB3M/p1683658526450009?thread_ts=1682966586.286049&cid=C052XABLB3M