### PR TITLE
feat: add prisma SQL migration for job-run internal flag backfill

### DIFF
--- a/apps/webapp/app/services/runs/createRun.server.ts
+++ b/apps/webapp/app/services/runs/createRun.server.ts
@@ -70,6 +70,7 @@ export class CreateRunService {
             ? eventRecord.externalAccountId
             : undefined,
           isTest: eventRecord.isTest,
+          internal: job.internal,
         },
       });
 

--- a/packages/database/prisma/migrations/20231005064823_add_job_run_internal/migration.sql
+++ b/packages/database/prisma/migrations/20231005064823_add_job_run_internal/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "JobRun" ADD COLUMN     "internal" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/database/prisma/migrations/20231005123839_job_run_internal_backfill/migration.sql
+++ b/packages/database/prisma/migrations/20231005123839_job_run_internal_backfill/migration.sql
@@ -1,0 +1,4 @@
+UPDATE "JobRun"
+SET "internal" = "Job"."internal"
+FROM "Job"
+WHERE "JobRun"."jobId" = "Job"."id";

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -666,6 +666,7 @@ model EventRecord {
 model JobRun {
   id     String @id @default(cuid())
   number Int
+  internal Boolean @default(false)
 
   job   Job    @relation(fields: [jobId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   jobId String


### PR DESCRIPTION
Closes #557

This builds on top of #563 and should ideally be merged after #563 goes live.

The intention is to separate the schema and API change from the backfill script. This way, the jobs & job runs that get created during the backfill execution can still have the correct `internal` flags set (the API takes care of it).


## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

- Verified the past runs of internal jobs have their job-run internal flag set to `true`.
- Verified that the migration runs only once.

---

## Changelog

- Add a backfill script that sets the `internal` flag for past `JobRun` entries.
- To avoid DB overload, chunks of jobs (100 - configurable) are used to load their associated job-runs. 

💯
