### PR TITLE
Use absolute image paths

### DIFF
--- a/docs/documentation/quickstarts/supabase.mdx
+++ b/docs/documentation/quickstarts/supabase.mdx
@@ -147,11 +147,11 @@ npx @trigger.dev/cli dev
 
 Head back to your Supabase Dashboard -> Auth, and create a new user (keep "Auto Confirm User?" checked)
 
-![create user](images/supabase-create-new-user.png)
+![create user](/images/supabase-create-new-user.png)
 
 Then navigate over to your Trigger.dev project dashboard and you should see the job running.
 
-![job running](images/supabase-job-running.png)
+![job running](/images/supabase-job-running.png)
 
 ## What's next?
 


### PR DESCRIPTION
Fixes #489

Looks fine during dev even with (wrong) relative paths, but this should sort it.