### PR TITLE
Feat: Update cron parser human readable string

### DIFF
--- a/apps/webapp/app/components/jobs/JobsTable.tsx
+++ b/apps/webapp/app/components/jobs/JobsTable.tsx
@@ -49,13 +49,13 @@ export function JobsTable({ jobs, noResultsText }: { jobs: ProjectJob[]; noResul
               <TableRow key={job.id} className="group">
                 <TableCell to={path}>
                   <span className="flex items-center gap-2">
-                    <NamedIcon name={job.event.icon} className="h-8 w-8" />
+                    <NamedIcon name={job.event.icon} className="w-8 h-8" />
                     <LabelValueStack
                       label={job.title}
                       value={
                         job.dynamic ? (
                           <span className="flex items-center gap-0.5">
-                            <NamedIcon name="dynamic" className="h-4 w-4" />{" "}
+                            <NamedIcon name="dynamic" className="w-4 h-4" />{" "}
                             <span className="uppercase">Dynamic:</span> {job.event.title}
                           </span>
                         ) : (
@@ -75,9 +75,9 @@ export function JobsTable({ jobs, noResultsText }: { jobs: ProjectJob[]; noResul
                       key={integration.key}
                       button={
                         <div className="relative">
-                          <NamedIcon name={integration.icon} className="h-6 w-6" />
+                          <NamedIcon name={integration.icon} className="w-6 h-6" />
                           {integration.setupStatus === "MISSING_FIELDS" && (
-                            <NamedIcon name="error" className="absolute -left-1 -top-1 h-4 w-4" />
+                            <NamedIcon name="error" className="absolute w-4 h-4 -left-1 -top-1" />
                           )}
                         </div>
                       }
@@ -99,7 +99,7 @@ export function JobsTable({ jobs, noResultsText }: { jobs: ProjectJob[]; noResul
                   {job.properties && (
                     <SimpleTooltip
                       button={
-                        <div className="flex max-w-[200px] items-start justify-start gap-5 truncate">
+                        <div className="flex max-w-[300px] items-start justify-start gap-5 truncate">
                           {job.properties.map((property, index) => (
                             <LabelValueStack
                               key={index}

--- a/packages/trigger-sdk/src/triggers/scheduled.ts
+++ b/packages/trigger-sdk/src/triggers/scheduled.ts
@@ -84,9 +84,13 @@ export class CronTrigger implements Trigger<ScheduledEventSpecification> {
   constructor(private options: CronOptions) {}
 
   get event() {
+    /**
+     * We need to concat `(UTC)` string at the end of the human readable string to avoid confusion 
+     * with execution time/last run of a job in the UI dashboard which is displayed in local time.
+     */
     const humanReadable = cronstrue.toString(this.options.cron, {
       throwExceptionOnParseError: false,
-    });
+    }).concat(" (UTC)");
 
     return {
       name: "trigger.scheduled",


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

- Add a schedule jobs and verify that the cron parser description is noted with (UTC)

---

## Changelog

- Fix hidden text on the jobs table
- Add `(UTC)` at the end of cron parser human readable string to avoid confusion with execution/last run time which is displayed as local time of the user

---

## Screenshots

Before:
<img width="610" alt="Before" src="https://github.com/triggerdotdev/trigger.dev/assets/35174855/130d6061-cbd4-4a52-bc69-ffd750b8597a">

After: 
<img width="673" alt="after" src="https://github.com/triggerdotdev/trigger.dev/assets/35174855/f7196fe9-ba3a-4b2c-8beb-f12d20520a8b">

💯
