### PR TITLE
chore: 🤖 improve migrations for docker container startup

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -4,7 +4,8 @@
   "version": "1.0.0",
   "sideEffects": false,
   "scripts": {
-    "build": "run-s build:*",
+    "build": "run-s build:**",
+    "build:db:seed": "esbuild --platform=node --bundle --minify --format=cjs ./prisma/seed.ts --outdir=prisma",
     "build:remix": "remix build",
     "build:server": "esbuild --platform=node --format=cjs ./server.ts --outdir=build",
     "dev": "cross-env PORT=3030 remix dev",
@@ -12,7 +13,7 @@
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "cross-env NODE_ENV=production node --max-old-space-size=8192 ./build/server.js",
     "typecheck": "tsc --noEmit",
-    "db:seed": "ts-node prisma/seed.ts",
+    "db:seed": "node prisma/seed.js",
     "generate:sourcemaps": "remix build --sourcemap",
     "clean:sourcemaps": "run-s clean:sourcemaps:*",
     "clean:sourcemaps:public": "rimraf ./build/**/*.map",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,13 +60,10 @@ COPY --from=production-deps --chown=node:node /triggerdotdev .
 COPY --from=builder --chown=node:node /triggerdotdev/apps/webapp/build/server.js ./apps/webapp/build/server.js
 COPY --from=builder --chown=node:node /triggerdotdev/apps/webapp/build ./apps/webapp/build
 COPY --from=builder --chown=node:node /triggerdotdev/apps/webapp/public ./apps/webapp/public
+COPY --from=builder --chown=node:node /triggerdotdev/apps/webapp/prisma/seed.js ./apps/webapp/prisma/seed.js
 COPY --from=builder --chown=node:node /triggerdotdev/scripts ./scripts
 
 EXPOSE 3000
-
-# This is needed to run migrations in the entrypoint.sh script (TODO: figure out a better way to do this)
-RUN npm install -g prisma@4.16.0
-RUN npm install -g ts-node@10.9.1
 
 USER node
 CMD ["./scripts/entrypoint.sh"]

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -5,8 +5,13 @@ if [ -n "$DATABASE_HOST" ]; then
   scripts/wait-for-it.sh ${DATABASE_HOST} -- echo "database is up"
 fi
 
-npx --no-install prisma migrate deploy --schema /triggerdotdev/packages/database/prisma/schema.prisma
-npx --no-install ts-node --transpile-only /triggerdotdev/apps/webapp/prisma/seed.ts
+# Run migrations
+pnpm --filter @trigger.dev/database db:migrate:deploy
+
+# Copy over required prisma files and invoke bundled seed file
+cp packages/database/prisma/schema.prisma apps/webapp/prisma/
+cp node_modules/@prisma/engines/libquery_engine-linux-arm64-openssl-1.1.x.so.node apps/webapp/prisma/
+pnpm --filter webapp db:seed
 
 cd /triggerdotdev/apps/webapp
 exec dumb-init pnpm run start


### PR DESCRIPTION
PR to remove global packages for DB migrations in the Dockerfile.

## Changes

### Prisma migrations

Executing the migrations by directly using the `db:migrate:deploy` script in the `@trigger.dev/database` package.

### Seed the DB

Instead of using `ts-node`, I'm using `esbuild` to bundle the `seed.ts` file and its dependencies into a `seed.js` file in the `builder` Dockerfile stage. Then we can just copy over the built `seed.js` file into the final Dockerfile layer and execute that file instead with `node`. Bundling the file like this requires us to copy over the `schema.prisma` schema file and the `libquery_engine-linux-arm64-openssl-1.1.x.so.node` prisma engine file to the `~/webapp/prisma` directory so that the bundled file can access external dependencies correctly.

## Testing

I verified this by adding a `webapp` service to the `~/docker/docker-compose.yml` file:
<img width="1050" alt="image" src="https://github.com/triggerdotdev/trigger.dev/assets/11434879/ca365006-488c-4099-a962-ccaec1c509cb">

After adding this service, I ran `pnpm docker` to spin up the docker-compose stack which built the `webapp` image. The logs of the running container of the newly built image showed no errors for any of the commands.

Bounty: /claim #191
