### PR TITLE
Cli: improve Next.js project detection

### DIFF
--- a/.changeset/unlucky-wombats-scream.md
+++ b/.changeset/unlucky-wombats-scream.md
@@ -2,4 +2,4 @@
 "@trigger.dev/cli": patch
 ---
 
-Detect Next.js project by looking at dependencies, not next.config.js
+Detect Next.js project by looking at dependencies if can't find next.config.js

--- a/.changeset/unlucky-wombats-scream.md
+++ b/.changeset/unlucky-wombats-scream.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/cli": patch
+---
+
+Detect Next.js project by looking at dependencies, not next.config.js

--- a/packages/cli/src/utils/detectNextJsProject.ts
+++ b/packages/cli/src/utils/detectNextJsProject.ts
@@ -9,7 +9,7 @@ export async function detectNextJsProject(path: string): Promise<boolean> {
     const packageJsonPath = pathModule.join(path, "package.json");
     const packageJsonContent = (await readJSONFile(packageJsonPath)) as PackageJson;
 
-    return packageJsonContent.dependencies?.next != null;
+    return packageJsonContent.dependencies?.next !== undefined;
   } catch (error) {
     // If the package.json file doesn't exist… then they've run it in the wrong folder
     return false;

--- a/packages/cli/src/utils/detectNextJsProject.ts
+++ b/packages/cli/src/utils/detectNextJsProject.ts
@@ -1,15 +1,17 @@
-import fs from "fs/promises";
 import pathModule from "path";
+import { type PackageJson } from "type-fest";
+import { readJSONFile } from "./fileSystem.js";
 
 /** Detects if the project is a Next.js project at path  */
 export async function detectNextJsProject(path: string): Promise<boolean> {
-  // Checks for the presence of a next.config.js file
+  // Checks for the presence of the next package in the package.json file
   try {
-    // Check if next.config.js file exists in the given path
-    await fs.access(pathModule.join(path, "next.config.js"));
-    return true;
+    const packageJsonPath = pathModule.join(path, "package.json");
+    const packageJsonContent = (await readJSONFile(packageJsonPath)) as PackageJson;
+
+    return packageJsonContent.dependencies?.next != null;
   } catch (error) {
-    // If next.config.js file doesn't exist, it's not a Next.js project
+    // If the package.json file doesn't exist… then they've run it in the wrong folder
     return false;
   }
 }

--- a/packages/cli/src/utils/readPackageJson.ts
+++ b/packages/cli/src/utils/readPackageJson.ts
@@ -1,0 +1,10 @@
+import pathModule from "path";
+import { type PackageJson } from "type-fest";
+import { readJSONFile } from "./fileSystem.js";
+
+export async function readPackageJson(directory: string): Promise<PackageJson | undefined> {
+  const packageJsonPath = pathModule.join(directory, "package.json");
+  return readJSONFile(packageJsonPath)
+    .then((f) => f as PackageJson)
+    .catch(() => undefined);
+}


### PR DESCRIPTION
## Problem

There isn't always a `next.config.js` file. 

## Solution
It's more reliable to look at the package.json dependencies object for a next key. 

Fixes #260 