### PR TITLE
Ability to disable organization runs + more obvious if you're over the free limit

### DIFF
--- a/apps/webapp/app/components/billing/FreePlanUsage.tsx
+++ b/apps/webapp/app/components/billing/FreePlanUsage.tsx
@@ -13,8 +13,15 @@ export function FreePlanUsage({ to, percentage }: { to: string; percentage: numb
     ["#22C55E", "#22C55E", "#F59E0B", "#F43F5E", "#F43F5E"]
   );
 
+  const hasHitLimit = cappedPercentage >= 1;
+
   return (
-    <div className="rounded border border-slate-900 bg-[#101722] p-2.5">
+    <div
+      className={cn(
+        "rounded border border-slate-900 bg-[#101722] p-2.5",
+        hasHitLimit && "border-rose-800/60"
+      )}
+    >
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-1">
           <ArrowUpCircleIcon className="h-5 w-5 text-dimmed" />

--- a/apps/webapp/app/components/billing/UpgradePrompt.tsx
+++ b/apps/webapp/app/components/billing/UpgradePrompt.tsx
@@ -5,6 +5,7 @@ import { formatNumberCompact } from "~/utils/numberFormatter";
 import { plansPath } from "~/utils/pathBuilder";
 import { LinkButton } from "../primitives/Buttons";
 import { Paragraph } from "../primitives/Paragraph";
+import { Callout } from "../primitives/Callout";
 
 type UpgradePromptProps = {
   organization: MatchedOrganization;
@@ -18,19 +19,25 @@ export function UpgradePrompt({ organization }: UpgradePromptProps) {
   }
 
   return (
-    <div className="flex h-full w-full items-center gap-4 bg-gradient-to-r from-transparent to-indigo-900/50 pr-1.5">
-      <Paragraph variant="extra-small" className="text-rose-500">
-        You have exceeded the monthly {formatNumberCompact(currentPlan.usage.runCountCap)} runs
-        limit
-      </Paragraph>
-      <LinkButton
-        variant={"primary/small"}
-        LeadingIcon={ArrowUpCircleIcon}
-        leadingIconClassName="px-0"
-        to={plansPath(organization)}
-      >
-        Upgrade
-      </LinkButton>
-    </div>
+    <Callout variant="error" className="flex h-full items-center rounded-none px-1 py-0">
+      <div className="flex items-center justify-between gap-3">
+        <Paragraph variant="extra-small" className="text-white">
+          {organization.runsEnabled
+            ? `You have exceeded the monthly ${formatNumberCompact(
+                currentPlan.usage.runCountCap
+              )} runs
+          limit`
+            : `No runs are executing because you have exceeded the free limit`}
+        </Paragraph>
+        <LinkButton
+          variant={"primary/small"}
+          LeadingIcon={ArrowUpCircleIcon}
+          leadingIconClassName="px-0"
+          to={plansPath(organization)}
+        >
+          Upgrade
+        </LinkButton>
+      </div>
+    </Callout>
   );
 }

--- a/apps/webapp/app/components/stories/FreePlanUsage.stories.tsx
+++ b/apps/webapp/app/components/stories/FreePlanUsage.stories.tsx
@@ -22,6 +22,7 @@ const mockOrganization: MatchedOrganization = {
   ],
   hasUnconfiguredIntegrations: false,
   memberCount: 1,
+  runsEnabled: true,
 };
 
 export const ProgressBar: Story = {

--- a/apps/webapp/app/presenters/OrganizationsPresenter.server.ts
+++ b/apps/webapp/app/presenters/OrganizationsPresenter.server.ts
@@ -94,6 +94,7 @@ export class OrganizationsPresenter {
         })),
         hasUnconfiguredIntegrations: org._count.integrations > 0,
         memberCount: org._count.members,
+        runsEnabled: org.runsEnabled,
       };
     });
   }

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.billing._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.billing._index/route.tsx
@@ -96,7 +96,7 @@ export default function Page() {
         <div className="flex flex-col gap-5 rounded border border-border p-6">
           {hitsRunLimit && (
             <Callout
-              variant={"pricing"}
+              variant={"error"}
               cta={
                 <LinkButton
                   variant="primary/small"
@@ -108,7 +108,7 @@ export default function Page() {
                 </LinkButton>
               }
             >
-              <Paragraph variant="small">
+              <Paragraph variant="small" className="text-white">
                 You have exceeded the monthly{" "}
                 {formatNumberCompact(currentPlan?.subscription?.limits.runs ?? 0)} runs limit.
                 Upgrade to a paid plan before{" "}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.billing.plans/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.billing.plans/route.tsx
@@ -65,7 +65,7 @@ export default function Page() {
         </Callout>
       )}
       {hitRunLimit && (
-        <Callout variant={"pricing"}>
+        <Callout variant={"error"}>
           {`You have exceeded the monthly
           ${formatNumberCompact(currentPlan!.subscription!.limits.runs!)} runs limit. Upgrade so you
           can continue to perform runs.`}

--- a/apps/webapp/app/routes/api.v1.jobs.$jobSlug.invoke.ts
+++ b/apps/webapp/app/routes/api.v1.jobs.$jobSlug.invoke.ts
@@ -72,7 +72,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     );
 
     if (!run) {
-      return json({ error: "Job count not be invoked" }, { status: 500 });
+      return json({ error: "Job could not be invoked" }, { status: 500 });
     }
 
     return json({ id: run.id });

--- a/apps/webapp/app/services/runs/createRun.server.ts
+++ b/apps/webapp/app/services/runs/createRun.server.ts
@@ -3,6 +3,7 @@ import { $transaction, PrismaClientOrTransaction } from "~/db.server";
 import { prisma } from "~/db.server";
 import { workerQueue } from "~/services/worker.server";
 import type { AuthenticatedEnvironment } from "../apiAuth.server";
+import { logger } from "../logger.server";
 
 export class CreateRunService {
   #prismaClient: PrismaClientOrTransaction;
@@ -25,6 +26,11 @@ export class CreateRunService {
     },
     options: { callbackUrl?: string } = {}
   ) {
+    if (!environment.organization.runsEnabled) {
+      logger.debug("Runs are disabled for this organization", environment);
+      return;
+    }
+
     const endpoint = await this.#prismaClient.endpoint.findUniqueOrThrow({
       where: {
         id: version.endpointId,

--- a/packages/database/prisma/migrations/20240116162443_added_organization_runs_enabled_column/migration.sql
+++ b/packages/database/prisma/migrations/20240116162443_added_organization_runs_enabled_column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Organization" ADD COLUMN     "runsEnabled" BOOLEAN NOT NULL DEFAULT true;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -114,6 +114,8 @@ model Organization {
 
   companySize String?
 
+  runsEnabled Boolean @default(true)
+
   environments RuntimeEnvironment[]
   connections  IntegrationConnection[]
   endpoints    Endpoint[]


### PR DESCRIPTION
Runs can be disabled for an organization, this will be used when free organizations on the cloud product are over their free runs allowance.

Also made some messages clearer when Orgs are over the free allowance, they were unclear of too hidden before so it could be confusing.

