### PR TITLE
feat: add internal flag to job-run table

### DIFF
--- a/apps/webapp/app/services/runs/createRun.server.ts
+++ b/apps/webapp/app/services/runs/createRun.server.ts
@@ -70,6 +70,7 @@ export class CreateRunService {
             ? eventRecord.externalAccountId
             : undefined,
           isTest: eventRecord.isTest,
+          internal: job.internal,
         },
       });
 

--- a/packages/database/prisma/migrations/20231005064823_add_job_run_internal/migration.sql
+++ b/packages/database/prisma/migrations/20231005064823_add_job_run_internal/migration.sql
@@ -1,2 +1,10 @@
 -- AlterTable
 ALTER TABLE "JobRun" ADD COLUMN     "internal" BOOLEAN NOT NULL DEFAULT false;
+
+/*
+  Backfill JobRun internal flag
+*/
+UPDATE "JobRun"
+SET "internal" = "Job"."internal"
+FROM "Job"
+WHERE "JobRun"."jobId" = "Job"."id";

--- a/packages/database/prisma/migrations/20231005064823_add_job_run_internal/migration.sql
+++ b/packages/database/prisma/migrations/20231005064823_add_job_run_internal/migration.sql
@@ -7,4 +7,4 @@ ALTER TABLE "JobRun" ADD COLUMN     "internal" BOOLEAN NOT NULL DEFAULT false;
 UPDATE "JobRun"
 SET "internal" = "Job"."internal"
 FROM "Job"
-WHERE "JobRun"."jobId" = "Job"."id";
+WHERE "JobRun"."jobId" = "Job"."id" AND "JobRun"."internal" = TRUE;

--- a/packages/database/prisma/migrations/20231005064823_add_job_run_internal/migration.sql
+++ b/packages/database/prisma/migrations/20231005064823_add_job_run_internal/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "JobRun" ADD COLUMN     "internal" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -666,6 +666,7 @@ model EventRecord {
 model JobRun {
   id     String @id @default(cuid())
   number Int
+  internal Boolean @default(false)
 
   job   Job    @relation(fields: [jobId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   jobId String


### PR DESCRIPTION
Closes #557

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

- Verified the migration is applied and the column is added to `JobRun` table.
- Verified the new job runs are using the `internal` flag from `Job` table (I did this by manually updating the `internal` flag for one of the jobs).

---

## Changelog

- Add new column `internal` in `JobRun` table (defaults to `false`)
- Set `JobRun` internal flag based on the job's definition in the `createRun` API.

💯
