### PR TITLE
fix: set error message in runTask & executeJob

### DIFF
--- a/.changeset/tricky-games-agree.md
+++ b/.changeset/tricky-games-agree.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+set error messages in runTask and executeJob

--- a/packages/trigger-sdk/src/io.ts
+++ b/packages/trigger-sdk/src/io.ts
@@ -818,8 +818,9 @@ export class IO {
             error: parsedError.data,
           });
         } else {
+          const message = typeof error === "string" ? error : JSON.stringify(error);
           await this._apiClient.failTask(this._id, task.id, {
-            error: { message: JSON.stringify(error), name: "Unknown Error" },
+            error: { name: "Unknown error", message },
           });
         }
 

--- a/packages/trigger-sdk/src/triggerClient.ts
+++ b/packages/trigger-sdk/src/triggerClient.ts
@@ -860,9 +860,10 @@ export class TriggerClient {
         return { status: "ERROR", error: errorWithStack.data };
       }
 
+      const message = typeof error === "string" ? error : JSON.stringify(error);
       return {
         status: "ERROR",
-        error: { message: "Unknown error" },
+        error: { name: "Unknown error", message },
       };
     }
   }


### PR DESCRIPTION
Closes #582 

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Verified throwing an Error object, string, and a custom object.

---

## Changelog

Set error message based on the type of Error.

---

## Screenshots

#### Throw Error Object

![Screenshot 2023-10-17 at 2 06 03 PM](https://github.com/triggerdotdev/trigger.dev/assets/132386067/a074e461-2051-4493-90dd-641d95318034)

#### Throw String

![Screenshot 2023-10-17 at 2 05 38 PM](https://github.com/triggerdotdev/trigger.dev/assets/132386067/47409427-3e5e-4a18-b850-e1b3bb1f9b77)


#### Throw Custom Object

![Screenshot 2023-10-17 at 2 05 50 PM](https://github.com/triggerdotdev/trigger.dev/assets/132386067/5bf1f08c-903f-4e3d-8a25-2bd2def130a9)


💯
