### PR TITLE
fix: explicitly set a charset for rendered HTML documents

### DIFF
--- a/apps/webapp/app/entry.server.tsx
+++ b/apps/webapp/app/entry.server.tsx
@@ -74,7 +74,7 @@ function serveTheBots(
       {
         // Use onAllReady to wait for the entire document to be ready
         onAllReady() {
-          responseHeaders.set("Content-Type", "text/html");
+          responseHeaders.set("Content-Type", "text/html; charset=utf-8");
           let body = new PassThrough();
           pipe(body);
           resolve(
@@ -114,7 +114,7 @@ function serveBrowsers(
         // use onShellReady to wait until a suspense boundary is triggered
         onShellReady() {
           shellReady = true;
-          responseHeaders.set("Content-Type", "text/html");
+          responseHeaders.set("Content-Type", "text/html; charset=utf-8");
           let body = new PassThrough();
           pipe(body);
           resolve(


### PR DESCRIPTION
HTTP 1.1 spec defaults to ISO-8859-1 as a charset but likely we want to to set it to UTF-8.

Being explicit with character encoding.