### PR TITLE
fix: show only the current user's dev env in run-test page

### DIFF
--- a/apps/webapp/app/presenters/TestJobPresenter.server.ts
+++ b/apps/webapp/app/presenters/TestJobPresenter.server.ts
@@ -66,6 +66,18 @@ export class TestJobPresenter {
           },
           where: {
             name: "latest",
+            environment: {
+              OR: [
+                {
+                  orgMember: null,
+                },
+                {
+                  orgMember: {
+                    userId,
+                  },
+                },
+              ],
+            },
           },
         },
         runs: {


### PR DESCRIPTION
Closes #710

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

- Verified that the environment shows only the current user's `dev` environment.
- Verified that the triggered test-run is associated with the current user's `dev` environment.

---

## Changelog

Filter the current user's dev environment when fetching job info in the `TestJobPresenter`.

---

## Screenshots

**Before**
<br>
![Screenshot 2023-10-31 at 10 53 39 AM](https://github.com/triggerdotdev/trigger.dev/assets/132386067/ceb9498a-5b9a-4897-a781-2d96fb2284df)

**After**
<br>
![Screenshot 2023-10-31 at 10 53 17 AM](https://github.com/triggerdotdev/trigger.dev/assets/132386067/25024366-687d-4816-ae71-0e071f4dac84)


💯
