### PR TITLE
feat: support async `io.runTask` error callback

### DIFF
--- a/.changeset/chatty-trainers-happen.md
+++ b/.changeset/chatty-trainers-happen.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+support async `io.runTask` error callback

--- a/packages/trigger-sdk/src/io.ts
+++ b/packages/trigger-sdk/src/io.ts
@@ -80,15 +80,17 @@ type JsonArray = Json[];
 type JsonRecord<T> = { [Property in keyof T]: Json };
 export type Json<T = any> = JsonPrimitive | JsonArray | JsonRecord<T>;
 
-export type RunTaskErrorCallback = (
-  error: unknown,
-  task: IOTask,
-  io: IO
-) =>
+type RunTaskErrorCallbackReturn =
   | { retryAt?: Date; error?: Error; jitter?: number; skipRetrying?: boolean }
   | Error
   | undefined
   | void;
+
+export type RunTaskErrorCallback = (
+  error: unknown,
+  task: IOTask,
+  io: IO
+) => RunTaskErrorCallbackReturn | Promise<RunTaskErrorCallbackReturn>;
 
 export type IOStats = {
   initialCachedTasks: number;
@@ -1300,7 +1302,7 @@ export class IO {
 
         if (onError) {
           try {
-            const onErrorResult = onError(error, task, this);
+            const onErrorResult = await onError(error, task, this);
 
             if (onErrorResult) {
               if (onErrorResult instanceof Error) {


### PR DESCRIPTION
Closes #909

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Ran with a [patched](https://gist.github.com/minyoung/1f165cca2f680795f0dd490ac0bda454) `@trigger.dev/sdk` (using [pnpm.patchedDependencies](https://pnpm.io/package_json#pnpmpatcheddependencies)), verified that there were no type errors and that returning `{ skipRetrying: true }` worked correctly with and without an async error callback (at different `task.attempt` values)

---

## Changelog

Support async `io.runTask` error callback

💯
