### PR TITLE
fix: CLI init now checks the devDependency and next.config.mjs

### DIFF
--- a/.changeset/angry-bobcats-deny.md
+++ b/.changeset/angry-bobcats-deny.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/cli": minor
+---
+
+CLI init now works when using next.config.mjs and next as a devDependency

--- a/packages/cli/src/frameworks/nextjs/index.ts
+++ b/packages/cli/src/frameworks/nextjs/index.ts
@@ -75,7 +75,10 @@ export class NextJs implements Framework {
 }
 
 async function detectNextConfigFile(path: string): Promise<boolean> {
-  return pathExists(pathModule.join(path, "next.config.js"));
+  return (
+    pathExists(pathModule.join(path, "next.config.js")) ||
+    pathExists(pathModule.join(path, "next.config.mjs"))
+  );
 }
 
 export async function detectNextDependency(path: string): Promise<boolean> {
@@ -84,7 +87,10 @@ export async function detectNextDependency(path: string): Promise<boolean> {
     return false;
   }
 
-  return packageJsonContent.dependencies?.next !== undefined;
+  return (
+    packageJsonContent.dependencies?.next !== undefined ||
+    packageJsonContent.devDependencies?.next !== undefined
+  );
 }
 
 export async function detectUseOfSrcDir(path: string): Promise<boolean> {


### PR DESCRIPTION
Closes #504 

## ✅ Checklist

- [X] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works


---

## Changelog



---

## Screenshots


💯
