### PR TITLE
feat: support for Express

### DIFF
--- a/apps/webapp/app/components/frameworks/FrameworkSelector.tsx
+++ b/apps/webapp/app/components/frameworks/FrameworkSelector.tsx
@@ -51,7 +51,7 @@ export function FrameworkSelector() {
           <FrameworkLink to={projectSetupNextjsPath(organization, project)} supported>
             <NextjsLogo className="w-32" />
           </FrameworkLink>
-          <FrameworkLink to={projectSetupExpressPath(organization, project)}>
+          <FrameworkLink to={projectSetupExpressPath(organization, project)} supported>
             <ExpressLogo className="w-36" />
           </FrameworkLink>
           <FrameworkLink to={projectSetupRemixPath(organization, project)}>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.setup.express/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.setup.express/route.tsx
@@ -1,21 +1,74 @@
-import { ExpressLogo } from "~/assets/logos/ExpressLogo";
-import { FrameworkComingSoon } from "~/components/frameworks/FrameworkComingSoon";
-import { BreadcrumbLink } from "~/components/navigation/NavBar";
+import { useState } from "react";
+import invariant from "tiny-invariant";
+import { useProjectSetupComplete } from "~/hooks/useProjectSetupComplete";
+import { useDevEnvironment } from "~/hooks/useEnvironments";
+import { useAppOrigin } from "~/hooks/useAppOrigin";
+import { useOrganization } from "~/hooks/useOrganizations";
+import { useProject } from "~/hooks/useProject";
 import { Handle } from "~/utils/handle";
-import { trimTrailingSlash } from "~/utils/pathBuilder";
+import { projectSetupPath, trimTrailingSlash } from "~/utils/pathBuilder";
+import { Callout } from "~/components/primitives/Callout";
+import { StepNumber } from "~/components/primitives/StepNumber";
+import { StepContentContainer } from "~/components/StepContentContainer";
+import { RunDevCommand, TriggerDevStep, InitCommand } from "~/components/SetupCommands";
+import { Header1 } from "~/components/primitives/Headers";
+import { LinkButton } from "~/components/primitives/Buttons";
+import { PageGradient } from "~/components/PageGradient";
+import { BreadcrumbLink } from "~/components/navigation/NavBar";
+import { Button } from "~/components/primitives/Buttons";
+import { Paragraph } from "~/components/primitives/Paragraph";
+import { InlineCode } from "~/components/code/InlineCode";
+import { ClipboardField } from "~/components/primitives/ClipboardField";
 
 export const handle: Handle = {
   breadcrumb: (match) => <BreadcrumbLink to={trimTrailingSlash(match.pathname)} title="Express" />,
 };
 
-export default function Page() {
+export default function SetupExpress() {
+  const organization = useOrganization();
+  const project = useProject();
+  useProjectSetupComplete();
+  const devEnvironment = useDevEnvironment();
+  const appOrigin = useAppOrigin();
+
+  invariant(devEnvironment, "devEnvironment is required");
+
   return (
-    <FrameworkComingSoon
-      frameworkName="Express"
-      githubIssueUrl="https://github.com/triggerdotdev/trigger.dev/issues/451"
-      githubIssueNumber={451}
-    >
-      <ExpressLogo className="w-56" />
-    </FrameworkComingSoon>
+    <PageGradient>
+      <div className="mx-auto max-w-3xl">
+        <Header1 spacing className="text-bright">
+          Get setup in 2 minutes for an existing Express project
+        </Header1>
+        <Callout
+          variant={"info"}
+          to="https://github.com/triggerdotdev/trigger.dev/discussions/451"
+          className="mb-8"
+        >
+          Trigger.dev has full support for serverless. We will be adding support for
+          long-running servers soon.
+        </Callout>
+        <StepNumber stepNumber="1" title="Run the CLI 'init' command in your existing Express project" />
+        <StepContentContainer>
+          <InitCommand appOrigin={appOrigin} apiKey={devEnvironment.apiKey} />
+          <Paragraph spacing variant="small">
+            You’ll notice a new folder in your project called 'jobs'. We’ve added a very
+            simple example Job in <InlineCode variant="extra-small">examples.ts</InlineCode>{" "}
+            to help you get started.
+          </Paragraph>
+        </StepContentContainer>
+        <StepNumber stepNumber="2" title="Run your Express app" />
+        <StepContentContainer>
+          <RunDevCommand />
+        </StepContentContainer>
+        <StepNumber stepNumber="3" title="Run the CLI 'dev' command" />
+        <StepContentContainer>
+          <TriggerDevStep />
+        </StepContentContainer>
+        <StepNumber stepNumber="4" title="Wait for Jobs" displaySpinner />
+        <StepContentContainer>
+          <Paragraph>This page will automatically refresh.</Paragraph>
+        </StepContentContainer>
+      </div>
+    </PageGradient>
   );
 }

--- a/docs/_snippets/manual-setup-express.mdx
+++ b/docs/_snippets/manual-setup-express.mdx
@@ -1,1 +1,239 @@
-We're in the process of building support for the Express framework. You can follow along with progress or contribute via [this GitHub issue](https://github.com/triggerdotdev/trigger.dev/issues).
+---
+title: "Express"
+sidebarTitle: "Express"
+description: "How to manually set up Trigger.dev in your Express project"
+---
+
+<Accordion defaultOpen title="Don't have an Express project yet to add Trigger.dev to? No problem, you can complete the Manual Setup using a blank Express project:">
+Create a blank project by creating a new Express application:
+
+```bash
+npm init -y
+npm install express
+```
+
+Trigger.dev works with Express applications.
+
+</Accordion>
+
+## Installing Required Packages
+
+To begin, install the necessary packages in your Express project directory:
+
+<CodeGroup>
+
+```bash npm
+
+npm install @trigger.dev/sdk @trigger-dev/express
+
+```
+
+```bash pnpm
+pnpm install @trigger.dev/sdk @trigger-dev/express
+
+```
+
+```bash yarn
+yarn add @trigger.dev/sdk @trigger-dev/express
+
+```
+
+</CodeGroup>
+
+<br />
+
+<Note>Ensure that you execute this command within an Express project.</Note>
+
+## Obtaining the Development API Key
+
+To locate your development API key, login to the [Trigger.dev
+dashboard](https://cloud.trigger.dev) and select the Project you want to
+connect to. Then click on the Environments & API Keys tab in the left menu.
+You can copy your development API Key from the field at the top of this page.
+(Your development key will start with `tr_dev_`).
+
+## Adding Environment Variables
+
+Create a `.env` file at the root of your project and include your Trigger API key and URL like this:
+
+```bash
+
+TRIGGER_API_KEY=ENTER_YOUR_DEVELOPMENT_API_KEY_HERE
+TRIGGER_API_URL=https://cloud.trigger.dev
+
+```
+
+Replace `ENTER_YOUR_DEVELOPMENT_API_KEY_HERE` with the actual API key obtained from the previous step.
+
+## Configuring the Trigger Client
+
+To set up the Trigger Client for your project, follow these steps:
+
+1. **Create Configuration File:**
+
+   In your project directory, create a configuration file named `trigger.ts` or `trigger.js`, depending on whether your project uses TypeScript (`.ts`) or JavaScript (`.js`).
+
+2. **Add Configuration Code:**
+
+   Open the configuration file you created and add the following code:
+
+   ```typescript
+   // trigger.ts (for TypeScript) or trigger.js (for JavaScript)
+
+    import { TriggerClient } from "@trigger.dev/sdk";
+
+    export const client = new TriggerClient({
+    id: "my-app",
+    apiKey: process.env.TRIGGER_API_KEY,
+    apiUrl: process.env.TRIGGER_API_URL,
+    });
+
+   ```
+
+   Replace **"my-app"** with an appropriate identifier for your project. The **apiKey** and **apiUrl** are obtained from the environment variables you set earlier.
+
+
+By following these steps, you'll configure the Trigger Client to work with your Express project.
+
+## Creating the API Route
+
+To establish an API route for interacting with Trigger.dev, follow these steps:
+
+1. Create a new route file (e.g., `route.js`) in your Express project.
+
+2. Add the following code to your route file:
+
+```javascript
+const express = require('express');
+const { createExpressRoute } = require('@trigger.dev/express');
+const { client } = require('./trigger'); // Update the path as per your project structure
+
+const router = express.Router();
+const { POST } = createExpressRoute(client);
+
+router.post('/trigger', POST);
+
+module.exports = router;
+```
+
+Make sure to update the path in the `require('./trigger')` statement to match the location of your Trigger Client configuration file.
+
+## Creating the Example Job
+
+1. Create a folder named `Jobs` alongside your Express project files.
+2. Inside the `Jobs` folder, add two files named `example.js` and `index.js`.
+
+<CodeGroup>
+
+```typescript example.(ts/js)
+const { eventTrigger } = require('@trigger.dev/sdk');
+const { client } = require('./trigger'); // Update the path as per your project structure
+
+// Your first job
+client.defineJob({
+  id: 'example-job',
+  name: 'Example Job',
+  version: '0.0.1',
+  trigger: eventTrigger({
+    name: 'example.event',
+  }),
+  run: async (payload, io, ctx) => {
+    await io.logger.info('Hello world!', { payload });
+
+    return {
+      message: 'Hello world!',
+    };
+  },
+});
+
+```
+
+```typescript index.ts/index.(ts/js)
+// import all your job files here
+
+module.exports = require('./example');
+```
+
+</CodeGroup>
+
+## Adding Configuration to `package.json`
+
+Inside the `package.json` file, add the following configuration under the root object:
+
+
+```json
+"trigger.dev": {
+  "endpointId": "my-app"
+}
+```
+
+Your `package.json` file might look something like this:
+
+```json
+{
+  "name": "my-app",
+  "version": "1.0.0",
+  "dependencies": {
+    // ... other dependencies
+  },
+  "trigger.dev": {
+    "endpointId": "my-app"
+  }
+}
+```
+
+Replace **"my-app"** with the appropriate identifier you used during the step for creating the Trigger Client.
+
+## Next Steps
+
+Start your Express project, and your Trigger.dev integration should work seamlessly
+
+In your project directory, run
+    
+```bash
+node route.js
+```
+
+This command starts your Express server and enables the Trigger.dev integration
+
+![Your first Job](/images/cli-dev.gif)
+
+<Warning>
+  Ensure your Express server is running locally before continuing. You must also leave this server
+  running while you develop.
+</Warning>
+
+In a **new terminal window or tab**, you can run Trigger.dev locally:
+
+<CodeGroup>
+
+```bash npm
+npx @trigger.dev/cli@latest dev
+```
+
+```bash pnpm
+pnpm dlx @trigger.dev/cli@latest dev
+```
+
+```bash yarn
+yarn dlx @trigger.dev/cli@latest dev
+```
+
+</CodeGroup>
+<br />
+<Note>
+   You can optionally pass the port if you're not running on port 3000 by adding
+  `--port 3001` to the end.
+</Note>
+<Note>
+  You can optionally pass the hostname if you're not running on localhost by adding
+  `--hostname <host>`. Example, in case your Express server is running on 0.0.0.0: `--hostname 0.0.0.0`.
+</Note>
+
+<Tip>
+  If your existing Express project utilizes middleware and you encounter any issues, such as
+  potential conflicts with Trigger.dev, it's recommended to refer to the troubleshooting guide at
+  [Middleware](/documentation/guides/platforms/express#middleware) for assistance. This guide can
+  help you address any concerns related to middleware conflicts and ensure the smooth functioning of
+  your project with Trigger.dev.
+</Tip>

--- a/docs/_snippets/manual-setup-express.mdx
+++ b/docs/_snippets/manual-setup-express.mdx
@@ -1,8 +1,3 @@
----
-title: "Express"
-sidebarTitle: "Express"
-description: "How to manually set up Trigger.dev in your Express project"
----
 
 <Accordion defaultOpen title="Don't have an Express project yet to add Trigger.dev to? No problem, you can complete the Manual Setup using a blank Express project:">
 Create a blank project by creating a new Express application:

--- a/docs/documentation/concepts/client-adaptors.mdx
+++ b/docs/documentation/concepts/client-adaptors.mdx
@@ -28,4 +28,4 @@ Each platform has one or more adaptors, see the guides below:
 | ------------------------------------------------- | -------------------- |
 | [Next.js](/documentation/guides/platforms/nextjs) | `createPagesRoute()` |
 | [Next.js](/documentation/guides/platforms/nextjs) | `createAppRoute()`   |
-| Express                                           | Coming soon          |
+| Express                                           | `createExpressRoute()` |

--- a/docs/documentation/concepts/client-adaptors.mdx
+++ b/docs/documentation/concepts/client-adaptors.mdx
@@ -28,4 +28,6 @@ Each platform has one or more adaptors, see the guides below:
 | ------------------------------------------------- | -------------------- |
 | [Next.js](/documentation/guides/platforms/nextjs) | `createPagesRoute()` |
 | [Next.js](/documentation/guides/platforms/nextjs) | `createAppRoute()`   |
-| Express                                           | `createExpressRoute()` |
+| [Astro](/documentation/guides/platforms/astro)    | `createAstroRoute()` |
+| [Remix](/documentation/guides/platforms/remix)    | `createRemixRoute()` |
+| [Express](/documentation/guides/platforms/express)| `createExpressRoute()` |

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -1,0 +1,9 @@
+# Express.js and Trigger.dev
+
+Trigger.dev has full support for the Express.js framework, including both the Pages and App router.
+
+For information about the using Trigger.dev in your Express.js app, check out these useful docs links:
+
+- [Quick start guide for getting setup with Trigger.dev in a Express.js project](https://trigger.dev/docs/documentation/quickstarts/express)
+- [Manually setup Express.js with Trigger.dev](https://trigger.dev/docs/documentation/guides/manual/express)
+- [Using Trigger.dev with Express.js, handling middleware and more](https://trigger.dev/docs/documentation/guides/platforms/express)


### PR DESCRIPTION
**Task 1 – Add a README.md file**
  - [x] Create a new README.md file inside the packages/express folder and copy in the contents from packages/nextjs/README.md. Adjust the wording to reference Express where needed, including updating the URLs.

**Task 2 – Write the documentation**
  - [x] Locate the manual-setup-express.mdx folder in /docs/_snippets/. Use this file to write your documentation, overwriting any contents of that file. Follow the structure of this Next.js example for reference when writing yours.
  - [x] Update the table at the bottom of the client-adaptors.mdx page with the framework you’ve worked on.

**Task 3 – Update the webapp onboarding**
  - [x] In the route.tsx page located in _app.orgs.$organizationSlug.projects.$projectParam.setup.express, replace the <FrameworkComingSoon/> component with your new onboarding steps. Follow the same structure as the Next.js example when creating your own. Ignore the very top step for adding this framework to a new project; just focus on the steps to add it to an existing project (so don’t include the <RadioGroup/> toggle selector at the top). Make sure you also include the useProjectSetupComplete(); hook at the top of the page – this triggers a particle effect when the new job is successfully created and redirects to the Jobs list 🥳.
  - [x] In the FrameworkSelector.tsx file, add “supported” to the framework you’ve worked on.

/claim #451