### PR TITLE
fix: stripe webhook validation

### DIFF
--- a/.changeset/shy-needles-push.md
+++ b/.changeset/shy-needles-push.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/stripe": patch
+---
+
+Fix SubtleCryptoProvider webhook validation

--- a/integrations/stripe/src/index.ts
+++ b/integrations/stripe/src/index.ts
@@ -1151,7 +1151,7 @@ async function webhookHandler(event: HandlerEvent<"HTTP">, logger: Logger) {
     const stripeClient = new StripeClient("", { apiVersion: "2022-11-15" });
 
     try {
-      const event = stripeClient.webhooks.constructEvent(rawBody, signature, source.secret);
+      const event = await stripeClient.webhooks.constructEventAsync(rawBody, signature, source.secret);
 
       return {
         events: [


### PR DESCRIPTION
The SubtleCryptoProvider cannot be used in a synchronous context. This is a problem for non-node environments where the Stripe client falls back to SubtleCryptoProvider.

Running the trigger.dev Stripe integration on Cloudflare Pages results in the following error:
```
{
  "error": {
    "name": "Error",
    "message": "SubtleCryptoProvider cannot be used in a synchronous context.\\nUse `await constructEventAsync(...)` instead of `constructEvent(...)`"
  },
  "timestamp": "2024-01-11T19:44:47.237Z",
  "name": "trigger.dev",
  "message": "[@trigger.dev/stripe] Error while validating webhook signature",
  "level": "error"
}
```

Even worse, without verbose logging enabled, this is just silently ignored and no event or job-run is triggered from trigger.dev

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Changelog

Fix Stripe integration webhook validation.


💯
