### PR TITLE
feat: added the ability to cancel scheduled Events based on the event ID

### DIFF
--- a/apps/webapp/app/platform/zodWorker.server.ts
+++ b/apps/webapp/app/platform/zodWorker.server.ts
@@ -205,7 +205,7 @@ export class ZodWorker<TMessageCatalog extends MessageCatalogSchema> {
       spec.queueName || null,
       spec.runAt || null,
       spec.maxAttempts || null,
-      spec.jobKey,
+      spec.jobKey || null,
       spec.priority || null,
       spec.jobKeyMode || null,
       spec.flags || null

--- a/apps/webapp/app/routes/api.v1.events.$eventId.cancel.ts
+++ b/apps/webapp/app/routes/api.v1.events.$eventId.cancel.ts
@@ -44,7 +44,6 @@ export async function action({ request, params }: ActionArgs) {
 
     return json(updatedEvent);
   } catch (err) {
-    //send the error
     logger.error("CancelEventService.call() error", {
       error: err,
     });

--- a/apps/webapp/app/routes/api.v1.events.$eventId.cancel.ts
+++ b/apps/webapp/app/routes/api.v1.events.$eventId.cancel.ts
@@ -1,0 +1,78 @@
+import type { ActionArgs, LoaderArgs } from "@remix-run/server-runtime";
+import { json } from "@remix-run/server-runtime";
+import { z } from "zod";
+import { prisma } from "~/db.server";
+import { authenticateApiRequest } from "~/services/apiAuth.server";
+import { workerQueue } from "~/services/worker.server";
+import { logger } from "~/services/logger.server";
+
+const ParamsSchema = z.object({
+  eventId: z.string(),
+});
+
+export async function loader({ request, params }: LoaderArgs) {
+  // Ensure this is a POST request
+  if (request.method.toUpperCase() !== "POST") {
+    return { status: 405, body: "Method Not Allowed" };
+  }
+
+  // Next authenticate the request
+  const authenticationResult = await authenticateApiRequest(request);
+
+  if (!authenticationResult) {
+    return json({ error: "Invalid or Missing API key" }, { status: 401 });
+  }
+
+  const authenticatedEnv = authenticationResult.environment;
+
+  const parsed = ParamsSchema.safeParse(params);
+
+  if (!parsed.success) {
+    return json({ error: "Invalid or Missing eventId" }, { status: 400 });
+  }
+
+  const { eventId } = parsed.data;
+
+  const event = await prisma.eventRecord.findFirst({
+    select: {
+      id: true,
+      name: true,
+      createdAt: true,
+      updatedAt: true,
+      environmentId: true,
+      runs: {
+        select: {
+          id: true,
+          status: true,
+          startedAt: true,
+          completedAt: true,
+        },
+      },
+    },
+    where: {
+      id: eventId,
+      environmentId: authenticatedEnv.id,
+    },
+  });
+  if (!event) {
+    return json({ error: "Event not found" }, { status: 404 });
+  }
+  // Update the event with cancelledAt
+  let updatedEvent;
+
+  try {
+    updatedEvent = await prisma.eventRecord.update({
+      where: { id: event.id },
+      data: { cancelledAt: new Date() },
+    });
+
+    // Dequeue the event only if the update is successful
+    await workerQueue.dequeue(updatedEvent.id, { tx: prisma });
+
+    return json(updatedEvent);
+  } catch (error) {
+    logger.error("Failed to update event", { error, event });
+
+    return json({ error: "Failed to update event" }, { status: 500 });
+  }
+}

--- a/apps/webapp/app/services/events/cancelEvent.server.ts
+++ b/apps/webapp/app/services/events/cancelEvent.server.ts
@@ -1,0 +1,60 @@
+import type { EventDispatcher, EventRecord } from "@trigger.dev/database";
+import type { EventFilter } from "@trigger.dev/core";
+import { EventFilterSchema, eventFilterMatches } from "@trigger.dev/core";
+import { $transaction, PrismaClientOrTransaction, prisma } from "~/db.server";
+import { logger } from "~/services/logger.server";
+import { workerQueue } from "../worker.server";
+import { AuthenticatedEnvironment } from "../apiAuth.server";
+
+export class CancelEventService {
+  #prismaClient: PrismaClientOrTransaction;
+
+  constructor(prismaClient: PrismaClientOrTransaction = prisma) {
+    this.#prismaClient = prismaClient;
+  }
+
+  public async call(environment: AuthenticatedEnvironment, eventId: string): Promise<EventRecord | undefined> {
+    return await $transaction(
+      this.#prismaClient,
+      async (tx) => {
+        const event = await tx.eventRecord.findFirst({
+          select: {
+            id: true,
+            name: true,
+            createdAt: true,
+            updatedAt: true,
+            environmentId: true,
+            runs: {
+              select: {
+                id: true,
+                status: true,
+                startedAt: true,
+                completedAt: true,
+              },
+            },
+          },
+          where: {
+            id: eventId,
+            environmentId: environment.id,
+          },
+        });
+
+        if (!event) {
+          return;
+        }
+
+        //update the cancelledAt column in the eventRecord table
+        const updatedEvent = await prisma.eventRecord.update({
+          where: { id: event.id },
+          data: { cancelledAt: new Date() },
+        });
+
+        // Dequeue the event after the db has been updated
+        await workerQueue.dequeue(event.id, { tx: prisma });
+
+        return updatedEvent;
+      },
+      { timeout: 10000 }
+    );
+  }
+}

--- a/apps/webapp/app/services/events/ingestSendEvent.server.ts
+++ b/apps/webapp/app/services/events/ingestSendEvent.server.ts
@@ -88,7 +88,7 @@ export class IngestSendEvent {
             {
               id: eventLog.id,
             },
-            { runAt: eventLog.deliverAt, tx, jobKey: eventLog.id }
+            { runAt: eventLog.deliverAt, tx, jobKey: `event:${eventLog.id}` }
           );
         }
 

--- a/apps/webapp/app/services/events/ingestSendEvent.server.ts
+++ b/apps/webapp/app/services/events/ingestSendEvent.server.ts
@@ -6,10 +6,7 @@ import { workerQueue } from "~/services/worker.server";
 export class IngestSendEvent {
   #prismaClient: PrismaClientOrTransaction;
 
-  constructor(
-    prismaClient: PrismaClientOrTransaction = prisma,
-    private deliverEvents = true
-  ) {
+  constructor(prismaClient: PrismaClientOrTransaction = prisma, private deliverEvents = true) {
     this.#prismaClient = prismaClient;
   }
 
@@ -91,7 +88,7 @@ export class IngestSendEvent {
             {
               id: eventLog.id,
             },
-            { runAt: eventLog.deliverAt, tx }
+            { runAt: eventLog.deliverAt, tx, jobKey: eventLog.id }
           );
         }
 

--- a/packages/database/prisma/migrations/20230814131639_added_cancelled_at_column_to_the_event_record_table/migration.sql
+++ b/packages/database/prisma/migrations/20230814131639_added_cancelled_at_column_to_the_event_record_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "EventRecord" ADD COLUMN     "cancelledAt" TIMESTAMP(3);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -640,6 +640,7 @@ model EventRecord {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  cancelledAt DateTime? 
 
   isTest Boolean  @default(false)
   runs   JobRun[]

--- a/packages/trigger-sdk/src/apiClient.ts
+++ b/packages/trigger-sdk/src/apiClient.ts
@@ -201,6 +201,22 @@ export class ApiClient {
     });
   }
 
+  async cancelEvent(eventId: string) {
+    const apiKey = await this.#apiKey();
+
+    this.#logger.debug("Cancelling event", {
+      eventId,
+    });
+
+    return await zodfetch(ApiEventLogSchema, `${this.#apiUrl}/api/v1/events/${eventId}/cancel`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+  }
+
   async updateSource(
     client: string,
     key: string,

--- a/packages/trigger-sdk/src/io.ts
+++ b/packages/trigger-sdk/src/io.ts
@@ -220,6 +220,29 @@ export class IO {
     );
   }
 
+  async cancelEvent(key: string | any[], eventId: string) {
+    return await this.runTask(
+      key,
+      {
+        name: "cancelEvent",
+        params: {
+          eventId,
+        },
+        properties: [
+          {
+            label: "id",
+            text: eventId,
+          },
+        ],
+        noop: true,
+      },
+      async (task) => {
+        return await this._triggerClient.cancelEvent(eventId);
+      }
+    );
+  }
+
+
   async updateSource(key: string | any[], options: { key: string } & UpdateTriggerSourceBody) {
     return this.runTask(
       key,

--- a/packages/trigger-sdk/src/triggerClient.ts
+++ b/packages/trigger-sdk/src/triggerClient.ts
@@ -556,6 +556,10 @@ export class TriggerClient {
     return this.#client.sendEvent(event, options);
   }
 
+  async cancelEvent(eventId: string) {
+    return this.#client.cancelEvent(eventId);
+  }
+
   async registerSchedule(id: string, key: string, schedule: ScheduleMetadata) {
     return this.#client.registerSchedule(this.id, id, key, schedule);
   }


### PR DESCRIPTION
## Description
Added a function to cancel scheduled Events based on their ID. 

## Changes
- added an API endpoint `api.v1.events.$eventId.cancel.ts` to update the cancelledAt column in the EventRecord table to the time the event was cancelled. 
- add a dequeue public function in the Zodworker class that handles removal of already scheduled jobs by calling the `graphile_worker.remove_job` SQL to remove the job.  
- Added a sendEvent function in the API Client class. 

fixes #230 
/claim #230 