### PR TITLE
Test, output and canceling improvements

### DIFF
--- a/apps/webapp/app/components/primitives/Table.tsx
+++ b/apps/webapp/app/components/primitives/Table.tsx
@@ -253,7 +253,7 @@ export const TableCellMenu = forwardRef<
 type TableBlankRowProps = {
   className?: string;
   colSpan: number;
-  children: ReactNode;
+  children?: ReactNode;
 };
 
 export const TableBlankRow = forwardRef<HTMLTableRowElement, TableBlankRowProps>(

--- a/apps/webapp/app/components/runs/v3/CancelRunDialog.tsx
+++ b/apps/webapp/app/components/runs/v3/CancelRunDialog.tsx
@@ -1,0 +1,43 @@
+import { StopCircleIcon } from "@heroicons/react/20/solid";
+import { useFetcher } from "@remix-run/react";
+import { Button } from "~/components/primitives/Buttons";
+import {
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+} from "~/components/primitives/Dialog";
+
+type CancelRunDialogProps = {
+  runFriendlyId: string;
+  redirectPath: string;
+};
+
+export function CancelRunDialog({ runFriendlyId, redirectPath }: CancelRunDialogProps) {
+  const cancelFetcher = useFetcher();
+
+  return (
+    <DialogContent>
+      <DialogHeader>Cancel this run?</DialogHeader>
+      <DialogDescription>
+        Canceling a run will stop execution. If you want to run this later you will have to replay
+        the entire run with the original payload.
+      </DialogDescription>
+      <DialogFooter>
+        <cancelFetcher.Form action={`/resources/taskruns/${runFriendlyId}/cancel`} method="post">
+          <Button
+            type="submit"
+            name="redirectUrl"
+            value={redirectPath}
+            variant="danger/small"
+            LeadingIcon={cancelFetcher.state === "idle" ? StopCircleIcon : "spinner-white"}
+            disabled={cancelFetcher.state !== "idle"}
+            shortcut={{ modifiers: ["meta"], key: "enter" }}
+          >
+            {cancelFetcher.state === "idle" ? "Cancel run" : "Canceling..."}
+          </Button>
+        </cancelFetcher.Form>
+      </DialogFooter>
+    </DialogContent>
+  );
+}

--- a/apps/webapp/app/components/runs/v3/TaskRunsTable.tsx
+++ b/apps/webapp/app/components/runs/v3/TaskRunsTable.tsx
@@ -15,6 +15,7 @@ import {
   TableBody,
   TableCell,
   TableCellChevron,
+  TableCellMenu,
   TableHeader,
   TableHeaderCell,
   TableRow,
@@ -22,7 +23,11 @@ import {
 import { formatDuration } from "@trigger.dev/core/v3";
 import { TaskRunStatusCombo } from "./TaskRunStatus";
 import { useEnvironments } from "~/hooks/useEnvironments";
-import { LinkButton } from "~/components/primitives/Buttons";
+import { Button, LinkButton } from "~/components/primitives/Buttons";
+import { StopCircleIcon } from "@heroicons/react/20/solid";
+import { Dialog, DialogTrigger } from "~/components/primitives/Dialog";
+import { CancelRunDialog } from "./CancelRunDialog";
+import { useLocation } from "@remix-run/react";
 
 type RunsTableProps = {
   total: number;
@@ -44,6 +49,7 @@ export function TaskRunsTable({
 }: RunsTableProps) {
   const organization = useOrganization();
   const project = useProject();
+  const location = useLocation();
 
   return (
     <Table>
@@ -104,7 +110,23 @@ export function TaskRunsTable({
                 <TableCell to={path}>
                   {run.createdAt ? <DateTime date={run.createdAt} /> : "–"}
                 </TableCell>
-                <TableCellChevron to={path} isSticky />
+                {run.isCancellable ? (
+                  <TableCellMenu isSticky>
+                    <Dialog>
+                      <DialogTrigger asChild>
+                        <Button variant="small-menu-item" LeadingIcon={StopCircleIcon}>
+                          Cancel run
+                        </Button>
+                      </DialogTrigger>
+                      <CancelRunDialog
+                        runFriendlyId={run.friendlyId}
+                        redirectPath={`${location.pathname}${location.search}`}
+                      />
+                    </Dialog>
+                  </TableCellMenu>
+                ) : (
+                  <TableCell to={path}>{""}</TableCell>
+                )}
               </TableRow>
             );
           })

--- a/apps/webapp/app/presenters/v3/RunListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/RunListPresenter.server.ts
@@ -23,6 +23,7 @@ const DEFAULT_PAGE_SIZE = 20;
 
 export type RunList = Awaited<ReturnType<RunListPresenter["call"]>>;
 export type RunListItem = RunList["runs"][0];
+export type RunListAppliedFilters = RunList["filters"];
 
 export class RunListPresenter {
   #prismaClient: PrismaClient;
@@ -233,6 +234,14 @@ export class RunListPresenter {
         previous,
       },
       possibleTasks: possibleTasks.map((task) => task.slug),
+      filters: {
+        tasks: tasks || [],
+        versions: versions || [],
+        statuses: statuses || [],
+        environments: environments || [],
+        from,
+        to,
+      },
       hasFilters,
     };
   }

--- a/apps/webapp/app/presenters/v3/RunListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/RunListPresenter.server.ts
@@ -2,6 +2,7 @@ import { Prisma, TaskRunAttemptStatus, TaskRunStatus } from "@trigger.dev/databa
 import { Direction } from "~/components/runs/RunStatuses";
 import { PrismaClient, prisma } from "~/db.server";
 import { getUsername } from "~/utils/username";
+import { CANCELLABLE_STATUSES } from "~/v3/services/cancelTaskRun.server";
 
 type RunListOptions = {
   userId: string;
@@ -221,6 +222,7 @@ export class RunListPresenter {
           version: run.version,
           taskIdentifier: run.taskIdentifier,
           attempts: Number(run.attempts),
+          isCancellable: CANCELLABLE_STATUSES.includes(run.status),
           environment: {
             type: environment.type,
             slug: environment.slug,

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -19,6 +19,7 @@ import {
 import { Header2 } from "~/components/primitives/Headers";
 import { Paragraph } from "~/components/primitives/Paragraph";
 import { Property, PropertyTable } from "~/components/primitives/PropertyTable";
+import { CancelRunDialog } from "~/components/runs/v3/CancelRunDialog";
 import { LiveTimer } from "~/components/runs/v3/LiveTimer";
 import { RunIcon } from "~/components/runs/v3/RunIcon";
 import { SpanEvents } from "~/components/runs/v3/SpanEvents";
@@ -54,7 +55,6 @@ export default function Page() {
   const organization = useOrganization();
   const project = useProject();
   const { runParam } = useParams();
-  const cancelFetcher = useFetcher();
 
   return (
     <div
@@ -176,38 +176,15 @@ export default function Page() {
                     Cancel run
                   </Button>
                 </DialogTrigger>
-                <DialogContent>
-                  <DialogHeader>Cancel this run?</DialogHeader>
-                  <DialogDescription>
-                    Canceling a run will stop execution. If you want to run this later you will have
-                    to replay the entire run with the original payload.
-                  </DialogDescription>
-                  <DialogFooter>
-                    <cancelFetcher.Form
-                      action={`/resources/taskruns/${event.runId}/cancel`}
-                      method="post"
-                    >
-                      <Button
-                        type="submit"
-                        name="redirectUrl"
-                        value={v3RunSpanPath(
-                          organization,
-                          project,
-                          { friendlyId: runParam },
-                          { spanId: event.spanId }
-                        )}
-                        variant="danger/small"
-                        LeadingIcon={
-                          cancelFetcher.state === "idle" ? StopCircleIcon : "spinner-white"
-                        }
-                        disabled={cancelFetcher.state !== "idle"}
-                        shortcut={{ modifiers: ["meta"], key: "enter" }}
-                      >
-                        {cancelFetcher.state === "idle" ? "Cancel run" : "Canceling..."}
-                      </Button>
-                    </cancelFetcher.Form>
-                  </DialogFooter>
-                </DialogContent>
+                <CancelRunDialog
+                  runFriendlyId={event.runId}
+                  redirectPath={v3RunSpanPath(
+                    organization,
+                    project,
+                    { friendlyId: runParam },
+                    { spanId: event.spanId }
+                  )}
+                />
               </Dialog>
             )}
           </div>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
@@ -581,11 +581,7 @@ function NodeStatusIcon({ node }: { node: RunEvent }) {
 }
 
 function TaskLine({ isError, isSelected }: { isError: boolean; isSelected: boolean }) {
-  return (
-    <div
-      className={cn("h-8 w-2 border-r", isError ? "border-rose-500/10" : "border-charcoal-800")}
-    />
-  );
+  return <div className={cn("h-8 w-2 border-r border-grid-bright")} />;
 }
 
 function ShowParentLink({ runFriendlyId }: { runFriendlyId: string }) {

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs._index/route.tsx
@@ -84,6 +84,7 @@ export default function Page() {
               <TaskRunsTable
                 total={list.runs.length}
                 hasFilters={list.hasFilters}
+                filters={list.filters}
                 runs={list.runs}
                 isLoading={isLoading}
                 currentUser={user}

--- a/apps/webapp/app/v3/eventRepository.server.ts
+++ b/apps/webapp/app/v3/eventRepository.server.ts
@@ -9,10 +9,10 @@ import {
   SpanEvents,
   TaskEventStyle,
   correctErrorStackTrace,
-  flattenAndNormalizeAttributes,
   flattenAttributes,
   isExceptionSpanEvent,
   omit,
+  primitiveValueOrflattenedAttributes,
   unflattenAttributes,
 } from "@trigger.dev/core/v3";
 import { Prisma, TaskEvent, TaskEventStatus, type TaskEventKind } from "@trigger.dev/database";
@@ -178,10 +178,7 @@ export class EventRepository {
       metadata: event.metadata as Attributes,
       style: event.style as Attributes,
       output: options?.attributes.output
-        ? flattenAndNormalizeAttributes(
-            options.attributes.output,
-            SemanticInternalAttributes.OUTPUT
-          )
+        ? primitiveValueOrflattenedAttributes(options.attributes.output, undefined)
         : undefined,
     });
   }

--- a/apps/webapp/app/v3/eventRepository.server.ts
+++ b/apps/webapp/app/v3/eventRepository.server.ts
@@ -564,7 +564,6 @@ export class EventRepository {
       queueName: options.attributes.queueName,
       batchId: options.attributes.batchId ?? undefined,
       properties: {
-        ...style,
         ...(flattenAttributes(metadata, SemanticInternalAttributes.METADATA) as Record<
           string,
           string

--- a/apps/webapp/app/v3/services/cancelTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/cancelTaskRun.server.ts
@@ -8,7 +8,7 @@ import { assertUnreachable } from "../utils/asserts.server";
 import { CancelAttemptService } from "./cancelAttempt.server";
 import { logger } from "~/services/logger.server";
 
-const CANCELLABLE_STATUSES: Array<TaskRunStatus> = [
+export const CANCELLABLE_STATUSES: Array<TaskRunStatus> = [
   "PENDING",
   "EXECUTING",
   "PAUSED",

--- a/packages/core/src/v3/index.ts
+++ b/packages/core/src/v3/index.ts
@@ -42,7 +42,7 @@ export { ConsoleInterceptor } from "./consoleInterceptor";
 export {
   flattenAttributes,
   unflattenAttributes,
-  flattenAndNormalizeAttributes,
+  primitiveValueOrflattenedAttributes,
 } from "./utils/flattenAttributes";
 export { defaultRetryOptions, calculateNextRetryDelay, calculateResetAt } from "./utils/retries";
 export { accessoryAttributes } from "./utils/styleAttributes";

--- a/packages/core/src/v3/utils/flattenAttributes.ts
+++ b/packages/core/src/v3/utils/flattenAttributes.ts
@@ -95,13 +95,27 @@ export function unflattenAttributes(obj: Attributes): Record<string, unknown> {
   return result;
 }
 
-export function flattenAndNormalizeAttributes(
+export function primitiveValueOrflattenedAttributes(
   obj: Record<string, unknown> | Array<unknown> | string | boolean | number | undefined,
-  prefix: string
-): Attributes {
+  prefix: string | undefined
+): Attributes | string | number | boolean | undefined {
+  if (
+    typeof obj === "string" ||
+    typeof obj === "number" ||
+    typeof obj === "boolean" ||
+    obj === null ||
+    obj === undefined
+  ) {
+    return obj;
+  }
+
   const attributes = flattenAttributes(obj, prefix);
 
-  if (typeof attributes[prefix] !== "undefined" && attributes[prefix] !== null) {
+  if (
+    prefix !== undefined &&
+    typeof attributes[prefix] !== "undefined" &&
+    attributes[prefix] !== null
+  ) {
     return attributes[prefix] as unknown as Attributes;
   }
 


### PR DESCRIPTION
- If you click from a task to runs and there are none, guide you to the test page (or docs)
- You can cancel directly from the runs page
- The output of a task was screwed up if it was an object, it had $output as a prefix