### PR TITLE
feat: support nestjs client adaptor

### DIFF
--- a/apps/webapp/app/components/frameworks/FrameworkSelector.tsx
+++ b/apps/webapp/app/components/frameworks/FrameworkSelector.tsx
@@ -72,7 +72,7 @@ export function FrameworkSelector() {
           <FrameworkLink to={projectSetupFastifyPath(organization, project)}>
             <FastifyLogo className="w-36" />
           </FrameworkLink>
-          <FrameworkLink to={projectSetupNestjsPath(organization, project)}>
+          <FrameworkLink to={projectSetupNestjsPath(organization, project)} supported>
             <NestjsLogo className="w-36" />
           </FrameworkLink>
         </div>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.setup.nestjs/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.setup.nestjs/route.tsx
@@ -1,21 +1,207 @@
-import { NestjsLogo } from "~/assets/logos/NestjsLogo";
-import { FrameworkComingSoon } from "~/components/frameworks/FrameworkComingSoon";
-import { BreadcrumbLink } from "~/components/navigation/NavBar";
+import { useState } from "react";
+import invariant from "tiny-invariant";
+import { useProjectSetupComplete } from "~/hooks/useProjectSetupComplete";
+import { useDevEnvironment } from "~/hooks/useEnvironments";
+import { useAppOrigin } from "~/hooks/useAppOrigin";
+import { useOrganization } from "~/hooks/useOrganizations";
+import { useProject } from "~/hooks/useProject";
 import { Handle } from "~/utils/handle";
-import { trimTrailingSlash } from "~/utils/pathBuilder";
+import { projectSetupPath, trimTrailingSlash } from "~/utils/pathBuilder";
+import { Callout } from "~/components/primitives/Callout";
+import { StepNumber } from "~/components/primitives/StepNumber";
+import { StepContentContainer } from "~/components/StepContentContainer";
+import { RunDevCommand, TriggerDevStep, InitCommand } from "~/components/SetupCommands";
+import { Header1 } from "~/components/primitives/Headers";
+import { LinkButton } from "~/components/primitives/Buttons";
+import { PageGradient } from "~/components/PageGradient";
+import { BreadcrumbLink } from "~/components/navigation/NavBar";
+import { Button } from "~/components/primitives/Buttons";
+import { Paragraph } from "~/components/primitives/Paragraph";
+import { InlineCode } from "~/components/code/InlineCode";
+import { ClipboardField } from "~/components/primitives/ClipboardField";
+import { CodeBlock } from "~/components/code/CodeBlock";
+import { ClientTabs, ClientTabsList, ClientTabsTrigger, ClientTabsContent } from "~/components/primitives/ClientTabs";
 
 export const handle: Handle = {
-  breadcrumb: (match) => <BreadcrumbLink to={trimTrailingSlash(match.pathname)} title="Nest.js" />,
+  breadcrumb: (match) => <BreadcrumbLink to={trimTrailingSlash(match.pathname)} title="NestJS" />,
 };
 
 export default function Page() {
+  useProjectSetupComplete();
+  const devEnvironment = useDevEnvironment();
+
+  invariant(devEnvironment, "devEnvironment is required");
+
   return (
-    <FrameworkComingSoon
-      frameworkName="Nest.js"
-      githubIssueUrl="https://github.com/triggerdotdev/trigger.dev/issues/449"
-      githubIssueNumber={449}
-    >
-      <NestjsLogo className="w-56" />
-    </FrameworkComingSoon>
+    <PageGradient>
+    <div className="mx-auto max-w-3xl">
+      <Header1 spacing className="text-bright">
+        Get setup in 5 minutes for an existing NestJS project
+      </Header1>
+      <Callout
+        variant={"info"}
+        to="https://github.com/triggerdotdev/trigger.dev/discussions/449"
+        className="mb-8"
+      >
+        Trigger.dev has full support for serverless. We will be adding support for
+        long-running servers soon.
+      </Callout>
+      <StepNumber stepNumber="1" title="Install the necessary packages in your NestJS project directory" />
+      <StepContentContainer>
+        <ClientTabs defaultValue="npm">
+          <ClientTabsList>
+            <ClientTabsTrigger value={"npm"}>npm</ClientTabsTrigger>
+            <ClientTabsTrigger value={"pnpm"}>pnpm</ClientTabsTrigger>
+            <ClientTabsTrigger value={"yarn"}>yarn</ClientTabsTrigger>
+          </ClientTabsList>
+          <ClientTabsContent value={"npm"}>
+            <ClipboardField
+              variant="primary/medium"
+              className="mb-4"
+              value={`npm install @trigger.dev/sdk @trigger-dev/nestjs`}
+            />
+          </ClientTabsContent>
+          <ClientTabsContent value={"pnpm"}>
+            <ClipboardField
+              variant="primary/medium"
+              className="mb-4"
+              value={`pnpm install @trigger.dev/sdk @trigger-dev/nestjs`}
+            />
+          </ClientTabsContent>
+          <ClientTabsContent value={"yarn"}>
+            <ClipboardField
+              variant="primary/medium"
+              className="mb-4"
+              value={`yarn add @trigger.dev/sdk @trigger-dev/nestjs`}
+            />
+          </ClientTabsContent>
+        </ClientTabs>
+
+        <Paragraph spacing variant="small">
+          Trigger.dev works with express or fastify platforms of NestJS.
+        </Paragraph>
+      </StepContentContainer>
+      <StepNumber stepNumber="2" title="Create a `.env` file at the root of your project and include your Trigger API key and URL like this:" />
+        <StepContentContainer>
+        <CodeBlock
+        showLineNumbers={false}
+        className="mb-4"
+        code={`TRIGGER_API_KEY = ENTER_YOUR_DEVELOPMENT_API_KEY_HERE
+TRIGGER_API_URL = https://cloud.trigger.dev
+        `
+          }
+        />
+        </StepContentContainer>
+      <StepNumber stepNumber="3" title="In your project directory, create a configuration file named `trigger.ts` and add the following code:" />
+        <StepContentContainer>
+        <CodeBlock
+        showLineNumbers={false}
+        className="mb-4"
+        code={`import { TriggerClient } from "@trigger.dev/sdk";
+        
+export const client = new TriggerClient({
+  id: "my-app",
+  apiKey: process.env.TRIGGER_API_KEY,
+  apiUrl: process.env.TRIGGER_API_URL,
+});
+
+client.defineJob({
+  id: 'example-job',
+  name: 'Example Job',
+  version: '0.0.1', // replace this with version of @trigger/sdk you're using
+  trigger: eventTrigger({
+    name: 'example.event',
+  }),
+  run: async (payload, io, ctx) => {
+    await io.logger.info('Hello world!', { payload });
+
+    return {
+      message: 'Hello world!',
+    };
+  },
+});
+        `
+          }
+        />
+        <Paragraph spacing variant="small">
+        Replace "my-app" with an appropriate identifier for your project.
+        </Paragraph>
+        </StepContentContainer>
+      <StepNumber stepNumber="4" title="In `app.module.ts` create a middleware for the specific `/api/trigger` route." />
+      <StepContentContainer>
+      <CodeBlock
+        showLineNumbers={false}
+        className="mb-4"
+        code={`
+        import { TriggerDevMiddlewareCreatorForExpress } from '@trigger.dev/nestjs';
+import { TriggerClient } from '@trigger.dev/sdk';
+import { client } from './trigger'; 
+
+@Module({
+  imports: [],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {
+    private triggerClient: TriggerClient
+    constructor() {
+        this.triggerClient = client; 
+    }
+    
+    configure(consumer: MiddlewareConsumer) {
+        consumer
+            .apply(TriggerDevMiddlewareCreatorForExpress(this.triggerClient))
+            .forRoutes('/api/trigger');
+    }
+}`
+          }
+        />
+        <Paragraph spacing variant="small">
+        If your NestJS application using Express platform then use <InlineCode variant="extra-small">TriggerDevMiddlewareCreatorForExpress</InlineCode></Paragraph>
+        <Paragraph spacing variant="small">
+        If your NestJS application using Fastify platform then use <InlineCode variant="extra-small">TriggerDevMiddlewareCreatorForFastify</InlineCode>
+        </Paragraph>
+      </StepContentContainer>
+      <StepNumber stepNumber="5" title="Start your NestJS project" />
+      <StepContentContainer>
+        <ClientTabs defaultValue="npm">
+          <ClientTabsList>
+            <ClientTabsTrigger value={"npm"}>npm</ClientTabsTrigger>
+            <ClientTabsTrigger value={"pnpm"}>pnpm</ClientTabsTrigger>
+            <ClientTabsTrigger value={"yarn"}>yarn</ClientTabsTrigger>
+          </ClientTabsList>
+          <ClientTabsContent value={"npm"}>
+            <ClipboardField
+              variant="primary/medium"
+              className="mb-4"
+              value={`npm run start:dev`}
+            />
+          </ClientTabsContent>
+          <ClientTabsContent value={"pnpm"}>
+            <ClipboardField
+              variant="primary/medium"
+              className="mb-4"
+              value={`pnpm run start:dev`}
+            />
+          </ClientTabsContent>
+          <ClientTabsContent value={"yarn"}>
+            <ClipboardField
+              variant="primary/medium"
+              className="mb-4"
+              value={`yarn start:dev`}
+            />
+          </ClientTabsContent>
+        </ClientTabs>
+      </StepContentContainer>
+      <StepNumber stepNumber="6" title="Run the CLI 'dev' command" />
+      <StepContentContainer>
+        <TriggerDevStep />
+      </StepContentContainer>
+      <StepNumber stepNumber="7" title="Wait for Jobs" displaySpinner />
+      <StepContentContainer>
+        <Paragraph>This page will automatically refresh.</Paragraph>
+      </StepContentContainer>
+    </div>
+  </PageGradient>
   );
 }

--- a/docs/_snippets/manual-setup-nestjs.mdx
+++ b/docs/_snippets/manual-setup-nestjs.mdx
@@ -1,0 +1,281 @@
+---
+title: "NestJS"
+sidebarTitle: "NestJS"
+description: "How to manually set up Trigger.dev in your NestJS project"
+---
+
+<Accordion defaultOpen title="Don't have an NestJS project yet to add Trigger.dev to? No problem, you can complete the Manual Setup using a blank NestJS project:">
+Create a blank project by creating a new NestJS application:
+
+```bash
+npm i -g @nestjs/cli
+nest new your-project-name
+```
+
+Trigger.dev works with NestJS applications.
+
+</Accordion>
+
+## Installing Required Packages
+
+To begin, install the necessary packages in your NestJS project directory:
+
+<CodeGroup>
+
+```bash npm
+
+npm install @trigger.dev/sdk @trigger-dev/nestjs
+
+```
+
+```bash pnpm
+pnpm install @trigger.dev/sdk @trigger-dev/nestjs
+
+```
+
+```bash yarn
+yarn add @trigger.dev/sdk @trigger-dev/nestjs
+
+```
+
+</CodeGroup>
+
+<br />
+
+<Note>Ensure that you execute this command within an NestJS project.</Note>
+
+## Obtaining the Development API Key
+
+To locate your development API key, login to the [Trigger.dev
+dashboard](https://cloud.trigger.dev) and select the Project you want to
+connect to. Then click on the Environments & API Keys tab in the left menu.
+You can copy your development API Key from the field at the top of this page.
+(Your development key will start with `tr_dev_`).
+
+## Adding Environment Variables
+
+Create a `.env` file at the root of your project and include your Trigger API key and URL like this:
+
+```bash
+
+TRIGGER_API_KEY=ENTER_YOUR_DEVELOPMENT_API_KEY_HERE
+TRIGGER_API_URL=https://cloud.trigger.dev
+
+```
+
+Replace `ENTER_YOUR_DEVELOPMENT_API_KEY_HERE` with the actual API key obtained from the previous step.
+
+## Configuring the Trigger Client
+
+To set up the Trigger Client for your project, follow these steps:
+
+1. **Create Configuration File:**
+
+   In your project directory, create a configuration file named `trigger.ts`.
+
+2. **Add Configuration Code:**
+
+   Open the configuration file you created and add the following code:
+
+   ```typescript
+   // trigger.ts (for TypeScript) or trigger.js (for JavaScript)
+
+    import { TriggerClient } from "@trigger.dev/sdk";
+
+    export const client = new TriggerClient({
+    id: "my-app",
+    apiKey: process.env.TRIGGER_API_KEY,
+    apiUrl: process.env.TRIGGER_API_URL,
+    });
+
+   ```
+
+   Replace **"my-app"** with an appropriate identifier for your project. The **apiKey** and **apiUrl** are obtained from the environment variables you set earlier.
+
+
+By following these steps, you'll configure the Trigger Client to work with your NestJS project.
+
+## Creating a Middleware for Trigger.dev
+
+To establish an API route for interacting with Trigger.dev, follow these steps:
+
+
+
+In `app.module.ts` create a middleware for the specific `/api/trigger` route.
+
+If you're using express platform for your NestJS application
+
+ ```ts
+ // In app.module.ts 
+import { TriggerDevMiddlewareCreatorForExpress } from '@trigger.dev/nestjs';
+import { TriggerClient } from '@trigger.dev/sdk';
+import { client } from './trigger'; 
+
+@Module({
+  imports: [],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {
+    private triggerClient: TriggerClient
+    constructor() {
+        this.triggerClient = client; 
+    }
+    
+    configure(consumer: MiddlewareConsumer) {
+        consumer
+            .apply(TriggerDevMiddlewareCreatorForExpress(this.triggerClient))
+            .forRoutes('/api/trigger');
+    }
+}
+```
+
+If you're using fastify platform for your NestJS application
+
+ ```ts
+ // In app.module.ts 
+
+import { TriggerDevMiddlewareCreatorForFastify } from '@trigger.dev/nestjs';
+import { TriggerClient } from '@trigger.dev/sdk';
+import { client } from './trigger';
+
+@Module({
+  imports: [],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {
+    private triggerClient: TriggerClient
+    constructor() {
+        this.triggerClient = client; // import the client from trigger.ts
+    }
+    
+    configure(consumer: MiddlewareConsumer) {
+        consumer
+            .apply(TriggerDevMiddlewareCreatorForFastify(this.triggerClient))
+            .forRoutes('/api/trigger');
+    }
+}
+```
+
+Make sure to update the path in the `import { client } from './trigger';` statement to match the location of your Trigger Client configuration file.
+
+## Creating the Example Job
+
+1. Create a folder named `Jobs` alongside your NestJS project files.
+2. Inside the `Jobs` folder, add two files named `example.js` and `index.js`.
+
+<CodeGroup>
+
+```typescript example.(ts/js)
+const { eventTrigger } = require('@trigger.dev/sdk');
+const { client } = require('./trigger'); // Update the path as per your project structure
+
+// Your first job
+client.defineJob({
+  id: 'example-job',
+  name: 'Example Job',
+  version: '0.0.1',
+  trigger: eventTrigger({
+    name: 'example.event',
+  }),
+  run: async (payload, io, ctx) => {
+    await io.logger.info('Hello world!', { payload });
+
+    return {
+      message: 'Hello world!',
+    };
+  },
+});
+
+```
+
+```typescript index.ts/index.(ts/js)
+// import all your job files here
+
+module.exports = require('./example');
+```
+
+</CodeGroup>
+
+## Adding Configuration to `package.json`
+
+Inside the `package.json` file, add the following configuration under the root object:
+
+
+```json
+"trigger.dev": {
+  "endpointId": "my-app"
+}
+```
+
+Your `package.json` file might look something like this:
+
+```json
+{
+  "name": "my-app",
+  "version": "1.0.0",
+  "dependencies": {
+    // ... other dependencies
+  },
+  "trigger.dev": {
+    "endpointId": "my-app"
+  }
+}
+```
+
+Replace **"my-app"** with the appropriate identifier you used during the step for creating the Trigger Client.
+
+## Next Steps
+
+Start your NestJS project, and your Trigger.dev integration should work seamlessly
+
+In your project directory, run
+
+```bash
+pnpm run start:dev
+```
+
+This command starts your NestJS server and enables the Trigger.dev integration
+
+![Your first Job](/images/cli-dev.gif)
+
+<Warning>
+  Ensure your NestJS server is running locally before continuing. You must also leave this server
+  running while you develop.
+</Warning>
+
+In a **new terminal window or tab**, you can run Trigger.dev locally:
+
+<CodeGroup>
+
+```bash npm
+npx @trigger.dev/cli@latest dev
+```
+
+```bash pnpm
+pnpm dlx @trigger.dev/cli@latest dev
+```
+
+```bash yarn
+yarn dlx @trigger.dev/cli@latest dev
+```
+
+</CodeGroup>
+<br />
+<Note>
+   You can optionally pass the port if you're not running on port 3000 by adding
+  `--port 3001` to the end.
+</Note>
+<Note>
+  You can optionally pass the hostname if you're not running on localhost by adding
+  `--hostname <host>`. Example, in case your NestJS server is running on 0.0.0.0: `--hostname 0.0.0.0`.
+</Note>
+
+<Tip>
+  If your existing NestJS project utilizes middleware and you encounter any issues, such as
+  potential conflicts with Trigger.dev, it's recommended to refer to the troubleshooting guide at
+  [Middleware](/documentation/guides/platforms/NestJS#middleware) for assistance. This guide can
+  help you address any concerns related to middleware conflicts and ensure the smooth functioning of
+  your project with Trigger.dev.
+</Tip>

--- a/docs/documentation/concepts/client-adaptors.mdx
+++ b/docs/documentation/concepts/client-adaptors.mdx
@@ -29,3 +29,5 @@ Each platform has one or more adaptors, see the guides below:
 | [Next.js](/documentation/guides/platforms/nextjs) | `createPagesRoute()` |
 | [Next.js](/documentation/guides/platforms/nextjs) | `createAppRoute()`   |
 | Express                                           | Coming soon          |
+| NestJS (Express)                                  | `TriggerDevMiddlewareCreatorForExpress()`|
+| NestJS (Fastify)                                  | `TriggerDevMiddlewareCreatorForFastify()`|

--- a/examples/nestjs-example/.eslintrc.js
+++ b/examples/nestjs-example/.eslintrc.js
@@ -1,0 +1,25 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: 'tsconfig.json',
+    tsconfigRootDir: __dirname,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint/eslint-plugin'],
+  extends: [
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+  ],
+  root: true,
+  env: {
+    node: true,
+    jest: true,
+  },
+  ignorePatterns: ['.eslintrc.js'],
+  rules: {
+    '@typescript-eslint/interface-name-prefix': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+  },
+};

--- a/examples/nestjs-example/.gitignore
+++ b/examples/nestjs-example/.gitignore
@@ -1,0 +1,35 @@
+# compiled output
+/dist
+/node_modules
+
+# Logs
+logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# OS
+.DS_Store
+
+# Tests
+/coverage
+/.nyc_output
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json

--- a/examples/nestjs-example/.prettierrc
+++ b/examples/nestjs-example/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/examples/nestjs-example/README.md
+++ b/examples/nestjs-example/README.md
@@ -1,0 +1,73 @@
+<p align="center">
+  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="200" alt="Nest Logo" /></a>
+</p>
+
+[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
+[circleci-url]: https://circleci.com/gh/nestjs/nest
+
+  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
+    <p align="center">
+<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
+<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
+<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
+<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
+<a href="https://coveralls.io/github/nestjs/nest?branch=master" target="_blank"><img src="https://coveralls.io/repos/github/nestjs/nest/badge.svg?branch=master#9" alt="Coverage" /></a>
+<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
+<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
+<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
+  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg"/></a>
+    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
+  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow"></a>
+</p>
+  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
+  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
+
+## Description
+
+[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
+
+## Installation
+
+```bash
+$ pnpm install
+```
+
+## Running the app
+
+```bash
+# development
+$ pnpm run start
+
+# watch mode
+$ pnpm run start:dev
+
+# production mode
+$ pnpm run start:prod
+```
+
+## Test
+
+```bash
+# unit tests
+$ pnpm run test
+
+# e2e tests
+$ pnpm run test:e2e
+
+# test coverage
+$ pnpm run test:cov
+```
+
+## Support
+
+Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
+
+## Stay in touch
+
+- Author - [Kamil Myśliwiec](https://kamilmysliwiec.com)
+- Website - [https://nestjs.com](https://nestjs.com/)
+- Twitter - [@nestframework](https://twitter.com/nestframework)
+
+## License
+
+Nest is [MIT licensed](LICENSE).

--- a/examples/nestjs-example/nest-cli.json
+++ b/examples/nestjs-example/nest-cli.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/nest-cli",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "deleteOutDir": true
+  }
+}

--- a/examples/nestjs-example/package.json
+++ b/examples/nestjs-example/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "nestjs-example",
+  "version": "0.0.1",
+  "description": "",
+  "author": "",
+  "private": true,
+  "license": "UNLICENSED",
+  "scripts": {
+    "build": "nest build",
+    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:debug": "nest start --debug --watch",
+    "start:prod": "node dist/main",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:cov": "jest --coverage",
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:e2e": "jest --config ./test/jest-e2e.json"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1",
+    "@trigger.dev/nestjs": "workspace:*",
+    "@trigger.dev/sdk": "2.1.0",
+    "@trigger.dev/core": "2.1.0"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "@nestjs/schematics": "^10.0.0",
+    "@nestjs/testing": "^10.0.0",
+    "@trigger.dev/cli": "workspace:*",
+    "@types/express": "^4.17.17",
+    "@types/jest": "^29.5.2",
+    "@types/node": "^20.3.1",
+    "@types/supertest": "^2.0.12",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "eslint": "^8.42.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "jest": "^29.5.0",
+    "prettier": "^3.0.0",
+    "source-map-support": "^0.5.21",
+    "supertest": "^6.3.3",
+    "ts-jest": "^29.1.0",
+    "ts-loader": "^9.4.3",
+    "ts-node": "^10.9.1",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^5.1.3"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": "src",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
+    "coverageDirectory": "../coverage",
+    "testEnvironment": "node"
+  },
+  "trigger.dev": {
+    "endpointId": "nestjs-example"
+  }
+}

--- a/examples/nestjs-example/src/app.controller.spec.ts
+++ b/examples/nestjs-example/src/app.controller.spec.ts
@@ -1,0 +1,22 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+describe('AppController', () => {
+  let appController: AppController;
+
+  beforeEach(async () => {
+    const app: TestingModule = await Test.createTestingModule({
+      controllers: [AppController],
+      providers: [AppService],
+    }).compile();
+
+    appController = app.get<AppController>(AppController);
+  });
+
+  describe('root', () => {
+    it('should return "Hello World!"', () => {
+      expect(appController.getHello()).toBe('Hello World!');
+    });
+  });
+});

--- a/examples/nestjs-example/src/app.controller.ts
+++ b/examples/nestjs-example/src/app.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppService } from './app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getHello(): string {
+    return this.appService.getHello();
+  }
+}

--- a/examples/nestjs-example/src/app.module.ts
+++ b/examples/nestjs-example/src/app.module.ts
@@ -1,0 +1,23 @@
+import { MiddlewareConsumer, Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+import { TriggerDevMiddlewareCreatorForExpress } from '@trigger.dev/nestjs';
+import { TriggerClient } from '@trigger.dev/sdk';
+import { client } from './trigger';
+
+@Module({
+  imports: [],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {
+  private triggerClient: TriggerClient;
+  constructor() {
+    this.triggerClient = client;
+  }
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(TriggerDevMiddlewareCreatorForExpress(this.triggerClient)) // If you're using fastify platform use TriggerDevMiddlewareCreatorForFastify middleware.
+      .forRoutes('/api/trigger');
+  }
+}

--- a/examples/nestjs-example/src/app.service.ts
+++ b/examples/nestjs-example/src/app.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getHello(): string {
+    return 'Hello World!';
+  }
+}

--- a/examples/nestjs-example/src/main.ts
+++ b/examples/nestjs-example/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/examples/nestjs-example/src/trigger.ts
+++ b/examples/nestjs-example/src/trigger.ts
@@ -1,0 +1,27 @@
+import { TriggerClient } from '@trigger.dev/sdk';
+import { eventTrigger } from "@trigger.dev/sdk";
+
+export const client = new TriggerClient({
+    id: "nestjs-example",
+    apiKey: process.env['TRIGGER_API_KEY'],
+    apiUrl: process.env['TRIGGER_API_URL'],
+    logLevel: 'debug',
+    ioLogLocalEnabled: true,
+    verbose: true,
+});
+
+client.defineJob({
+    id: "hello-nestjs",
+    name: "Hello Nestjs",
+    version: "2.1.0",
+    trigger: eventTrigger({
+      name: "starter.hello-nes",
+    }),
+    run: async (_payload, io, _ctx) => {
+      await io.wait("wait", 15);
+      await io.logger.info("Hello Nestjs !");
+      return {
+        message: "Hello Nestjs!",
+      };
+    },
+});

--- a/examples/nestjs-example/test/app.e2e-spec.ts
+++ b/examples/nestjs-example/test/app.e2e-spec.ts
@@ -1,0 +1,24 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from './../src/app.module';
+
+describe('AppController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('/ (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/')
+      .expect(200)
+      .expect('Hello World!');
+  });
+});

--- a/examples/nestjs-example/test/jest-e2e.json
+++ b/examples/nestjs-example/test/jest-e2e.json
@@ -1,0 +1,9 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": ".e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  }
+}

--- a/examples/nestjs-example/tsconfig.build.json
+++ b/examples/nestjs-example/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+}

--- a/examples/nestjs-example/tsconfig.json
+++ b/examples/nestjs-example/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2021",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": false,
+    "noImplicitAny": false,
+    "strictBindCallApply": false,
+    "forceConsistentCasingInFileNames": false,
+    "noFallthroughCasesInSwitch": false
+  }
+}

--- a/packages/nestjs/LICENSE
+++ b/packages/nestjs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Trigger.dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/nestjs/README.md
+++ b/packages/nestjs/README.md
@@ -1,0 +1,9 @@
+# Nest.js and Trigger.dev
+
+Trigger.dev has support for the Nest.js framework with middleware support for both express and fastify platforms.
+
+For information about the using Trigger.dev in your Nest.js app, check out these useful docs links:
+
+- [Quick start guide for getting setup with Trigger.dev in a Nest.js project](https://trigger.dev/docs/documentation/quickstarts/nestjs)
+- [Manually setup Nest.js with Trigger.dev](https://trigger.dev/docs/documentation/guides/manual/nestjs)
+- [Using Trigger.dev with Nest.js, handling middleware and more](https://trigger.dev/docs/documentation/guides/platforms/nestjs)

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@trigger.dev/nestjs",
+  "version": "1.0.0",
+  "description": "Official Nest.js adapter for Trigger.dev",
+  "author": "",
+  "private": true,
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "clean": "rimraf dist",
+    "build": "npm run clean && npm run build:tsup",
+    "build:tsup": "tsup"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/platform-fastify": "^10.2.4",
+    "@remix-run/web-fetch": "^4.3.5",
+    "fastify": "^4.22.2",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "@nestjs/schematics": "^10.0.0",
+    "@nestjs/testing": "^10.0.0",
+    "@trigger.dev/sdk": "workspace:^2.1.0",
+    "@trigger.dev/tsconfig": "workspace:*",
+    "@types/debug": "^4.1.7",
+    "@types/express": "^4.17.17",
+    "@types/jest": "^29.5.2",
+    "@types/node": "^20.3.1",
+    "rimraf": "^3.0.2",
+    "source-map-support": "^0.5.21",
+    "ts-loader": "^9.4.3",
+    "ts-node": "^10.9.1",
+    "tsconfig-paths": "^4.2.0",
+    "tsup": "^6.5.0",
+    "tsx": "^3.12.1",
+    "typescript": "^5.1.3"
+  },
+  "peerDependencies": {
+    "@trigger.dev/sdk": "workspace:^2.1.0"
+  }
+}

--- a/packages/nestjs/src/index.ts
+++ b/packages/nestjs/src/index.ts
@@ -1,0 +1,2 @@
+export { TriggerDevMiddlewareCreatorForExpress } from './middlewares/trigger-dev.express-middleware';
+export { TriggerDevMiddlewareCreatorForFastify } from './middlewares/trigger-dev.fastify-middleware';

--- a/packages/nestjs/src/middlewares/trigger-dev.express-middleware.ts
+++ b/packages/nestjs/src/middlewares/trigger-dev.express-middleware.ts
@@ -1,0 +1,72 @@
+import { Injectable, mixin, NestMiddleware, HttpStatus,  Type } from '@nestjs/common';
+import { TriggerClient } from "@trigger.dev/sdk";
+import { Response as ResponseExpress, Request } from 'express';
+import { Request as StandardRequest } from "@remix-run/web-fetch";
+
+/**
+ * This is a functional middleware for Nest.js to use with an existing nest.js application which is using express platform.
+ * @param client - The TriggerClient to use for the middleware
+ * @example
+ * ```ts
+ * // In app.module.ts 
+ * export class AppModule {
+ *      constructor(private readonly triggerClient: TriggerClient) {
+ *          this.triggerClient = new TriggerClient({
+ *             id: "my-client",
+ *             apiKey: process.env["TRIGGER_API_KEY"],
+ *          })
+ *      }
+ *      
+ *      configure(consumer: MiddlewareConsumer) {
+ *          consumer
+ *              .apply(TriggerDevMiddlewareCreatorForExpress(this.triggerClient))
+ *              .forRoutes('/api/trigger');
+ *      }
+ * }
+ * ```
+ */
+export function TriggerDevMiddlewareCreatorForExpress(client: TriggerClient): Type<NestMiddleware> {
+
+    @Injectable()
+    class TriggerDevMiddleware implements NestMiddleware {
+        constructor(){}
+        
+        async use(req: Request, res: ResponseExpress, next: (error?: any) => void) {
+            try {
+                const standardRequest = this.convertToStandardRequest(req);
+                const triggerClientResponse = await client.handleRequest(standardRequest);
+
+                if (!triggerClientResponse) {
+                    
+                    res.status(HttpStatus.NOT_FOUND).send({ error: "Not found" });
+                    return;
+                }
+                
+                res.status(triggerClientResponse.status).json(triggerClientResponse.body);
+
+            } catch (error) {
+                next(error);
+            }
+
+        }
+
+        private convertToStandardRequest(req: Request): StandardRequest {
+            const { headers: nextHeaders, method } = req;
+
+            const headers : Record<string, string> = {} 
+            Object.entries(nextHeaders).forEach(([key, value]) => {
+                headers[key] = value as string;
+            });
+            
+            // Create a new Request object (hardcode the url because it doesn't really matter what it is)
+            return new StandardRequest("https://express.js/api/trigger", {
+            headers,
+            method,
+            // @ts-ignore
+            body: req.body ? JSON.stringify(req.body) : req,
+            });
+        }
+    }
+
+    return mixin(TriggerDevMiddleware);
+}

--- a/packages/nestjs/src/middlewares/trigger-dev.fastify-middleware.ts
+++ b/packages/nestjs/src/middlewares/trigger-dev.fastify-middleware.ts
@@ -1,0 +1,74 @@
+import { Injectable, mixin, NestMiddleware, HttpStatus,  Type } from '@nestjs/common';
+import { TriggerClient } from "@trigger.dev/sdk";
+import { FastifyRequest, FastifyReply } from 'fastify';
+import { Request as StandardRequest } from "@remix-run/web-fetch";
+
+/**
+ * This is a functional middleware for Nest.js to use with an existing nest.js application which is using fastify platform.
+ * @param client - The TriggerClient to use for the middleware
+ * @example
+ * ```ts
+ * // In app.module.ts 
+ * export class AppModule {
+ *      constructor(private readonly triggerClient: TriggerClient) {
+ *          this.triggerClient = new TriggerClient({
+ *             id: "my-client",
+ *             apiKey: process.env["TRIGGER_API_KEY"],
+ *          })
+ *      }
+ *      
+ *      configure(consumer: MiddlewareConsumer) {
+ *          consumer
+ *              .apply(TriggerDevMiddlewareCreatorForFastify(this.triggerClient))
+ *              .forRoutes('/api/trigger');
+ *      }
+ * }
+ * ```
+ */
+export function TriggerDevMiddlewareCreatorForFastify(client: TriggerClient): Type<NestMiddleware> {
+
+    @Injectable()
+    class TriggerDevMiddleware implements NestMiddleware {
+        constructor(){}
+        
+        async use(req: FastifyRequest['raw'], res: FastifyReply['raw'], next: (error?: any) => void) {
+            try {
+                const standardRequest = this.convertToStandardRequest(req);
+                const triggerClientResponse = await client.handleRequest(standardRequest);
+
+                if (!triggerClientResponse) {
+                    
+                    res.writeHead(HttpStatus.NOT_FOUND, { "content-type": "application/json"})
+                    res.write({ error: "Not found" });
+                    res.end();
+                    return;
+                }
+
+                res.writeHead(triggerClientResponse.status, { "content-type": "application/json"});
+                res.write(triggerClientResponse.body);
+                res.end();
+            } catch (error) {
+                next(error);
+            }
+
+        }
+        private convertToStandardRequest(req: FastifyRequest['raw']): StandardRequest {
+            const { headers: nextHeaders, method } = req;
+
+            const headers : Record<string, string> = {} 
+            Object.entries(nextHeaders).forEach(([key, value]) => {
+                headers[key] = value as string;
+            });
+            
+            // Create a new Request object (hardcode the url because it doesn't really matter what it is)
+            return new StandardRequest("https://fastify.js/api/trigger", {
+            headers,
+            method,
+            // @ts-ignore
+            body: req.body ? JSON.stringify(req.body) : req,
+            });
+        }
+    }
+
+    return mixin(TriggerDevMiddleware);
+}

--- a/packages/nestjs/tsconfig.json
+++ b/packages/nestjs/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@trigger.dev/tsconfig/node18.json",
+  "include": ["./src/**/*.ts", "tsup.config.ts"],
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "declaration": false,
+    "declarationMap": false,
+    "lib": ["DOM", "DOM.Iterable"],
+    "paths": {
+      "@trigger.dev/sdk": ["../trigger-sdk/src/index"],
+      "@trigger.dev/sdk/*": ["../trigger-sdk/src/*"]
+    }
+  },
+  "exclude": ["node_modules"]
+}

--- a/packages/nestjs/tsup.config.ts
+++ b/packages/nestjs/tsup.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig([
+  {
+    name: "main",
+    entry: ["./src/index.ts"],
+    outDir: "./dist",
+    platform: "node",
+    format: ["cjs"],
+    legacyOutput: true,
+    sourcemap: true,
+    clean: true,
+    bundle: true,
+    splitting: false,
+    dts: true,
+    external: ["http", "https", "util", "events", "tty", "os", "timers"],
+    esbuildPlugins: [],
+  },
+]);


### PR DESCRIPTION
Task 1 - Nest.js Adaptor
- [x] Create the adaptor for Nest.js. 
- [x] Create a basic Nest.js project that uses the adaptor in examples/nestjs folder. Include a basic Job in Trigger.dev, e.g. a simple Job that just does a delay inside it. 

Task 2 – Add a README.md file
- [x] Create a new README.md file inside the packages/nestjs folder

Task 3- Write Documentation
- [x] Locate the manual-setup-nestjs.mdx folder in `/docs/_snippets/` Use this file to write your documentation, overwriting any contents of that file. 
- [x] Update the table at the bottom of the client-adaptors.mdx page with the framework.

Task 4 – Update the webapp onboarding
- [x] In the route.tsx page located in `_app.orgs.$organizationSlug.projects.$projectParam.setup.nestjs` replace the <FrameworkComingSoon/> component with your new onboarding steps. 
- [x]  In the `FrameworkSelector.tsx` file, add “supported” to the framework you

/claim #449 

https://github.com/triggerdotdev/trigger.dev/assets/22212945/e897f480-b0ea-45a4-8cbc-455296c71d79


