### PR TITLE
[TRI-1426] : Improve the Resend integration documentation

### DIFF
--- a/docs/integrations/apis/resend-tasks.mdx
+++ b/docs/integrations/apis/resend-tasks.mdx
@@ -14,9 +14,6 @@ Tasks are executed after the job is triggered and are the main building blocks o
 Send an email to a recipient with a text payload. [Official Resend Docs](https://resend.com/docs/api-reference/emails/send-email)
 
 ```ts example.ts
-run: async (io, ctx) => {
-  // The 'run' function is asynchronous and takes 'io' and 'ctx' as parameters.
-
   // Using the 'io.resend.sendEmail' method to send an email using the Resend service.
   await io.resend.sendEmail("send-email", {
     to: <recipient-email-address>, // Recipient's email address.

--- a/docs/integrations/apis/resend-tasks.mdx
+++ b/docs/integrations/apis/resend-tasks.mdx
@@ -1,0 +1,146 @@
+---
+title: Resend tasks
+sidebarTitle: Tasks
+---
+
+Tasks are executed after the job is triggered and are the main building blocks of a job. You can string together as many tasks as you want.
+
+---
+
+## All tasks
+
+### `sendEmail`
+
+Send an email to a recipient with a text payload. [Official Resend Docs](https://resend.com/docs/api-reference/emails/send-email)
+
+```ts example.ts
+run: async (payload, io, ctx) => {
+  // The 'run' function is asynchronous and takes 'payload,' 'io,' and 'ctx' as parameters.
+
+  // Using the 'io.resend.sendEmail' method to send an email using the Resend service.
+  await io.resend.sendEmail("send-email", {
+    to: payload.to, // Recipient's email address, obtained from the 'payload' parameter.
+    subject: payload.subject, // Email subject, obtained from the 'payload' parameter.
+    text: payload.text, // Plain text content of the email, obtained from the 'payload' parameter.
+    from: "Trigger.dev <hello@email.trigger.dev>", // Sender's email address and name.
+  });
+}
+```
+
+## Example usage
+
+In this example we'll create a task that sends a basic email built using React & Typescript to a 'to' email address with a 'subject', a 'text' field and a 'from' email address.
+Here we use [Zod](/documentation/guides/zod), a TypeScript-first schema declaration and validation library.
+
+```ts example.ts
+// Importing necessary modules and packages.
+import { TriggerClient, eventTrigger } from "@trigger.dev/sdk";
+import { Resend } from "@trigger.dev/resend";
+import { z } from "zod";
+
+// Importing React and React Email components for creating styled emails.
+import { Html } from "@react-email/html";
+import { Head } from "@react-email/head";
+import { Text } from "@react-email/text";
+import { Button } from "@react-email/button";
+import { Section } from "@react-email/section";
+import { Preview } from "@react-email/preview";
+import { Container } from "@react-email/container";
+
+// Creating an instance of the TriggerClient with a unique identifier "jobs-showcase."
+const client = new TriggerClient({ id: "jobs-showcase" });
+
+// Creating an instance of the Resend client with an API key obtained from an environment variable.
+const resend = new Resend({
+  id: "resend",
+  apiKey: process.env.RESEND_API_KEY!,
+});
+
+// Defining styles for the email's HTML components.
+const container = {
+  width: "480px",
+  margin: "0 auto",
+  padding: "20px 0 48px",
+};
+
+const title = {
+  fontSize: "24px",
+  lineHeight: 1.25,
+};
+
+const section = {
+  padding: "24px",
+  border: "solid 1px #dedede",
+  borderRadius: "5px",
+  textAlign: "center" as const,
+};
+
+const text = {
+  margin: "0 0 10px 0",
+  textAlign: "left" as const,
+};
+
+const button = {
+  fontSize: "14px",
+  font: "bold",
+  backgroundColor: "#28a745",
+  color: "#fff",
+  lineHeight: 1.5,
+  borderRadius: "0.2em",
+  textAlign: "center" as const,
+};
+
+// React component for creating a styled email.
+function BasicEmail({ name, text }: { name: string; text: string }) {
+  return (
+    <Html>
+      <Head />
+      <Preview>Welcome to Acme Inc!</Preview>
+      <Container style={container}>
+        <Section style={section}>
+          <Text>Hey {name}!</Text>
+          <Text>{text}</Text>
+          <Button style={button} pY={4} pX={4} href="https://acmecompany.inc/">
+            Get started
+          </Button>
+        </Section>
+      </Container>
+    </Html>
+  );
+}
+
+// Defining a job that sends a basic email built using React and Typescript.
+client.defineJob({
+  id: "resend-send-react-email", // Unique identifier for the job.
+  name: "Resend: send react email", // A specific name for the job.
+  version: "1.0.0", // Version number for the job.
+  trigger: eventTrigger({ //triggering an event to send email
+    name: "send.email",
+    schema: z.object({ //initiating the Zod schema
+      to: z.string(),  //Storing EmailTo as a string in the Zod Object
+      subject: z.string(), //Storing Subject as a string in the Zod Object
+      text: z.string(), //Storing EmailBodyText as a string in the Zod Object
+      name: z.string(), //Storing Name as a string in the Zod Object
+      from: z.string(), //Storing EmailFrom as a string in the Zod Object
+    }),
+  }),
+  integrations: {
+    resend, // Integrating the Resend client into this job.
+  },
+  run: async (payload, io, ctx) => {
+    // Inside the 'run' function, an email is sent using the Resend service.
+
+    await io.resend.sendEmail("send-email", {
+      to: payload.to,
+      subject: payload.subject,
+      text: payload.text,
+      from: payload.from,
+      react: <BasicEmail name={payload.name} text={payload.text} />,
+    });
+  },
+});
+
+// If you're not using Express, you can remove these lines.
+import { createExpressServer } from "@trigger.dev/express";
+createExpressServer(client);
+```

--- a/docs/integrations/apis/resend-tasks.mdx
+++ b/docs/integrations/apis/resend-tasks.mdx
@@ -14,15 +14,15 @@ Tasks are executed after the job is triggered and are the main building blocks o
 Send an email to a recipient with a text payload. [Official Resend Docs](https://resend.com/docs/api-reference/emails/send-email)
 
 ```ts example.ts
-run: async (payload, io, ctx) => {
-  // The 'run' function is asynchronous and takes 'payload,' 'io,' and 'ctx' as parameters.
+run: async (io, ctx) => {
+  // The 'run' function is asynchronous and takes 'io' and 'ctx' as parameters.
 
   // Using the 'io.resend.sendEmail' method to send an email using the Resend service.
   await io.resend.sendEmail("send-email", {
-    to: payload.to, // Recipient's email address, obtained from the 'payload' parameter.
-    subject: payload.subject, // Email subject, obtained from the 'payload' parameter.
-    text: payload.text, // Plain text content of the email, obtained from the 'payload' parameter.
-    from: "Trigger.dev <hello@email.trigger.dev>", // Sender's email address and name.
+    to: <recipient-email-address>, // Recipient's email address.
+    subject: <email-subject>, // Email subject.
+    text: <email-body>, // Plain text content of the email.
+    from: "Your-Name <your-email-address>", // Sender's email address and name.
   });
 }
 ```

--- a/docs/integrations/apis/resend.mdx
+++ b/docs/integrations/apis/resend.mdx
@@ -1,10 +1,22 @@
 ---
-title: Resend
+title: Resend overview & authentication
+sidebarTitle: Overview & authentication
 ---
 
-<Snippet file="integration-getting-started.mdx" />
+## Overview
 
-## Installation
+Resend is the email API for developers.
+It's a simple, elegant interface so you can start sending emails in minutes. It fits right into your code with SDKs for your favorite programming languages.
+
+<Card
+  title="Jobs Showcase - Resend"
+  icon="rocket"
+  href="https://trigger.dev/showcase?tags=&integrations=resend"
+>
+  Check out pre-built Resend jobs in our showcase.
+</Card>
+
+## Installing the Resend packages
 
 <CodeGroup>
 
@@ -35,50 +47,12 @@ const resend = new Resend({
 });
 ```
 
-## Example
-
-In this example we use [Zod](/documentation/guides/zod), a TypeScript-first schema declaration and validation library.
-
-```ts
-import { Resend } from "@trigger.dev/resend";
-import { Job, eventTrigger } from "@trigger.dev/sdk";
-import { z } from "zod";
-
-...
-
-const resend = new Resend({
-  id: "resend",
-  apiKey: process.env.RESEND_API_KEY!,
-});
-
-client.defineJob({
-  id: "send-resend-email",
-  name: "Send Resend Email",
-  version: "0.1.0",
-  trigger: eventTrigger({
-    name: "send.email",
-    schema: z.object({
-      to: z.union([z.string(), z.array(z.string())]),
-      subject: z.string(),
-      text: z.string(),
-    }),
-  }),
-  integrations: {
-    resend,
-  },
-  run: async (payload, io, ctx) => {
-    await io.resend.sendEmail("send-email", {
-      to: payload.to,
-      subject: payload.subject,
-      text: payload.text,
-      from: "Trigger.dev <hello@email.trigger.dev>",
-    });
-  },
-});
-```
-
 ## Tasks
 
-| Function Name | Description   |
-| ------------- | ------------- |
-| `sendEmail`   | Send an email |
+Once you have set up a Resend client, you can use it to create tasks.
+
+<CardGroup>
+  <Card title="Tasks" icon="sparkles" href="/integrations/apis/resend-tasks">
+    Perform tasks such as automating and scheduling of emails to clients over a period of time.
+  </Card>
+</CardGroup>

--- a/docs/integrations/apis/resend.mdx
+++ b/docs/integrations/apis/resend.mdx
@@ -36,7 +36,7 @@ yarn add @trigger.dev/resend@latest
 
 ## Authentication
 
-Resend supports API Keys
+Resend supports API Keys. You can find the official documentation on creating API keys for Resend [here](https://resend.com/docs/api-reference/api-keys/create-api-key).
 
 ```ts
 import { Resend } from "@trigger.dev/resend";

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -270,7 +270,13 @@
           ]
         },
         "integrations/apis/replicate",
-        "integrations/apis/resend",
+        {
+          "group": "Resend",
+          "pages": [
+            "integrations/apis/resend",
+            "integrations/apis/resend-tasks"
+          ]
+        },
         "integrations/apis/sendgrid",
         {
           "group": "Slack",


### PR DESCRIPTION
Closes #661 

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the docs site and it works properly.

---

## Testing

I locally deployed the Docs Website using Netlify and verified all the changes.


#### Video Snapshot

https://github.com/triggerdotdev/trigger.dev/assets/47860497/eebc64e7-20d8-4d51-9d21-5bee54c7ffd3

---

## Changelog

The Resend Documentation has been updated such that it follows the same format as the GitHub Integration.

Resend Documentation is now divided into two sections.
- Resend Overview and Authentication
- Resend tasks

---

## Screenshots

#### Overview and Authentication Page

![image](https://github.com/triggerdotdev/trigger.dev/assets/47860497/ea38bb26-9be1-434e-85c8-f63ba45a72e7)


#### Tasks Page

![tasks1](https://github.com/triggerdotdev/trigger.dev/assets/47860497/d7a1c95d-829b-460e-8bbc-47a5dac5c15e)


![tasks2](https://github.com/triggerdotdev/trigger.dev/assets/47860497/53f5a342-1414-4ec9-acbc-1bb235325a27)

