### PR TITLE
Fix typo in `deployment-automatic` docs

### DIFF
--- a/docs/documentation/guides/deployment-automatic.mdx
+++ b/docs/documentation/guides/deployment-automatic.mdx
@@ -34,7 +34,7 @@ You can add a step to the GitHub Action that deploys your app.
 ```yaml .github/workflows/release.yml
 - name: 🚀 Refresh Trigger.dev Jobs
    env:
-      DEPLOY_TEST_HOOK: ${{ secrets.TRIGGER_ENDPOINT_HOOK }}
+      TRIGGER_ENDPOINT_HOOK: ${{ secrets.TRIGGER_ENDPOINT_HOOK }}
    run: |
       curl -X POST $TRIGGER_ENDPOINT_HOOK
 ```


### PR DESCRIPTION
Env var in docs is wrong

Sorry im not sure what the PR title convention is and if I need to run the changesets command

## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [ ] The PR title follows the convention.
- [ ] I ran and tested the code works

---

## Testing

N/A

---

## Changelog

Update docs

---

## Screenshots

N/A

💯
