### PR TITLE
v3: CLI profile support

### DIFF
--- a/packages/cli-v3/src/cli/common.ts
+++ b/packages/cli-v3/src/cli/common.ts
@@ -10,12 +10,14 @@ export const CommonCommandOptions = z.object({
   apiUrl: z.string().optional(),
   logLevel: z.enum(["debug", "info", "log", "warn", "error", "none"]).default("log"),
   skipTelemetry: z.boolean().default(false),
+  profile: z.string().default("default"),
 });
 
 export type CommonCommandOptions = z.infer<typeof CommonCommandOptions>;
 
 export function commonOptions(command: Command) {
   return command
+    .option("--profile <profile>", "The login profile to use", "default")
     .option("-a, --api-url <value>", "Override the API URL", "https://api.trigger.dev")
     .option(
       "-l, --log-level <level>",
@@ -25,9 +27,9 @@ export function commonOptions(command: Command) {
     .option("--skip-telemetry", "Opt-out of sending telemetry");
 }
 
-export class SkipLoggingError extends Error {}
-export class SkipCommandError extends Error {}
-export class OutroCommandError extends SkipCommandError {}
+export class SkipLoggingError extends Error { }
+export class SkipCommandError extends Error { }
+export class OutroCommandError extends SkipCommandError { }
 
 export async function handleTelemetry(action: () => Promise<void>) {
   try {

--- a/packages/cli-v3/src/cli/index.ts
+++ b/packages/cli-v3/src/cli/index.ts
@@ -3,12 +3,10 @@ import { configureDeployCommand } from "../commands/deploy.js";
 import { configureDevCommand } from "../commands/dev.js";
 import { configureInitCommand } from "../commands/init.js";
 import { configureLoginCommand } from "../commands/login.js";
-import { logoutCommand } from "../commands/logout.js";
-import { updateCommand } from "../commands/update.js";
+import { configureLogoutCommand } from "../commands/logout.js";
 import { configureWhoamiCommand } from "../commands/whoami.js";
 import { COMMAND_NAME } from "../consts.js";
 import { getVersion } from "../utilities/getVersion.js";
-import { printInitialBanner } from "../utilities/initialBanner.js";
 
 export const program = new Command();
 
@@ -19,35 +17,7 @@ program
 
 configureLoginCommand(program);
 configureInitCommand(program);
-
-program
-  .command("logout")
-  .description("Logout of Trigger.dev")
-  .version(getVersion(), "-v, --version", "Display the version number")
-  .action(async (options) => {
-    try {
-      await printInitialBanner(false);
-      await logoutCommand(options);
-      //todo login command
-    } catch (e) {
-      //todo error reporting
-      throw e;
-    }
-  });
-
 configureDevCommand(program);
 configureDeployCommand(program);
-
-program
-  .command("update")
-  .description(
-    "Updates all @trigger.dev/* packages to their latest compatible versions or the specified version"
-  )
-  .argument("[path]", "The path to the directory that contains the package.json file", ".")
-  .option("-t, --to <version tag>", "The version to update to (ex: 2.1.4)", "latest")
-  .action(async (path, options) => {
-    await printInitialBanner(false);
-    await updateCommand(path, options);
-  });
-
 configureWhoamiCommand(program);
+configureLogoutCommand(program);

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -134,7 +134,7 @@ async function _deployCommand(dir: string, options: DeployCommandOptions) {
 
   intro("Deploying project");
 
-  const authorization = await login({ embedded: true, defaultApiUrl: options.apiUrl });
+  const authorization = await login({ embedded: true, defaultApiUrl: options.apiUrl, profile: options.profile });
 
   if (!authorization.ok) {
     if (authorization.error === "fetch failed") {

--- a/packages/cli-v3/src/commands/init.ts
+++ b/packages/cli-v3/src/commands/init.ts
@@ -80,7 +80,7 @@ async function _initCommand(dir: string, options: InitCommandOptions) {
 
   intro("Initializing project");
 
-  const authorization = await login({ embedded: true, defaultApiUrl: options.apiUrl });
+  const authorization = await login({ embedded: true, defaultApiUrl: options.apiUrl, profile: options.profile });
 
   if (!authorization.ok) {
     if (authorization.error === "fetch failed") {
@@ -96,6 +96,7 @@ async function _initCommand(dir: string, options: InitCommandOptions) {
     "cli.userId": authorization.userId,
     "cli.email": authorization.email,
     "cli.config.apiUrl": authorization.auth.apiUrl,
+    "cli.config.profile": authorization.profile,
   });
 
   if (!options.overrideConfig) {

--- a/packages/cli-v3/src/commands/logout.ts
+++ b/packages/cli-v3/src/commands/logout.ts
@@ -1,15 +1,41 @@
-import { readAuthConfigFile, writeAuthConfigFile } from "../utilities/configFiles.js";
+import { Command } from "commander";
+import { readAuthConfigProfile, writeAuthConfigProfile } from "../utilities/configFiles.js";
 import { logger } from "../utilities/logger.js";
+import { CommonCommandOptions, commonOptions, handleTelemetry, wrapCommandAction } from "../cli/common.js";
+import { printInitialBanner } from "../utilities/initialBanner.js";
+import { z } from "zod";
 
-export async function logoutCommand(options: any) {
-  const config = readAuthConfigFile();
+const LogoutCommandOptions = CommonCommandOptions;
+
+type LogoutCommandOptions = z.infer<typeof LogoutCommandOptions>;
+
+export function configureLogoutCommand(program: Command) {
+  return commonOptions(program
+    .command("logout")
+    .description("Logout of Trigger.dev"))
+    .action(async (options) => {
+      await handleTelemetry(async () => {
+        await printInitialBanner(false);
+        await logoutCommand(options);
+      });
+    });
+}
+
+export async function logoutCommand(options: unknown) {
+  return await wrapCommandAction("logoutCommand", LogoutCommandOptions, options, async (opts) => {
+    return await logout(opts);
+  });
+}
+
+export async function logout(options: LogoutCommandOptions) {
+  const config = readAuthConfigProfile(options.profile);
 
   if (!config?.accessToken) {
-    logger.info("You are already logged out");
+    logger.info(`You are already logged out [${options.profile ?? "default"}]`);
     return;
   }
 
-  writeAuthConfigFile({ ...config, accessToken: undefined, apiUrl: undefined });
+  writeAuthConfigProfile({ ...config, accessToken: undefined, apiUrl: undefined }, options.profile);
 
-  logger.info("Logged out");
+  logger.info(`Logged out of Trigger.dev [${options.profile ?? "default"}]`);
 }

--- a/packages/cli-v3/src/commands/whoami.ts
+++ b/packages/cli-v3/src/commands/whoami.ts
@@ -1,68 +1,65 @@
-import { note, spinner } from "@clack/prompts";
+import { intro, note, spinner } from "@clack/prompts";
 import { chalkLink } from "../utilities/colors.js";
 import { logger } from "../utilities/logger.js";
 import { isLoggedIn } from "../utilities/session.js";
 import { Command } from "commander";
 import { printInitialBanner } from "../utilities/initialBanner.js";
-import { CommonCommandOptions } from "../cli/common.js";
+import { CommonCommandOptions, commonOptions, handleTelemetry, wrapCommandAction } from "../cli/common.js";
 import { z } from "zod";
 import { CliApiClient } from "../apiClient.js";
 
 type WhoAmIResult =
   | {
-      success: true;
-      data: {
-        userId: string;
-        email: string;
-        dashboardUrl: string;
-      };
-    }
-  | {
-      success: false;
-      error: string;
+    success: true;
+    data: {
+      userId: string;
+      email: string;
+      dashboardUrl: string;
     };
+  }
+  | {
+    success: false;
+    error: string;
+  };
 
 const WhoamiCommandOptions = CommonCommandOptions;
 
 type WhoamiCommandOptions = z.infer<typeof WhoamiCommandOptions>;
 
 export function configureWhoamiCommand(program: Command) {
-  program
+  return commonOptions(program
     .command("whoami")
-    .description("display the current logged in user and project details")
-    .option(
-      "-l, --log-level <level>",
-      "The log level to use (debug, info, log, warn, error, none)",
-      "log"
-    )
+    .description("display the current logged in user and project details"))
     .action(async (options) => {
-      try {
-        await printInitialBanner();
-        await whoAmI(WhoamiCommandOptions.parse(options));
-      } catch (e) {
-        throw e;
-      }
+      await handleTelemetry(async () => {
+        await printInitialBanner(false);
+        await whoAmICommand(options);
+      });
     });
+}
+
+export async function whoAmICommand(options: unknown) {
+  return await wrapCommandAction("whoamiCommand", WhoamiCommandOptions, options, async (opts) => {
+    return await whoAmI(opts);
+  });
 }
 
 export async function whoAmI(
   options?: WhoamiCommandOptions,
   embedded: boolean = false
 ): Promise<WhoAmIResult> {
-  if (options?.logLevel) {
-    logger.loggerLevel = options?.logLevel;
-  }
+  intro(`Displaying your account details [${options?.profile ?? "default"}]`);
 
   const loadingSpinner = spinner();
   loadingSpinner.start("Checking your account details");
 
-  const authentication = await isLoggedIn();
+  const authentication = await isLoggedIn(options?.profile);
 
   if (!authentication.ok) {
     if (authentication.error === "fetch failed") {
       loadingSpinner.stop("Fetch failed. Platform down?");
     } else {
-      loadingSpinner.stop("You must login first. Use `trigger.dev login` to login.");
+      loadingSpinner.stop(`You must login first. Use \`trigger.dev login --profile ${options?.profile ?? "default"}\` to login.`);
     }
 
     return {
@@ -90,7 +87,7 @@ export async function whoAmI(
 Email: ${userData.data.email}
 URL: ${chalkLink(authentication.auth.apiUrl)}
 `,
-      "Account details"
+      `Account details [${authentication.profile}]`
     );
   } else {
     loadingSpinner.stop(`Retrieved your account details for ${userData.data.email}`);


### PR DESCRIPTION
You can now pass `--profile` to any of the v3 CLI commands to use that profile for auth in the CLI:

```sh
npx trigger.dev login --profile test
npx trigger.dev dev --profile test
npx trigger.dev deploy --profile test
```

If you don't pass a profile flag the `default` profile will be used.