### PR TITLE
fix: Decouple zod from `eventTrigger`

### DIFF
--- a/.changeset/strong-seas-impress.md
+++ b/.changeset/strong-seas-impress.md
@@ -1,0 +1,6 @@
+---
+"@trigger.dev/sdk": patch
+"@trigger.dev/core": patch
+---
+
+Decouple zod

--- a/apps/webapp/app/components/jobs/JobsTable.tsx
+++ b/apps/webapp/app/components/jobs/JobsTable.tsx
@@ -198,6 +198,7 @@ function classForJobStatus(status: JobRunStatus) {
     case "WAITING_ON_CONNECTIONS":
     case "PENDING":
     case "UNRESOLVED_AUTH":
+    case "INVALID_PAYLOAD":
       return "text-rose-500";
     default:
       return "";

--- a/apps/webapp/app/components/run/RunCompletedDetail.tsx
+++ b/apps/webapp/app/components/run/RunCompletedDetail.tsx
@@ -2,7 +2,7 @@ import { CodeBlock } from "~/components/code/CodeBlock";
 import { DateTime } from "~/components/primitives/DateTime";
 import { Paragraph } from "~/components/primitives/Paragraph";
 import { RunStatusIcon, RunStatusLabel } from "~/components/runs/RunStatuses";
-import { MatchedRun, useRun } from "~/hooks/useRun";
+import { MatchedRun } from "~/hooks/useRun";
 import { formatDuration } from "~/utils";
 import {
   RunPanel,

--- a/apps/webapp/app/components/runs/RunStatuses.tsx
+++ b/apps/webapp/app/components/runs/RunStatuses.tsx
@@ -17,7 +17,8 @@ export function hasFinished(status: JobRunStatus): boolean {
     status === "ABORTED" ||
     status === "TIMED_OUT" ||
     status === "CANCELED" ||
-    status === "UNRESOLVED_AUTH"
+    status === "UNRESOLVED_AUTH" ||
+    status === "INVALID_PAYLOAD"
   );
 }
 
@@ -49,6 +50,7 @@ export function RunStatusIcon({ status, className }: { status: JobRunStatus; cla
     case "TIMED_OUT":
       return <ExclamationTriangleIcon className={cn(runStatusClassNameColor(status), className)} />;
     case "UNRESOLVED_AUTH":
+    case "INVALID_PAYLOAD":
       return <XCircleIcon className={cn(runStatusClassNameColor(status), className)} />;
     case "WAITING_ON_CONNECTIONS":
       return <WrenchIcon className={cn(runStatusClassNameColor(status), className)} />;
@@ -77,6 +79,7 @@ export function runBasicStatus(status: JobRunStatus): RunBasicStatus {
     case "UNRESOLVED_AUTH":
     case "CANCELED":
     case "ABORTED":
+    case "INVALID_PAYLOAD":
       return "FAILED";
     case "SUCCESS":
       return "COMPLETED";
@@ -111,6 +114,8 @@ export function runStatusTitle(status: JobRunStatus): string {
       return "Canceled";
     case "UNRESOLVED_AUTH":
       return "Unresolved auth";
+    case "INVALID_PAYLOAD":
+      return "Invalid payload";
     default: {
       const _exhaustiveCheck: never = status;
       throw new Error(`Non-exhaustive match for value: ${status}`);
@@ -130,6 +135,7 @@ export function runStatusClassNameColor(status: JobRunStatus): string {
       return "text-amber-300";
     case "FAILURE":
     case "UNRESOLVED_AUTH":
+    case "INVALID_PAYLOAD":
       return "text-rose-500";
     case "TIMED_OUT":
       return "text-amber-300";

--- a/packages/core/src/schemas/api.ts
+++ b/packages/core/src/schemas/api.ts
@@ -2,7 +2,7 @@ import { ulid } from "ulid";
 import { z } from "zod";
 import { Prettify } from "../types";
 import { addMissingVersionField } from "./addMissingVersionField";
-import { ErrorWithStackSchema } from "./errors";
+import { ErrorWithStackSchema, SchemaErrorSchema } from "./errors";
 import { EventRuleSchema } from "./eventFilter";
 import { ConnectionAuthSchema, IntegrationConfigSchema } from "./integrations";
 import { DeserializedJsonSchema, SerializableJsonSchema } from "./json";
@@ -437,6 +437,13 @@ export const RunJobErrorSchema = z.object({
 
 export type RunJobError = z.infer<typeof RunJobErrorSchema>;
 
+export const RunJobInvalidPayloadErrorSchema = z.object({
+  status: z.literal("INVALID_PAYLOAD"),
+  errors: z.array(SchemaErrorSchema),
+});
+
+export type RunJobInvalidPayloadError = z.infer<typeof RunJobInvalidPayloadErrorSchema>;
+
 export const RunJobUnresolvedAuthErrorSchema = z.object({
   status: z.literal("UNRESOLVED_AUTH_ERROR"),
   issues: z.record(z.object({ id: z.string(), error: z.string() })),
@@ -477,6 +484,7 @@ export type RunJobSuccess = z.infer<typeof RunJobSuccessSchema>;
 export const RunJobResponseSchema = z.discriminatedUnion("status", [
   RunJobErrorSchema,
   RunJobUnresolvedAuthErrorSchema,
+  RunJobInvalidPayloadErrorSchema,
   RunJobResumeWithTaskSchema,
   RunJobRetryWithTaskSchema,
   RunJobCanceledWithTaskSchema,

--- a/packages/core/src/schemas/errors.ts
+++ b/packages/core/src/schemas/errors.ts
@@ -7,3 +7,10 @@ export const ErrorWithStackSchema = z.object({
 });
 
 export type ErrorWithStack = z.infer<typeof ErrorWithStackSchema>;
+
+export const SchemaErrorSchema = z.object({
+  path: z.array(z.string()),
+  message: z.string(),
+});
+
+export type SchemaError = z.infer<typeof SchemaErrorSchema>;

--- a/packages/core/src/schemas/runs.ts
+++ b/packages/core/src/schemas/runs.ts
@@ -14,6 +14,7 @@ export const RunStatusSchema = z.union([
   z.literal("ABORTED"),
   z.literal("CANCELED"),
   z.literal("UNRESOLVED_AUTH"),
+  z.literal("INVALID_PAYLOAD"),
 ]);
 
 export const RunTaskSchema = z.object({

--- a/packages/database/prisma/migrations/20230922205611_add_invalid_payload_run_status/migration.sql
+++ b/packages/database/prisma/migrations/20230922205611_add_invalid_payload_run_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "JobRunStatus" ADD VALUE 'INVALID_PAYLOAD';

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -732,6 +732,7 @@ enum JobRunStatus {
   ABORTED
   CANCELED
   UNRESOLVED_AUTH
+  INVALID_PAYLOAD
 }
 
 model JobRunExecution {

--- a/packages/trigger-sdk/package.json
+++ b/packages/trigger-sdk/package.json
@@ -39,8 +39,7 @@
     "ulid": "^2.3.0",
     "uuid": "^9.0.0",
     "ws": "^8.11.0",
-    "zod": "3.21.4",
-    "zod-error": "1.5.0"
+    "zod": "3.21.4"
   },
   "devDependencies": {
     "@trigger.dev/tsconfig": "workspace:*",

--- a/packages/trigger-sdk/src/errors.ts
+++ b/packages/trigger-sdk/src/errors.ts
@@ -1,4 +1,4 @@
-import { ErrorWithStack, ServerTask } from "@trigger.dev/core";
+import { ErrorWithStack, SchemaError, ServerTask } from "@trigger.dev/core";
 
 export class ResumeWithTaskError {
   constructor(public task: ServerTask) {}
@@ -14,6 +14,10 @@ export class RetryWithTaskError {
 
 export class CanceledWithTaskError {
   constructor(public task: ServerTask) {}
+}
+
+export class ParsedPayloadSchemaError {
+  constructor(public schemaErrors: SchemaError[]) {}
 }
 
 /** Use this function if you're using a `try/catch` block to catch errors.

--- a/packages/trigger-sdk/src/triggerClient.ts
+++ b/packages/trigger-sdk/src/triggerClient.ts
@@ -31,7 +31,12 @@ import {
   StatusUpdate,
 } from "@trigger.dev/core";
 import { ApiClient } from "./apiClient";
-import { CanceledWithTaskError, ResumeWithTaskError, RetryWithTaskError } from "./errors";
+import {
+  CanceledWithTaskError,
+  ParsedPayloadSchemaError,
+  ResumeWithTaskError,
+  RetryWithTaskError,
+} from "./errors";
 import { TriggerIntegration } from "./integrations";
 import { IO } from "./io";
 import { createIOWithIntegrations } from "./ioWithIntegrations";
@@ -712,6 +717,10 @@ export class TriggerClient {
 
       return { status: "SUCCESS", output };
     } catch (error) {
+      if (error instanceof ParsedPayloadSchemaError) {
+        return { status: "INVALID_PAYLOAD", errors: error.schemaErrors };
+      }
+
       if (error instanceof ResumeWithTaskError) {
         return { status: "RESUME_WITH_TASK", task: error.task };
       }

--- a/packages/trigger-sdk/src/triggers/externalSource.ts
+++ b/packages/trigger-sdk/src/triggers/externalSource.ts
@@ -1,5 +1,3 @@
-import { z } from "zod";
-
 import {
   DisplayProperty,
   EventFilter,
@@ -16,7 +14,7 @@ import { IOWithIntegrations, TriggerIntegration } from "../integrations";
 import { IO } from "../io";
 import { Job } from "../job";
 import { TriggerClient } from "../triggerClient";
-import type { EventSpecification, Trigger, TriggerContext } from "../types";
+import type { EventSpecification, SchemaParser, Trigger, TriggerContext } from "../types";
 import { slugifyId } from "../utils";
 import { SerializableJson } from "@trigger.dev/core";
 import { ConnectionAuth } from "@trigger.dev/core";
@@ -154,8 +152,8 @@ type ExternalSourceOptions<
 > = {
   id: string;
   version: string;
-  schema: z.Schema<TParams>;
-  optionSchema?: z.Schema<TTriggerOptionDefinitions>;
+  schema: SchemaParser<TParams>;
+  optionSchema?: SchemaParser<TTriggerOptionDefinitions>;
   integration: TIntegration;
   register: RegisterFunction<TIntegration, TParams, TChannel, TTriggerOptionDefinitions>;
   filter?: FilterFunction<TParams, TTriggerOptionDefinitions>;

--- a/packages/trigger-sdk/src/types.ts
+++ b/packages/trigger-sdk/src/types.ts
@@ -105,3 +105,16 @@ export interface EventSpecification<TEvent extends any> {
 
 export type EventTypeFromSpecification<TEventSpec extends EventSpecification<any>> =
   TEventSpec extends EventSpecification<infer TEvent> ? TEvent : never;
+
+export type SchemaParserIssue = { path: PropertyKey[]; message: string };
+
+export type SchemaParserResult<T> =
+  | {
+      success: true;
+      data: T;
+    }
+  | { success: false; error: { issues: SchemaParserIssue[] } };
+
+export type SchemaParser<T extends unknown = unknown> = {
+  safeParse: (a: unknown) => SchemaParserResult<T>;
+};

--- a/packages/trigger-sdk/src/utils/formatSchemaErrors.ts
+++ b/packages/trigger-sdk/src/utils/formatSchemaErrors.ts
@@ -1,0 +1,9 @@
+import type { SchemaError } from "@trigger.dev/core";
+import { SchemaParserIssue } from "../types";
+
+export function formatSchemaErrors(errors: SchemaParserIssue[]): SchemaError[] {
+  return errors.map((error) => {
+    const { path, message } = error;
+    return { path: path.map(String), message };
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -990,7 +990,6 @@ importers:
       uuid: ^9.0.0
       ws: ^8.11.0
       zod: 3.21.4
-      zod-error: 1.5.0
     dependencies:
       '@trigger.dev/core': link:../core
       chalk: 5.2.0
@@ -1007,7 +1006,6 @@ importers:
       uuid: 9.0.0
       ws: 8.12.0
       zod: 3.21.4
-      zod-error: 1.5.0
     devDependencies:
       '@trigger.dev/tsconfig': link:../../config-packages/tsconfig
       '@types/debug': 4.1.7

--- a/references/job-catalog/package.json
+++ b/references/job-catalog/package.json
@@ -43,7 +43,6 @@
     "@types/node": "20.4.2",
     "typescript": "5.1.6",
     "zod": "3.21.4",
-    "@trigger.dev/airtable": "workspace:*",
     "@trigger.dev/linear": "workspace:*"
   },
   "trigger.dev": {

--- a/references/job-catalog/src/events.ts
+++ b/references/job-catalog/src/events.ts
@@ -58,51 +58,18 @@ client.defineJob({
 });
 
 client.defineJob({
-  id: "example-job",
-  name: "Example Job: a joke with a delay",
+  id: "zod-schema",
+  name: "Job with Zod Schema",
   version: "0.0.2",
   trigger: eventTrigger({
-    name: "shayan.event",
+    name: "zod.schema",
     schema: z.object({
       userId: z.string(),
       delay: z.number(),
     }),
   }),
   run: async (payload, io, ctx) => {
-    await io.wait("sleeping", payload.delay);
-
-    await io.runTask(
-      "init",
-      async () => {
-        console.log("init function ran", payload.userId);
-      },
-      { name: "init" }
-    );
-
-    await io.runTask(
-      "failable",
-      async (task) => {
-        if (task.attempts > 2) {
-          console.log("task succeeded");
-          return {
-            ok: true,
-          };
-        }
-        console.log("task failed");
-        throw new Error(`Task failed on ${task.attempts} attempt(s)`);
-      },
-      { name: "task-1", retry: { limit: 3 } }
-    );
-
-    await io.runTask(
-      "log",
-      async () => {
-        console.log("hello from the job", payload.userId);
-      },
-      {
-        name: "log",
-      }
-    );
+    await io.logger.info("Hello World", { ctx, payload });
   },
 });
 


### PR DESCRIPTION
Zod Schemas is no longer required for validating/inferring event triggers. We’ve taken inspiration from how domain-functions did it: https://github.com/seasonedcc/domain-functions/pull/114

This also introduces a new run state called "Invalid Payload" when a Zod or other schema fails to successfully parse the event payload. Currently it just silently fails with no feedback.

Closes #487 

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

I ran some of the reference jobs in references/job-catalog/src/events.ts and made sure the new Invalid Payload error worked and made sure the types worked on Zod 3.21.4 and Zod 3.22.2

---

## Changelog

- See above

---

## Screenshots

<img width="858" alt="CleanShot 2023-09-22 at 14 31 48@2x" src="https://github.com/triggerdotdev/trigger.dev/assets/534/9ca63659-b044-4f2c-931a-18c8e2623cd7">

💯
