### PR TITLE
fix: avoid crashing the Node.js app on uncaught exceptions

### DIFF
--- a/.changeset/smooth-dodos-obey.md
+++ b/.changeset/smooth-dodos-obey.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/express": patch
+---
+
+fix: avoid crashing the Node.js app on uncaught exceptions

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -66,18 +66,21 @@ export function createMiddleware(client: TriggerClient, path: string = "/api/tri
       return;
     }
 
-    const request = convertToStandardRequest(req);
+    try {
+      const request = convertToStandardRequest(req);
 
-    const response = await client.handleRequest(request);
+      const response = await client.handleRequest(request);
 
-    if (!response) {
-      res.status(404).json({ error: "Not found" });
+      if (!response) {
+        res.status(404).json({ error: "Not found" });
 
-      return;
-    }
+        return;
+      }
 
-    res.status(response.status).json(response.body);
-  };
+      res.status(response.status).json(response.body);
+    } catch (error) {
+      next(error)
+    };
 }
 
 function convertToStandardRequest(req: express.Request): StandardRequest {


### PR DESCRIPTION
Fixes #306 by properly creating an exception handler for the middleware code that would otherwise cause the Node.js process to crash.

The new error handler will forward the error thrown to the next middleware until an error handling takes place in the Express app and is the responsibility of the user to define and handle it as they choose to.