### PR TITLE
fix: support express jsonParser middleware if used in the Express app

### DIFF
--- a/.changeset/sixty-windows-run.md
+++ b/.changeset/sixty-windows-run.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/express": patch
+---
+
+fix: support express jsonParser middleware if used in the Express app

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -94,6 +94,6 @@ function convertToStandardRequest(req: express.Request): StandardRequest {
     headers,
     method,
     // @ts-ignore
-    body: req,
+    body: req.body ? JSON.stringify(req.body) : req,
   });
 }


### PR DESCRIPTION
Fixes #308 to support both scenarios in which:
1. Express makes use of a body parser middleware such as `express.json()` or `bodyParser.json()` (see references [here](https://expressjs.com/en/resources/middleware/body-parser.html) in official Express docs)
2. Express app doesn't explicitly use a body parser and the request parsing falls back to a readable stream passed to the underlying fetch implementation 