### PR TITLE
feat: allow cancelling jobs from trigger-client sdk

### DIFF
--- a/.changeset/orange-falcons-smile.md
+++ b/.changeset/orange-falcons-smile.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": minor
+---
+
+allow cancelling jobs from trigger-client

--- a/.changeset/orange-falcons-smile.md
+++ b/.changeset/orange-falcons-smile.md
@@ -1,5 +1,5 @@
 ---
-"@trigger.dev/sdk": minor
+"@trigger.dev/sdk": patch
 ---
 
 allow cancelling jobs from trigger-client

--- a/apps/webapp/app/routes/api.v1.runs.$runId.cancel.ts
+++ b/apps/webapp/app/routes/api.v1.runs.$runId.cancel.ts
@@ -4,7 +4,7 @@ import { PrismaErrorSchema } from "~/db.server";
 import { z } from "zod";
 import { authenticateApiRequest } from "~/services/apiAuth.server";
 import { CancelRunService } from "~/services/runs/cancelRun.server";
-import { GetRunInput, GetRunService } from "~/services/runs/getRun.server";
+import { ApiRunPresenter } from "~/presenters/ApiRunPresenter.server";
 
 const ParamsSchema = z.object({
   runId: z.string(),
@@ -31,9 +31,9 @@ export async function action({ request, params }: ActionArgs) {
 
   const { runId } = parsed.data;
 
-  const cancelRunService = new CancelRunService();
+  const service = new CancelRunService();
   try {
-    await cancelRunService.call({ runId });
+    await service.call({ runId });
   } catch (error) {
     const prismaError = PrismaErrorSchema.safeParse(error);
     // Record not found in the database
@@ -44,10 +44,10 @@ export async function action({ request, params }: ActionArgs) {
     }
   }
 
-  const getRunService = new GetRunService();
-  const jobRun = await getRunService.call({
+  const presenter = new ApiRunPresenter();
+  const jobRun = await presenter.call({
     runId: runId,
-  } as GetRunInput);
+  });
 
   if (!jobRun) {
     return json({ message: "Run not found" }, { status: 404 });

--- a/apps/webapp/app/routes/api.v1.runs.$runId.cancel.ts
+++ b/apps/webapp/app/routes/api.v1.runs.$runId.cancel.ts
@@ -1,0 +1,71 @@
+import type { ActionArgs } from "@remix-run/server-runtime";
+import { json } from "@remix-run/server-runtime";
+import { PrismaErrorSchema } from "~/db.server";
+import { z } from "zod";
+import { authenticateApiRequest } from "~/services/apiAuth.server";
+import { CancelRunService } from "~/services/runs/cancelRun.server";
+import { GetRunInput, GetRunService } from "~/services/runs/getRun.server";
+
+const ParamsSchema = z.object({
+  runId: z.string(),
+});
+
+export async function action({ request, params }: ActionArgs) {
+  // Ensure this is a POST request
+  if (request.method.toUpperCase() !== "POST") {
+    return { status: 405, body: "Method Not Allowed" };
+  }
+
+  // Authenticate the request
+  const authenticationResult = await authenticateApiRequest(request);
+
+  if (!authenticationResult) {
+    return json({ error: "Invalid or Missing API Key" }, { status: 401 });
+  }
+
+  const parsed = ParamsSchema.safeParse(params);
+
+  if (!parsed.success) {
+    return json({ error: "Invalid or Missing runId" }, { status: 400 });
+  }
+
+  const { runId } = parsed.data;
+
+  const cancelRunService = new CancelRunService();
+  try {
+    await cancelRunService.call({ runId });
+  } catch (error) {
+    const prismaError = PrismaErrorSchema.safeParse(error);
+    // Record not found in the database
+    if (prismaError.success && prismaError.data.code === "P2005") {
+      return json({ error: "Run not found" }, { status: 404 });
+    } else {
+      return json({ error: "Internal Server Error" }, { status: 500 });
+    }
+  }
+
+  const getRunService = new GetRunService();
+  const jobRun = await getRunService.call({
+    runId: runId,
+  } as GetRunInput);
+
+  if (!jobRun) {
+    return json({ message: "Run not found" }, { status: 404 });
+  }
+
+  return json({
+    id: jobRun.id,
+    status: jobRun.status,
+    startedAt: jobRun.startedAt,
+    updatedAt: jobRun.updatedAt,
+    completedAt: jobRun.completedAt,
+    output: jobRun.output,
+    tasks: jobRun.tasks,
+    statuses: jobRun.statuses.map((s) => ({
+      ...s,
+      state: s.state ?? undefined,
+      data: s.data ?? undefined,
+      history: s.history ?? undefined,
+    })),
+  });
+}

--- a/apps/webapp/app/routes/api.v1.runs.$runId.ts
+++ b/apps/webapp/app/routes/api.v1.runs.$runId.ts
@@ -1,8 +1,8 @@
 import type { LoaderArgs } from "@remix-run/server-runtime";
 import { json } from "@remix-run/server-runtime";
 import { z } from "zod";
+import { ApiRunPresenter } from "~/presenters/ApiRunPresenter.server";
 import { authenticateApiRequest } from "~/services/apiAuth.server";
-import { GetRunInput, GetRunService } from "~/services/runs/getRun.server";
 import { apiCors } from "~/utils/apiCors";
 import { taskListToTree } from "~/utils/taskListToTree";
 
@@ -53,14 +53,14 @@ export async function loader({ request, params }: LoaderArgs) {
   const showTaskDetails = query.taskdetails && authenticationResult.type === "PRIVATE";
   const take = Math.min(query.take, 50);
 
-  const service = new GetRunService();
-  const jobRun = await service.call({
+  const presenter = new ApiRunPresenter();
+  const jobRun = await presenter.call({
     runId: runId,
     maxTasks: take,
     taskDetails: showTaskDetails,
     subTasks: query.subtasks,
     cursor: query.cursor,
-  } as GetRunInput);
+  });
 
   if (!jobRun) {
     return apiCors(request, json({ message: "Run not found" }, { status: 404 }));

--- a/apps/webapp/app/services/runs/getRun.server.ts
+++ b/apps/webapp/app/services/runs/getRun.server.ts
@@ -1,0 +1,70 @@
+import { PrismaClient, prisma } from "~/db.server";
+import { z } from "zod";
+
+const GetRunInputSchema = z.object({
+  runId: z.string(),
+  maxTasks: z.number().default(20),
+  taskDetails: z.boolean().default(false),
+  subTasks: z.boolean().default(false),
+  cursor: z.string().optional(),
+});
+
+export type GetRunInput = z.infer<typeof GetRunInputSchema>;
+
+export class GetRunService {
+  #prismaClient: PrismaClient;
+
+  constructor(prismaClient: PrismaClient = prisma) {
+    this.#prismaClient = prismaClient;
+  }
+
+  public async call(input: GetRunInput) {
+    const parsedInput = GetRunInputSchema.parse(input);
+
+    const take = Math.min(parsedInput.maxTasks, 50);
+
+    return await prisma.jobRun.findUnique({
+      where: {
+        id: input.runId,
+      },
+      select: {
+        id: true,
+        status: true,
+        startedAt: true,
+        updatedAt: true,
+        completedAt: true,
+        environmentId: true,
+        output: true,
+        tasks: {
+          select: {
+            id: true,
+            parentId: true,
+            displayKey: true,
+            status: true,
+            name: true,
+            icon: true,
+            startedAt: true,
+            completedAt: true,
+            params: parsedInput.taskDetails,
+            output: parsedInput.taskDetails,
+          },
+          where: {
+            parentId: parsedInput.subTasks ? undefined : null,
+          },
+          orderBy: {
+            id: "asc",
+          },
+          take: take + 1,
+          cursor: parsedInput.cursor
+            ? {
+                id: parsedInput.cursor,
+              }
+            : undefined,
+        },
+        statuses: {
+          select: { key: true, label: true, state: true, data: true, history: true },
+        },
+      },
+    });
+  }
+}

--- a/packages/trigger-sdk/src/apiClient.ts
+++ b/packages/trigger-sdk/src/apiClient.ts
@@ -399,6 +399,22 @@ export class ApiClient {
     );
   }
 
+  async cancelRun(runId: string) {
+    const apiKey = await this.#apiKey();
+
+    this.#logger.debug("Cancelling Run", {
+      runId,
+    });
+
+    return await zodfetch(GetRunSchema, `${this.#apiUrl}/api/v1/runs/${runId}/cancel`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+  }
+
   async getRunStatuses(runId: string) {
     const apiKey = await this.#apiKey();
 

--- a/packages/trigger-sdk/src/triggerClient.ts
+++ b/packages/trigger-sdk/src/triggerClient.ts
@@ -642,6 +642,10 @@ export class TriggerClient {
     return this.#client.getRun(runId, options);
   }
 
+  async cancelRun(runId: string) {
+    return this.#client.cancelRun(runId);
+  }
+
   async getRuns(jobSlug: string, options?: GetRunsOptions) {
     return this.#client.getRuns(jobSlug, options);
   }


### PR DESCRIPTION
Closes #554

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

- Validated the SDK functionality
- Verified the job cancellation from SDK
- Verified the job cancellation from the Dashboard

---

## Changelog

- Introduced `api/v1/runs/$runId/cancel` endpoint.
- Added `cancelJob` function to SDK.
- Consolidated the Job Run fetch into a `GetRunService`. This will be used in both `GET api/v1/runs/$runId` and `POST api/v1/runs/$runId/cancel` API.
- The new `cancel-job` endpoint returns basic job-run information and does not accept any search parameters (as it does in the get-run API). I don't think it makes sense to accept search parameters in the `cancel` API. The intention is if the user wants additional information, they can use the `get-run` with the `runId`.

---

## Screenshots

#### Test Job
![Screenshot 2023-10-05 at 11 17 58 AM](https://github.com/triggerdotdev/trigger.dev/assets/132386067/37f768e2-e624-4150-b11e-c878c5a88bb9)

#### Cancelled
![Screenshot 2023-10-05 at 11 17 45 AM](https://github.com/triggerdotdev/trigger.dev/assets/132386067/e7971ed4-57e7-4c9f-807a-9060f42cf8b1)

#### Cancel Run API Response
![Screenshot 2023-10-05 at 11 17 07 AM](https://github.com/triggerdotdev/trigger.dev/assets/132386067/36ce3af7-1cba-42a1-8a5d-a64fe844deaf)


💯
