### PR TITLE
v3: shared queue pool

### DIFF
--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -101,6 +101,9 @@ const EnvironmentSchema = z.object({
   EVENTS_BATCH_SIZE: z.coerce.number().int().default(100),
   EVENTS_BATCH_INTERVAL: z.coerce.number().int().default(1000),
   EVENTS_DEFAULT_LOG_RETENTION: z.coerce.number().int().default(7),
+  SHARED_QUEUE_CONSUMER_POOL_SIZE: z.coerce.number().int().default(10),
+  SHARED_QUEUE_CONSUMER_INTERVAL_MS: z.coerce.number().int().default(100),
+  SHARED_QUEUE_CONSUMER_NEXT_TICK_INTERVAL_MS: z.coerce.number().int().default(100),
 
   // Development OTEL environment variables
   DEV_OTEL_EXPORTER_OTLP_ENDPOINT: z.string().optional(),

--- a/apps/webapp/app/v3/handleSocketIo.server.ts
+++ b/apps/webapp/app/v3/handleSocketIo.server.ts
@@ -168,6 +168,7 @@ function createSharedQueueConsumerNamespace(io: Server) {
         namespace: sharedQueue.namespace,
         socket,
         logger,
+        poolSize: env.SHARED_QUEUE_CONSUMER_POOL_SIZE,
       });
 
       sharedSocketConnection.onClose.attach((closeEvent) => {

--- a/apps/webapp/app/v3/marqs.server.ts
+++ b/apps/webapp/app/v3/marqs.server.ts
@@ -6,7 +6,7 @@ import { singleton } from "~/utils/singleton";
 import { AsyncWorker } from "./marqs/asyncWorker.server";
 import { logger } from "~/services/logger.server";
 import { attributesFromAuthenticatedEnv } from "./tracer.server";
-import { Span, SpanKind, SpanOptions, trace } from "@opentelemetry/api";
+import { Span, SpanKind, SpanOptions, context, propagation, trace } from "@opentelemetry/api";
 import {
   SEMATTRS_MESSAGE_ID,
   SEMATTRS_MESSAGING_OPERATION,
@@ -102,6 +102,8 @@ export class MarQS {
           env.type === "DEVELOPMENT"
             ? `${constants.ENV_PART}:${env.id}:${constants.SHARED_QUEUE}`
             : constants.SHARED_QUEUE;
+
+        propagation.inject(context.active(), messageData);
 
         const messagePayload: MessagePayload = {
           version: "1",


### PR DESCRIPTION
This adds:
- Shared queue consumer pool with configurable size and intervals
- Configurable retry checkpoint threshold
- Improved tracing for marqs messages
- Some new (optional) env vars for the above