### PR TITLE
Faster jobs page

### DIFF
--- a/apps/webapp/app/components/runs/RunsTable.tsx
+++ b/apps/webapp/app/components/runs/RunsTable.tsx
@@ -77,11 +77,11 @@ export function RunsTable({
       <TableBody>
         {total === 0 && !hasFilters ? (
           <TableBlankRow colSpan={showJob ? 10 : 9}>
-            <NoRuns title="No runs found" />
+            {!isLoading && <NoRuns title="No runs found" />}
           </TableBlankRow>
         ) : runs.length === 0 ? (
           <TableBlankRow colSpan={showJob ? 10 : 9}>
-            <NoRuns title="No runs match your filters" />
+            {!isLoading && <NoRuns title="No runs match your filters" />}
           </TableBlankRow>
         ) : (
           runs.map((run) => {

--- a/apps/webapp/app/presenters/JobListPresenter.server.ts
+++ b/apps/webapp/app/presenters/JobListPresenter.server.ts
@@ -9,6 +9,7 @@ import { Project } from "~/models/project.server";
 import { User } from "~/models/user.server";
 import { z } from "zod";
 import { projectPath } from "~/utils/pathBuilder";
+import { JobRunStatus } from "@trigger.dev/database";
 
 export type ProjectJob = Awaited<ReturnType<JobListPresenter["call"]>>[0];
 
@@ -43,14 +44,6 @@ export class JobListPresenter {
         id: true,
         slug: true,
         title: true,
-        runs: {
-          select: {
-            createdAt: true,
-            status: true,
-          },
-          take: 1,
-          orderBy: [{ createdAt: "desc" }],
-        },
         integrations: {
           select: {
             key: true,
@@ -105,6 +98,28 @@ export class JobListPresenter {
       orderBy: [{ title: "asc" }],
     });
 
+    const latestRuns = await this.#prismaClient.$queryRaw<
+      {
+        createdAt: Date;
+        status: JobRunStatus;
+        jobId: string;
+        rn: BigInt;
+      }[]
+    >`
+    SELECT * FROM (
+      SELECT 
+          "id", 
+          "createdAt", 
+          "status", 
+          "jobId",
+          ROW_NUMBER() OVER(PARTITION BY "jobId" ORDER BY "createdAt" DESC) as rn
+      FROM 
+          "public"."JobRun" 
+      WHERE 
+          "jobId" IN (${Prisma.join(jobs.map((j) => j.id))})
+  ) t
+  WHERE rn = 1;`;
+
     return jobs
       .flatMap((job) => {
         const version = job.versions.at(0);
@@ -132,6 +147,8 @@ export class JobListPresenter {
           properties = [...properties, ...versionProperties];
         }
 
+        const latestRun = latestRuns.find((r) => r.jobId === job.id);
+
         return [
           {
             id: job.id,
@@ -155,7 +172,7 @@ export class JobListPresenter {
               (i) => i.setupStatus === "MISSING_FIELDS"
             ),
             environment: version.environment,
-            lastRun: job.runs.at(0),
+            lastRun: latestRun,
             properties,
             projectSlug: job.project.slug,
           },

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.jobs.$jobParam._index/ListPagination.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.jobs.$jobParam._index/ListPagination.tsx
@@ -5,8 +5,8 @@ import { cn } from "~/utils/cn";
 
 type List = {
   pagination: {
-    next: string | undefined;
-    previous: string | undefined;
+    next?: string | undefined;
+    previous?: string | undefined;
   };
 };
 

--- a/packages/database/prisma/migrations/20240130165343_add_composite_index_to_job_run_for_job_id_and_created_at/migration.sql
+++ b/packages/database/prisma/migrations/20240130165343_add_composite_index_to_job_run_for_job_id_and_created_at/migration.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_jobrun_jobId_createdAt ON "public"."JobRun" ("jobId", "createdAt" DESC);


### PR DESCRIPTION
The Jobs page was slow to load because getting the last run for each job was very slow.

Prisma was doing a weird query where it was returning all of the runs for a project, and then in code it was getting the latest one for each job. The query took about 1 second but then the code took a very long time for organizations with millions of runs.

The new query only gets the latest run for each org, then does the join in code.

I've also added a composite index to make getting the latest run faster. Plus use defer on the runs page.