### PR TITLE
Fix: Magic link login not working properly when booted from docker

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --write .",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "cross-env NODE_ENV=production node --max-old-space-size=8192 ./build/server.js",
-    "start-from-docker": "cross-env node --max-old-space-size=8192 ./build/server.js",
+    "start:local": "cross-env node --max-old-space-size=8192 ./build/server.js",
     "typecheck": "tsc --noEmit",
     "db:seed": "node prisma/seed.js",
     "db:seed:local": "ts-node prisma/seed.ts",

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --write .",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "cross-env NODE_ENV=production node --max-old-space-size=8192 ./build/server.js",
+    "start_docker": "cross-env node --max-old-space-size=8192 ./build/server.js",
     "typecheck": "tsc --noEmit",
     "db:seed": "node prisma/seed.js",
     "db:seed:local": "ts-node prisma/seed.ts",

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --write .",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "cross-env NODE_ENV=production node --max-old-space-size=8192 ./build/server.js",
-    "start_docker": "cross-env node --max-old-space-size=8192 ./build/server.js",
+    "start-from-docker": "cross-env node --max-old-space-size=8192 ./build/server.js",
     "typecheck": "tsc --noEmit",
     "db:seed": "node prisma/seed.js",
     "db:seed:local": "ts-node prisma/seed.ts",

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -14,4 +14,4 @@ cp node_modules/@prisma/engines/*.node apps/webapp/prisma/
 pnpm --filter webapp db:seed
 
 cd /triggerdotdev/apps/webapp
-exec dumb-init pnpm run start-from-docker
+exec dumb-init pnpm run start:local

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -14,4 +14,4 @@ cp node_modules/@prisma/engines/*.node apps/webapp/prisma/
 pnpm --filter webapp db:seed
 
 cd /triggerdotdev/apps/webapp
-exec dumb-init pnpm run start_docker
+exec dumb-init pnpm run start-from-docker

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -14,4 +14,4 @@ cp node_modules/@prisma/engines/*.node apps/webapp/prisma/
 pnpm --filter webapp db:seed
 
 cd /triggerdotdev/apps/webapp
-exec dumb-init pnpm run start
+exec dumb-init pnpm run start_docker


### PR DESCRIPTION
## Problem
When using docker-compose to deploy to any remote environment, the same problem as #186 occurs.
This is caused by the following factors happening at the same time:

1. the `Secure` attribute exception does not work because the domain is not `localhost` (or browsers that respect the `Secure` attribute even on `localhost`, such as safari).
1. `NODE_ENV` is fixed to `production` and `Secure: NODE_ENV === "production"` is always `true`.

It can be reproduced in the local environment by replacing `http://localhost` with `http://127.0.0.1.nip.io`.

This pull request solves factor 2. of the above factors.
Therefore, it is assumed that #186 will be resolved in many cases.

## Detailed cause of occurrence
When booted from a docker image, `entrypoint` calls `/docker/scripts/entrypoint.sh`,
Inside it, `exec dumb-init pnpm run start` is executed.
where `cross-env NODE_ENV=production node --max-old-space-size=8192 . /build/server.js` will be executed.
At this time, since `NODE_ENV` is fixed to `production`, even if environment variables are specified in `env_file` etc., they are overwritten and the above problem occurs.

## Solution
Add `start-from-docker` command to `package.json` and call it when starting from docker container.
The command is exactly the same as `start` except that `NODE_ENV` is not overwritten.
This fix will ensure that the `NODE_ENV` specified in the `.env` file is respected and the above bug is repaired.

/claim #186
