### PR TITLE
CLI: detect package manager using artifacts if they exist

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -30,9 +30,11 @@ export type InitCommandOptions = {
 type ResolvedOptions = Required<InitCommandOptions>;
 
 export const initCommand = async (options: InitCommandOptions) => {
-  renderTitle();
-
   telemetryClient.init.started(options);
+
+  const resolvedPath = resolvePath(options.projectPath);
+
+  await renderTitle(resolvedPath);
 
   if (options.triggerUrl === CLOUD_TRIGGER_URL) {
     logger.info(`✨ Initializing project in Trigger.dev Cloud`);
@@ -42,7 +44,6 @@ export const initCommand = async (options: InitCommandOptions) => {
     logger.info(`✨ Initializing Trigger.dev in project`);
   }
 
-  const resolvedPath = resolvePath(options.projectPath);
   // Detect if are are in a Next.js project
   const isNextJsProject = await detectNextJsProject(resolvedPath);
 

--- a/packages/cli/src/utils/addDependencies.ts
+++ b/packages/cli/src/utils/addDependencies.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import { execa } from "execa";
 import ora, { type Ora } from "ora";
 import pathModule from "path";
-import { getUserPkgManager, type PackageManager } from "./getUserPkgManager.js";
+import { getUserPackageManager, type PackageManager } from "./getUserPkgManager.js";
 import fs from "fs/promises";
 import fetch from "node-fetch";
 import { z } from "zod";
@@ -18,7 +18,7 @@ export type InstalledPackage = {
 };
 
 export async function addDependencies(projectDir: string, packages: Array<InstallPackage>) {
-  const pkgManager = getUserPkgManager();
+  const pkgManager = await getUserPackageManager(projectDir);
 
   const spinner = ora("Adding @trigger.dev dependencies to package.json...").start();
 

--- a/packages/cli/src/utils/getUserPkgManager.ts
+++ b/packages/cli/src/utils/getUserPkgManager.ts
@@ -1,6 +1,17 @@
+import pathModule from "path";
+import { pathExists } from "./fileSystem.js";
+
 export type PackageManager = "npm" | "pnpm" | "yarn";
 
-export const getUserPkgManager: () => PackageManager = () => {
+export async function getUserPackageManager(path: string): Promise<PackageManager> {
+  try {
+    return detectPackageManagerFromArtifacts(path);
+  } catch (error) {
+    return detectPackageManagerFromCurrentCommand();
+  }
+}
+
+function detectPackageManagerFromCurrentCommand(): PackageManager {
   // This environment variable is set by npm and yarn but pnpm seems less consistent
   const userAgent = process.env.npm_config_user_agent;
 
@@ -16,4 +27,22 @@ export const getUserPkgManager: () => PackageManager = () => {
     // If no user agent is set, assume npm
     return "npm";
   }
-};
+}
+
+async function detectPackageManagerFromArtifacts(path: string): Promise<PackageManager> {
+  const packageFiles = [
+    { name: "yarn.lock", pm: "yarn" } as const,
+    { name: "pnpm-lock.yaml", pm: "pnpm" } as const,
+    { name: "package-lock.json", pm: "npm" } as const,
+    { name: "npm-shrinkwrap.json", pm: "npm" } as const,
+  ];
+
+  for (const { name, pm } of packageFiles) {
+    const exists = await pathExists(pathModule.join(path, name));
+    if (exists) {
+      return pm;
+    }
+  }
+
+  throw new Error("Could not detect package manager from artifacts");
+}

--- a/packages/cli/src/utils/installDependencies.ts
+++ b/packages/cli/src/utils/installDependencies.ts
@@ -1,4 +1,4 @@
-import { getUserPkgManager, type PackageManager } from "./getUserPkgManager.js";
+import { getUserPackageManager, type PackageManager } from "./getUserPkgManager.js";
 import { logger } from "./logger.js";
 import ora, { type Ora } from "ora";
 import chalk from "chalk";
@@ -7,7 +7,7 @@ import { execa } from "execa";
 export async function installDependencies(projectDir: string) {
   logger.info("Installing dependencies...");
 
-  const pkgManager = getUserPkgManager();
+  const pkgManager = await getUserPackageManager(projectDir);
 
   const installSpinner = await runInstallCommand(pkgManager, projectDir);
 

--- a/packages/cli/src/utils/renderTitle.ts
+++ b/packages/cli/src/utils/renderTitle.ts
@@ -1,6 +1,6 @@
 import gradient from "gradient-string";
 import { TITLE_TEXT } from "../consts.js";
-import { getUserPkgManager } from "./getUserPkgManager.js";
+import { getUserPackageManager } from "./getUserPkgManager.js";
 
 // colors brought in from vscode poimandres theme
 const poimandresTheme = {
@@ -12,11 +12,11 @@ const poimandresTheme = {
   yellow: "#fffac2",
 };
 
-export const renderTitle = () => {
+export const renderTitle = async (projectDirectory: string) => {
   const triggerGradient = gradient(Object.values(poimandresTheme));
 
   // resolves weird behavior where the ascii is offset
-  const pkgManager = getUserPkgManager();
+  const pkgManager = await getUserPackageManager(projectDirectory);
   if (pkgManager === "yarn" || pkgManager === "pnpm") {
     console.log("");
   }


### PR DESCRIPTION
## Problem
People can run `npx @trigger.dev/cli ……` but they're actually using yarn/pnpm. 

It's better to first try and detect the package manager by looking for "artifacts", e.g. package-lock.json, yarn.lock, etc.

Only if they don't exist we fallback to using the old method, `process.env.npm_config_user_agent`.