### PR TITLE
Fixed node:buffer import in `@trigger.dev/core`

### DIFF
--- a/.changeset/wild-bananas-drop.md
+++ b/.changeset/wild-bananas-drop.md
@@ -1,0 +1,7 @@
+---
+"@trigger.dev/core-backend": patch
+"@trigger.dev/sdk": patch
+"@trigger.dev/core": patch
+---
+
+Moved Logger to core-backend, no longer importing node:buffer in core/react

--- a/apps/webapp/app/services/db/pgListen.server.ts
+++ b/apps/webapp/app/services/db/pgListen.server.ts
@@ -1,9 +1,9 @@
+import { Logger } from "@trigger.dev/core-backend";
 import type { PoolClient } from "pg";
 import { z } from "zod";
-import { Logger } from "@trigger.dev/core";
 import { logger } from "~/services/logger.server";
-import { NotificationCatalog, NotificationChannel, notificationCatalog } from "./types";
 import { safeJsonParse } from "~/utils/json";
+import { NotificationCatalog, NotificationChannel, notificationCatalog } from "./types";
 
 export class PgListenService {
   #poolClient: PoolClient;

--- a/apps/webapp/app/services/logger.server.ts
+++ b/apps/webapp/app/services/logger.server.ts
@@ -1,5 +1,5 @@
-import type { LogLevel } from "@trigger.dev/core";
-import { Logger } from "@trigger.dev/core";
+import type { LogLevel } from "@trigger.dev/core-backend";
+import { Logger } from "@trigger.dev/core-backend";
 import { sensitiveDataReplacer } from "./sensitiveDataReplacer";
 import { AsyncLocalStorage } from "async_hooks";
 

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./bloom";
+export * from "./logger";

--- a/packages/core-backend/src/logger.ts
+++ b/packages/core-backend/src/logger.ts
@@ -196,11 +196,5 @@ function prettyPrintBytes(value: unknown): string {
 function getSizeInBytes(value: unknown) {
   const jsonString = JSON.stringify(value);
 
-  if (typeof window === "undefined") {
-    // Node.js environment
-    return Buffer.byteLength(jsonString, "utf8");
-  } else {
-    // Browser environment
-    return new TextEncoder().encode(jsonString).length;
-  }
+  return Buffer.byteLength(jsonString, "utf8");
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,3 @@
-export * from "./logger";
 export * from "./schemas";
 export * from "./types";
 export * from "./utils";

--- a/packages/trigger-sdk/src/apiClient.ts
+++ b/packages/trigger-sdk/src/apiClient.ts
@@ -20,8 +20,6 @@ import {
   JobRunStatusRecordSchema,
   KeyValueStoreResponseBody,
   KeyValueStoreResponseBodySchema,
-  LogLevel,
-  Logger,
   RegisterScheduleResponseBodySchema,
   RegisterSourceEventSchemaV2,
   RegisterSourceEventV2,
@@ -40,6 +38,7 @@ import {
   assertExhaustive,
   urlWithSearchParams,
 } from "@trigger.dev/core";
+import { LogLevel, Logger } from "@trigger.dev/core-backend";
 import { env } from "node:process";
 
 import { z } from "zod";

--- a/packages/trigger-sdk/src/io.ts
+++ b/packages/trigger-sdk/src/io.ts
@@ -11,8 +11,6 @@ import {
   FetchTimeoutOptions,
   InitialStatusUpdate,
   IntervalOptions,
-  LogLevel,
-  Logger,
   RunTaskOptions,
   SendEvent,
   SendEventOptions,
@@ -21,6 +19,7 @@ import {
   UpdateWebhookBody,
   supportsFeature,
 } from "@trigger.dev/core";
+import { LogLevel, Logger } from "@trigger.dev/core-backend";
 import { BloomFilter } from "@trigger.dev/core-backend";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { webcrypto } from "node:crypto";

--- a/packages/trigger-sdk/src/job.ts
+++ b/packages/trigger-sdk/src/job.ts
@@ -3,11 +3,11 @@ import {
   IntegrationConfig,
   InvokeOptions,
   JobMetadata,
-  LogLevel,
   Prettify,
   RunNotification,
   SuccessfulRunNotification,
 } from "@trigger.dev/core";
+import { LogLevel } from "@trigger.dev/core-backend";
 import { ConcurrencyLimit } from "./concurrencyLimit";
 import { IOWithIntegrations, TriggerIntegration } from "./integrations";
 import { runLocalStorage } from "./runLocalStorage";

--- a/packages/trigger-sdk/src/triggers/externalSource.ts
+++ b/packages/trigger-sdk/src/triggers/externalSource.ts
@@ -1,25 +1,25 @@
 import {
+  ConnectionAuth,
   DisplayProperty,
   EventFilter,
   HandleTriggerSource,
   HttpSourceResponseMetadata,
-  Logger,
   NormalizedResponse,
+  Prettify,
   RegisterTriggerSource,
   SendEvent,
+  SerializableJson,
   TriggerMetadata,
   deepMergeFilters,
 } from "@trigger.dev/core";
+import { Logger } from "@trigger.dev/core-backend";
+import type { Buffer } from "buffer";
 import { IOWithIntegrations, TriggerIntegration } from "../integrations";
 import { IO } from "../io";
 import { Job } from "../job";
 import { TriggerClient } from "../triggerClient";
 import type { EventSpecification, SchemaParser, Trigger, TriggerContext } from "../types";
 import { slugifyId } from "../utils";
-import { SerializableJson } from "@trigger.dev/core";
-import { ConnectionAuth } from "@trigger.dev/core";
-import { Prettify } from "@trigger.dev/core";
-import type { Buffer } from "buffer";
 
 export type HttpSourceEvent = {
   url: string;

--- a/packages/trigger-sdk/src/types.ts
+++ b/packages/trigger-sdk/src/types.ts
@@ -2,24 +2,21 @@ import type {
   DisplayProperty,
   EventFilter,
   FailedRunNotification,
-  Logger,
   OverridableRunTaskOptions,
   Prettify,
   RedactString,
   RegisteredOptionsDiff,
-  RunNotificationJobMetadata,
-  RunNotificationRunMetadata,
   RunTaskOptions,
   RuntimeEnvironmentType,
-  ServerTask,
   SourceEventOption,
   SuccessfulRunNotification,
   TriggerMetadata,
 } from "@trigger.dev/core";
+import { Logger } from "@trigger.dev/core-backend";
+import type TypedEmitter from "typed-emitter";
+import { z } from "zod";
 import { Job } from "./job";
 import { TriggerClient } from "./triggerClient";
-import { z } from "zod";
-import type TypedEmitter from "typed-emitter";
 
 export type {
   DisplayProperty,
@@ -124,8 +121,8 @@ export type TypedEventSpecificationExample<TEvent> = {
   id: string;
   name: string;
   icon?: string;
-  payload: TEvent
-}
+  payload: TEvent;
+};
 
 export interface EventSpecification<TEvent extends any, TInvoke extends any = TEvent> {
   name: string | string[];


### PR DESCRIPTION
This removes the import to `node:buffer` in `@trigger.dev/core` by moving our `Logging` class to our `@trigger.dev/core-backend` package. `@trigger.dev/core` is a dependency of `@trigger.dev/react`, so this was causing issues when attempting to import `node:buffer` into a frontend build of Next.js Pages Router.