### PR TITLE
fix: Fail client-side on invalid Stripe event names

### DIFF
--- a/.changeset/three-worms-impress.md
+++ b/.changeset/three-worms-impress.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/stripe": patch
+---
+
+Stripe will now fail client-side on invalid event names.

--- a/integrations/stripe/src/index.ts
+++ b/integrations/stripe/src/index.ts
@@ -22,6 +22,27 @@ import { Charges } from "./charges";
 import { Checkout } from "./checkout";
 import { Customers } from "./customers";
 import * as events from "./events";
+import {
+  ChargeEventNames,
+  ChargeEventNamesSchema,
+  CheckoutSessionEventNames,
+  CheckoutSessionEventNamesSchema,
+  CustomerEventNames,
+  CustomerSubscriptionEventNames,
+  CustomerSubscriptionEventNamesSchema,
+  ExternalAccountEventNames,
+  ExternalAccountEventNamesSchema,
+  PaymentIntentEventNames,
+  PaymentIntentEventNamesSchema,
+  PayoutEventNames,
+  PayoutEventNamesSchema,
+  PersonEventNames,
+  PersonEventNamesSchema,
+  PriceEventNames,
+  PriceEventNamesSchema,
+  ProductEventNames,
+  ProductEventNamesSchema,
+} from "./schemas";
 import { Subscriptions } from "./subscriptions";
 import { WebhookEndpoints } from "./webhookEndpoints";
 
@@ -183,10 +204,13 @@ export class Stripe implements TriggerIntegration {
    * });
    * ```
    */
-  onPrice(
-    params?: TriggerParams & { events?: Array<"price.created" | "price.updated" | "price.deleted"> }
-  ) {
-    const event = { ...events.onPrice, name: params?.events ?? events.onPrice.name };
+  onPrice(params?: TriggerParams & { events?: PriceEventNames }) {
+    const parsedEvents = PriceEventNamesSchema.optional().parse(params?.events);
+
+    const event = {
+      ...events.onPrice,
+      name: parsedEvents ?? events.onPrice.name,
+    };
 
     return createTrigger(this.source, event, params ?? { connect: false });
   }
@@ -234,12 +258,13 @@ export class Stripe implements TriggerIntegration {
    * });
    * ```
    */
-  onProduct(
-    params?: TriggerParams & {
-      events?: Array<"product.created" | "product.updated" | "product.deleted">;
-    }
-  ) {
-    const event = { ...events.onProduct, name: params?.events ?? events.onProduct.name };
+  onProduct(params?: TriggerParams & { events?: ProductEventNames }) {
+    const parsedEvents = ProductEventNamesSchema.optional().parse(params?.events);
+
+    const event = {
+      ...events.onProduct,
+      name: parsedEvents ?? events.onProduct.name,
+    };
 
     return createTrigger(this.source, event, params ?? { connect: false });
   }
@@ -287,19 +312,12 @@ export class Stripe implements TriggerIntegration {
    * });
    * ```
    */
-  onCheckoutSession(
-    params?: TriggerParams & {
-      events?: Array<
-        | "checkout.session.completed"
-        | "checkout.session.async_payment_succeeded"
-        | "checkout.session.async_payment_failed"
-        | "checkout.session.expired"
-      >;
-    }
-  ) {
+  onCheckoutSession(params?: TriggerParams & { events?: CheckoutSessionEventNames }) {
+    const parsedEvents = CheckoutSessionEventNamesSchema.optional().parse(params?.events);
+
     const event = {
       ...events.onCheckoutSession,
-      name: params?.events ?? events.onCheckoutSession.name,
+      name: parsedEvents ?? events.onCheckoutSession.name,
     };
 
     return createTrigger(this.source, event, params ?? { connect: false });
@@ -349,22 +367,12 @@ export class Stripe implements TriggerIntegration {
    * });
    * ```
    */
-  onCustomerSubscription(
-    params?: TriggerParams & {
-      events?: Array<
-        | "customer.subscription.created"
-        | "customer.subscription.deleted"
-        | "customer.subscription.updated"
-        | "customer.subscription.paused"
-        | "customer.subscription.pending_update_applied"
-        | "customer.subscription.pending_update_expired"
-        | "customer.subscription.resumed"
-      >;
-    }
-  ) {
+  onCustomerSubscription(params?: TriggerParams & { events?: CustomerSubscriptionEventNames }) {
+    const parsedEvents = CustomerSubscriptionEventNamesSchema.optional().parse(params?.events);
+
     const event = {
       ...events.onCustomerSubscription,
-      name: params?.events ?? events.onCustomerSubscription.name,
+      name: parsedEvents ?? events.onCustomerSubscription.name,
     };
 
     return createTrigger(this.source, event, params ?? { connect: false });
@@ -454,11 +462,9 @@ export class Stripe implements TriggerIntegration {
    * });
    * ```
    */
-  onCustomer(
-    params?: TriggerParams & {
-      events?: Array<"customer.created" | "customer.deleted">;
-    }
-  ) {
+  onCustomer(params?: TriggerParams & { events?: CustomerEventNames }) {
+    const parsedEvents = CustomerSubscriptionEventNamesSchema.optional().parse(params?.events);
+
     const event = {
       ...events.onCustomer,
       name: params?.events ?? events.onCustomer.name,
@@ -510,22 +516,12 @@ export class Stripe implements TriggerIntegration {
    * });
    * ```
    */
-  onCharge(
-    params?: TriggerParams & {
-      events?: Array<
-        | "charge.captured"
-        | "charge.expired"
-        | "charge.failed"
-        | "charge.pending"
-        | "charge.refunded"
-        | "charge.succeeded"
-        | "charge.updated"
-      >;
-    }
-  ) {
+  onCharge(params?: TriggerParams & { events?: ChargeEventNames }) {
+    const parsedEvents = ChargeEventNamesSchema.optional().parse(params?.events);
+
     const event = {
       ...events.onCharge,
-      name: params?.events ?? events.onCharge.name,
+      name: parsedEvents ?? events.onCharge.name,
     };
 
     return createTrigger(this.source, event, params ?? { connect: false });
@@ -602,18 +598,12 @@ export class Stripe implements TriggerIntegration {
    * });
    * ```
    */
-  onExternalAccount(
-    params?: TriggerParams & {
-      events?: Array<
-        | "account.external_account.created"
-        | "account.external_account.deleted"
-        | "account.external_account.updated"
-      >;
-    }
-  ) {
+  onExternalAccount(params?: TriggerParams & { events?: ExternalAccountEventNames }) {
+    const parsedEvents = ExternalAccountEventNamesSchema.optional().parse(params?.events);
+
     const event = {
       ...events.onExternalAccount,
-      name: params?.events ?? events.onExternalAccount.name,
+      name: parsedEvents ?? events.onExternalAccount.name,
     };
 
     return createTrigger(this.source, event, params ?? { connect: false });
@@ -674,14 +664,12 @@ export class Stripe implements TriggerIntegration {
    * });
    * ```
    */
-  onPerson(
-    params?: TriggerParams & {
-      events?: Array<"person.created" | "person.deleted" | "person.updated">;
-    }
-  ) {
+  onPerson(params?: TriggerParams & { events?: PersonEventNames }) {
+    const parsedEvents = PersonEventNamesSchema.optional().parse(params?.events);
+
     const event = {
       ...events.onPerson,
-      name: params?.events ?? events.onPerson.name,
+      name: parsedEvents ?? events.onPerson.name,
     };
 
     return createTrigger(this.source, event, params ?? { connect: false });
@@ -730,23 +718,12 @@ export class Stripe implements TriggerIntegration {
    * });
    * ```
    */
-  onPaymentIntent(
-    params?: TriggerParams & {
-      events?: Array<
-        | "payment_intent.created"
-        | "payment_intent.succeeded"
-        | "payment_intent.canceled"
-        | "payment_intent.processing"
-        | "payment_intent.requires_action"
-        | "payment_intent.amount_capturable_updated"
-        | "payment_intent.payment_failed"
-        | "payment_intent.partially_funded"
-      >;
-    }
-  ) {
+  onPaymentIntent(params?: TriggerParams & { events?: PaymentIntentEventNames }) {
+    const parsedEvents = PaymentIntentEventNamesSchema.optional().parse(params?.events);
+
     const event = {
       ...events.onPaymentIntent,
-      name: params?.events ?? events.onPaymentIntent.name,
+      name: parsedEvents ?? events.onPaymentIntent.name,
     };
 
     return createTrigger(this.source, event, params ?? { connect: false });
@@ -854,21 +831,12 @@ export class Stripe implements TriggerIntegration {
    * });
    * ```
    */
-  onPayout(
-    params?: TriggerParams & {
-      events?: Array<
-        | "payout.canceled"
-        | "payout.created"
-        | "payout.failed"
-        | "payout.paid"
-        | "payout.reconciliation_completed"
-        | "payout.updated"
-      >;
-    }
-  ) {
+  onPayout(params?: TriggerParams & { events?: PayoutEventNames }) {
+    const parsedEvents = PayoutEventNamesSchema.optional().parse(params?.events);
+
     const event = {
       ...events.onPayout,
-      name: params?.events ?? events.onPayout.name,
+      name: parsedEvents ?? events.onPayout.name,
     };
 
     return createTrigger(this.source, event, params ?? { connect: false });

--- a/integrations/stripe/src/schemas.ts
+++ b/integrations/stripe/src/schemas.ts
@@ -1,0 +1,90 @@
+import { z } from "zod"
+
+export const PriceEventNamesSchema = z.array(z.enum(["price.created", "price.updated", "price.deleted"]));
+export type PriceEventNames = z.infer<typeof PriceEventNamesSchema>;
+
+export const ProductEventNamesSchema = z.array(
+  z.enum(["product.created", "product.updated", "product.deleted"])
+);
+export type ProductEventNames = z.infer<typeof ProductEventNamesSchema>;
+
+export const CheckoutSessionEventNamesSchema = z.array(
+  z.enum([
+    "checkout.session.completed",
+    "checkout.session.async_payment_succeeded",
+    "checkout.session.async_payment_failed",
+    "checkout.session.expired",
+  ])
+);
+export type CheckoutSessionEventNames = z.infer<typeof CheckoutSessionEventNamesSchema>;
+
+export const CustomerSubscriptionEventNamesSchema = z.array(
+  z.enum([
+    "customer.subscription.created",
+    "customer.subscription.deleted",
+    "customer.subscription.updated",
+    "customer.subscription.paused",
+    "customer.subscription.pending_update_applied",
+    "customer.subscription.pending_update_expired",
+    "customer.subscription.resumed",
+  ])
+);
+export type CustomerSubscriptionEventNames = z.infer<typeof CustomerSubscriptionEventNamesSchema>;
+
+export const CustomerEventNamesSchema = z.array(
+  z.enum(["customer.created", "customer.updated", "customer.deleted"])
+);
+export type CustomerEventNames = z.infer<typeof CustomerEventNamesSchema>;
+
+export const ChargeEventNamesSchema = z.array(
+  z.enum([
+    "charge.captured",
+    "charge.expired",
+    "charge.failed",
+    "charge.pending",
+    "charge.refunded",
+    "charge.succeeded",
+    "charge.updated",
+  ])
+);
+export type ChargeEventNames = z.infer<typeof ChargeEventNamesSchema>;
+
+export const ExternalAccountEventNamesSchema = z.array(
+  z.enum([
+    "account.external_account.created",
+    "account.external_account.updated",
+    "account.external_account.deleted",
+  ])
+);
+export type ExternalAccountEventNames = z.infer<typeof ExternalAccountEventNamesSchema>;
+
+export const PersonEventNamesSchema = z.array(
+  z.enum(["person.created", "person.updated", "person.deleted"])
+);
+export type PersonEventNames = z.infer<typeof PersonEventNamesSchema>;
+
+export const PaymentIntentEventNamesSchema = z.array(
+  z.enum([
+    "payment_intent.created",
+    "payment_intent.succeeded",
+    "payment_intent.canceled",
+    "payment_intent.processing",
+    "payment_intent.requires_action",
+    "payment_intent.amount_capturable_updated",
+    "payment_intent.payment_failed",
+    "payment_intent.partially_funded",
+  ])
+);
+export type PaymentIntentEventNames = z.infer<typeof PaymentIntentEventNamesSchema>;
+
+export const PayoutEventNamesSchema = z.array(
+  z.enum([
+    "payout.canceled",
+    "payout.created",
+    "payout.failed",
+    "payout.paid",
+    "payout.reconciliation_completed",
+    "payout.updated",
+  ])
+);
+export type PayoutEventNames = z.infer<typeof PayoutEventNamesSchema>;


### PR DESCRIPTION
Closes #426

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Ran custom Stripe examples in `job-catalog` to test failures and passes.

---

## Changelog

- Added schemas and types
- Parsed schemas before creating triggers

---

## Examples

```ts
// trying to use invalid event names like this.. 
stripe.onPrice({
  // @ts-ignore
  events: ["price.created", "price.updated", "test.abc"],
}

// ...now produces descriptive errors without sending data anywhere
{
  received: 'test.abc',
  code: 'invalid_enum_value',
  options: [Array],
  path: [Array],
  message: "Invalid enum value. Expected 'price.created' | 'price.updated' | 'price.deleted', received 'test.abc'"
}
```

💯
