### PR TITLE
Fix: Set `NODE_ENV=production` in Supabase self-hosting docs

### DIFF
--- a/docs/documentation/guides/self-hosting/supabase.mdx
+++ b/docs/documentation/guides/self-hosting/supabase.mdx
@@ -29,6 +29,14 @@ ENCRYPTION_KEY=1189c93e399856a2a9a1454496171b2e
 ...
 ```
 
+3. Set `NODE_ENV` to production:
+
+```sh .env (excerpt)
+...
+NODE_ENV=production
+...
+```
+
 ## Create a Supabase DB
 
 <Tip>Alternative: [Self-host Supabase](https://supabase.com/docs/guides/self-hosting/docker)</Tip>
@@ -84,7 +92,7 @@ ENCRYPTION_KEY=1189c93e399856a2a9a1454496171b2e
 DATABASE_URL=postgresql://postgres:<PASSWORD>@db.<ID>.supabase.co:5432/postgres?schema=triggerdotdev
 DIRECT_URL=${DATABASE_URL}
 
-NODE_ENV=development
+NODE_ENV=production
 RUNTIME_PLATFORM=docker-compose
 ```
 


### PR DESCRIPTION
Closes #693 

Working as per issue report.

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

