### PR TITLE
docs: crontrigger.mdx fix link to /docs/sdk/job

### DIFF
--- a/docs/sdk/crontrigger.mdx
+++ b/docs/sdk/crontrigger.mdx
@@ -1,6 +1,6 @@
 ---
 title: "cronTrigger()"
-description: "`cronTrigger()` is set as a [Job's trigger](/sdk/job) to trigger a Job on a recurring schedule using a CRON expression."
+description: "`cronTrigger()` is set as a [Job's trigger](/docs/sdk/job) to trigger a Job on a recurring schedule using a CRON expression."
 ---
 
 ## Development


### PR DESCRIPTION
Fixes link in docs to the correct page. Currently goes to a 404 when clicking "Job's trigger" link, seen here: https://trigger.dev/docs/sdk/crontrigger