### PR TITLE
chore: updated the type in the eventId argument

### DIFF
--- a/.changeset/nervous-masks-rest.md
+++ b/.changeset/nervous-masks-rest.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/react": patch
+---
+
+chore: updated the type in the eventId argument

--- a/packages/react/src/events.ts
+++ b/packages/react/src/events.ts
@@ -42,7 +42,7 @@ export function useEventDetails(eventId: string | undefined): UseEventDetailsRes
 }
 
 export function useEventRunDetails(
-  eventId: string,
+  eventId: string | undefined,
   options?: RunDetailOptions
 ): UseRunDetailsResult {
   const event = useEventDetails(eventId);


### PR DESCRIPTION
closes #385 

Tested that undefined can now be accepted as an argument for useEventRunDetails in the nextjs-example folder. `useEventRunDetails(undefined)`