### PR TITLE
Fix/autoyield canceled run

### DIFF
--- a/apps/webapp/app/services/runs/performRunExecutionV3.server.ts
+++ b/apps/webapp/app/services/runs/performRunExecutionV3.server.ts
@@ -207,7 +207,18 @@ export class PerformRunExecutionV3Service {
 
       forceYieldCoordinator.deregisterRun(run.id);
 
-      //todo if cancelled then return
+      //if the run has been canceled while it's being executed, we shouldn't do anything more
+      const updatedRun = await this.#prismaClient.jobRun.findUnique({
+        select: {
+          status: true,
+        },
+        where: {
+          id: run.id,
+        },
+      });
+      if (!updatedRun || updatedRun.status === "CANCELED") {
+        return;
+      }
 
       if (!response) {
         return await this.#failRunExecutionWithRetry(

--- a/apps/webapp/app/services/runs/performRunExecutionV3.server.ts
+++ b/apps/webapp/app/services/runs/performRunExecutionV3.server.ts
@@ -207,6 +207,8 @@ export class PerformRunExecutionV3Service {
 
       forceYieldCoordinator.deregisterRun(run.id);
 
+      //todo if cancelled then return
+
       if (!response) {
         return await this.#failRunExecutionWithRetry(
           run,


### PR DESCRIPTION
Closes #888 

If a run has been canceled but is still executing we want to avoid doing any updates to the run. When the executing stops we check if the run is now canceled, if it is then we exit.