### PR TITLE
Adds Missing syntax highlight to part of manual setup documentation

### DIFF
--- a/docs/documentation/guides/manual.mdx
+++ b/docs/documentation/guides/manual.mdx
@@ -138,7 +138,7 @@ To establish an API route for interacting with Trigger.dev, follow these steps b
     1. Create a new file named `trigger.(ts/js)` within the `pages/api/` directory.
     2. Add the following code to `trigger.(ts/js)`:
 
-    ```
+    ```typescript
     import { createPagesRoute } from "@trigger.dev/nextjs";
     import { client } from "@/trigger";
     import "@/Jobs";


### PR DESCRIPTION
related to https://github.com/triggerdotdev/trigger.dev/pull/286 

added the missing syntax highlight. currently its looking like this 
![Screenshot 2023-08-10 at 10 09 01 AM](https://github.com/triggerdotdev/trigger.dev/assets/14201280/11063f83-fa2a-4e37-aa4c-ac74710834bf)

This PR will adds the syntax highlight to this section
 