### PR TITLE
test/add test on get user pkg manager

### DIFF
--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -2,5 +2,9 @@
 export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ["<rootDir>/test/**/*.ts?(x)", "<rootDir>/test/**/?(*.)+(spec|test).ts?(x)"],
+  testMatch: [
+    "<rootDir>/test/**/*.ts?(x)",
+    "<rootDir>/test/**/?(*.)+(spec|test).ts?(x)",
+    "<rootDir>/src/**/?(*.)+(spec|test).ts?(x)"
+  ],
 };

--- a/packages/cli/src/utils/getUserPkgManager.spec.ts
+++ b/packages/cli/src/utils/getUserPkgManager.spec.ts
@@ -1,0 +1,26 @@
+import { pathExists } from "./fileSystem";
+import { getUserPackageManager } from "./getUserPkgManager";
+
+
+
+describe(getUserPackageManager.name, () => {
+  describe(`should use ${pathExists.name} to check for package manager artifacts`, () => {
+    it.todo('should return "yarn" if yarn.lock exists');
+
+    it.todo('should return "pnpm" if pnpm-lock.yaml exists');
+
+    it.todo('should return "npm" if package-lock.json exists');
+
+    it.todo('should return "npm" if npm-shrinkwrap.json exists');
+  });
+  
+  describe(`if doesn't found a artifacts, should use ${process.env.npm_config_user_agent} to detect package manager`, () => {
+    it.todo('should return "yarn" if process.env.npm_config_user_agent starts with "yarn"');
+
+    it.todo('should return "pnpm" if process.env.npm_config_user_agent starts with "pnpm"');
+
+    it.todo('if doesn\'t start with "yarn" or "pnpm", should return "npm"');
+
+    it.todo('should return "npm" if process.env.npm_config_user_agent is not set');
+  });
+})

--- a/packages/cli/src/utils/getUserPkgManager.spec.ts
+++ b/packages/cli/src/utils/getUserPkgManager.spec.ts
@@ -65,12 +65,32 @@ describe(getUserPackageManager.name, () => {
   });
   
   describe(`if doesn't found a artifacts, should use process.env.npm_config_user_agent to detect package manager`, () => {
-    it.todo('should return "yarn" if process.env.npm_config_user_agent starts with "yarn"');
+    beforeEach(() => {
+      (pathExists as jest.Mock).mockResolvedValue(false);
+    })
 
-    it.todo('should return "pnpm" if process.env.npm_config_user_agent starts with "pnpm"');
+    it('should return "yarn" if process.env.npm_config_user_agent starts with "yarn"', async () => {
+      process.env.npm_config_user_agent = 'yarn';
 
-    it.todo('if doesn\'t start with "yarn" or "pnpm", should return "npm"');
+      expect(await getUserPackageManager(path)).toBe('yarn');
+    });
 
-    it.todo('should return "npm" if process.env.npm_config_user_agent is not set');
+    it('should return "pnpm" if process.env.npm_config_user_agent starts with "pnpm"', async () => {
+      process.env.npm_config_user_agent = 'pnpm';
+
+      expect(await getUserPackageManager(path)).toBe('pnpm');
+    });
+
+    it('if doesn\'t start with "yarn" or "pnpm", should return "npm"', async () => {
+      process.env.npm_config_user_agent = randomUUID();
+
+      expect(await getUserPackageManager(path)).toBe('npm');
+    });
+
+    it('should return "npm" if process.env.npm_config_user_agent is not set', async () => {
+      delete process.env.npm_config_user_agent;
+
+      expect(await getUserPackageManager(path)).toBe('npm');
+    });
   });
 })

--- a/packages/cli/src/utils/getUserPkgManager.spec.ts
+++ b/packages/cli/src/utils/getUserPkgManager.spec.ts
@@ -1,10 +1,44 @@
+import { randomUUID } from "crypto";
 import { pathExists } from "./fileSystem";
 import { getUserPackageManager } from "./getUserPkgManager";
+import { join } from "path";
 
+jest.mock('path', () => ({
+  join: jest.fn().mockImplementation((...paths: string[]) => paths.join('/')),
+}))
 
+jest.mock('./fileSystem', () => ({
+  pathExists: jest.fn().mockResolvedValue(false),
+}));
 
 describe(getUserPackageManager.name, () => {
+  let path: string;
+
+  beforeEach(() => {
+    path = randomUUID();
+  });
+
+  afterEach(jest.clearAllMocks);
+
   describe(`should use ${pathExists.name} to check for package manager artifacts`, () => {
+    it('should join the path with the artifact name', async () => {
+      await getUserPackageManager(path);
+
+      expect(join).toBeCalledWith(path, 'yarn.lock');
+      expect(join).toBeCalledWith(path, 'pnpm-lock.yaml');
+      expect(join).toBeCalledWith(path, 'package-lock.json');
+    });
+
+    it(`should call ${pathExists.name} with the path.join result`, async () => {
+      const expected = randomUUID();
+
+      (join as jest.Mock).mockReturnValue(expected);
+
+      await getUserPackageManager(path);
+
+      expect(pathExists).toBeCalledWith(expected);
+    });
+
     it.todo('should return "yarn" if yarn.lock exists');
 
     it.todo('should return "pnpm" if pnpm-lock.yaml exists');
@@ -14,7 +48,7 @@ describe(getUserPackageManager.name, () => {
     it.todo('should return "npm" if npm-shrinkwrap.json exists');
   });
   
-  describe(`if doesn't found a artifacts, should use ${process.env.npm_config_user_agent} to detect package manager`, () => {
+  describe(`if doesn't found a artifacts, should use process.env.npm_config_user_agent to detect package manager`, () => {
     it.todo('should return "yarn" if process.env.npm_config_user_agent starts with "yarn"');
 
     it.todo('should return "pnpm" if process.env.npm_config_user_agent starts with "pnpm"');

--- a/packages/cli/src/utils/getUserPkgManager.ts
+++ b/packages/cli/src/utils/getUserPkgManager.ts
@@ -1,5 +1,5 @@
 import pathModule from "path";
-import { pathExists } from "./fileSystem.js";
+import { pathExists } from "./fileSystem";
 
 export type PackageManager = "npm" | "pnpm" | "yarn";
 


### PR DESCRIPTION
- chore: make possible to write tests aside with implementations
- test: write getUserPkgManager test TO-DOs
- test: add test to building the path
- test: add tests to manual file checking
- test: add tests to npm_config_user_agent
