### PR TITLE
feat: 🎸 filter organization > project > jobs to internal=false

### DIFF
--- a/apps/webapp/app/models/organization.server.ts
+++ b/apps/webapp/app/models/organization.server.ts
@@ -46,7 +46,11 @@ export function getOrganizations({ userId }: { userId: User["id"] }) {
         include: {
           _count: {
             select: {
-              jobs: true,
+              jobs: {
+                where: {
+                  internal: false,
+                },
+              },
             },
           },
         },


### PR DESCRIPTION
PR to filter out internal jobs in the `getOrganizaions` call. I did the filtering in the actual prisma call so that the correct count propagates throughout the app. The change should be reflected in the following places:

1. The home page org list
<img width="1052" alt="image" src="https://github.com/triggerdotdev/trigger.dev/assets/11434879/4080b2e5-0246-4de5-a846-20baf72c3917">

2. The project page for a given org
<img width="1054" alt="image" src="https://github.com/triggerdotdev/trigger.dev/assets/11434879/86e48627-4465-4f8b-b774-d47c28122a2b">

3. The breadcrumb project menu once #195 is implemented

/claim #193