### PR TITLE
We want retrying enabled in dev by default, it’s confusing otherwise

### DIFF
--- a/.changeset/loud-actors-remember.md
+++ b/.changeset/loud-actors-remember.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Default to retrying enabled in dev when running init

--- a/packages/cli-v3/src/templates/trigger.config.ts.template
+++ b/packages/cli-v3/src/templates/trigger.config.ts.template
@@ -4,7 +4,7 @@ export const config: TriggerConfig = {
   project: "${projectRef}",
   logLevel: "log",
   retries: {
-    enabledInDev: false,
+    enabledInDev: true,
     default: {
       maxAttempts: 3,
       minTimeoutInMs: 1000,


### PR DESCRIPTION
This changes the default `trigger.config.ts` setting for `retries.enabledInDev` to be true.