### PR TITLE
Multiple machine CLI support

### DIFF
--- a/apps/webapp/app/routes/api.v1.token.ts
+++ b/apps/webapp/app/routes/api.v1.token.ts
@@ -23,7 +23,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const anyBody = await request.json();
   const body = GetPersonalAccessTokenRequestSchema.safeParse(anyBody);
   if (!body.success) {
-    return json({ message: generateErrorMessage(body.error.issues) }, { status: 422 });
+    return json({ error: generateErrorMessage(body.error.issues) }, { status: 422 });
   }
 
   try {
@@ -45,6 +45,6 @@ export async function action({ request }: ActionFunctionArgs) {
       return json({ error: error.message }, { status: 400 });
     }
 
-    return json({ error: "Something went wrong" }, { status: 500 });
+    return json({ error: "Something went wrong" }, { status: 400 });
   }
 }

--- a/apps/webapp/app/routes/api.v2.whoami.ts
+++ b/apps/webapp/app/routes/api.v2.whoami.ts
@@ -8,29 +8,34 @@ import { authenticateApiRequestWithPersonalAccessToken } from "~/services/person
 
 export async function loader({ request }: LoaderFunctionArgs) {
   logger.info("whoami v2", { url: request.url });
+  try {
+    const authenticationResult = await authenticateApiRequestWithPersonalAccessToken(request);
+    if (!authenticationResult) {
+      return json({ error: "Invalid or Missing Access Token" }, { status: 401 });
+    }
 
-  const authenticationResult = await authenticateApiRequestWithPersonalAccessToken(request);
-  if (!authenticationResult) {
-    return json({ error: "Invalid or Missing Access Token" }, { status: 401 });
+    const user = await prisma.user.findUnique({
+      select: {
+        email: true,
+      },
+      where: {
+        id: authenticationResult.userId,
+      },
+    });
+
+    if (!user) {
+      return json({ error: "User not found" }, { status: 404 });
+    }
+
+    const result: WhoAmIResponse = {
+      userId: authenticationResult.userId,
+      email: user.email,
+      dashboardUrl: env.APP_ORIGIN,
+    };
+    return json(result);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : "Something went wrong";
+    logger.error("Error in whoami v2", { error: errorMessage });
+    return json({ error: errorMessage }, { status: 400 });
   }
-
-  const user = await prisma.user.findUnique({
-    select: {
-      email: true,
-    },
-    where: {
-      id: authenticationResult.userId,
-    },
-  });
-
-  if (!user) {
-    return json({ error: "User not found" }, { status: 404 });
-  }
-
-  const result: WhoAmIResponse = {
-    userId: authenticationResult.userId,
-    email: user.email,
-    dashboardUrl: env.APP_ORIGIN,
-  };
-  return json(result);
 }


### PR DESCRIPTION
You couldn't be logged in to the CLI on multiple machines at once. We have one token that is called "cli" and if you tried to create another it would delete the old one, effectively logging you out of your other machine.

- If you login to another CLI it will associate an existing "cli" token with the authorization code
- Improved the error messages from some of the endpoints (use "error" key and don't return 500s which appear as "Something went wrong".