### PR TITLE
fix: Allow self-hosted trigger.dev installations to add OAuth integrations

### DIFF
--- a/apps/webapp/app/components/integrations/ConnectToOAuthForm.tsx
+++ b/apps/webapp/app/components/integrations/ConnectToOAuthForm.tsx
@@ -52,7 +52,7 @@ export function ConnectToOAuthForm({
       onValidate({ formData }) {
         return parse(formData, {
           // Create the schema without any constraint defined
-          schema: createSchema(),
+          schema: createSchema({isManagedCloud}),
         });
       },
     });
@@ -119,21 +119,23 @@ export function ConnectToOAuthForm({
         </InputGroup>
         <input type="hidden" name="clientType" value={clientType} />
         <div>
-          <Header2>Use my OAuth App</Header2>
-          <Paragraph variant="small" className="mb-2">
-            To use your own OAuth app, check the option below and insert the details.
-          </Paragraph>
-          <Checkbox
-            id="hasCustomClient"
-            label="Use my OAuth App"
-            variant="simple/small"
-            disabled={requiresCustomOAuthApp}
-            onChange={(checked) => setUseMyOAuthApp(checked)}
-            {...conform.input(hasCustomClient, { type: "checkbox" })}
-            defaultChecked={requiresCustomOAuthApp}
-          />
+          <InputGroup fullWidth>
+            <Header2>Use my OAuth App</Header2>
+            <Paragraph variant="small">
+              To use your own OAuth app, check the option below and insert the details.
+            </Paragraph>
+            <Checkbox
+              id="hasCustomClient"
+              label="Use my OAuth App"
+              variant="simple/small"
+              onChange={(checked) => setUseMyOAuthApp(checked)}
+              {...conform.input(hasCustomClient, { type: "checkbox" })}
+              defaultChecked={requiresCustomOAuthApp}
+            />
+            <FormError>{hasCustomClient.error}</FormError>
+          </InputGroup>
           {useMyOAuthApp && (
-            <div className="ml-6 mt-2">
+            <div className="ml-6">
               <Paragraph variant="small" className="mb-2">
                 Set the callback url to <CodeBlock code={callbackUrl} showLineNumbers={false} />
               </Paragraph>

--- a/apps/webapp/app/components/integrations/UpdateOAuthForm.tsx
+++ b/apps/webapp/app/components/integrations/UpdateOAuthForm.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import simplur from "simplur";
 import { useFeatures } from "~/hooks/useFeatures";
 import { useTextFilter } from "~/hooks/useTextFilter";
+import { createSchema } from "~/routes/resources.connection.$organizationId.oauth2.$integrationId";
 import { ApiAuthenticationMethodOAuth2, Integration, Scope } from "~/services/externalApis/types";
 import { cn } from "~/utils/cn";
 import { CodeBlock } from "../code/CodeBlock";
@@ -19,7 +20,6 @@ import { InputGroup } from "../primitives/InputGroup";
 import { Label } from "../primitives/Label";
 import { Paragraph } from "../primitives/Paragraph";
 import { Client } from "~/presenters/IntegrationsPresenter.server";
-import { schema } from "~/routes/resources.connection.$organizationId.oauth2.$integrationId";
 
 export type Status = "loading" | "idle";
 
@@ -49,7 +49,7 @@ export function UpdateOAuthForm({
     lastSubmission: fetcher.data as any,
     onValidate({ formData }) {
       return parse(formData, {
-        schema,
+        schema: createSchema({isManagedCloud}),
       });
     },
   });
@@ -109,19 +109,21 @@ export function UpdateOAuthForm({
         </InputGroup>
         <input type="hidden" name="clientType" value={clientType} />
         <div>
-          <Header2>Use my OAuth App</Header2>
-          <Paragraph variant="small" className="mb-2">
-            To use your own OAuth app, check the option below and insert the details.
-          </Paragraph>
-          <Checkbox
-            id="hasCustomClient"
-            label="Use my OAuth App"
-            variant="simple/small"
-            disabled={requiresCustomOAuthApp}
-            onChange={(checked) => setUseMyOAuthApp(checked)}
-            {...conform.input(hasCustomClient, { type: "checkbox" })}
-            defaultChecked={requiresCustomOAuthApp}
-          />
+          <InputGroup fullWidth>
+            <Header2>Use my OAuth App</Header2>
+            <Paragraph variant="small" className="mb-2">
+              To use your own OAuth app, check the option below and insert the details.
+            </Paragraph>
+            <Checkbox
+              id="hasCustomClient"
+              label="Use my OAuth App"
+              variant="simple/small"
+              onChange={(checked) => setUseMyOAuthApp(checked)}
+              {...conform.input(hasCustomClient, { type: "checkbox" })}
+              defaultChecked={requiresCustomOAuthApp}
+            />
+            <FormError>{hasCustomClient.error}</FormError>
+          </InputGroup>
           {useMyOAuthApp && (
             <div className="ml-6 mt-2">
               <Paragraph variant="small" className="mb-2">

--- a/apps/webapp/app/routes/resources.connection.$organizationId.oauth2.$integrationId.ts
+++ b/apps/webapp/app/routes/resources.connection.$organizationId.oauth2.$integrationId.ts
@@ -7,45 +7,61 @@ import { prisma } from "~/db.server";
 import { integrationAuthRepository } from "~/services/externalApis/integrationAuthRepository.server";
 import { requireUserId } from "~/services/session.server";
 import { requestUrl } from "~/utils/requestUrl.server";
+import { featuresForRequest } from "~/features.server";
 
-export const schema = z
-  .object({
-    integrationIdentifier: z.string(),
-    integrationAuthMethod: z.string(),
-    title: z.string().min(2, "The title must be unique and at least 2 characters long"),
-    description: z.string().optional(),
-    hasCustomClient: z.preprocess((value) => value === "on", z.boolean()),
-    customClientId: z.string().optional(),
-    customClientSecret: z.string().optional(),
-    clientType: z.union([z.literal("DEVELOPER"), z.literal("EXTERNAL")]),
-    redirectTo: z.string(),
-    scopes: z.preprocess(
-      (data) => (typeof data === "string" ? [data] : data),
-      z
-        .array(z.string(), {
-          required_error: "You must select at least one scope",
-        })
-        .nonempty("You must select at least one scope")
-    ),
-  })
-  .refine(
-    (value) => {
-      if (value.hasCustomClient) {
-        return (
-          value.customClientId !== undefined &&
-          value.customClientId !== "" &&
-          value.customClientSecret !== undefined &&
-          value.customClientSecret !== ""
-        );
-      }
-      return true;
-    },
-    {
-      message:
-        "You must enter a Client ID and Client secret if you want to use your own OAuth app.",
-      path: ["customClientId"],
+export function createSchema(
+    constraints: {
+        isManagedCloud: boolean
     }
-  );
+) {
+  return z
+    .object({
+      integrationIdentifier: z.string(),
+      integrationAuthMethod: z.string(),
+      title: z.string().min(2, "The title must be unique and at least 2 characters long"),
+      description: z.string().optional(),
+      hasCustomClient: z
+        .preprocess((value) => value === "on", z.boolean())
+        .superRefine((hasCustomClient, ctx) => {
+          if (!hasCustomClient && !constraints.isManagedCloud) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: "Self-hosted trigger.dev installations must supply their own OAuth credentials.",
+            })
+          }
+        }),
+      customClientId: z.string().optional(),
+      customClientSecret: z.string().optional(),
+      clientType: z.union([z.literal("DEVELOPER"), z.literal("EXTERNAL")]),
+      redirectTo: z.string(),
+      scopes: z.preprocess(
+        (data) => (typeof data === "string" ? [data] : data),
+        z
+          .array(z.string(), {
+            required_error: "You must select at least one scope",
+          })
+          .nonempty("You must select at least one scope")
+      ),
+    })
+    .refine(
+      (value) => {
+        if (value.hasCustomClient) {
+          return (
+            value.customClientId !== undefined &&
+            value.customClientId !== "" &&
+            value.customClientSecret !== undefined &&
+            value.customClientSecret !== ""
+          );
+        }
+        return true;
+      },
+      {
+        message:
+          "You must enter a Client ID and Client secret if you want to use your own OAuth app.",
+        path: ["customClientId"],
+      }
+    )
+}
 
 const ParamsSchema = z.object({
   organizationId: z.string(),
@@ -64,10 +80,18 @@ export async function action({ request, params }: ActionFunctionArgs) {
       { status: 405 }
     );
   }
+
+  const { isManagedCloud } = featuresForRequest(request);
+
   const { integrationId, organizationId } = ParamsSchema.parse(params);
 
   const formData = await request.formData();
-  const submission = parse(formData, { schema });
+
+  const formSchema = createSchema({
+    isManagedCloud
+  })
+
+  const submission = parse(formData, { schema: formSchema });
 
   if (!submission.value || submission.intent !== "submit") {
     return json(submission);

--- a/apps/webapp/app/routes/resources.connection.$organizationId.oauth2.ts
+++ b/apps/webapp/app/routes/resources.connection.$organizationId.oauth2.ts
@@ -72,14 +72,14 @@ export function createSchema(
       description: z.string().optional(),
       hasCustomClient: z
           .preprocess((value) => value === "on", z.boolean())
-          .superRefine((hasCustomClient, ctx) => {
+          /*.superRefine((hasCustomClient, ctx) => {
             if (!hasCustomClient && !constraints.isManagedCloud) {
               ctx.addIssue({
                 code: z.ZodIssueCode.custom,
                 message: "Self-hosted trigger.dev installations must supply their own OAuth credentials.",
               })
             }
-          }),
+          })*/,
       customClientId: z.string().optional(),
       customClientSecret: z.string().optional(),
       clientType: z.union([z.literal("DEVELOPER"), z.literal("EXTERNAL")]),
@@ -88,6 +88,17 @@ export function createSchema(
         (data) => (typeof data === "string" ? [data] : data),
         z.array(z.string()).default([])
       ),
+    })
+    .refine((value) => {
+      if (value.hasCustomClient) {
+        return true;
+      }
+
+      return !(value.clientType == "EXTERNAL" || !constraints.isManagedCloud);
+    }, {
+      message:
+        "Self-hosted trigger.dev installations must supply their own OAuth credentials.",
+      path: ["hasCustomClient"]
     })
     .refine(
       (value) => {


### PR DESCRIPTION
Fixes triggerdotdev/trigger.dev#856

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Using an installation of trigger.dev with a clean database I:
- Attempted to add a Slack integration with the "Use my OAuth App" checkbox unchecked
- Added a Slack integration using OAuth credentials for my company's Slack server
- Set its status to "MISSING_FIELDS" (`UPDATE "Integration" SET "setupStatus" = 'MISSING_FIELDS'`)
- Open the "update" form using the "Integrations Missing Fields" workflow
- Note: I can't figure out how to properly trigger that workflow, so I can't fully step through this case, but it does make it to where it attempts to write to the secret store, which means the client form and server request validation function properly.

---

## Changelog

Updated `ConnectToOAuthForm` and `UpdateOAuthForm` components (and associated server route handlers) to enable the "Use my OAuth App" checkbox on self-hosted installations, but validate its state on form submission.

---

## Screenshots

![image](https://i.imgur.com/BSC9J2U.png)
![image](https://i.imgur.com/JGXETmR.png)
