### PR TITLE
FIX: [TRI-1444] Allow only logins from WHITELISTED_EMAILS fixes #685

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,8 @@ APP_ORIGIN=http://localhost:3030
 NODE_ENV=development
 
 # OPTIONAL VARIABLES
+# This is used for validating emails that are allowed to log in. Every email that do not match this regex will be rejected.
+# WHITELISTED_EMAILS="authorized@yahoo\.com|authorized@gmail\.com"
 # This is used for logging in via GitHub. You can leave these commented out if you don't want to use GitHub for authentication.
 # AUTH_GITHUB_CLIENT_ID=
 # AUTH_GITHUB_CLIENT_SECRET=

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { SecretStoreOptionsSchema } from "./services/secrets/secretStore.server";
+import { isValidRegex } from "./utils/regex";
 
 const EnvironmentSchema = z.object({
   NODE_ENV: z.union([z.literal("development"), z.literal("production"), z.literal("test")]),
@@ -10,6 +11,7 @@ const EnvironmentSchema = z.object({
   SESSION_SECRET: z.string(),
   MAGIC_LINK_SECRET: z.string(),
   ENCRYPTION_KEY: z.string(),
+  WHITELISTED_EMAILS: z.string().refine(isValidRegex, "WHITELISTED_EMAILS must be a valid regex.").optional(),
   REMIX_APP_PORT: z.string().optional(),
   LOGIN_ORIGIN: z.string().default("http://localhost:3030"),
   APP_ORIGIN: z.string().default("http://localhost:3030"),

--- a/apps/webapp/app/models/user.server.ts
+++ b/apps/webapp/app/models/user.server.ts
@@ -1,6 +1,7 @@
 import type { Prisma, User } from "@trigger.dev/database";
 import type { GitHubProfile } from "remix-auth-github";
 import { prisma } from "~/db.server";
+import { env } from "~/env.server";
 export type { User } from "@trigger.dev/database";
 
 type FindOrCreateMagicLink = {
@@ -36,6 +37,10 @@ export async function findOrCreateUser(input: FindOrCreateUser): Promise<LoggedI
 export async function findOrCreateMagicLinkUser(
   input: FindOrCreateMagicLink
 ): Promise<LoggedInUser> {
+  if (env.WHITELISTED_EMAILS && !new RegExp(env.WHITELISTED_EMAILS).test(input.email)) {
+    throw new Error("This email is unauthorized");
+  }
+
   const existingUser = await prisma.user.findFirst({
     where: {
       email: input.email,

--- a/apps/webapp/app/routes/magic.tsx
+++ b/apps/webapp/app/routes/magic.tsx
@@ -7,6 +7,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   await authenticator.authenticate("email-link", request, {
     successRedirect: redirectTo ?? "/",
-    failureRedirect: "/login",
+    failureRedirect: "/login/magic",
   });
 }

--- a/apps/webapp/app/utils/regex.ts
+++ b/apps/webapp/app/utils/regex.ts
@@ -1,0 +1,8 @@
+export function isValidRegex(regex: string) {
+  try {
+    new RegExp(regex);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}


### PR DESCRIPTION
Closes #685 

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

1. Set `WHITELISTED_EMAILS` in .env with a regex with allowed emails.
2. Start the webapp with the command `pnpm run dev --filter webapp`.
3. Trying to log in with an unauthorized email should show an error.
4. Trying to log in with an authorized email should log in or create the account.

---

## Changelog

User can now set a WHITELISTED_EMAILS environment variable that must be a valid Regex to list the authorized emails.

---

## Screenshots

![image](https://github.com/triggerdotdev/trigger.dev/assets/6059379/c8d51ef2-c1ab-459b-9321-6391029e8ba9)

💯
