### PR TITLE
feat: 🎸 add live refreshing to Environments & API key page

### DIFF
--- a/apps/webapp/app/presenters/EnvironmentsStreamPresenter.server.ts
+++ b/apps/webapp/app/presenters/EnvironmentsStreamPresenter.server.ts
@@ -1,0 +1,143 @@
+import { PrismaClient, prisma } from "~/db.server";
+import { Project } from "~/models/project.server";
+import { User } from "~/models/user.server";
+import { sse } from "~/utils/sse";
+
+type EnvironmentSignalsMap = {
+  [x: string]: {
+    lastUpdatedAt: number;
+    lastTotalEndpointUpdatedTime: number;
+    lastTotalIndexingUpdatedTime: number;
+  };
+};
+
+export class EnvironmentsStreamPresenter {
+  #prismaClient: PrismaClient;
+
+  constructor(prismaClient: PrismaClient = prisma) {
+    this.#prismaClient = prismaClient;
+  }
+
+  public async call({
+    request,
+    userId,
+    projectSlug,
+  }: {
+    request: Request;
+    userId: User["id"];
+    projectSlug: Project["slug"];
+  }) {
+    let lastEnvironmentSignals: EnvironmentSignalsMap;
+
+    return sse({
+      request,
+      run: async (send, stop) => {
+        const nextEnvironmentSignals = await this.#runForUpdates({
+          userId,
+          projectSlug,
+        });
+
+        if (!nextEnvironmentSignals) {
+          return stop();
+        }
+
+        const lastEnvironmentIds = lastEnvironmentSignals
+          ? Object.keys(lastEnvironmentSignals)
+          : [];
+        const nextEnvironmentIds = Object.keys(nextEnvironmentSignals);
+
+        if (
+          //push update if the number of environments is different
+          nextEnvironmentIds.length !== lastEnvironmentIds.length ||
+          //push update if the list of ids is different
+          lastEnvironmentIds.some((id) => !nextEnvironmentSignals[id]) ||
+          nextEnvironmentIds.some((id) => !lastEnvironmentSignals[id]) ||
+          //push update if any signals changed
+          nextEnvironmentIds.some(
+            (id) =>
+              nextEnvironmentSignals[id].lastUpdatedAt !==
+                lastEnvironmentSignals[id].lastUpdatedAt ||
+              nextEnvironmentSignals[id].lastTotalEndpointUpdatedTime !==
+                lastEnvironmentSignals[id].lastTotalEndpointUpdatedTime ||
+              nextEnvironmentSignals[id].lastTotalIndexingUpdatedTime !==
+                lastEnvironmentSignals[id].lastTotalIndexingUpdatedTime
+          )
+        ) {
+          send({ data: new Date().toISOString() });
+        }
+
+        lastEnvironmentSignals = nextEnvironmentSignals;
+      },
+    });
+  }
+
+  async #runForUpdates({
+    userId,
+    projectSlug,
+  }: {
+    userId: User["id"];
+    projectSlug: Project["slug"];
+  }) {
+    const environments = await this.#prismaClient.runtimeEnvironment.findMany({
+      select: {
+        id: true,
+        updatedAt: true,
+        endpoints: {
+          select: {
+            updatedAt: true,
+            indexings: {
+              select: {
+                updatedAt: true,
+              },
+            },
+          },
+        },
+      },
+      where: {
+        project: {
+          slug: projectSlug,
+        },
+        organization: {
+          members: {
+            some: {
+              userId,
+            },
+          },
+        },
+      },
+    });
+
+    if (!environments) return null;
+
+    const environmentSignalsMap = environments.reduce<EnvironmentSignalsMap>(
+      (acc, environment) => {
+        const lastUpdatedAt = environment.updatedAt.getTime();
+        const lastTotalEndpointUpdatedTime = environment.endpoints.reduce(
+          (prev, endpoint) => prev + endpoint.updatedAt.getTime(),
+          0
+        );
+        const lastTotalIndexingUpdatedTime = environment.endpoints.reduce(
+          (prev, endpoint) =>
+            prev +
+            endpoint.indexings.reduce(
+              (prev, indexing) => prev + indexing.updatedAt.getTime(),
+              0
+            ),
+          0
+        );
+
+        return {
+          ...acc,
+          [environment.id]: {
+            lastUpdatedAt,
+            lastTotalEndpointUpdatedTime,
+            lastTotalIndexingUpdatedTime,
+          },
+        };
+      },
+      {}
+    );
+
+    return environmentSignalsMap;
+  }
+}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.environments.stream/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.environments.stream/route.tsx
@@ -1,0 +1,16 @@
+import { LoaderArgs } from "@remix-run/server-runtime";
+import { EnvironmentsStreamPresenter } from "~/presenters/EnvironmentsStreamPresenter.server";
+import { requireUserId } from "~/services/session.server";
+import { ProjectParamSchema } from "~/utils/pathBuilder";
+
+export const loader = async ({ request, params }: LoaderArgs) => {
+  const userId = await requireUserId(request);
+  const { projectParam } = ProjectParamSchema.parse(params);
+
+  const presenter = new EnvironmentsStreamPresenter();
+  return await presenter.call({
+    request,
+    userId,
+    projectSlug: projectParam,
+  });
+};

--- a/apps/webapp/app/utils/pathBuilder.ts
+++ b/apps/webapp/app/utils/pathBuilder.ts
@@ -143,6 +143,13 @@ export function projectEnvironmentsPath(
   return `${projectPath(organization, project)}/environments`;
 }
 
+export function projectEnvironmentsStreamingPath(
+  organization: OrgForPath,
+  project: ProjectForPath
+) {
+  return `${projectEnvironmentsPath(organization, project)}/stream`;
+}
+
 export function endpointStreamingPath(environment: { id: string }) {
   return `/resources/environments/${environment.id}/endpoint/stream`;
 }


### PR DESCRIPTION
PR to add live refreshing to the **Environments & API Key** page.

I followed a similar pattern to what we do on the **Run** page. The key part of this PR is correctly determining _when_ to refresh the page. I expanded on the logic found in the [Environment endpoint stream sse loader](https://github.com/triggerdotdev/trigger.dev/blob/main/apps/webapp/app/routes/resources.environments.%24environmentParam.endpoint.stream.ts#L32). That `sse` implementation seems to handle calculating a diff between a _single_ environment. I expanded on that and recreated the same thing for _multiple_ environments (i.e. all the environments that appear on the **Environments & API Key** page).

## Testing
1. I spun up the trigger.dev app locally
2. I created a new NextJS app locally
3. I followed the [trigger dev quickstart guide](https://trigger.dev/docs/documentation/quickstart) to set up a new integration (this sets up a new integration with 1 example job)
4. While both the trigger.dev and NextJS app were running, I added a new job to my NextJS app
5. I waited for the **Environments & API Key** page to auto-refresh and show that I had 2 jobs instead of 1 job
6. I removed the second job from my NextJS app
7. I waited for the **Environments & API Key** page to auto-refresh and show that I had 1 job instead of 2 jobs

Bounty: /claim #156 