### PR TITLE
Upgrade resend integration to use resend-node 2.0.0

### DIFF
--- a/.changeset/mighty-dodos-study.md
+++ b/.changeset/mighty-dodos-study.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/resend": patch
+---
+
+Upgrade resend integration to use resend-node 2.0.0

--- a/docs/integrations/apis/resend.mdx
+++ b/docs/integrations/apis/resend.mdx
@@ -67,7 +67,7 @@ client.defineJob({
     resend,
   },
   run: async (payload, io, ctx) => {
-    await io.resend.sendEmail("send-email", {
+    await io.resend.emails.send("send-email", {
       to: payload.to,
       subject: payload.subject,
       text: payload.text,
@@ -79,6 +79,10 @@ client.defineJob({
 
 ## Tasks
 
-| Function Name | Description   |
-| ------------- | ------------- |
-| `sendEmail`   | Send an email |
+| Function Name   | Description                      |
+| --------------- | -------------------------------- |
+| `emails.send`   | Send an email                    |
+| `emails.create` | Create an email                  |
+| `emails.get`    | Get an email                     |
+| `batch.send`    | Send a batch of emails at once   |
+| `batch.create`  | Create a batch of emails at once |

--- a/integrations/resend/package.json
+++ b/integrations/resend/package.json
@@ -26,9 +26,9 @@
   "dependencies": {
     "@trigger.dev/integration-kit": "workspace:^2.2.4",
     "@trigger.dev/sdk": "workspace:^2.2.4",
-    "resend": "^1.0.0"
+    "resend": "^2.0.0"
   },
   "engines": {
-    "node": ">=16.8.0"
+    "node": ">=18.0.0"
   }
 }

--- a/integrations/resend/src/batch.ts
+++ b/integrations/resend/src/batch.ts
@@ -1,0 +1,81 @@
+import { IntegrationTaskKey, retry } from "@trigger.dev/sdk";
+import { Resend } from "resend";
+import type { ResendRunTask } from "./index";
+import { handleResendError } from "./utils";
+
+type SendEmailResult = NonNullable<Awaited<ReturnType<Resend["batch"]["send"]>>["data"]>;
+type CreateEmailResult = NonNullable<Awaited<ReturnType<Resend["batch"]["create"]>>["data"]>;
+
+export class Batch {
+  constructor(private runTask: ResendRunTask) {}
+
+  send(
+    key: IntegrationTaskKey,
+    payload: Parameters<Resend["batch"]["send"]>[0],
+    options?: Parameters<Resend["batch"]["send"]>[1]
+  ): Promise<SendEmailResult> {
+    return this.runTask(
+      key,
+      async (client, task) => {
+        const { error, data } = await client.batch.send(payload, options);
+
+        if (error) {
+          throw error;
+        }
+
+        if (!data) {
+          throw new Error("No data returned from Resend");
+        }
+
+        return data;
+      },
+      {
+        name: "Send Batch Email",
+        params: payload,
+        properties: [
+          {
+            label: "Count",
+            text: String(payload.length),
+          },
+        ],
+        retry: retry.standardBackoff,
+      },
+      handleResendError
+    );
+  }
+
+  create(
+    key: IntegrationTaskKey,
+    payload: Parameters<Resend["batch"]["create"]>[0],
+    options?: Parameters<Resend["batch"]["create"]>[1]
+  ): Promise<CreateEmailResult> {
+    return this.runTask(
+      key,
+      async (client, task) => {
+        const { error, data } = await client.batch.create(payload, options);
+
+        if (error) {
+          throw error;
+        }
+
+        if (!data) {
+          throw new Error("No data returned from Resend");
+        }
+
+        return data;
+      },
+      {
+        name: "Create Batch Email",
+        params: payload,
+        properties: [
+          {
+            label: "Count",
+            text: String(payload.length),
+          },
+        ],
+        retry: retry.standardBackoff,
+      },
+      handleResendError
+    );
+  }
+}

--- a/integrations/resend/src/emails.ts
+++ b/integrations/resend/src/emails.ts
@@ -1,0 +1,123 @@
+import { IntegrationTaskKey, Prettify, retry } from "@trigger.dev/sdk";
+import type { ResendRunTask } from "./index";
+import { Resend } from "resend";
+import { handleResendError } from "./utils";
+
+type SendEmailResult = NonNullable<Awaited<ReturnType<Resend["emails"]["send"]>>["data"]>;
+type CreateEmailResult = NonNullable<Awaited<ReturnType<Resend["emails"]["create"]>>["data"]>;
+type GetEmailResult = NonNullable<Awaited<ReturnType<Resend["emails"]["get"]>>["data"]>;
+
+export class Emails {
+  constructor(private runTask: ResendRunTask) {}
+
+  send(
+    key: IntegrationTaskKey,
+    payload: Parameters<Resend["emails"]["send"]>[0],
+    options?: Parameters<Resend["emails"]["send"]>[1]
+  ): Promise<SendEmailResult> {
+    return this.runTask(
+      key,
+      async (client, task) => {
+        const { error, data } = await client.emails.send(payload, options);
+
+        if (error) {
+          throw error;
+        }
+
+        if (!data) {
+          throw new Error("No data returned from Resend");
+        }
+
+        return data;
+      },
+      {
+        name: "Send Email",
+        params: payload,
+        properties: [
+          {
+            label: "From",
+            text: payload.from,
+          },
+          {
+            label: "To",
+            text: Array.isArray(payload.to) ? payload.to.join(", ") : payload.to,
+          },
+          ...(payload.subject ? [{ label: "Subject", text: payload.subject }] : []),
+        ],
+        retry: retry.standardBackoff,
+      },
+      handleResendError
+    );
+  }
+
+  create(
+    key: IntegrationTaskKey,
+    payload: Parameters<Resend["emails"]["create"]>[0],
+    options?: Parameters<Resend["emails"]["create"]>[1]
+  ): Promise<CreateEmailResult> {
+    return this.runTask(
+      key,
+      async (client, task) => {
+        const { error, data } = await client.emails.create(payload, options);
+
+        if (error) {
+          throw error;
+        }
+
+        if (!data) {
+          throw new Error("No data returned from Resend");
+        }
+
+        return data;
+      },
+      {
+        name: "Create Email",
+        params: payload,
+        properties: [
+          {
+            label: "From",
+            text: payload.from,
+          },
+          {
+            label: "To",
+            text: Array.isArray(payload.to) ? payload.to.join(", ") : payload.to,
+          },
+          ...(payload.subject ? [{ label: "Subject", text: payload.subject }] : []),
+        ],
+        retry: retry.standardBackoff,
+      },
+      handleResendError
+    );
+  }
+
+  get(key: IntegrationTaskKey, payload: string): Promise<GetEmailResult> {
+    return this.runTask(
+      key,
+      async (client, task) => {
+        const { error, data } = await client.emails.get(payload);
+
+        if (error) {
+          throw error;
+        }
+
+        if (!data) {
+          throw new Error("No data returned from Resend");
+        }
+
+        return data;
+      },
+      {
+        name: "Get Email",
+        params: payload,
+        properties: [
+          {
+            label: "ID",
+            text: payload,
+          },
+        ],
+        retry: retry.standardBackoff,
+      },
+      handleResendError
+    );
+  }
+}

--- a/integrations/resend/src/utils.ts
+++ b/integrations/resend/src/utils.ts
@@ -1,0 +1,52 @@
+import { ErrorResponse } from "resend";
+
+interface ResendErrorResponse extends ErrorResponse {
+  statusCode: number;
+}
+
+function isRequestError(error: unknown): error is ResendErrorResponse {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    "name" in error &&
+    typeof error.name === "string" &&
+    "statusCode" in error &&
+    typeof error.statusCode === "number"
+  );
+}
+
+// See https://resend.com/docs/api-reference/errors
+const retriableErrorCode = ["rate_limit_exceeded", "application_error", "internal_server_error"];
+
+export function handleResendError(error: unknown) {
+  if (isRequestError(error)) {
+    if (retriableErrorCode.includes(error.name)) {
+      return error;
+    }
+
+    return {
+      skipRetrying: true,
+      error,
+    };
+  }
+
+  if (error instanceof Error) {
+    return error;
+  }
+
+  if (typeof error === "string") {
+    return new Error(error);
+  }
+
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return new Error(error.message);
+  }
+
+  return new Error("Unknown error");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -530,13 +530,13 @@ importers:
       '@trigger.dev/sdk': workspace:^2.2.4
       '@trigger.dev/tsconfig': workspace:*
       '@types/node': '18'
-      resend: ^1.0.0
+      resend: ^2.0.0
       rimraf: ^3.0.2
       tsup: ^6.5.0
     dependencies:
       '@trigger.dev/integration-kit': link:../../packages/integration-kit
       '@trigger.dev/sdk': link:../../packages/trigger-sdk
-      resend: 1.0.0
+      resend: 2.0.0
     devDependencies:
       '@trigger.dev/tsconfig': link:../../config-packages/tsconfig
       '@types/node': 18.15.13
@@ -10601,6 +10601,16 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
+  /@react-email/render/0.0.9:
+    resolution: {integrity: sha512-nrim7wiACnaXsGtL7GF6jp3Qmml8J6vAjAH88jkC8lIbfNZaCyuPQHANjyYIXlvQeAbsWADQJFZgOHUqFqjh/A==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      html-to-text: 9.0.5
+      pretty: 2.0.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
+
   /@react-email/section/0.0.1:
     resolution: {integrity: sha512-Pb2HcGNhTOtFRJVB+Kq2vTUnd8M+LuZBuHfpUD16ua/m2/mbW5WeXAfSuJ2Tl6qspzvDKLHqVX+o6HBc1qgl2Q==}
     dependencies:
@@ -11152,6 +11162,13 @@ packages:
     dependencies:
       domhandler: 5.0.3
       selderee: 0.10.0
+    dev: false
+
+  /@selderee/plugin-htmlparser2/0.11.0:
+    resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
+    dependencies:
+      domhandler: 5.0.3
+      selderee: 0.11.0
     dev: false
 
   /@sendgrid/client/7.7.0:
@@ -17627,7 +17644,6 @@ packages:
   /deepmerge/4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /default-browser-id/3.0.0:
     resolution: {integrity: sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==}
@@ -20552,7 +20568,7 @@ packages:
       chalk: 4.1.2
       chokidar: 3.5.3
       cosmiconfig: 7.1.0
-      deepmerge: 4.2.2
+      deepmerge: 4.3.1
       fs-extra: 10.1.0
       memfs: 3.5.3
       minimatch: 3.1.2
@@ -21581,6 +21597,17 @@ packages:
       selderee: 0.10.0
     dev: false
 
+  /html-to-text/9.0.5:
+    resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@selderee/plugin-htmlparser2': 0.11.0
+      deepmerge: 4.3.1
+      dom-serializer: 2.0.0
+      htmlparser2: 8.0.2
+      selderee: 0.11.0
+    dev: false
+
   /html-void-elements/2.0.1:
     resolution: {integrity: sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==}
 
@@ -21609,6 +21636,15 @@ packages:
 
   /htmlparser2/8.0.1:
     resolution: {integrity: sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.0.1
+      entities: 4.4.0
+    dev: false
+
+  /htmlparser2/8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
     dependencies:
       domelementtype: 2.3.0
       domhandler: 5.0.3
@@ -26130,6 +26166,13 @@ packages:
       peberminta: 0.8.0
     dev: false
 
+  /parseley/0.12.1:
+    resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
+    dependencies:
+      leac: 0.6.0
+      peberminta: 0.9.0
+    dev: false
+
   /parseurl/1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -26220,6 +26263,10 @@ packages:
 
   /peberminta/0.8.0:
     resolution: {integrity: sha512-YYEs+eauIjDH5nUEGi18EohWE0nV2QbGTqmxQcqgZ/0g+laPCQmuIqq7EBLVi9uim9zMgfJv0QBZEnQ3uHw/Tw==}
+    dev: false
+
+  /peberminta/0.9.0:
+    resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
     dev: false
 
   /peek-stream/1.1.3:
@@ -28218,15 +28265,11 @@ packages:
       - debug
     dev: false
 
-  /resend/1.0.0:
-    resolution: {integrity: sha512-8LEE4gncmcm8bsvxvahZFpFk5hxUrKdagqWoX/MRXVU2YZ9coYxqZDeDYXG9pexz1A694bjE1hiQbBAA+bHAow==}
-    engines: {node: '>=16'}
+  /resend/2.0.0:
+    resolution: {integrity: sha512-jAh0DN84ZjjmzGM2vMjJ1hphPBg1mG98dzopF7kJzmin62v8ESg4og2iCKWdkAboGOT2SeO5exbr/8Xh8gLddw==}
+    engines: {node: '>=18'}
     dependencies:
-      '@react-email/render': 0.0.7
-      node-fetch: 2.6.12
-      type-fest: 3.13.0
-    transitivePeerDependencies:
-      - encoding
+      '@react-email/render': 0.0.9
     dev: false
 
   /resize-observer-polyfill/1.5.1:
@@ -28618,6 +28661,12 @@ packages:
     resolution: {integrity: sha512-DEL/RW/f4qLw/NrVg97xKaEBC8IpzIG2fvxnzCp3Z4yk4jQ3MXom+Imav9wApjxX2dfS3eW7x0DXafJr85i39A==}
     dependencies:
       parseley: 0.11.0
+    dev: false
+
+  /selderee/0.11.0:
+    resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
+    dependencies:
+      parseley: 0.12.1
     dev: false
 
   /sembear/0.5.2:


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Added additional usages of Resend to the job reference file, as well as tested the deprecated API

---

## Changelog

- Upgrade resend integration package to use the [v2.0.0](https://github.com/resendlabs/resend-node/releases/tag/v2.0.0) resend SDK
- Fixes an issue where `@trigger.dev/resend` wasn't usable on Next.js 14
- Added batch APIs
- Added `emails.get`
- Adopt the "fluent" interface style of the SDK, and deprecate `io.resend.sendEmail`
