### PR TITLE
Fix: Shopify build and webhook indexing

### DIFF
--- a/integrations/shopify/tsup.config.ts
+++ b/integrations/shopify/tsup.config.ts
@@ -1,7 +1,22 @@
-import { defineConfig, deepMergeOptions, integrationOptions } from "@trigger.dev/tsup";
+import { defineConfig } from "tsup";
 
-const options = deepMergeOptions(integrationOptions, {
-  // extend base config here
-});
-
-export default defineConfig(options);
+export default defineConfig([
+  {
+    name: "main",
+    entry: ["./src/index.ts"],
+    outDir: "./dist",
+    platform: "node",
+    format: ["cjs"],
+    legacyOutput: true,
+    sourcemap: true,
+    clean: true,
+    bundle: true,
+    splitting: false,
+    dts: true,
+    treeshake: {
+      preset: "smallest",
+    },
+    esbuildPlugins: [],
+    external: ["http", "https", "util", "events", "tty", "os", "timers"],
+  },
+]);

--- a/packages/core/src/schemas/api.ts
+++ b/packages/core/src/schemas/api.ts
@@ -380,7 +380,7 @@ export type HttpEndpointMetadata = z.infer<typeof HttpEndpointMetadataSchema>;
 export const IndexEndpointResponseSchema = z.object({
   jobs: z.array(JobMetadataSchema),
   sources: z.array(SourceMetadataSchema),
-  webhooks: z.array(WebhookMetadataSchema),
+  webhooks: z.array(WebhookMetadataSchema).optional(),
   dynamicTriggers: z.array(DynamicTriggerEndpointMetadataSchema),
   dynamicSchedules: z.array(RegisterDynamicSchedulePayloadSchema),
   httpEndpoints: z.array(HttpEndpointMetadataSchema).optional(),


### PR DESCRIPTION
- The Shopify build was trying to use the new `@trigger.dev/tsup` package that hasn't been merged yet
- To support old SDKs, webhooks may now be undefined while indexing