### PR TITLE
v3: fix digest extraction

### DIFF
--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -94,7 +94,7 @@ export function configureDeployCommand(program: Command) {
       .option("-c, --config <config file>", "The name of the config file, found at [path]")
       .option(
         "-p, --project-ref <project ref>",
-        "The project ref. Required if there is no config file."
+        "The project ref. Required if there is no config file. This will override the project specified in the config file."
       )
   )
     .addOption(

--- a/packages/cli-v3/src/utilities/configFiles.ts
+++ b/packages/cli-v3/src/utilities/configFiles.ts
@@ -164,9 +164,13 @@ export async function readConfig(
 
   // import the config file
   const userConfigModule = await import(builtConfigFileHref);
+
+  // The --project-ref CLI arg will always override the project specified in the config file
   const rawConfig = await normalizeConfig(
-    userConfigModule ? userConfigModule.config : { project: options?.projectRef }
+    userConfigModule?.config,
+    options?.projectRef ? { project: options?.projectRef } : undefined
   );
+
   const config = Config.parse(rawConfig);
 
   return {
@@ -198,10 +202,14 @@ export async function resolveConfig(path: string, config: Config): Promise<Resol
   return config as ResolvedConfig;
 }
 
-export async function normalizeConfig(config: any): Promise<any> {
+export async function normalizeConfig(config: any, overrides?: Record<string, any>): Promise<any> {
+  let normalized = config;
+
   if (typeof config === "function") {
-    config = config();
+    normalized = await config();
   }
 
-  return await config;
+  normalized = { ...normalized, ...overrides };
+
+  return normalized;
 }


### PR DESCRIPTION
This fixes extracting image digests from docker build logs. We inadvertently checked multiple lines at once while the regex assumed single ones. Also fixes the `--project-ref` CLI arg to correctly override the config file setting.