### PR TITLE
Enhancement/lower max attempts for enqueued task for development environment

### DIFF
--- a/apps/webapp/app/models/jobRunExecution.server.ts
+++ b/apps/webapp/app/models/jobRunExecution.server.ts
@@ -27,6 +27,7 @@ export type EnqueueRunExecutionV2Options = {
   runAt?: Date;
   resumeTaskId?: string;
   isRetry?: boolean;
+  skipRetrying?: boolean
 };
 
 export async function enqueueRunExecutionV2(
@@ -47,6 +48,7 @@ export async function enqueueRunExecutionV2(
       tx,
       runAt: options.runAt,
       jobKey: `job_run:${run.id}`,
+      maxAttempts: options.skipRetrying ? 1 : undefined
     }
   );
 }

--- a/apps/webapp/app/services/endpoints/createEndpoint.server.ts
+++ b/apps/webapp/app/services/endpoints/createEndpoint.server.ts
@@ -4,6 +4,7 @@ import { AuthenticatedEnvironment } from "../apiAuth.server";
 import { EndpointApi } from "../endpointApi.server";
 import { workerQueue } from "../worker.server";
 import { env } from "~/env.server";
+import { RuntimeEnvironmentTypeSchema } from "../../../../../packages/core/src";
 
 const indexingHookIdentifier = customAlphabet("0123456789abcdefghijklmnopqrstuvxyz", 10);
 
@@ -83,7 +84,10 @@ export class CreateEndpointService {
             id: endpoint.id,
             source: "INTERNAL",
           },
-          { tx }
+          {
+            tx,
+            maxAttempts: environment.type === RuntimeEnvironmentTypeSchema.Enum.DEVELOPMENT ? 1 : undefined
+          }
         );
 
         return endpoint;

--- a/apps/webapp/app/services/endpoints/validateCreateEndpoint.server.ts
+++ b/apps/webapp/app/services/endpoints/validateCreateEndpoint.server.ts
@@ -5,6 +5,7 @@ import { AuthenticatedEnvironment } from "../apiAuth.server";
 import { workerQueue } from "../worker.server";
 import { CreateEndpointError } from "./createEndpoint.server";
 import { EndpointApi } from "../endpointApi.server";
+import { RuntimeEnvironmentTypeSchema } from "../../../../../packages/core/src";
 
 const indexingHookIdentifier = customAlphabet("0123456789abcdefghijklmnopqrstuvxyz", 10);
 
@@ -67,7 +68,10 @@ export class ValidateCreateEndpointService {
             id: endpoint.id,
             source: "INTERNAL",
           },
-          { tx }
+          {
+            tx,
+            maxAttempts: environment?.type === RuntimeEnvironmentTypeSchema.Enum.DEVELOPMENT ? 1 : undefined
+          }
         );
 
         return endpoint;

--- a/apps/webapp/app/services/runs/continueRun.server.ts
+++ b/apps/webapp/app/services/runs/continueRun.server.ts
@@ -1,5 +1,6 @@
 import { $transaction, Prisma, PrismaClient, prisma } from "~/db.server";
 import { enqueueRunExecutionV2 } from "~/models/jobRunExecution.server";
+import { RuntimeEnvironmentTypeSchema } from "../../../../../packages/core/src";
 
 const RESUMABLE_STATUSES = ["FAILURE", "TIMED_OUT", "ABORTED", "CANCELED"];
 
@@ -35,7 +36,9 @@ export class ContinueRunService {
           },
         });
 
-        await enqueueRunExecutionV2(run, tx);
+        await enqueueRunExecutionV2(run, tx, {
+          skipRetrying: run.environment.type === RuntimeEnvironmentTypeSchema.Enum.DEVELOPMENT,
+        });
       },
       { timeout: 10000 }
     );

--- a/apps/webapp/app/services/sources/handleHttpSource.server.ts
+++ b/apps/webapp/app/services/sources/handleHttpSource.server.ts
@@ -2,6 +2,7 @@ import type { PrismaClient } from "~/db.server";
 import { prisma } from "~/db.server";
 import { workerQueue } from "../worker.server";
 import { requestUrl } from "~/utils/requestUrl.server";
+import { RuntimeEnvironmentTypeSchema } from "../../../../../packages/core/src";
 
 export class HandleHttpSourceService {
   #prismaClient: PrismaClient;
@@ -55,6 +56,7 @@ export class HandleHttpSourceService {
           {
             queueName: `endpoint-${triggerSource.endpointId}`,
             tx,
+            maxAttempts: triggerSource.environment.type === RuntimeEnvironmentTypeSchema.Enum.DEVELOPMENT ? 1 : undefined
           }
         );
       });

--- a/apps/webapp/app/services/tasks/performTaskOperation.server.ts
+++ b/apps/webapp/app/services/tasks/performTaskOperation.server.ts
@@ -4,6 +4,7 @@ import {
   FetchRetryOptions,
   FetchRetryStrategy,
   RedactString,
+  RuntimeEnvironmentTypeSchema,
   calculateRetryAt,
 } from "@trigger.dev/core";
 import type { Task } from "@trigger.dev/database";
@@ -244,7 +245,9 @@ export class PerformTaskOperationService {
   }
 
   async #resumeRunExecution(task: NonNullable<FoundTask>, prisma: PrismaClientOrTransaction) {
-    await enqueueRunExecutionV2(task.run, prisma);
+    await enqueueRunExecutionV2(task.run, prisma, {
+      skipRetrying: task?.run?.environment?.type === RuntimeEnvironmentTypeSchema.Enum.DEVELOPMENT,
+    });
   }
 }
 


### PR DESCRIPTION
closes #393 
/claim #393 

In this PR I have done the below changes :

1. added a new optional boolean flag skipRetrying for the options of enqueueRunExecutionV2 to restrict maxAttempts to 1 if the flag is true.
2.  updated the calls to enqueueRunExecutionV2 so that it skips retrying for development enviroment.
3.  updated the workerQueue.enqueue call for deliverHttpSourceRequest so that it just attempts once for development enviroment.
4.  updated the workerQueue.enqueue call for indexEndpoint so that it just attempts once for development enviroment.


Note: I have
n't updated the call from this function as it only fetches the endpoints which are already having a enviorment type of production 

![Screenshot 08-27-2023 19 05 31](https://github.com/triggerdotdev/trigger.dev/assets/60315087/ae99594c-738a-4e95-ac3f-30b1577c017f)

Please let me know if any further changes is required, Thank You. It was fun contributing this awesome codebase