### PR TITLE
v3: fix start hook

### DIFF
--- a/.changeset/polite-ducks-switch.md
+++ b/.changeset/polite-ducks-switch.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Fix post start hooks

--- a/packages/cli-v3/src/Containerfile.prod
+++ b/packages/cli-v3/src/Containerfile.prod
@@ -1,7 +1,10 @@
 FROM node:20-bookworm-slim@sha256:d4cdfc305abe5ea78da7167bf78263c22596dc332f2654b662890777ea166224 AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y --no-install-recommends dumb-init && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    busybox \
+    dumb-init \
+    && rm -rf /var/lib/apt/lists/*
 
 # Create and set workdir with appropriate permissions
 RUN mkdir /app && chown node:node /app


### PR DESCRIPTION
Switch to busybox wget and only call start hook for restores, to reduce the impact of any future issues.