### PR TITLE
Fix yalt.dev connection timeouts by increasing timeout from 1s to 5s

### DIFF
--- a/.changeset/plenty-snails-smile.md
+++ b/.changeset/plenty-snails-smile.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/cli": patch
+---
+
+Increase the yalt.dev connection timeout to 5 seconds

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -542,7 +542,7 @@ async function createNativeTunnel(
       https,
       {
         WebSocket: WebSocket.default,
-        connectionTimeout: 1000,
+        connectionTimeout: getConnectionTimeoutValue(),
         maxRetries: 10,
       },
       { verbose: process.env.TUNNEL_VERBOSE === "1" }
@@ -555,6 +555,14 @@ async function createNativeTunnel(
     spinner.fail(`Failed to create tunnel.\n${e}`);
     return;
   }
+}
+
+function getConnectionTimeoutValue() {
+  if (typeof process.env.TUNNEL_CONNECTION_TIMEOUT === "string") {
+    return parseInt(process.env.TUNNEL_CONNECTION_TIMEOUT);
+  }
+
+  return 5000;
 }
 
 async function createNgrokTunnel(hostname: string, port: number, spinner: Ora) {


### PR DESCRIPTION
This fixes the issue that emits this log pattern when running the `@trigger.dev/cli dev` command:

```
Error: WebSocket was closed before the connection was established
    at WebSocket.close (/Users/eric/code/triggerdotdev/package-tests/nextjs-auto-yield/node_modules/ws/lib/websocket.js:287:7)
    at _ReconnectingWebSocket._disconnect (file:///Users/eric/code/triggerdotdev/package-tests/nextjs-auto-yield/node_modules/partysocket/dist/chunk-KQKM3KLR.mjs:378:16)
    at _ReconnectingWebSocket._handleError (file:///Users/eric/code/triggerdotdev/package-tests/nextjs-auto-yield/node_modules/partysocket/dist/chunk-KQKM3KLR.mjs:410:10)
    at _ReconnectingWebSocket._handleTimeout (file:///Users/eric/code/triggerdotdev/package-tests/nextjs-auto-yield/node_modules/partysocket/dist/chunk-KQKM3KLR.mjs:369:10)
    at Timeout.<anonymous> (file:///Users/eric/code/triggerdotdev/package-tests/nextjs-auto-yield/node_modules/partysocket/dist/chunk-KQKM3KLR.mjs:359:20)
    at listOnTimeout (node:internal/timers:569:17)
    at process.processTimers (node:internal/timers:512:7)
Emitted 'error' event on WebSocket instance at:
    at emitErrorAndClose (/Users/eric/code/triggerdotdev/package-tests/nextjs-auto-yield/node_modules/ws/lib/websocket.js:1016:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
```

This was being caused by an overly aggressive connection timeout value of 1 second. Most people didn't hit this timeout but in some cases (and in some locations) this could happen. This PR increases the connection timeout to 5 second.

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

I used a VPN to connect threw New Zealand and before this change would consistently get the connection timeout issue above. After the change I no longer saw the error (sorry New Zealanders)