### PR TITLE
Add typed filters to `Linear` getAll helper

### DIFF
--- a/.changeset/sour-jars-punch.md
+++ b/.changeset/sour-jars-punch.md
@@ -2,4 +2,4 @@
 "@trigger.dev/linear": patch
 ---
 
-Fix `getAll` pagination helper params
+Fix `getAll` helper and search function params

--- a/.changeset/sour-jars-punch.md
+++ b/.changeset/sour-jars-punch.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/linear": patch
+---
+
+Fix `getAll` pagination helper params

--- a/integrations/linear/src/index.ts
+++ b/integrations/linear/src/index.ts
@@ -182,7 +182,7 @@ export class Linear implements TriggerIntegration {
   >(
     task: TTask,
     key: IntegrationTaskKey,
-    params: Nullable<QueryVariables> = {}
+    params: Parameters<TTask>[1] = {}
   ): Promise<Awaited<ReturnType<TTask>>["nodes"]> {
     const boundTask = task.bind(this as any);
 

--- a/integrations/linear/src/index.ts
+++ b/integrations/linear/src/index.ts
@@ -695,7 +695,7 @@ export class Linear implements TriggerIntegration {
     key: IntegrationTaskKey,
     params: {
       term: string;
-      variables?: L.SearchDocumentsQueryVariables;
+      variables?:  Parameters<LinearClient["searchDocuments"]>[1];
     }
   ): LinearReturnType<DocumentSearchPayload> {
     return this.runTask(
@@ -862,7 +862,7 @@ export class Linear implements TriggerIntegration {
     key: IntegrationTaskKey,
     params: {
       term: string;
-      variables?: L.SearchIssuesQueryVariables;
+      variables?: Parameters<LinearClient["searchIssues"]>[1];
     }
   ): LinearReturnType<IssueSearchPayload> {
     return this.runTask(
@@ -1273,7 +1273,7 @@ export class Linear implements TriggerIntegration {
     key: IntegrationTaskKey,
     params: {
       term: string;
-      variables?: L.SearchProjectsQueryVariables;
+      variables?: Parameters<LinearClient["searchProjects"]>[1];
     }
   ): LinearReturnType<ProjectSearchPayload> {
     return this.runTask(


### PR DESCRIPTION
The helper previously accepted all valid params _except_ filters. It will now accept entity-specific filters as it should.

_edit:_ Also fixed search function params.

### Some suggestions

Maybe we could adopt a params pattern that exactly mirrors that of the target SDK, e.g.:

```ts
 function searchDocuments(
    key: IntegrationTaskKey,
    ...params: Parameters<LinearClient["searchDocuments"]>
  ): LinearReturnType<DocumentSearchPayload> {
    return this.runTask(
      key,
      async (client) => {
        const payload = await client.searchDocuments(...params);
...
// Option #1
linear.searchDocuments("task-key", "search terms", { first: 5 })

// Option #2 - alternatively as single array param
linear.searchDocuments("task-key", ["search terms", { first: 5 }])
```

Would prevent having to create keys, particularly for non-object params. These are never user-facing when using the original SDK, except for type hints. Currently:

```ts
// Option #3
linear.searchDocuments("task-key", {
  term: "search terms",
  variables: { first: 5 }
})
```

Alternatively, can merge params, but could cause key conflicts in rare cases:

```ts
// Option #4
linear.searchDocuments("task-key", {
  term: "search terms",
  first: 5
})
```

### Summary

Would be great to standardise the params pattern across integrations! Personally prefer Option 1 or 2.