### PR TITLE
Fixes #583 by filtering out properties with missing values

### DIFF
--- a/.changeset/sharp-lobsters-cross.md
+++ b/.changeset/sharp-lobsters-cross.md
@@ -1,0 +1,6 @@
+---
+"@trigger.dev/resend": patch
+"@trigger.dev/core": patch
+---
+
+Allow task property values to be blank, but strip them out before persisting them

--- a/apps/webapp/app/routes/api.v1.runs.$runId.tasks.ts
+++ b/apps/webapp/app/routes/api.v1.runs.$runId.tasks.ts
@@ -280,7 +280,7 @@ export class RunTaskService {
           noop: taskBody.noop,
           delayUntil: taskBody.delayUntil,
           params: taskBody.params ?? undefined,
-          properties: taskBody.properties ?? undefined,
+          properties: this.#filterProperties(taskBody.properties) ?? undefined,
           redact: taskBody.redact ?? undefined,
           operation: taskBody.operation,
           callbackUrl,
@@ -324,5 +324,15 @@ export class RunTaskService {
     });
 
     return task ? taskWithAttemptsToServerTask(task) : undefined;
+  }
+
+  #filterProperties(properties: RunTaskBodyOutput["properties"]): RunTaskBodyOutput["properties"] {
+    if (!properties) return;
+
+    return properties.filter((property) => {
+      if (!property) return false;
+
+      return typeof property.label === "string" && typeof property.text === "string";
+    });
   }
 }

--- a/docs/sdk/io/runtask.mdx
+++ b/docs/sdk/io/runtask.mdx
@@ -128,6 +128,7 @@ The wrappers at `io.integration.runTask()` expose the underlying Integration cli
         The value of the property.
       </ResponseField>
     </Expandable>
+
   </ResponseField>
 
 </Expandable>
@@ -135,7 +136,7 @@ The wrappers at `io.integration.runTask()` expose the underlying Integration cli
 
 <ResponseField name="onError" type="function">
   An optional callback that will be called when the Task fails. You can perform
-  logic in here and optionally return a custom error object. Returning an object with `{ retryAt: Date, error?: Error }` will retry the Task at the specified Date. You can also just return a new `Error` object to throw a new error. Return nothing to rethrow the original error.
+  logic in here and optionally return a custom error object. Returning an object with `{ retryAt: Date, error?: Error }` will retry the Task at the specified Date. You can also just return a new `Error` object to throw a new error. Returning `null` or `undefined` will rethrow the original error. If you want to force retrying to be skipped, return `{ skipRetrying: true }`.
 
   <Expandable title="arguments">
     <ResponseField name="error" type="unknown">

--- a/integrations/resend/src/index.ts
+++ b/integrations/resend/src/index.ts
@@ -25,6 +25,9 @@ function isRequestError(error: unknown): error is ErrorResponse {
   return typeof error === "object" && error !== null && "statusCode" in error;
 }
 
+// See https://resend.com/docs/api-reference/errors
+const skipRetryingErrors = [422, 401, 403, 404, 405, 422];
+
 function onError(error: unknown) {
   if (!isRequestError(error)) {
     if (error instanceof Error) {
@@ -32,6 +35,12 @@ function onError(error: unknown) {
     }
 
     return new Error("Unknown error");
+  }
+
+  if (skipRetryingErrors.includes(error.statusCode)) {
+    return {
+      skipRetrying: true,
+    };
   }
 
   return new Error(error.message);

--- a/packages/core/src/schemas/api.ts
+++ b/packages/core/src/schemas/api.ts
@@ -664,6 +664,7 @@ export const RunTaskBodyInputSchema = RunTaskOptionsSchema.extend({
 export type RunTaskBodyInput = z.infer<typeof RunTaskBodyInputSchema>;
 
 export const RunTaskBodyOutputSchema = RunTaskBodyInputSchema.extend({
+  properties: z.array(DisplayPropertySchema.partial()).optional(),
   params: DeserializedJsonSchema.optional().nullable(),
   callback: z
     .object({

--- a/references/job-catalog/src/resend.ts
+++ b/references/job-catalog/src/resend.ts
@@ -43,4 +43,32 @@ client.defineJob({
   },
 });
 
+client.defineJob({
+  id: "send-resend-email-from-blank",
+  name: "Send Resend Email From Blank",
+  version: "0.1.0",
+  trigger: eventTrigger({
+    name: "send.email",
+    schema: z.object({
+      to: z.union([z.string(), z.array(z.string())]),
+      subject: z.string(),
+      text: z.string(),
+      from: z.string().optional(),
+    }),
+  }),
+  integrations: {
+    resend,
+  },
+  run: async (payload, io, ctx) => {
+    const response = await io.resend.sendEmail("📧", {
+      to: payload.to,
+      subject: payload.subject,
+      text: payload.text,
+      from: payload.from!,
+    });
+
+    await io.logger.info("Sent email", { response });
+  },
+});
+
 createExpressServer(client);


### PR DESCRIPTION
This also improves the retrying behavior of the resend integration by skipping retrying certain client errors

Closes #583

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

I created a new job to recreate this issue in job-catalog/resend.ts

---

## Changelog

- Update the parsing logic on the server to allow task properties with falsy values
- Filter out properties that have falsy values before persisting
- Improve the resend integration by skipping retries for certain client errors

---

## Screenshots

<img width="1324" alt="CleanShot 2023-10-08 at 07 36 54@2x" src="https://github.com/triggerdotdev/trigger.dev/assets/534/69161038-236b-4651-b99f-2fb0d7719756">


💯
