### PR TITLE
Fix duplicated integration icons in the Jobs table

### DIFF
--- a/apps/webapp/app/presenters/JobListPresenter.server.ts
+++ b/apps/webapp/app/presenters/JobListPresenter.server.ts
@@ -145,6 +145,12 @@ export class JobListPresenter {
           setupStatus: integration.integration.setupStatus,
         }));
 
+        //deduplicate integrations
+        const uniqueIntegrations = new Map<string, (typeof integrations)[0]>();
+        integrations.forEach((i) => {
+          uniqueIntegrations.set(i.key, i);
+        });
+
         let properties: DisplayProperty[] = [];
 
         if (eventSpecification.properties) {
@@ -176,7 +182,7 @@ export class JobListPresenter {
                   }`
                 : undefined,
             },
-            integrations,
+            integrations: Array.from(uniqueIntegrations.values()),
             hasIntegrationsRequiringAction: integrations.some(
               (i) => i.setupStatus === "MISSING_FIELDS"
             ),


### PR DESCRIPTION
Multiple icons can get rendered in the Job list… I can't reproduce this locally but this PR deduplicates them in the presenter which hopefully will fix the problem.

![CleanShot 2024-02-13 at 10 15 49](https://github.com/triggerdotdev/trigger.dev/assets/10635986/644c02d0-6cb8-43a5-9b26-6fa022e74614)
