### PR TITLE
(regression) fix: remove invalid envFile response field in sendEvent cmd

### DIFF
--- a/.changeset/tiny-candles-type.md
+++ b/.changeset/tiny-candles-type.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/cli": patch
+---
+
+remove unused envFile param in sendEvent.ts cmd

--- a/packages/cli/src/commands/sendEvent.ts
+++ b/packages/cli/src/commands/sendEvent.ts
@@ -36,7 +36,7 @@ export async function sendEventCommand(path: string, anyOptions: any) {
     return;
   }
 
-  const { apiUrl, envFile, apiKey } = apiDetails;
+  const { apiUrl, apiKey } = apiDetails;
 
   const parsedPayload = safeJSONParse(options.payload);
 


### PR DESCRIPTION
Regression on #532 merge since the `getTriggerApiDetails` response structure has changed.

Older `envFile` response param wasn't used in `sendEvent.ts`, hence removed it.