### PR TITLE
Corrected clone link for Windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ branch are tagged into a release monthly.
    ```
 
    > If you are on windows, run the following command on gitbash with admin privileges:
-   > `git clone -c core.symlinks=true https://triggerdotdev/trigger.dev.git`
+   > `git clone -c core.symlinks=true https://github.com/triggerdotdev/trigger.dev.git`
 
 2. Navigate to the project folder
    ```


### PR DESCRIPTION
#While going through the Contribution.md file I found incorrect URL for cloning the project on a Windows machine
![image](https://github.com/triggerdotdev/trigger.dev/assets/61023134/f46f3964-f2ff-4aee-9cb4-f4cd7d775772)
#318 