### PR TITLE
Standardize Page Titles

### DIFF
--- a/docs/documentation/concepts/triggers/introduction.mdx
+++ b/docs/documentation/concepts/triggers/introduction.mdx
@@ -1,5 +1,6 @@
 ---
 title: Introduction
+sidebarTitle: "Triggers: Introduction"
 description: "A Trigger is what starts a Job Run. It can be a webhook, a schedule, or an event."
 ---
 

--- a/docs/documentation/guides/react-hooks.mdx
+++ b/docs/documentation/guides/react-hooks.mdx
@@ -1,5 +1,6 @@
 ---
-title: "React hooks"
+title: "Overview"
+sidebarTitle: "React hooks: Overview"
 description: "How to show the live status of Job Runs in your React app"
 ---
 


### PR DESCRIPTION
Updated page titles in the docs to follow the format: Group: Page (e.g., Triggers: Introduction, React Hooks: Overview).
Added sidebarTitle field to the markdown frontmatter to retain the original sidebar group titles while displaying the updated page titles.
#527 