### PR TITLE
Use TaskRunStatus (instead of TaskRunAttemptStatus)

### DIFF
--- a/apps/webapp/app/components/runs/v3/RunFilters.tsx
+++ b/apps/webapp/app/components/runs/v3/RunFilters.tsx
@@ -1,6 +1,7 @@
 import { TrashIcon } from "@heroicons/react/20/solid";
 import { useNavigate } from "@remix-run/react";
-import { RuntimeEnvironment, TaskRunAttemptStatus } from "@trigger.dev/database";
+import { RuntimeEnvironment, TaskRunAttemptStatus, TaskRunStatus } from "@trigger.dev/database";
+import type { TaskRunStatus as TaskRunStatusType } from "@trigger.dev/database";
 import { useCallback } from "react";
 import { z } from "zod";
 import { useOptimisticLocation } from "~/hooks/useOptimisticLocation";
@@ -16,21 +17,10 @@ import {
   SelectValue,
 } from "../../primitives/Select";
 import { TimeFrameFilter } from "../TimeFrameFilter";
-import { TaskRunStatus } from "./TaskRunStatus";
+import { TaskRunStatusCombo } from "./TaskRunStatus";
 
-export const allTaskRunStatuses = [
-  "ENQUEUED",
-  "PENDING",
-  "EXECUTING",
-  "PAUSED",
-  "FAILED",
-  "COMPLETED",
-  "CANCELED",
-] as const;
-
-export type ExtendedTaskAttemptStatus = (typeof allTaskRunStatuses)[number];
-
-export const TaskAttemptStatus = z.enum(allTaskRunStatuses);
+export const allTaskRunStatuses = Object.values(TaskRunStatus) as TaskRunStatusType[];
+export const TaskAttemptStatus = z.nativeEnum(TaskRunStatus);
 
 export const TaskRunListSearchFilters = z.object({
   cursor: z.string().optional(),
@@ -174,7 +164,7 @@ export function RunsFilters({ possibleEnvironments, possibleTasks }: RunFiltersP
             </SelectItem>
             {allTaskRunStatuses.map((status) => (
               <SelectItem key={status} value={status}>
-                <TaskRunStatus status={status} className="text-xs" />
+                <TaskRunStatusCombo status={status} className="text-xs" />
               </SelectItem>
             ))}
           </SelectContent>

--- a/apps/webapp/app/components/runs/v3/TaskRunAttemptStatus.tsx
+++ b/apps/webapp/app/components/runs/v3/TaskRunAttemptStatus.tsx
@@ -1,0 +1,132 @@
+import {
+  CheckCircleIcon,
+  ClockIcon,
+  NoSymbolIcon,
+  PauseCircleIcon,
+  RectangleStackIcon,
+  XCircleIcon,
+} from "@heroicons/react/20/solid";
+import { TaskRunAttemptStatus } from "@trigger.dev/database";
+import type { TaskRunAttemptStatus as TaskRunAttemptStatusType } from "@trigger.dev/database";
+import { Spinner } from "~/components/primitives/Spinner";
+import { cn } from "~/utils/cn";
+
+export const allTaskRunAttemptStatuses = Object.values(
+  TaskRunAttemptStatus
+) as TaskRunAttemptStatusType[];
+
+export type ExtendedTaskAttemptStatus = (typeof allTaskRunAttemptStatuses)[number] | "ENQUEUED";
+
+export function TaskRunAttemptStatusCombo({
+  status,
+  className,
+}: {
+  status: ExtendedTaskAttemptStatus | null;
+  className?: string;
+}) {
+  return (
+    <span className={cn("flex items-center gap-1", className)}>
+      <TaskRunAttemptStatusIcon status={status} className="h-4 w-4" />
+      <TaskRunAttemptStatusLabel status={status} />
+    </span>
+  );
+}
+
+export function TaskRunAttemptStatusLabel({
+  status,
+}: {
+  status: ExtendedTaskAttemptStatus | null;
+}) {
+  return (
+    <span className={runAttemptStatusClassNameColor(status)}>{runAttemptStatusTitle(status)}</span>
+  );
+}
+
+export function TaskRunAttemptStatusIcon({
+  status,
+  className,
+}: {
+  status: ExtendedTaskAttemptStatus | null;
+  className: string;
+}) {
+  if (status === null) {
+    return <RectangleStackIcon className={cn(runAttemptStatusClassNameColor(status), className)} />;
+  }
+
+  switch (status) {
+    case "ENQUEUED":
+      return (
+        <RectangleStackIcon className={cn(runAttemptStatusClassNameColor(status), className)} />
+      );
+    case "PENDING":
+      return <ClockIcon className={cn(runAttemptStatusClassNameColor(status), className)} />;
+    case "EXECUTING":
+      return <Spinner className={cn(runAttemptStatusClassNameColor(status), className)} />;
+    case "PAUSED":
+      return <PauseCircleIcon className={cn(runAttemptStatusClassNameColor(status), className)} />;
+    case "FAILED":
+      return <XCircleIcon className={cn(runAttemptStatusClassNameColor(status), className)} />;
+    case "CANCELED":
+      return <NoSymbolIcon className={cn(runAttemptStatusClassNameColor(status), className)} />;
+    case "COMPLETED":
+      return <CheckCircleIcon className={cn(runAttemptStatusClassNameColor(status), className)} />;
+    default: {
+      const _exhaustiveCheck: never = status;
+      throw new Error(`Non-exhaustive match for value: ${status}`);
+    }
+  }
+}
+
+export function runAttemptStatusClassNameColor(status: ExtendedTaskAttemptStatus | null): string {
+  if (status === null) {
+    return "text-charcoal-500";
+  }
+
+  switch (status) {
+    case "ENQUEUED":
+      return "text-charcoal-500";
+    case "PENDING":
+      return "text-charcoal-500";
+    case "EXECUTING":
+      return "text-pending";
+    case "PAUSED":
+      return "text-amber-300";
+    case "FAILED":
+      return "text-error";
+    case "CANCELED":
+      return "text-charcoal-500";
+    case "COMPLETED":
+      return "text-success";
+    default: {
+      const _exhaustiveCheck: never = status;
+      throw new Error(`Non-exhaustive match for value: ${status}`);
+    }
+  }
+}
+
+export function runAttemptStatusTitle(status: ExtendedTaskAttemptStatus | null): string {
+  if (status === null) {
+    return "Enqueued";
+  }
+
+  switch (status) {
+    case "ENQUEUED":
+      return "Enqueued";
+    case "PENDING":
+      return "Pending";
+    case "EXECUTING":
+      return "Executing";
+    case "PAUSED":
+      return "Paused";
+    case "FAILED":
+      return "Failed";
+    case "CANCELED":
+      return "Canceled";
+    case "COMPLETED":
+      return "Completed";
+    default: {
+      const _exhaustiveCheck: never = status;
+      throw new Error(`Non-exhaustive match for value: ${status}`);
+    }
+  }
+}

--- a/apps/webapp/app/components/runs/v3/TaskRunAttemptStatus.tsx
+++ b/apps/webapp/app/components/runs/v3/TaskRunAttemptStatus.tsx
@@ -6,8 +6,8 @@ import {
   RectangleStackIcon,
   XCircleIcon,
 } from "@heroicons/react/20/solid";
-import { TaskRunAttemptStatus } from "@trigger.dev/database";
 import type { TaskRunAttemptStatus as TaskRunAttemptStatusType } from "@trigger.dev/database";
+import { TaskRunAttemptStatus } from "@trigger.dev/database";
 import { Spinner } from "~/components/primitives/Spinner";
 import { cn } from "~/utils/cn";
 

--- a/apps/webapp/app/components/runs/v3/TaskRunStatus.tsx
+++ b/apps/webapp/app/components/runs/v3/TaskRunStatus.tsx
@@ -1,4 +1,7 @@
 import {
+  ArrowPathIcon,
+  BoltSlashIcon,
+  BugAntIcon,
   CheckCircleIcon,
   ClockIcon,
   NoSymbolIcon,
@@ -6,15 +9,15 @@ import {
   RectangleStackIcon,
   XCircleIcon,
 } from "@heroicons/react/20/solid";
+import { TaskRunStatus } from "@trigger.dev/database";
 import { Spinner } from "~/components/primitives/Spinner";
 import { cn } from "~/utils/cn";
-import { ExtendedTaskAttemptStatus } from "./RunFilters";
 
-export function TaskRunStatus({
+export function TaskRunStatusCombo({
   status,
   className,
 }: {
-  status: ExtendedTaskAttemptStatus | null;
+  status: TaskRunStatus;
   className?: string;
 }) {
   return (
@@ -25,7 +28,7 @@ export function TaskRunStatus({
   );
 }
 
-export function TaskRunStatusLabel({ status }: { status: ExtendedTaskAttemptStatus | null }) {
+export function TaskRunStatusLabel({ status }: { status: TaskRunStatus }) {
   return <span className={runStatusClassNameColor(status)}>{runStatusTitle(status)}</span>;
 }
 
@@ -33,28 +36,30 @@ export function TaskRunStatusIcon({
   status,
   className,
 }: {
-  status: ExtendedTaskAttemptStatus | null;
+  status: TaskRunStatus;
   className: string;
 }) {
-  if (status === null) {
-    return <RectangleStackIcon className={cn(runStatusClassNameColor(status), className)} />;
-  }
-
   switch (status) {
-    case "ENQUEUED":
-      return <RectangleStackIcon className={cn(runStatusClassNameColor(status), className)} />;
     case "PENDING":
-      return <ClockIcon className={cn(runStatusClassNameColor(status), className)} />;
+      return <RectangleStackIcon className={cn(runStatusClassNameColor(status), className)} />;
     case "EXECUTING":
       return <Spinner className={cn(runStatusClassNameColor(status), className)} />;
+    case "WAITING_TO_RESUME":
+      return <ClockIcon className={cn(runStatusClassNameColor(status), className)} />;
+    case "RETRYING_AFTER_FAILURE":
+      return <ArrowPathIcon className={cn(runStatusClassNameColor(status), className)} />;
     case "PAUSED":
       return <PauseCircleIcon className={cn(runStatusClassNameColor(status), className)} />;
-    case "FAILED":
-      return <XCircleIcon className={cn(runStatusClassNameColor(status), className)} />;
     case "CANCELED":
       return <NoSymbolIcon className={cn(runStatusClassNameColor(status), className)} />;
-    case "COMPLETED":
+    case "INTERRUPTED":
+      return <BoltSlashIcon className={cn(runStatusClassNameColor(status), className)} />;
+    case "COMPLETED_SUCCESSFULLY":
       return <CheckCircleIcon className={cn(runStatusClassNameColor(status), className)} />;
+    case "COMPLETED_WITH_ERRORS":
+      return <XCircleIcon className={cn(runStatusClassNameColor(status), className)} />;
+    case "SYSTEM_FAILURE":
+      return <BugAntIcon className={cn(runStatusClassNameColor(status), className)} />;
 
     default: {
       const _exhaustiveCheck: never = status;
@@ -63,26 +68,28 @@ export function TaskRunStatusIcon({
   }
 }
 
-export function runStatusClassNameColor(status: ExtendedTaskAttemptStatus | null): string {
-  if (status === null) {
-    return "text-charcoal-500";
-  }
-
+export function runStatusClassNameColor(status: TaskRunStatus): string {
   switch (status) {
-    case "ENQUEUED":
-      return "text-charcoal-500";
     case "PENDING":
       return "text-charcoal-500";
     case "EXECUTING":
       return "text-pending";
+    case "WAITING_TO_RESUME":
+      return "text-charcoal-500";
+    case "RETRYING_AFTER_FAILURE":
+      return "text-charcoal-500";
     case "PAUSED":
       return "text-amber-300";
-    case "FAILED":
-      return "text-error";
     case "CANCELED":
       return "text-charcoal-500";
-    case "COMPLETED":
+    case "INTERRUPTED":
+      return "text-error";
+    case "COMPLETED_SUCCESSFULLY":
       return "text-success";
+    case "COMPLETED_WITH_ERRORS":
+      return "text-error";
+    case "SYSTEM_FAILURE":
+      return "text-error";
     default: {
       const _exhaustiveCheck: never = status;
       throw new Error(`Non-exhaustive match for value: ${status}`);
@@ -90,26 +97,28 @@ export function runStatusClassNameColor(status: ExtendedTaskAttemptStatus | null
   }
 }
 
-export function runStatusTitle(status: ExtendedTaskAttemptStatus | null): string {
-  if (status === null) {
-    return "Enqueued";
-  }
-
+export function runStatusTitle(status: TaskRunStatus): string {
   switch (status) {
-    case "ENQUEUED":
-      return "Enqueued";
     case "PENDING":
-      return "Pending";
+      return "Enqueued";
     case "EXECUTING":
       return "Executing";
+    case "WAITING_TO_RESUME":
+      return "Waiting";
+    case "RETRYING_AFTER_FAILURE":
+      return "Retrying";
     case "PAUSED":
       return "Paused";
-    case "FAILED":
-      return "Failed";
     case "CANCELED":
       return "Canceled";
-    case "COMPLETED":
+    case "INTERRUPTED":
+      return "Interrupted";
+    case "COMPLETED_SUCCESSFULLY":
       return "Completed";
+    case "COMPLETED_WITH_ERRORS":
+      return "Failed";
+    case "SYSTEM_FAILURE":
+      return "System failure";
     default: {
       const _exhaustiveCheck: never = status;
       throw new Error(`Non-exhaustive match for value: ${status}`);

--- a/apps/webapp/app/components/runs/v3/TaskRunsTable.tsx
+++ b/apps/webapp/app/components/runs/v3/TaskRunsTable.tsx
@@ -19,8 +19,8 @@ import {
   TableHeaderCell,
   TableRow,
 } from "../../primitives/Table";
-import { TaskRunStatus } from "./TaskRunStatus";
 import { formatDuration } from "@trigger.dev/core/v3";
+import { TaskRunStatusCombo } from "./TaskRunStatus";
 
 type RunsTableProps = {
   total: number;
@@ -82,7 +82,7 @@ export function TaskRunsTable({
                   <EnvironmentLabel environment={run.environment} userName={usernameForEnv} />
                 </TableCell>
                 <TableCell to={path}>
-                  <TaskRunStatus status={run.status} />
+                  <TaskRunStatusCombo status={run.status} />
                 </TableCell>
                 <TableCell to={path}>
                   {run.startedAt ? <DateTime date={run.startedAt} /> : "–"}

--- a/apps/webapp/app/presenters/v3/TestTaskPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/TestTaskPresenter.server.ts
@@ -1,4 +1,4 @@
-import { TaskRunAttemptStatus } from "@trigger.dev/database";
+import { TaskRunAttemptStatus, TaskRunStatus } from "@trigger.dev/database";
 import { PrismaClient, prisma } from "~/db.server";
 import { getUsername } from "~/utils/username";
 
@@ -53,7 +53,7 @@ export class TestTaskPresenter {
         number: BigInt;
         friendlyId: string;
         createdAt: Date;
-        status: TaskRunAttemptStatus;
+        status: TaskRunStatus;
         payload: string;
         payloadType: string;
         runtimeEnvironmentId: string;
@@ -73,13 +73,6 @@ export class TestTaskPresenter {
       ORDER BY 
           tr."createdAt" DESC
       LIMIT 5
-    ), latestattempts AS (
-        SELECT
-            "taskRunId",
-            status,
-            ROW_NUMBER() OVER(PARTITION BY "taskRunId" ORDER BY "createdAt" DESC) AS rank
-        FROM
-            "TaskRunAttempt"
     )
     SELECT 
         taskr.id,
@@ -87,17 +80,12 @@ export class TestTaskPresenter {
         taskr."friendlyId",
         taskr."taskIdentifier",
         taskr."createdAt",
-        tra.status,
+        taskr.status,
         taskr.payload,
         taskr."payloadType",
         taskr."runtimeEnvironmentId"
     FROM 
         taskruns AS taskr
-    LEFT JOIN
-        latestattempts AS tra
-        ON taskr.id = tra."taskRunId"
-    WHERE
-        tra.rank = 1
     ORDER BY
         taskr."createdAt" DESC;`;
 

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -15,7 +15,7 @@ import { RunIcon } from "~/components/runs/v3/RunIcon";
 import { SpanEvents } from "~/components/runs/v3/SpanEvents";
 import { SpanTitle } from "~/components/runs/v3/SpanTitle";
 import { TaskPath } from "~/components/runs/v3/TaskPath";
-import { TaskRunStatus } from "~/components/runs/v3/TaskRunStatus";
+import { TaskRunAttemptStatusCombo } from "~/components/runs/v3/TaskRunAttemptStatus";
 import { useOrganization } from "~/hooks/useOrganizations";
 import { useProject } from "~/hooks/useProject";
 import { SpanPresenter } from "~/presenters/v3/SpanPresenter.server";
@@ -85,7 +85,7 @@ export default function Page() {
             )}
             {event.style.variant === "primary" && (
               <Property label="Status">
-                <TaskRunStatus
+                <TaskRunAttemptStatusCombo
                   status={
                     event.isCancelled
                       ? "CANCELED"

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
@@ -3,7 +3,6 @@ import {
   ChevronRightIcon,
   MagnifyingGlassMinusIcon,
   MagnifyingGlassPlusIcon,
-  NoSymbolIcon,
 } from "@heroicons/react/20/solid";
 import { Link, Outlet, useNavigate, useRevalidator } from "@remix-run/react";
 import { LoaderFunctionArgs } from "@remix-run/server-runtime";
@@ -27,10 +26,8 @@ import { Slider } from "~/components/primitives/Slider";
 import { Switch } from "~/components/primitives/Switch";
 import * as Timeline from "~/components/primitives/Timeline";
 import { TreeView, useTree } from "~/components/primitives/TreeView/TreeView";
-import { LiveCountUp, LiveTimer } from "~/components/runs/v3/LiveTimer";
 import { RunIcon } from "~/components/runs/v3/RunIcon";
 import { SpanTitle, eventBackgroundClassName } from "~/components/runs/v3/SpanTitle";
-import { TaskRunAttemptStatusIcon } from "~/components/runs/v3/TaskRunAttemptStatus";
 import { TaskRunStatusIcon, runStatusClassNameColor } from "~/components/runs/v3/TaskRunStatus";
 import { useDebounce } from "~/hooks/useDebounce";
 import { useEventSource } from "~/hooks/useEventSource";
@@ -569,14 +566,14 @@ function NodeStatusIcon({ node }: { node: RunEvent }) {
   }
 
   if (node.data.isError) {
-    return <TaskRunAttemptStatusIcon status="FAILED" className={cn("size-4")} />;
+    return <TaskRunStatusIcon status="COMPLETED_WITH_ERRORS" className={cn("size-4")} />;
   }
 
   if (node.data.isPartial) {
     return <TaskRunStatusIcon status={"EXECUTING"} className={cn("size-4")} />;
   }
 
-  return <TaskRunAttemptStatusIcon status="COMPLETED" className={cn("size-4")} />;
+  return <TaskRunStatusIcon status="COMPLETED_SUCCESSFULLY" className={cn("size-4")} />;
 }
 
 function TaskLine({ isError, isSelected }: { isError: boolean; isSelected: boolean }) {

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
@@ -237,6 +237,9 @@ function TasksTreeView({
     },
   });
 
+  const minTimelineWidth = initialTimelineDimensions?.width ?? 300;
+  const maxTimelineWidth = minTimelineWidth * 10;
+
   return (
     <div className="grid h-full grid-rows-[2.5rem_1fr] overflow-hidden">
       <div className="mx-3 flex items-center justify-between gap-2 border-b border-grid-dimmed">
@@ -382,8 +385,8 @@ function TasksTreeView({
               durationMs={nanosecondsToMilliseconds(totalDuration * 1.05)}
               scale={scale}
               className="h-full overflow-hidden"
-              minWidth={initialTimelineDimensions?.width ?? 300}
-              maxWidth={2000}
+              minWidth={minTimelineWidth}
+              maxWidth={maxTimelineWidth}
             >
               {/* Follows the cursor */}
               <CurrentTimeIndicator totalDuration={totalDuration} />

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
@@ -30,6 +30,7 @@ import { TreeView, useTree } from "~/components/primitives/TreeView/TreeView";
 import { LiveCountUp, LiveTimer } from "~/components/runs/v3/LiveTimer";
 import { RunIcon } from "~/components/runs/v3/RunIcon";
 import { SpanTitle, eventBackgroundClassName } from "~/components/runs/v3/SpanTitle";
+import { TaskRunAttemptStatusIcon } from "~/components/runs/v3/TaskRunAttemptStatus";
 import { TaskRunStatusIcon, runStatusClassNameColor } from "~/components/runs/v3/TaskRunStatus";
 import { useDebounce } from "~/hooks/useDebounce";
 import { useEventSource } from "~/hooks/useEventSource";
@@ -568,14 +569,14 @@ function NodeStatusIcon({ node }: { node: RunEvent }) {
   }
 
   if (node.data.isError) {
-    return <TaskRunStatusIcon status="FAILED" className={cn("size-4")} />;
+    return <TaskRunAttemptStatusIcon status="FAILED" className={cn("size-4")} />;
   }
 
   if (node.data.isPartial) {
     return <TaskRunStatusIcon status={"EXECUTING"} className={cn("size-4")} />;
   }
 
-  return <TaskRunStatusIcon status="COMPLETED" className={cn("size-4")} />;
+  return <TaskRunAttemptStatusIcon status="COMPLETED" className={cn("size-4")} />;
 }
 
 function TaskLine({ isError, isSelected }: { isError: boolean; isSelected: boolean }) {

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.test.tasks.$taskParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.test.tasks.$taskParam/route.tsx
@@ -22,6 +22,7 @@ import {
 } from "~/components/primitives/Resizable";
 import { TaskPath } from "~/components/runs/v3/TaskPath";
 import { TaskRunAttemptStatusCombo } from "~/components/runs/v3/TaskRunAttemptStatus";
+import { TaskRunStatusCombo } from "~/components/runs/v3/TaskRunStatus";
 import { redirectBackWithErrorMessage, redirectWithSuccessMessage } from "~/models/message.server";
 import { TestTaskPresenter } from "~/presenters/v3/TestTaskPresenter.server";
 import { requireUserId } from "~/services/session.server";
@@ -210,7 +211,7 @@ export default function Page() {
                       </Paragraph>
                       <div className="flex items-center gap-1 text-xs text-text-dimmed">
                         <div>Run #{run.number}</div>
-                        <TaskRunAttemptStatusCombo status={run.status} />
+                        <TaskRunStatusCombo status={run.status} />
                       </div>
                     </div>
                   </button>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.test.tasks.$taskParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.test.tasks.$taskParam/route.tsx
@@ -3,7 +3,6 @@ import { parse } from "@conform-to/zod";
 import { BeakerIcon } from "@heroicons/react/20/solid";
 import { Form, useActionData, useNavigation, useSubmit } from "@remix-run/react";
 import { ActionFunction, LoaderFunctionArgs, json } from "@remix-run/server-runtime";
-import { TaskRunAttemptStatus } from "@trigger.dev/database";
 import { useCallback, useRef, useState } from "react";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { z } from "zod";
@@ -21,7 +20,6 @@ import {
   ResizablePanelGroup,
 } from "~/components/primitives/Resizable";
 import { TaskPath } from "~/components/runs/v3/TaskPath";
-import { TaskRunAttemptStatusCombo } from "~/components/runs/v3/TaskRunAttemptStatus";
 import { TaskRunStatusCombo } from "~/components/runs/v3/TaskRunStatus";
 import { redirectBackWithErrorMessage, redirectWithSuccessMessage } from "~/models/message.server";
 import { TestTaskPresenter } from "~/presenters/v3/TestTaskPresenter.server";

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.test.tasks.$taskParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.test.tasks.$taskParam/route.tsx
@@ -3,6 +3,7 @@ import { parse } from "@conform-to/zod";
 import { BeakerIcon } from "@heroicons/react/20/solid";
 import { Form, useActionData, useNavigation, useSubmit } from "@remix-run/react";
 import { ActionFunction, LoaderFunctionArgs, json } from "@remix-run/server-runtime";
+import { TaskRunAttemptStatus } from "@trigger.dev/database";
 import { useCallback, useRef, useState } from "react";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { z } from "zod";
@@ -20,7 +21,7 @@ import {
   ResizablePanelGroup,
 } from "~/components/primitives/Resizable";
 import { TaskPath } from "~/components/runs/v3/TaskPath";
-import { TaskRunStatus } from "~/components/runs/v3/TaskRunStatus";
+import { TaskRunAttemptStatusCombo } from "~/components/runs/v3/TaskRunAttemptStatus";
 import { redirectBackWithErrorMessage, redirectWithSuccessMessage } from "~/models/message.server";
 import { TestTaskPresenter } from "~/presenters/v3/TestTaskPresenter.server";
 import { requireUserId } from "~/services/session.server";
@@ -209,7 +210,7 @@ export default function Page() {
                       </Paragraph>
                       <div className="flex items-center gap-1 text-xs text-text-dimmed">
                         <div>Run #{run.number}</div>
-                        <TaskRunStatus status={run.status} />
+                        <TaskRunAttemptStatusCombo status={run.status} />
                       </div>
                     </div>
                   </button>


### PR DESCRIPTION
- The task list now shows the latest run using TaskRunStatus
- The run list uses the TaskRunStatus, and the status filters
- The test page uses the TaskRunStatus for recent payloads

Also made it so you can do 10x zoom on the span timeline

I created some new components for TaskRunStatus. We still have TaskRunAttemptStatus components which can be used.