### PR TITLE
Fix for #731, integrations getting stuck if OAuth then moved to API key

### DIFF
--- a/apps/webapp/app/services/jobs/registerJob.server.ts
+++ b/apps/webapp/app/services/jobs/registerJob.server.ts
@@ -446,6 +446,7 @@ export class RegisterJobService {
             title: jobIntegration.metadata.name,
             authSource: "LOCAL",
             connectionType: "DEVELOPER",
+            setupStatus: "COMPLETE",
             definition: {
               connectOrCreate: {
                 where: {
@@ -524,6 +525,7 @@ export class RegisterJobService {
             title: jobIntegration.metadata.name,
             authSource: "RESOLVER",
             connectionType: "EXTERNAL",
+            setupStatus: "COMPLETE",
             definition: {
               connectOrCreate: {
                 where: {


### PR DESCRIPTION
Closes #731 

## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [ ] The PR title follows the convention.
- [ ] I ran and tested the code works

---

## Testing

- [ ] Create an integration that's OAuth (like SendGrid)
- [ ] Sync it to the dashboard
- [ ] Check it's in an incomplete state on the integrations page
- [ ] In your code add an `apiKey`
- [ ] Save and sync
- [ ] The integration should now be setup as "LOCAL"