### PR TITLE
Fix opanai code example in docs

### DIFF
--- a/docs/integrations/apis/openai/chat.mdx
+++ b/docs/integrations/apis/openai/chat.mdx
@@ -26,7 +26,7 @@ await io.openai.chat.completions.create("chat-completion", {
 Creates a model response for the given chat conversation, but runs the request in the background using [io.backgroundFetch()](/sdk/io/backgroundfetch)
 
 ```ts example.ts
-await io.openai.chat.completions.create("chat-completion", {
+await io.openai.chat.completions.backgroundCreate("chat-completion", {
   model: "gpt-3.5-turbo",
   messages: [
     {


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

_[Describe the steps you took to test this change]_

---

## Changelog

Doc's code example for openai [`completions.backgroundCreate()`](https://trigger.dev/docs/integrations/apis/openai/chat#completions-backgroundcreate) was incorrectly using `completions.create()`

---

## Screenshots

_[Screenshots]_
