### PR TITLE
fix: Address unintended type coercion in PageInfoPropertyComponent

### DIFF
--- a/apps/webapp/app/components/primitives/PageHeader.tsx
+++ b/apps/webapp/app/components/primitives/PageHeader.tsx
@@ -129,10 +129,10 @@ function PageInfoPropertyContent({
       {label && (
         <Paragraph variant="extra-small/caps" className="mt-0.5 whitespace-nowrap">
           {label}
-          {value && ":"}
+          {value !== undefined && ":"}
         </Paragraph>
       )}
-      {value && <Paragraph variant="small">{value}</Paragraph>}
+      {value !== undefined && <Paragraph variant="small">{value}</Paragraph>}
     </div>
   );
 }


### PR DESCRIPTION
Fixes triggerdotdev/trigger.dev#858

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

1. Navigated to integration detail page and noted the Jobs item appears correctly now when its value is 0.

---

## Changelog

Change PageInfoPropertyComponent to do an explicit undefined check instead of a truthy/falsy comparison.

---

## Screenshots

![image](https://i.imgur.com/3X2i3OX.png)

💯
