### PR TITLE
Fix: Allow errors and special values on Airtable field set

### DIFF
--- a/.changeset/silent-snails-float.md
+++ b/.changeset/silent-snails-float.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/airtable": patch
+---
+
+Extend the Airtable field set to accept formula errors and special values

--- a/integrations/airtable/src/base.ts
+++ b/integrations/airtable/src/base.ts
@@ -38,6 +38,8 @@ export class Table<TFields extends AirtableFieldSet> {
       async (client) => {
         const result = await client
           .base(this.baseId)
+          // official types are wrong - we need to use our extended AirtableFieldSet here
+          // @ts-ignore
           .table<TFields>(this.tableName)
           .select(params)
           .all();
@@ -55,6 +57,8 @@ export class Table<TFields extends AirtableFieldSet> {
     return this.runTask(
       key,
       async (client) => {
+        // official types are wrong - we need to use our extended AirtableFieldSet here
+        // @ts-ignore
         const result = await client.base(this.baseId).table<TFields>(this.tableName).find(recordId);
         return toSerializableRecord<TFields>(result);
       },
@@ -75,6 +79,8 @@ export class Table<TFields extends AirtableFieldSet> {
       async (client) => {
         const result = await client
           .base(this.baseId)
+          // official types are wrong - we need to use our extended AirtableFieldSet here
+          // @ts-ignore
           .table<TFields>(this.tableName)
           .create(records);
         return result.map((record) => toSerializableRecord<TFields>(record));
@@ -96,6 +102,8 @@ export class Table<TFields extends AirtableFieldSet> {
       async (client) => {
         const result = await client
           .base(this.baseId)
+          // official types are wrong - we need to use our extended AirtableFieldSet here
+          // @ts-ignore
           .table<TFields>(this.tableName)
           .update(records);
         return result.map((record) => toSerializableRecord<TFields>(record));
@@ -117,6 +125,8 @@ export class Table<TFields extends AirtableFieldSet> {
       async (client) => {
         const result = await client
           .base(this.baseId)
+          // official types are wrong - we need to use our extended AirtableFieldSet here
+          // @ts-ignore
           .table<TFields>(this.tableName)
           .destroy(recordIds);
         return result.map((record) => toSerializableRecord<TFields>(record));

--- a/integrations/airtable/src/types.ts
+++ b/integrations/airtable/src/types.ts
@@ -9,7 +9,8 @@ export type AirtableFieldSet = {
     | Collaborator
     | Collaborator[]
     | string[]
-    | Attachment[];
+    | Attachment[]
+    | Formula;
 };
 
 export type Collaborator = {
@@ -30,6 +31,16 @@ export type Attachment = {
     full: Thumbnail;
   };
 };
+
+export type FormulaError = {
+  error: string;
+};
+
+export type FormulaSpecialValue = {
+  specialValue: "Infinity" | "NaN";
+};
+
+export type Formula = string | number | FormulaError | FormulaSpecialValue;
 
 export type Thumbnail = {
   url: string;


### PR DESCRIPTION
Closes #645 

We may have to extend this further in the future. See https://github.com/Airtable/airtable.js/issues/389 and the proposed fix for even more types.

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Added a formula job to the Airtable entry in the `job-catalog`.

To test:

1. Create the fields as specified by the Formulas type.
2. Cause errors and special values by dividing by zero, leaving both number fields empty, etc.

---

## Changelog

- Extended the field set type by formula errors and special values
- Extended the `job-catalog` entry with a formula example

💯
