### PR TITLE
Auto update endpoint URL on redirect

### DIFF
--- a/apps/webapp/app/services/endpointApi.server.ts
+++ b/apps/webapp/app/services/endpointApi.server.ts
@@ -123,6 +123,7 @@ export class EndpointApi {
         "x-trigger-api-key": this.apiKey,
         "x-trigger-action": "INDEX_ENDPOINT",
       },
+      redirect: "manual",
     });
 
     return {

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -9,6 +9,7 @@
     "build:remix": "remix build",
     "build:server": "esbuild --platform=node --format=cjs ./server.ts --outdir=build",
     "dev": "cross-env PORT=3030 remix dev",
+    "dev:manual": "cross-env PORT=3030 remix dev -c \"node ./build/server.js\"",
     "format": "prettier --write .",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "cross-env NODE_ENV=production node --max-old-space-size=8192 ./build/server.js",


### PR DESCRIPTION
Closes #786

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Tested against a URL redirecting using a 308 on Vercel (root -> www) and made sure the endpoint URL was updated and the indexing completed successfully.

---

## Changelog

We will now detect redirects when doing an endpoint indexing request and update the endpoint URL to "follow" the redirect, and then retry the indexing. If that happens more than 5 times, we will abort. If the response is a redirect with no location URL, we will abort.
