### PR TITLE
fix: Handle ngrok config upgrade error in createTunnel function

### DIFF
--- a/.changeset/three-flies-sneeze.md
+++ b/.changeset/three-flies-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/cli": patch
+---
+
+fix: Handle ngrok config upgrade error in createTunnel function


### PR DESCRIPTION
## Description

This PR addresses the issue where the `createTunnel` function fails to handle a specific ngrok error message that indicates the requirement for a `version` property in the configuration. The code has been refactored to handle this error message appropriately and perform the necessary configuration upgrade before retrying the tunnel creation.

## Changes Made

- Refactored the `createTunnel` function to identify and handle the ngrok error message indicating the need for a `version` property in the configuration.
- Added logic to upgrade the ngrok configuration using the `ngrok config upgrade` command when the error message is detected.
- Improved error handling and logging to provide clear information about the configuration upgrade process and tunnel creation attempts.

## How to Test

1. Simulate the specific ngrok error by intentionally removing the `version` property from the ngrok configuration.
2. Run the application and invoke the `createTunnel` function with a test port.
3. Observe the logs and confirm that the error message is correctly identified, the configuration upgrade is attempted, and the tunnel creation is retried after the upgrade.

Fixes #284 
/claim #284 

