### PR TITLE
Event Trigger Example Payload: Fix unsetting icon, and Use fallback icon in case of invalid icon-name.

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.jobs.$jobParam.test/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.jobs.$jobParam.test/route.tsx
@@ -35,6 +35,7 @@ import { TestJobService } from "~/services/jobs/testJob.server";
 import { requireUserId } from "~/services/session.server";
 import { cn } from "~/utils/cn";
 import { Handle } from "~/utils/handle";
+import { isValidIcon } from "~/utils/icon";
 import { JobParamsSchema, jobRunDashboardPath, trimTrailingSlash } from "~/utils/pathBuilder";
 
 export const loader = async ({ request, params }: LoaderArgs) => {
@@ -228,7 +229,7 @@ export default function Page() {
                       }}
                     >
                       <DetailCell
-                        leadingIcon={example.icon ?? CodeBracketIcon}
+                        leadingIcon={isValidIcon(example.icon) ? example.icon : CodeBracketIcon}
                         leadingIconClassName="text-blue-500"
                         label={example.name}
                         trailingIcon={example.id === selectedCodeSampleId ? "check" : "plus"}

--- a/apps/webapp/app/services/jobs/registerJob.server.ts
+++ b/apps/webapp/app/services/jobs/registerJob.server.ts
@@ -229,7 +229,7 @@ export class RegisterJobService {
           },
           update: {
             name: example.name,
-            icon: example.icon,
+            icon: example.icon ?? null,
             payload: example.payload,
           },
         });

--- a/apps/webapp/app/utils/icon.ts
+++ b/apps/webapp/app/utils/icon.ts
@@ -1,0 +1,9 @@
+import { hasIcon } from "@trigger.dev/companyicons";
+import { iconNames as namedIcons } from "~/components/primitives/NamedIcon";
+
+export const isValidIcon = (icon?: string): boolean => {
+  if (!icon) {
+    return false;
+  }
+  return namedIcons.includes(icon) || hasIcon(icon);
+};


### PR DESCRIPTION
@ericallam  Something I came across while working on #534.

1. The API does not support unsetting an icon because Prisma differentiates between a variable having an `undefined` value vs `null` value ([ref](https://www.prisma.io/docs/concepts/components/prisma-client/null-and-undefined)). When the user wishes to unset the example icon and does not send a value, the server fails to update the DB since it sets the value as `undefined`.
2. When the user provides an invalid name for the `icon` property, an empty icon is displayed in the dashboard.

I created this PR to fix the above issues.


## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

### Fix Unsetting Icon
- Verified setting an icon.
- Verified unsetting icon.
- Verified re-setting the icon.

### Use Fallback Icon
- Verified that a valid icon is used when provided in the example (both internal named-icons, and company-icons package).
- Verified that the fallback icon (CodeBracket) is used when either no icon (or) an invalid icon is provided.

---

## Changelog

- During update, set the example icon as `null` in the DB if it is not available in the trigger definition.
- Add a `isValidIcon` method that checks if the icon is present is either `named-icons` or `company-icons`.
- Use fallback icon (CodeBracket) in the trigger example payload section if the provided icon is invalid.

💯
