### PR TITLE
Fix: [TRI-1444] Only allow logins from whitelisted_emails (for self-hosting)#685

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,8 @@ APP_ORIGIN=http://localhost:3030
 NODE_ENV=development
 
 # OPTIONAL VARIABLES
+# This is used for Restricting logins other than whitelisted emails for self-hosted authentication.
+#WHITELISTED_EMAILS="matt@gmail\.com|jane@yahoo\.com"
 # This is used for logging in via GitHub. You can leave these commented out if you don't want to use GitHub for authentication.
 # AUTH_GITHUB_CLIENT_ID=
 # AUTH_GITHUB_CLIENT_SECRET=

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -10,6 +10,7 @@ const EnvironmentSchema = z.object({
   SESSION_SECRET: z.string(),
   MAGIC_LINK_SECRET: z.string(),
   ENCRYPTION_KEY: z.string(),
+  WHITELISTED_EMAILS:z.string().optional(),
   REMIX_APP_PORT: z.string().optional(),
   LOGIN_ORIGIN: z.string().default("http://localhost:3030"),
   APP_ORIGIN: z.string().default("http://localhost:3030"),

--- a/apps/webapp/app/routes/magic.tsx
+++ b/apps/webapp/app/routes/magic.tsx
@@ -7,6 +7,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   await authenticator.authenticate("email-link", request, {
     successRedirect: redirectTo ?? "/",
-    failureRedirect: "/login",
+    failureRedirect: "/login/magic",
   });
 }

--- a/apps/webapp/app/services/auth.server.ts
+++ b/apps/webapp/app/services/auth.server.ts
@@ -11,7 +11,7 @@ const authenticator = new Authenticator<AuthUser>(sessionStorage);
 
 const isGithubAuthSupported =
   typeof env.AUTH_GITHUB_CLIENT_ID === "string" &&
-  typeof env.AUTH_GITHUB_CLIENT_SECRET === "string";
+  typeof env.AUTH_GITHUB_CLIENT_SECRET === "string" && !env.WHITELISTED_EMAILS;
 
 if (env.AUTH_GITHUB_CLIENT_ID && env.AUTH_GITHUB_CLIENT_SECRET) {
   addGitHubStrategy(authenticator, env.AUTH_GITHUB_CLIENT_ID, env.AUTH_GITHUB_CLIENT_SECRET);


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

## Steps

1. **Setting `WHITELISTED_EMAILS` in `.env.example`**:
   - I added the `WHITELISTED_EMAILS`(which is optional) variable to `.env.example` under `# OPTIONAL VARIABLES` with the value `matt@gmail\.com|jane@yahoo\.com`.
   - I ensured that the application reads this environment variable correctly.
   - I have implimented the changes mentioned in the last PR https://github.com/triggerdotdev/trigger.dev/pull/692#issue-1964822193

## Testing

I have tested the changes in this pull request as follows:
1. ** Values to check wether the `WHITELISTED_EMAILS` validation works 
   - `matt@gmail.com` or `jane@yahoo.com`

## Screenshots


https://github.com/triggerdotdev/trigger.dev/assets/106991686/717704f3-5d3f-4fc1-9458-072b0614fe5c



💯
