### PR TITLE
fix: CLI dev command doesn't work if you're already running ngrok

### DIFF
--- a/.changeset/lovely-beers-collect.md
+++ b/.changeset/lovely-beers-collect.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/cli": patch
+---
+
+provided a fix to the CLI dev command tunnel not working if you are already running ngrok

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -258,6 +258,16 @@ async function createTunnel(port: number, spinner: Ora) {
         return;
       }
     }
+    if (
+      typeof error.message === "string" &&
+      error.message.includes("connect ECONNREFUSED 127.0.0.1:4041")
+    ) {
+      spinner.fail(
+        `Ngrok failed to create a tunnel for port ${port} because ngrok is already running`
+      );
+      return;
+    }
+    spinner.fail(`Ngrok failed to create a tunnel for port ${port}.\n${error.message}`);
     return;
   }
 }


### PR DESCRIPTION
fixes #403 

<img width="475" alt="Screenshot 2023-08-26 at 4 06 36 PM" src="https://github.com/triggerdotdev/trigger.dev/assets/92148630/56558b75-eff2-4783-8d27-87281d60b37f">

@matt-aitken I'm open to better ways of handling this, would love your thoughts on this. 

