### PR TITLE
fix: avoid code duplication by repostioning the default switch case

### DIFF
--- a/apps/webapp/app/components/run/RunOverview.tsx
+++ b/apps/webapp/app/components/run/RunOverview.tsx
@@ -273,6 +273,7 @@ function BlankTasks({
   basicStatus: RunBasicStatus;
 }) {
   switch (basicStatus) {
+    default:
     case "COMPLETED":
       return <Paragraph variant="small">There were no tasks for this run.</Paragraph>;
     case "FAILED":
@@ -288,8 +289,6 @@ function BlankTasks({
           <TaskCardSkeleton />
         </div>
       );
-    default:
-      return <Paragraph variant="small">There were no tasks for this run.</Paragraph>;
   }
 }
 


### PR DESCRIPTION
Small code clean up (on the borderline of nitpick so we can dismiss if not up to your taste).

This change proposes handling the same case for 'default' and 'completed'. I figured it'd be easier on the eye this way rather than to create a new variable and re-use it.