### PR TITLE
fix: set auth-method for OAuth integration clients

### DIFF
--- a/apps/webapp/app/presenters/IntegrationClientPresenter.server.ts
+++ b/apps/webapp/app/presenters/IntegrationClientPresenter.server.ts
@@ -121,11 +121,11 @@ export class IntegrationClientPresenter {
       },
       authMethod: {
         type:
-          integration.authMethod?.type ?? integration.authSource === "RESOLVER" ? "local" : "local",
+          integration.authMethod?.type ??
+          (integration.authSource === "RESOLVER" ? "local" : "local"),
         name:
-          integration.authMethod?.name ?? integration.authSource === "RESOLVER"
-            ? "Auth Resolver"
-            : "Local Auth",
+          integration.authMethod?.name ??
+          (integration.authSource === "RESOLVER" ? "Auth Resolver" : "Local Auth"),
       },
       help,
     };


### PR DESCRIPTION
## Issue
The additional tabs (Connections, and Scopes) for OAuth connections were not displayed.
This is because the nullish coalescing operator takes precedence over ternary operator. So, the auth-method type and name were not set properly when the auth-method is OAuth.

Operator Precedence Explanation: [Stack Overflow](https://stackoverflow.com/a/67575538/21819000)

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Verified that the additional tabs are displayed for OAuth integrations

---

## Changelog

- Wrap the auth-source ternary check in parenthesis to increase operator precedence

---

## Screenshots

**Before**
<br>
<img width="341" alt="Screenshot 2023-10-31 at 12 56 38 PM" src="https://github.com/triggerdotdev/trigger.dev/assets/132386067/50756597-2a8d-4b23-9b57-193ec8a02109">
<br>
**After**
<br>
<img width="329" alt="Screenshot 2023-10-31 at 12 54 41 PM" src="https://github.com/triggerdotdev/trigger.dev/assets/132386067/30c254c4-038a-459b-b811-72332bbdebf4">


💯
