### PR TITLE
Ensure jobs are configured for Resumability

### DIFF
--- a/.changeset/tough-fans-clean.md
+++ b/.changeset/tough-fans-clean.md
@@ -1,0 +1,6 @@
+---
+"@trigger.dev/sdk": patch
+"@trigger.dev/core": patch
+---
+
+Ensure jobs are configured for Resumability

--- a/apps/webapp/app/components/run/RunCompletedDetail.tsx
+++ b/apps/webapp/app/components/run/RunCompletedDetail.tsx
@@ -52,7 +52,13 @@ export function RunCompletedDetail({ run }: { run: MatchedRun }) {
           )}
         </RunPanelIconSection>
         <RunPanelDivider />
-        {run.error && <RunPanelError text={run.error.message} stackTrace={run.error.stack} />}
+        {run.error && (
+          <RunPanelError
+            text={run.error.message}
+            error={JSON.stringify(run.error.output, null, 2)}
+            stackTrace={run.error.stack}
+          />
+        )}
         {run.output ? (
           <CodeBlock language="json" code={run.output} maxLines={36} />
         ) : (

--- a/apps/webapp/app/components/run/RunOverview.tsx
+++ b/apps/webapp/app/components/run/RunOverview.tsx
@@ -164,6 +164,17 @@ export function RunOverview({ run, trigger, showRerun, paths }: RunOverviewProps
         <div className="grid h-full grid-cols-2 gap-2">
           <div className="flex flex-col gap-6 overflow-y-auto py-4 pl-4 pr-2 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-slate-700">
             <div>
+              {run.impure && (
+                <Callout
+                  variant={"error"}
+                  to="https://trigger.dev/docs/documentation/concepts/tasks"
+                  className="mb-4"
+                >
+                  This Run produces some side-effects (external API calls, random number generators,
+                  etc.) that are not wrapped in Tasks - this can cause unpredictable results. Read
+                  the docs to view the solution.
+                </Callout>
+              )}
               {run.status === "SUCCESS" &&
                 (run.tasks.length === 0 || run.tasks.every((t) => t.noop)) && (
                   <Callout
@@ -261,7 +272,11 @@ export function RunOverview({ run, trigger, showRerun, paths }: RunOverviewProps
                     </RunPanelIconSection>
                     <RunPanelDivider />
                     {run.error && (
-                      <RunPanelError text={run.error.message} stackTrace={run.error.stack} />
+                      <RunPanelError
+                        text={run.error.message}
+                        error={JSON.stringify(run.error.output, null, 2)}
+                        stackTrace={run.error.stack}
+                      />
                     )}
                     {run.output ? (
                       <CodeBlock language="json" code={run.output} maxLines={10} />

--- a/apps/webapp/app/components/run/TaskCard.tsx
+++ b/apps/webapp/app/components/run/TaskCard.tsx
@@ -77,7 +77,13 @@ export function TaskCard({
             styleName={style?.style}
           />
           <RunPanelBody>
-            {error && <RunPanelError text={error.message} stackTrace={error.stack} />}
+            {error && (
+              <RunPanelError
+                text={error.message}
+                error={JSON.stringify(error.output, null, 2)}
+                stackTrace={error.stack}
+              />
+            )}
             {description && <RunPanelDescription text={description} variant={style?.variant} />}
             <RunPanelIconSection>
               {displayKey && <RunPanelIconProperty icon="key" label="Key" value={displayKey} />}

--- a/apps/webapp/app/presenters/RunPresenter.server.ts
+++ b/apps/webapp/app/presenters/RunPresenter.server.ts
@@ -87,6 +87,7 @@ export class RunPresenter {
       error: runError,
       executionDuration: run.executionDuration,
       executionCount: run.executionCount,
+      impure: run.impure,
     };
   }
 
@@ -119,6 +120,7 @@ export class RunPresenter {
         output: true,
         executionCount: true,
         executionDuration: true,
+        impure: true,
         version: {
           select: {
             version: true,

--- a/packages/core/src/schemas/api.ts
+++ b/packages/core/src/schemas/api.ts
@@ -708,6 +708,19 @@ export const RunJobCanceledWithTaskSchema = z.object({
 
 export type RunJobCanceledWithTask = z.infer<typeof RunJobCanceledWithTaskSchema>;
 
+export const RunJobImpureErrorSchema = z.object({
+  status: z.literal("IMPURE_JOB"),
+  error: z.object({
+    message: z.string(),
+    output: z.object({
+      initial: DeserializedJsonSchema.optional(),
+      reRun: DeserializedJsonSchema.optional(),
+    }),
+  }),
+});
+
+export type RunJobImpureError = z.infer<typeof RunJobImpureErrorSchema>;
+
 export const RunJobSuccessSchema = z.object({
   status: z.literal("SUCCESS"),
   output: DeserializedJsonSchema.optional(),
@@ -716,6 +729,7 @@ export const RunJobSuccessSchema = z.object({
 export type RunJobSuccess = z.infer<typeof RunJobSuccessSchema>;
 
 export const RunJobErrorResponseSchema = z.union([
+  RunJobImpureErrorSchema,
   RunJobAutoYieldExecutionErrorSchema,
   RunJobAutoYieldWithCompletedTaskExecutionErrorSchema,
   RunJobYieldExecutionErrorSchema,
@@ -738,6 +752,7 @@ export const RunJobResumeWithParallelTaskSchema = z.object({
 export type RunJobResumeWithParallelTask = z.infer<typeof RunJobResumeWithParallelTaskSchema>;
 
 export const RunJobResponseSchema = z.discriminatedUnion("status", [
+  RunJobImpureErrorSchema,
   RunJobAutoYieldExecutionErrorSchema,
   RunJobAutoYieldWithCompletedTaskExecutionErrorSchema,
   RunJobYieldExecutionErrorSchema,

--- a/packages/core/src/schemas/errors.ts
+++ b/packages/core/src/schemas/errors.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
+import { DeserializedJsonSchema } from "./json";
 
 export const ErrorWithStackSchema = z.object({
   message: z.string(),
   name: z.string().optional(),
   stack: z.string().optional(),
+  output: DeserializedJsonSchema.optional(),
 });
 
 export type ErrorWithStack = z.infer<typeof ErrorWithStackSchema>;

--- a/packages/database/prisma/migrations/20231129180410_add_impure_to_job_run/migration.sql
+++ b/packages/database/prisma/migrations/20231129180410_add_impure_to_job_run/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "JobRun" ADD COLUMN     "impure" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -794,6 +794,8 @@ model JobRun {
 
   forceYieldImmediately Boolean @default(false)
 
+  impure Boolean @default(false)
+
   tasks              Task[]
   runConnections     RunConnection[]
   missingConnections MissingConnection[]

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,5 +1,6 @@
 import {
   RunJobBody,
+  RuntimeEnvironmentType,
   SendEvent,
   SendEventBodySchema,
   SendEventOptions,
@@ -85,7 +86,11 @@ const buildRequest = (action: TriggerAction, apiKey: string, opts: Record<string
   });
 };
 
-const buildRequestBody = (event: RunJobBody["event"], job: RunJobBody["job"]): RunJobBody => ({
+const buildRequestBody = (
+  event: RunJobBody["event"],
+  job: RunJobBody["job"],
+  env?: RuntimeEnvironmentType
+): RunJobBody => ({
   event,
   job,
   run: {
@@ -97,7 +102,7 @@ const buildRequestBody = (event: RunJobBody["event"], job: RunJobBody["job"]): R
   environment: {
     id: String(Math.random()),
     slug: "test-env",
-    type: "DEVELOPMENT",
+    type: env ?? "DEVELOPMENT",
   },
   organization: {
     id: String(Math.random()),
@@ -117,6 +122,7 @@ export const createJobTester =
     opts: {
       payload?: TriggerEventType<TTrigger>;
       tasks?: TTasks;
+      env?: RuntimeEnvironmentType;
     } = {}
   ): Promise<
     {
@@ -193,7 +199,7 @@ export const createJobTester =
     };
 
     const request = buildRequest("EXECUTE_JOB", client.apiKey() ?? "", {
-      body: buildRequestBody(eventLog, job),
+      body: buildRequestBody(eventLog, job, opts.env),
       jobId: job.id,
     });
     const requestResult = await client.handleRequest(request);

--- a/packages/trigger-sdk/src/errors.ts
+++ b/packages/trigger-sdk/src/errors.ts
@@ -1,5 +1,9 @@
-import { DisplayProperty } from "@trigger.dev/core";
+import { DeserializedJson, DisplayProperty } from "@trigger.dev/core";
 import { ErrorWithStack, SchemaError, ServerTask } from "@trigger.dev/core";
+
+export class ImpureJobError {
+  constructor(public output: { initial?: DeserializedJson; reRun?: DeserializedJson }) {}
+}
 
 export class ResumeWithTaskError {
   constructor(public task: ServerTask) {}


### PR DESCRIPTION
This PR adds the ability to detect when job runs can produce inconsistent output (when timed out / network issues).

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

- Verified the callout is displayed for impure jobs only.

---

## Changelog

- Re-run internal jobs when in the development environment.
- Throw an `ImpureJobError` and display a Banner/Callout in `RunOverview`.

---

## Screen Recording
https://github.com/triggerdotdev/trigger.dev/assets/132386067/f3134144-37fa-418f-8261-dcfe31220193



💯
