### PR TITLE
feat: 🎸 add project job count pill to breadcrumb project menu

### DIFF
--- a/apps/webapp/app/components/navigation/ProjectsMenu.tsx
+++ b/apps/webapp/app/components/navigation/ProjectsMenu.tsx
@@ -1,5 +1,7 @@
 import { RouteMatch } from "@remix-run/react";
 import { Fragment, useState } from "react";
+import simplur from "simplur";
+import { Badge } from "~/components/primitives/Badge";
 import {
   useIsNewOrganizationPage,
   useOrganizations,
@@ -49,7 +51,12 @@ export function ProjectsMenu({ matches }: { matches: RouteMatch[] }) {
                     <PopoverMenuItem
                       key={project.id}
                       to={projectPath(organization, project)}
-                      title={project.name}
+                      title={
+                        <div className="flex w-[calc(100%-44px)] items-center justify-between pl-1 text-bright">
+                          <span className="grow text-left">{project.name}</span>
+                          <Badge className="mr-0.5">{simplur`${project._count.jobs} job[|s]`}</Badge>
+                        </div>
+                      }
                       isSelected={isSelected}
                       icon="folder"
                     />


### PR DESCRIPTION
PR to add a project job count pill component to the project menu in the breadcrumb.

<img width="375" alt="image" src="https://github.com/triggerdotdev/trigger.dev/assets/11434879/c4c8e662-bfb3-4b4a-ab92-9d11e9d62ab8">

Bounty: /claim https://github.com/triggerdotdev/trigger.dev/issues/192