### PR TITLE
Add pgAdmin to compose file

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3"
 
 volumes:
   database-data:
+  pgadmin-data:
 
 networks:
   app_network:
@@ -22,3 +23,21 @@ services:
       - app_network
     ports:
       - 5432:5432
+
+  pgadmin:
+    container_name: pgadmin
+    image: dpage/pgadmin4:7
+    restart: always
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@example.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+      PGADMIN_DISABLE_POSTFIX: true
+    volumes:
+      - pgadmin-data:/var/lib/pgadmin
+      - ./pgadmin/servers.json:/pgadmin4/servers.json
+    networks:
+      - app_network
+    ports:
+      - 5480:80
+    depends_on:
+      - database

--- a/docker/pgadmin/servers.json
+++ b/docker/pgadmin/servers.json
@@ -1,0 +1,13 @@
+{
+  "Servers": {
+    "1": {
+      "Name": "Trigger.dev",
+      "Group": "Trigger.dev",
+      "Port": 5432,
+      "Username": "postgres",
+      "Host": "database",
+      "SSLMode": "prefer",
+      "MaintenanceDB": "postgres"
+    }
+  }
+}


### PR DESCRIPTION
The DB password isn't pre-configured as it requires a rather unsightly workaround.

### Instructions

1. Start just like the DB: `pnpm run docker`
2. Access at http://localhost:5480
3. Email: `admin@example.com`
4. Password: `admin`
5. Select the Trigger.dev DB, enter and save password: `postgres`