### PR TITLE
Fix: Remove fixed public schema name from migration to enable custom schema names

### DIFF
--- a/packages/database/prisma/migrations/20240130165343_add_composite_index_to_job_run_for_job_id_and_created_at/migration.sql
+++ b/packages/database/prisma/migrations/20240130165343_add_composite_index_to_job_run_for_job_id_and_created_at/migration.sql
@@ -1,1 +1,1 @@
-CREATE INDEX idx_jobrun_jobId_createdAt ON "public"."JobRun" ("jobId", "createdAt" DESC);
+CREATE INDEX idx_jobrun_jobId_createdAt ON "JobRun" ("jobId", "createdAt" DESC);


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Migration "20240130165343_add_composite_index_to_job_run_for_job_id_and_created_at" had a fixed "public" schema in the migration, preventing from running it against a custom schema name, like proposed in the docs. 

---

## Changelog

Removed "public" from migration. 
