### PR TITLE
v3: Fixes for using `(batch)triggerAndWait` with idempotency keys

### DIFF
--- a/.changeset/sharp-emus-compare.md
+++ b/.changeset/sharp-emus-compare.md
@@ -1,0 +1,13 @@
+---
+"@trigger.dev/sdk": patch
+"trigger.dev": patch
+"@trigger.dev/core": patch
+---
+
+When using idempotency keys, triggerAndWait and batchTriggerAndWait will still work even if the existing runs have already been completed (or even partially completed, in the case of batchTriggerAndWait)
+
+- TaskRunExecutionResult.id is now the run friendlyId, not the attempt friendlyId
+- A single TaskRun can now have many batchItems, in the case of batchTriggerAndWait while using idempotency keys
+- A run’s idempotencyKey is now added to the ctx as well as the TaskEvent and displayed in the span view
+- When resolving batchTriggerAndWait, the runtimes no longer reject promises, leading to an error in the parent task
+

--- a/apps/webapp/app/components/runs/RunFilters.tsx
+++ b/apps/webapp/app/components/runs/RunFilters.tsx
@@ -32,6 +32,7 @@ import {
 import { TimeFrameFilter } from "./TimeFrameFilter";
 import { Button } from "../primitives/Buttons";
 import { useCallback } from "react";
+import assertNever from "assert-never";
 
 export function RunsFilters() {
   const navigate = useNavigate();
@@ -182,8 +183,7 @@ export function FilterStatusIcon({
     case "FAILED":
       return <XCircleIcon className={cn(filterStatusClassNameColor(status), className)} />;
     default: {
-      const _exhaustiveCheck: never = status;
-      throw new Error(`Non-exhaustive match for value: ${status}`);
+      assertNever(status);
     }
   }
 }
@@ -205,8 +205,7 @@ export function filterStatusTitle(status: FilterableStatus): string {
     case "TIMEDOUT":
       return "Timed out";
     default: {
-      const _exhaustiveCheck: never = status;
-      throw new Error(`Non-exhaustive match for value: ${status}`);
+      assertNever(status);
     }
   }
 }
@@ -228,8 +227,7 @@ export function filterStatusClassNameColor(status: FilterableStatus): string {
     case "TIMEDOUT":
       return "text-amber-300";
     default: {
-      const _exhaustiveCheck: never = status;
-      throw new Error(`Non-exhaustive match for value: ${status}`);
+      assertNever(status);
     }
   }
 }

--- a/apps/webapp/app/components/runs/RunStatuses.tsx
+++ b/apps/webapp/app/components/runs/RunStatuses.tsx
@@ -11,6 +11,7 @@ import type { JobRunStatus } from "@trigger.dev/database";
 import { cn } from "~/utils/cn";
 import { Spinner } from "../primitives/Spinner";
 import { z } from "zod";
+import assertNever from "assert-never";
 
 export function RunStatus({ status }: { status: JobRunStatus }) {
   return (
@@ -51,8 +52,7 @@ export function RunStatusIcon({ status, className }: { status: JobRunStatus; cla
     case "CANCELED":
       return <NoSymbolIcon className={cn(runStatusClassNameColor(status), className)} />;
     default: {
-      const _exhaustiveCheck: never = status;
-      throw new Error(`Non-exhaustive match for value: ${status}`);
+      assertNever(status);
     }
   }
 }
@@ -89,8 +89,7 @@ export function runStatusTitle(status: JobRunStatus): string {
     case "INVALID_PAYLOAD":
       return "Invalid payload";
     default: {
-      const _exhaustiveCheck: never = status;
-      throw new Error(`Non-exhaustive match for value: ${status}`);
+      assertNever(status);
     }
   }
 }
@@ -123,8 +122,7 @@ export function runStatusClassNameColor(status: JobRunStatus): string {
     case "CANCELED":
       return "text-charcoal-500";
     default: {
-      const _exhaustiveCheck: never = status;
-      throw new Error(`Non-exhaustive match for value: ${status}`);
+      assertNever(status);
     }
   }
 }

--- a/apps/webapp/app/components/runs/v3/DeploymentStatus.tsx
+++ b/apps/webapp/app/components/runs/v3/DeploymentStatus.tsx
@@ -5,6 +5,7 @@ import {
   XCircleIcon,
 } from "@heroicons/react/20/solid";
 import { WorkerDeploymentStatus } from "@trigger.dev/database";
+import assertNever from "assert-never";
 import { Spinner } from "~/components/primitives/Spinner";
 import { cn } from "~/utils/cn";
 
@@ -54,8 +55,7 @@ export function DeploymentStatusIcon({
         />
       );
     default: {
-      const _exhaustiveCheck: never = status;
-      throw new Error(`Non-exhaustive match for value: ${status}`);
+      assertNever(status);
     }
   }
 }
@@ -74,8 +74,7 @@ export function deploymentStatusClassNameColor(status: WorkerDeploymentStatus): 
     case "FAILED":
       return "text-error";
     default: {
-      const _exhaustiveCheck: never = status;
-      throw new Error(`Non-exhaustive match for value: ${status}`);
+      assertNever(status);
     }
   }
 }
@@ -97,8 +96,7 @@ export function deploymentStatusTitle(status: WorkerDeploymentStatus): string {
     case "FAILED":
       return "Failed";
     default: {
-      const _exhaustiveCheck: never = status;
-      throw new Error(`Non-exhaustive match for value: ${status}`);
+      assertNever(status);
     }
   }
 }

--- a/apps/webapp/app/components/runs/v3/TaskRunAttemptStatus.tsx
+++ b/apps/webapp/app/components/runs/v3/TaskRunAttemptStatus.tsx
@@ -8,6 +8,7 @@ import {
 } from "@heroicons/react/20/solid";
 import type { TaskRunAttemptStatus as TaskRunAttemptStatusType } from "@trigger.dev/database";
 import { TaskRunAttemptStatus } from "@trigger.dev/database";
+import assertNever from "assert-never";
 import { SnowflakeIcon } from "lucide-react";
 import { Spinner } from "~/components/primitives/Spinner";
 import { cn } from "~/utils/cn";
@@ -72,8 +73,7 @@ export function TaskRunAttemptStatusIcon({
     case "COMPLETED":
       return <CheckCircleIcon className={cn(runAttemptStatusClassNameColor(status), className)} />;
     default: {
-      const _exhaustiveCheck: never = status;
-      throw new Error(`Non-exhaustive match for value: ${status}`);
+      assertNever(status);
     }
   }
 }
@@ -99,8 +99,7 @@ export function runAttemptStatusClassNameColor(status: ExtendedTaskAttemptStatus
     case "COMPLETED":
       return "text-success";
     default: {
-      const _exhaustiveCheck: never = status;
-      throw new Error(`Non-exhaustive match for value: ${status}`);
+      assertNever(status);
     }
   }
 }
@@ -126,8 +125,7 @@ export function runAttemptStatusTitle(status: ExtendedTaskAttemptStatus | null):
     case "COMPLETED":
       return "Completed";
     default: {
-      const _exhaustiveCheck: never = status;
-      throw new Error(`Non-exhaustive match for value: ${status}`);
+      assertNever(status);
     }
   }
 }

--- a/apps/webapp/app/components/runs/v3/TaskRunStatus.tsx
+++ b/apps/webapp/app/components/runs/v3/TaskRunStatus.tsx
@@ -10,6 +10,7 @@ import {
   XCircleIcon,
 } from "@heroicons/react/20/solid";
 import { TaskRunStatus } from "@trigger.dev/database";
+import assertNever from "assert-never";
 import { SnowflakeIcon } from "lucide-react";
 import { Spinner } from "~/components/primitives/Spinner";
 import { cn } from "~/utils/cn";
@@ -88,8 +89,7 @@ export function TaskRunStatusIcon({
       return <FireIcon className={cn(runStatusClassNameColor(status), className)} />;
 
     default: {
-      const _exhaustiveCheck: never = status;
-      throw new Error(`Non-exhaustive match for value: ${status}`);
+      assertNever(status);
     }
   }
 }
@@ -120,8 +120,7 @@ export function runStatusClassNameColor(status: TaskRunStatus): string {
     case "CRASHED":
       return "text-error";
     default: {
-      const _exhaustiveCheck: never = status;
-      throw new Error(`Non-exhaustive match for value: ${status}`);
+      assertNever(status);
     }
   }
 }
@@ -153,8 +152,7 @@ export function runStatusTitle(status: TaskRunStatus): string {
     case "CRASHED":
       return "Crashed";
     default: {
-      const _exhaustiveCheck: never = status;
-      throw new Error(`Non-exhaustive match for value: ${status}`);
+      assertNever(status);
     }
   }
 }

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -76,7 +76,6 @@ const EnvironmentSchema = z.object({
   REDIS_PASSWORD: z.string().optional(),
   REDIS_TLS_DISABLED: z.string().optional(),
 
-  DEFAULT_QUEUE_EXECUTION_CONCURRENCY_LIMIT: z.coerce.number().int().default(5),
   DEFAULT_ENV_EXECUTION_CONCURRENCY_LIMIT: z.coerce.number().int().default(10),
   DEFAULT_ORG_EXECUTION_CONCURRENCY_LIMIT: z.coerce.number().int().default(10),
   DEFAULT_DEV_ENV_EXECUTION_ATTEMPTS: z.coerce.number().int().positive().default(1),

--- a/apps/webapp/app/models/taskRun.server.ts
+++ b/apps/webapp/app/models/taskRun.server.ts
@@ -1,0 +1,108 @@
+import {
+  TaskRunError,
+  TaskRunExecutionResult,
+  TaskRunFailedExecutionResult,
+  TaskRunSuccessfulExecutionResult,
+} from "@trigger.dev/core/v3";
+import {
+  BatchTaskRunItemStatus,
+  TaskRun,
+  TaskRunAttempt,
+  TaskRunAttemptStatus,
+  TaskRunStatus,
+} from "@trigger.dev/database";
+import { assertNever } from "assert-never";
+
+const SUCCESSFUL_STATUSES = [TaskRunStatus.COMPLETED_SUCCESSFULLY];
+const FAILURE_STATUSES = [
+  TaskRunStatus.CANCELED,
+  TaskRunStatus.INTERRUPTED,
+  TaskRunStatus.COMPLETED_WITH_ERRORS,
+  TaskRunStatus.SYSTEM_FAILURE,
+  TaskRunStatus.CRASHED,
+];
+
+export type TaskRunWithAttempts = TaskRun & {
+  attempts: TaskRunAttempt[];
+};
+
+export function executionResultForTaskRun(
+  taskRun: TaskRunWithAttempts
+): TaskRunExecutionResult | undefined {
+  if (SUCCESSFUL_STATUSES.includes(taskRun.status)) {
+    // find the last attempt that was successful
+    const attempt = taskRun.attempts.find((a) => a.status === TaskRunAttemptStatus.COMPLETED);
+
+    if (!attempt) {
+      return undefined;
+    }
+
+    return {
+      ok: true,
+      id: taskRun.friendlyId,
+      output: attempt.output ?? undefined,
+      outputType: attempt.outputType,
+    } satisfies TaskRunSuccessfulExecutionResult;
+  }
+
+  if (FAILURE_STATUSES.includes(taskRun.status)) {
+    if (taskRun.status === TaskRunStatus.CANCELED) {
+      return {
+        ok: false,
+        id: taskRun.friendlyId,
+        error: {
+          type: "INTERNAL_ERROR",
+          code: "TASK_RUN_CANCELLED",
+        },
+      } satisfies TaskRunFailedExecutionResult;
+    }
+
+    const attempt = taskRun.attempts.find((a) => a.status === TaskRunAttemptStatus.FAILED);
+
+    if (!attempt) {
+      return undefined;
+    }
+
+    const error = TaskRunError.safeParse(attempt.error);
+
+    if (!error.success) {
+      return {
+        ok: false,
+        id: taskRun.friendlyId,
+        error: {
+          type: "INTERNAL_ERROR",
+          code: "CONFIGURED_INCORRECTLY",
+        },
+      } satisfies TaskRunFailedExecutionResult;
+    }
+
+    return {
+      ok: false,
+      id: taskRun.friendlyId,
+      error: error.data,
+    } satisfies TaskRunFailedExecutionResult;
+  }
+}
+
+export function batchTaskRunItemStatusForRunStatus(status: TaskRunStatus): BatchTaskRunItemStatus {
+  switch (status) {
+    case TaskRunStatus.COMPLETED_SUCCESSFULLY:
+      return BatchTaskRunItemStatus.COMPLETED;
+    case TaskRunStatus.CANCELED:
+    case TaskRunStatus.INTERRUPTED:
+    case TaskRunStatus.COMPLETED_WITH_ERRORS:
+    case TaskRunStatus.SYSTEM_FAILURE:
+    case TaskRunStatus.CRASHED:
+    case TaskRunStatus.COMPLETED_WITH_ERRORS:
+      return BatchTaskRunItemStatus.FAILED;
+    case TaskRunStatus.PENDING:
+    case TaskRunStatus.WAITING_FOR_DEPLOY:
+    case TaskRunStatus.WAITING_TO_RESUME:
+    case TaskRunStatus.RETRYING_AFTER_FAILURE:
+    case TaskRunStatus.EXECUTING:
+    case TaskRunStatus.PAUSED:
+      return BatchTaskRunItemStatus.PENDING;
+    default:
+      assertNever(status);
+  }
+}

--- a/apps/webapp/app/presenters/v3/ApiBatchResultsPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ApiBatchResultsPresenter.server.ts
@@ -1,0 +1,46 @@
+import { BatchTaskRunExecutionResult } from "@trigger.dev/core/v3";
+import { executionResultForTaskRun } from "~/models/taskRun.server";
+import { AuthenticatedEnvironment } from "~/services/apiAuth.server";
+import { BasePresenter } from "./basePresenter.server";
+
+export class ApiBatchResultsPresenter extends BasePresenter {
+  public async call(
+    friendlyId: string,
+    env: AuthenticatedEnvironment
+  ): Promise<BatchTaskRunExecutionResult | undefined> {
+    return this.traceWithEnv("call", env, async (span) => {
+      const batchRun = await this._prisma.batchTaskRun.findUnique({
+        where: {
+          friendlyId,
+          runtimeEnvironmentId: env.id,
+        },
+        include: {
+          items: {
+            include: {
+              taskRun: {
+                include: {
+                  attempts: {
+                    orderBy: {
+                      createdAt: "desc",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      if (!batchRun) {
+        return undefined;
+      }
+
+      return {
+        id: batchRun.friendlyId,
+        items: batchRun.items
+          .map((item) => executionResultForTaskRun(item.taskRun))
+          .filter(Boolean),
+      };
+    });
+  }
+}

--- a/apps/webapp/app/presenters/v3/ApiRunResultPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ApiRunResultPresenter.server.ts
@@ -1,0 +1,33 @@
+import { TaskRunExecutionResult } from "@trigger.dev/core/v3";
+import { executionResultForTaskRun } from "~/models/taskRun.server";
+import { AuthenticatedEnvironment } from "~/services/apiAuth.server";
+import { BasePresenter } from "./basePresenter.server";
+
+export class ApiRunResultPresenter extends BasePresenter {
+  public async call(
+    friendlyId: string,
+    env: AuthenticatedEnvironment
+  ): Promise<TaskRunExecutionResult | undefined> {
+    return this.traceWithEnv("call", env, async (span) => {
+      const taskRun = await this._prisma.taskRun.findUnique({
+        where: {
+          friendlyId,
+          runtimeEnvironmentId: env.id,
+        },
+        include: {
+          attempts: {
+            orderBy: {
+              createdAt: "desc",
+            },
+          },
+        },
+      });
+
+      if (!taskRun) {
+        return undefined;
+      }
+
+      return executionResultForTaskRun(taskRun);
+    });
+  }
+}

--- a/apps/webapp/app/presenters/v3/basePresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/basePresenter.server.ts
@@ -1,0 +1,34 @@
+import { Span, SpanKind } from "@opentelemetry/api";
+import { PrismaClientOrTransaction, prisma } from "~/db.server";
+import { AuthenticatedEnvironment } from "~/services/apiAuth.server";
+import { attributesFromAuthenticatedEnv, tracer } from "../../v3/tracer.server";
+
+export abstract class BasePresenter {
+  constructor(protected readonly _prisma: PrismaClientOrTransaction = prisma) {}
+
+  protected async traceWithEnv<T>(
+    trace: string,
+    env: AuthenticatedEnvironment,
+    fn: (span: Span) => Promise<T>
+  ): Promise<T> {
+    return tracer.startActiveSpan(
+      `${this.constructor.name}.${trace}`,
+      { attributes: attributesFromAuthenticatedEnv(env), kind: SpanKind.SERVER },
+      async (span) => {
+        try {
+          return await fn(span);
+        } catch (e) {
+          if (e instanceof Error) {
+            span.recordException(e);
+          } else {
+            span.recordException(new Error(String(e)));
+          }
+
+          throw e;
+        } finally {
+          span.end();
+        }
+      }
+    );
+  }
+}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -130,6 +130,9 @@ export default function Page() {
             )}
             <Property label="Message">{event.message}</Property>
             <Property label="Task ID">{event.taskSlug}</Property>
+            {event.idempotencyKey && (
+              <Property label="Idempotency key">{event.idempotencyKey}</Property>
+            )}
             {event.taskPath && event.taskExportName && (
               <Property label="Task">
                 <TaskPath

--- a/apps/webapp/app/routes/api.v1.runs.$runParam.replay.ts
+++ b/apps/webapp/app/routes/api.v1.runs.$runParam.replay.ts
@@ -1,12 +1,10 @@
 import type { ActionFunctionArgs } from "@remix-run/server-runtime";
 import { json } from "@remix-run/server-runtime";
-import { PrismaErrorSchema, prisma } from "~/db.server";
 import { z } from "zod";
+import { prisma } from "~/db.server";
 import { authenticateApiRequest } from "~/services/apiAuth.server";
-import { CancelRunService } from "~/services/runs/cancelRun.server";
-import { ApiRunPresenter } from "~/presenters/ApiRunPresenter.server";
-import { ReplayTaskRunService } from "~/v3/services/replayTaskRun.server";
 import { logger } from "~/services/logger.server";
+import { ReplayTaskRunService } from "~/v3/services/replayTaskRun.server";
 
 const ParamsSchema = z.object({
   /* This is the run friendly ID */

--- a/apps/webapp/app/routes/api.v1.runs.$runParam.result.ts
+++ b/apps/webapp/app/routes/api.v1.runs.$runParam.result.ts
@@ -1,0 +1,44 @@
+import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
+import { json } from "@remix-run/server-runtime";
+import { z } from "zod";
+import { ApiRunResultPresenter } from "~/presenters/v3/ApiRunResultPresenter.server";
+import { authenticateApiRequest } from "~/services/apiAuth.server";
+
+const ParamsSchema = z.object({
+  /* This is the run friendly ID */
+  runParam: z.string(),
+});
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  // Authenticate the request
+  const authenticationResult = await authenticateApiRequest(request);
+
+  if (!authenticationResult) {
+    return json({ error: "Invalid or Missing API Key" }, { status: 401 });
+  }
+
+  const parsed = ParamsSchema.safeParse(params);
+
+  if (!parsed.success) {
+    return json({ error: "Invalid or missing run ID" }, { status: 400 });
+  }
+
+  const { runParam } = parsed.data;
+
+  try {
+    const presenter = new ApiRunResultPresenter();
+    const result = await presenter.call(runParam, authenticationResult.environment);
+
+    if (!result) {
+      return json({ error: "Run either doesn't exist or is not finished" }, { status: 404 });
+    }
+
+    return json(result);
+  } catch (error) {
+    if (error instanceof Error) {
+      return json({ error: error.message }, { status: 500 });
+    } else {
+      return json({ error: JSON.stringify(error) }, { status: 500 });
+    }
+  }
+}

--- a/apps/webapp/app/v3/eventRepository.server.ts
+++ b/apps/webapp/app/v3/eventRepository.server.ts
@@ -63,6 +63,7 @@ export type TraceAttributes = Partial<
     | "batchId"
     | "payload"
     | "payloadType"
+    | "idempotencyKey"
   >
 >;
 
@@ -371,6 +372,7 @@ export class EventRepository {
         id: event.spanId,
         parentId: event.parentId ?? undefined,
         runId: event.runId,
+        idempotencyKey: event.idempotencyKey,
         data: {
           message: event.message,
           style: event.style,
@@ -459,7 +461,7 @@ export class EventRepository {
     const links: SpanLink[] = [];
 
     if (messagingEvent.success && messagingEvent.data) {
-      if ("id" in messagingEvent.data.message) {
+      if (messagingEvent.data.message && "id" in messagingEvent.data.message) {
         if (messagingEvent.data.message.id.startsWith("run_")) {
           links.push({
             type: "run",
@@ -719,6 +721,7 @@ export class EventRepository {
       links: links as unknown as Prisma.InputJsonValue,
       payload: options.attributes.payload,
       payloadType: options.attributes.payloadType,
+      idempotencyKey: options.attributes.idempotencyKey,
     };
 
     if (options.immediate) {

--- a/apps/webapp/app/v3/marqs/devQueueConsumer.server.ts
+++ b/apps/webapp/app/v3/marqs/devQueueConsumer.server.ts
@@ -118,7 +118,7 @@ export class DevQueueConsumer {
     completion: TaskRunExecutionResult,
     execution: TaskRunExecution
   ) {
-    this._inProgressAttempts.delete(completion.id);
+    this._inProgressAttempts.delete(execution.attempt.id);
 
     if (completion.ok) {
       this._taskSuccesses++;
@@ -424,7 +424,7 @@ export class DevQueueConsumer {
           orderBy: { number: "desc" },
         },
         tags: true,
-        batchItem: {
+        batchItems: {
           include: {
             batchTaskRun: true,
           },
@@ -499,6 +499,7 @@ export class DevQueueConsumer {
         createdAt: lockedTaskRun.createdAt,
         tags: lockedTaskRun.tags.map((tag) => tag.name),
         isTest: lockedTaskRun.isTest,
+        idempotencyKey: lockedTaskRun.idempotencyKey ?? undefined,
       },
       queue: {
         id: queue.friendlyId,
@@ -520,9 +521,10 @@ export class DevQueueConsumer {
         slug: this.env.project.slug,
         name: this.env.project.name,
       },
-      batch: lockedTaskRun.batchItem?.batchTaskRun
-        ? { id: lockedTaskRun.batchItem.batchTaskRun.friendlyId }
-        : undefined,
+      batch:
+        lockedTaskRun.batchItems[0] && lockedTaskRun.batchItems[0].batchTaskRun
+          ? { id: lockedTaskRun.batchItems[0].batchTaskRun.friendlyId }
+          : undefined,
     };
 
     const environmentRepository = new EnvironmentVariablesRepository();

--- a/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
+++ b/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
@@ -812,7 +812,7 @@ class SharedQueueTasks {
     if (ok) {
       const success: TaskRunSuccessfulExecutionResult = {
         ok,
-        id: attempt.friendlyId,
+        id: attempt.taskRun.friendlyId,
         output: attempt.output ?? undefined,
         outputType: attempt.outputType,
       };
@@ -820,7 +820,7 @@ class SharedQueueTasks {
     } else {
       const failure: TaskRunFailedExecutionResult = {
         ok,
-        id: attempt.friendlyId,
+        id: attempt.taskRun.friendlyId,
         error: attempt.error as TaskRunError,
       };
       return failure;
@@ -848,7 +848,7 @@ class SharedQueueTasks {
         taskRun: {
           include: {
             tags: true,
-            batchItem: {
+            batchItems: {
               include: {
                 batchTaskRun: true,
               },
@@ -956,6 +956,7 @@ class SharedQueueTasks {
         createdAt: taskRun.createdAt,
         tags: taskRun.tags.map((tag) => tag.name),
         isTest: taskRun.isTest,
+        idempotencyKey: taskRun.idempotencyKey ?? undefined,
       },
       queue: {
         id: queue.friendlyId,
@@ -977,9 +978,10 @@ class SharedQueueTasks {
         slug: attempt.runtimeEnvironment.project.slug,
         name: attempt.runtimeEnvironment.project.name,
       },
-      batch: taskRun.batchItem?.batchTaskRun
-        ? { id: taskRun.batchItem.batchTaskRun.friendlyId }
-        : undefined,
+      batch:
+        taskRun.batchItems[0] && taskRun.batchItems[0].batchTaskRun
+          ? { id: taskRun.batchItems[0].batchTaskRun.friendlyId }
+          : undefined,
       worker: {
         id: attempt.backgroundWorkerId,
         contentHash: attempt.backgroundWorker.contentHash,

--- a/apps/webapp/app/v3/marqs/types.ts
+++ b/apps/webapp/app/v3/marqs/types.ts
@@ -1,4 +1,3 @@
-import { RedisOptions } from "ioredis";
 import { z } from "zod";
 import { AuthenticatedEnvironment } from "~/services/apiAuth.server";
 

--- a/apps/webapp/app/v3/otlpExporter.server.ts
+++ b/apps/webapp/app/v3/otlpExporter.server.ts
@@ -352,6 +352,7 @@ function extractResourceProperties(attributes: KeyValue[]) {
     queueId: extractStringAttribute(attributes, SemanticInternalAttributes.QUEUE_ID),
     queueName: extractStringAttribute(attributes, SemanticInternalAttributes.QUEUE_NAME),
     batchId: extractStringAttribute(attributes, SemanticInternalAttributes.BATCH_ID),
+    idempotencyKey: extractStringAttribute(attributes, SemanticInternalAttributes.IDEMPOTENCY_KEY),
   };
 }
 

--- a/apps/webapp/app/v3/services/cancelTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/cancelTaskRun.server.ts
@@ -4,9 +4,9 @@ import { marqs } from "~/v3/marqs/index.server";
 import { devPubSub } from "../marqs/devPubSub.server";
 import { BaseService } from "./baseService.server";
 import { socketIo } from "../handleSocketIo.server";
-import { assertUnreachable } from "../utils/asserts.server";
 import { CancelAttemptService } from "./cancelAttempt.server";
 import { logger } from "~/services/logger.server";
+import assertNever from "assert-never";
 
 export const CANCELLABLE_STATUSES: Array<TaskRunStatus> = [
   "PENDING",
@@ -148,7 +148,7 @@ export class CancelTaskRunService extends BaseService {
             break;
           }
           default: {
-            assertUnreachable(attempt.status);
+            assertNever(attempt.status);
           }
         }
       }

--- a/apps/webapp/app/v3/services/completeAttempt.server.ts
+++ b/apps/webapp/app/v3/services/completeAttempt.server.ts
@@ -39,10 +39,12 @@ export class CompleteAttemptService extends BaseService {
     env?: AuthenticatedEnvironment;
     checkpoint?: CheckpointData;
   }): Promise<"COMPLETED" | "RETRIED"> {
-    const taskRunAttempt = await findAttempt(this._prisma, completion.id);
+    const taskRunAttempt = await findAttempt(this._prisma, execution.attempt.id);
 
     if (!taskRunAttempt) {
-      logger.error("[CompleteAttemptService] Task run attempt not found", { id: completion.id });
+      logger.error("[CompleteAttemptService] Task run attempt not found", {
+        id: execution.attempt.id,
+      });
 
       // Update the task run to be failed
       await this._prisma.taskRun.update({
@@ -76,7 +78,7 @@ export class CompleteAttemptService extends BaseService {
     env?: AuthenticatedEnvironment
   ): Promise<"COMPLETED"> {
     await this._prisma.taskRunAttempt.update({
-      where: { friendlyId: completion.id },
+      where: { id: taskRunAttempt.id },
       data: {
         status: "COMPLETED",
         completedAt: new Date(),
@@ -144,7 +146,7 @@ export class CompleteAttemptService extends BaseService {
     }
 
     await this._prisma.taskRunAttempt.update({
-      where: { friendlyId: completion.id },
+      where: { id: taskRunAttempt.id },
       data: {
         status: "FAILED",
         completedAt: new Date(),

--- a/apps/webapp/app/v3/services/resumeTaskRunDependencies.server.ts
+++ b/apps/webapp/app/v3/services/resumeTaskRunDependencies.server.ts
@@ -12,7 +12,7 @@ export class ResumeTaskRunDependenciesService extends BaseService {
       include: {
         taskRun: {
           include: {
-            batchItem: true,
+            batchItems: true,
             dependency: {
               include: {
                 dependentAttempt: true,
@@ -34,14 +34,16 @@ export class ResumeTaskRunDependenciesService extends BaseService {
       return;
     }
 
-    const { batchItem, dependency } = taskAttempt.taskRun;
+    const { batchItems, dependency } = taskAttempt.taskRun;
 
-    if (!batchItem && !dependency) {
+    if (!batchItems.length && !dependency) {
       return;
     }
 
-    if (batchItem) {
-      await this.#resumeBatchItem(batchItem, taskAttempt);
+    if (batchItems.length) {
+      for (const batchItem of batchItems) {
+        await this.#resumeBatchItem(batchItem, taskAttempt);
+      }
       return;
     }
 

--- a/apps/webapp/app/v3/utils/asserts.server.ts
+++ b/apps/webapp/app/v3/utils/asserts.server.ts
@@ -1,3 +1,0 @@
-export function assertUnreachable(x: never): never {
-  throw new Error("Didn't expect to get here");
-}

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -96,6 +96,7 @@
     "@uiw/react-codemirror": "^4.19.5",
     "@upstash/ratelimit": "^1.0.1",
     "@whatwg-node/fetch": "^0.9.14",
+    "assert-never": "^1.2.1",
     "aws4fetch": "^1.0.18",
     "class-variance-authority": "^0.5.2",
     "clsx": "^1.2.1",

--- a/packages/cli-v3/src/workers/dev/worker-facade.ts
+++ b/packages/cli-v3/src/workers/dev/worker-facade.ts
@@ -117,7 +117,7 @@ const handler = new ZodMessageHandler({
           execution,
           result: {
             ok: false,
-            id: execution.attempt.id,
+            id: execution.run.id,
             error: {
               type: "INTERNAL_ERROR",
               code: TaskRunErrorCodes.TASK_ALREADY_RUNNING,
@@ -139,7 +139,7 @@ const handler = new ZodMessageHandler({
           execution,
           result: {
             ok: false,
-            id: execution.attempt.id,
+            id: execution.run.id,
             error: {
               type: "INTERNAL_ERROR",
               code: TaskRunErrorCodes.COULD_NOT_FIND_EXECUTOR,

--- a/packages/cli-v3/src/workers/prod/worker-facade.ts
+++ b/packages/cli-v3/src/workers/prod/worker-facade.ts
@@ -182,7 +182,7 @@ const zodIpc = new ZodIpcConnection({
             execution: _execution,
             result: {
               ok: false,
-              id: _execution.attempt.id,
+              id: _execution.run.id,
               error: {
                 type: "INTERNAL_ERROR",
                 code: TaskRunErrorCodes.GRACEFUL_EXIT_TIMEOUT,

--- a/packages/cli-v3/src/workers/prod/worker-facade.ts
+++ b/packages/cli-v3/src/workers/prod/worker-facade.ts
@@ -110,7 +110,7 @@ const zodIpc = new ZodIpcConnection({
           execution,
           result: {
             ok: false,
-            id: execution.attempt.id,
+            id: execution.run.id,
             error: {
               type: "INTERNAL_ERROR",
               code: TaskRunErrorCodes.TASK_ALREADY_RUNNING,
@@ -131,7 +131,7 @@ const zodIpc = new ZodIpcConnection({
           execution,
           result: {
             ok: false,
-            id: execution.attempt.id,
+            id: execution.run.id,
             error: {
               type: "INTERNAL_ERROR",
               code: TaskRunErrorCodes.COULD_NOT_FIND_EXECUTOR,

--- a/packages/core/src/v3/logger/taskLogger.ts
+++ b/packages/core/src/v3/logger/taskLogger.ts
@@ -108,8 +108,20 @@ export class NoopTaskLogger implements TaskLogger {
 
 function safeJsonProcess(value?: Record<string, unknown>): Record<string, unknown> | undefined {
   try {
-    return JSON.parse(JSON.stringify(value));
+    return JSON.parse(JSON.stringify(value, jsonErrorReplacer));
   } catch {
     return value;
   }
+}
+
+function jsonErrorReplacer(key: string, value: unknown) {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+    };
+  }
+
+  return value;
 }

--- a/packages/core/src/v3/schemas/common.ts
+++ b/packages/core/src/v3/schemas/common.ts
@@ -74,6 +74,7 @@ export const TaskRun = z.object({
   tags: z.array(z.string()),
   isTest: z.boolean().default(false),
   createdAt: z.coerce.date(),
+  idempotencyKey: z.string().optional(),
 });
 
 export type TaskRun = z.infer<typeof TaskRun>;

--- a/packages/core/src/v3/semanticInternalAttributes.ts
+++ b/packages/core/src/v3/semanticInternalAttributes.ts
@@ -41,4 +41,5 @@ export const SemanticInternalAttributes = {
   RETRY_DELAY: "retry.delay",
   RETRY_COUNT: "retry.count",
   LINK_TITLE: "$link.title",
+  IDEMPOTENCY_KEY: "ctx.run.idempotencyKey",
 };

--- a/packages/core/src/v3/tasks/taskContextManager.ts
+++ b/packages/core/src/v3/tasks/taskContextManager.ts
@@ -68,6 +68,7 @@ export class TaskContextManager {
         [SemanticInternalAttributes.ORGANIZATION_SLUG]: this.ctx.organization.slug,
         [SemanticInternalAttributes.ORGANIZATION_NAME]: this.ctx.organization.name,
         [SemanticInternalAttributes.BATCH_ID]: this.ctx.batch?.id,
+        [SemanticInternalAttributes.IDEMPOTENCY_KEY]: this.ctx.run.idempotencyKey,
       };
     }
 

--- a/packages/core/src/v3/workers/taskExecutor.ts
+++ b/packages/core/src/v3/workers/taskExecutor.ts
@@ -116,7 +116,7 @@ export class TaskExecutor {
 
                   return {
                     ok: true,
-                    id: execution.attempt.id,
+                    id: execution.run.id,
                     output: finalOutput.data,
                     outputType: finalOutput.dataType,
                   } satisfies TaskRunExecutionResult;
@@ -125,7 +125,7 @@ export class TaskExecutor {
 
                   return {
                     ok: false,
-                    id: execution.attempt.id,
+                    id: execution.run.id,
                     error: {
                       type: "INTERNAL_ERROR",
                       code: TaskRunErrorCodes.TASK_OUTPUT_ERROR,
@@ -150,7 +150,7 @@ export class TaskExecutor {
                   recordSpanException(span, handleErrorResult.error ?? runError);
 
                   return {
-                    id: execution.attempt.id,
+                    id: execution.run.id,
                     ok: false,
                     error: handleErrorResult.error
                       ? parseError(handleErrorResult.error)
@@ -164,7 +164,7 @@ export class TaskExecutor {
 
                   return {
                     ok: false,
-                    id: execution.attempt.id,
+                    id: execution.run.id,
                     error: {
                       type: "INTERNAL_ERROR",
                       code: TaskRunErrorCodes.HANDLE_ERROR_ERROR,

--- a/packages/database/prisma/migrations/20240418092931_make_idempotency_key_optional/migration.sql
+++ b/packages/database/prisma/migrations/20240418092931_make_idempotency_key_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "TaskRun" ALTER COLUMN "idempotencyKey" DROP NOT NULL;

--- a/packages/database/prisma/migrations/20240418093153_add_idempotency_key_to_task_event/migration.sql
+++ b/packages/database/prisma/migrations/20240418093153_add_idempotency_key_to_task_event/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "TaskEvent" ADD COLUMN     "idempotencyKey" TEXT;

--- a/packages/database/prisma/migrations/20240418100819_make_batch_task_run_idempotency_key_optional/migration.sql
+++ b/packages/database/prisma/migrations/20240418100819_make_batch_task_run_idempotency_key_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "BatchTaskRun" ALTER COLUMN "idempotencyKey" DROP NOT NULL;

--- a/packages/database/prisma/migrations/20240418114019_make_batch_run_item_run_id_non_unique/migration.sql
+++ b/packages/database/prisma/migrations/20240418114019_make_batch_run_item_run_id_non_unique/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "BatchTaskRunItem_taskRunId_key";

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1588,7 +1588,7 @@ model TaskRun {
 
   status TaskRunStatus @default(PENDING)
 
-  idempotencyKey String
+  idempotencyKey String?
   taskIdentifier String
 
   isTest Boolean @default(false)
@@ -1625,7 +1625,7 @@ model TaskRun {
 
   concurrencyKey String?
 
-  batchItem              BatchTaskRunItem?
+  batchItems             BatchTaskRunItem[]
   dependency             TaskRunDependency?
   CheckpointRestoreEvent CheckpointRestoreEvent[]
 
@@ -1816,6 +1816,8 @@ model TaskEvent {
   runId     String
   runIsTest Boolean @default(false)
 
+  idempotencyKey String?
+
   taskSlug       String
   taskPath       String?
   taskExportName String?
@@ -1913,7 +1915,7 @@ model BatchTaskRun {
 
   status BatchTaskRunStatus @default(PENDING)
 
-  idempotencyKey String
+  idempotencyKey String?
   taskIdentifier String
 
   checkpointEvent   CheckpointRestoreEvent? @relation(fields: [checkpointEventId], references: [id], onDelete: Cascade, onUpdate: Cascade)
@@ -1948,7 +1950,7 @@ model BatchTaskRunItem {
   batchTaskRunId String
 
   taskRun   TaskRun @relation(fields: [taskRunId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  taskRunId String  @unique
+  taskRunId String
 
   taskRunAttempt   TaskRunAttempt? @relation(fields: [taskRunAttemptId], references: [id], onDelete: SetNull, onUpdate: Cascade)
   taskRunAttemptId String?

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,6 +402,9 @@ importers:
       '@whatwg-node/fetch':
         specifier: ^0.9.14
         version: 0.9.14
+      assert-never:
+        specifier: ^1.2.1
+        version: 1.2.1
       aws4fetch:
         specifier: ^1.0.18
         version: 1.0.18
@@ -15825,6 +15828,10 @@ packages:
       pvtsutils: 1.3.5
       pvutils: 1.1.3
       tslib: 2.6.2
+    dev: false
+
+  /assert-never@1.2.1:
+    resolution: {integrity: sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==}
     dev: false
 
   /assert-plus@1.0.0:

--- a/references/v3-catalog/src/handleError.ts
+++ b/references/v3-catalog/src/handleError.ts
@@ -1,5 +1,7 @@
-import type { HandleErrorFunction } from "@trigger.dev/sdk/v3";
+import { logger, type HandleErrorFunction } from "@trigger.dev/sdk/v3";
 
 export const handleError: HandleErrorFunction = async (payload, error, { ctx, retry }) => {
-  console.log("GOT TO handleError FUNCTION");
+  logger.log("handling error", { error });
+
+  return { skipRetrying: true };
 };

--- a/references/v3-catalog/src/trigger/idempotencyKeys.ts
+++ b/references/v3-catalog/src/trigger/idempotencyKeys.ts
@@ -1,0 +1,78 @@
+import { task, wait } from "@trigger.dev/sdk/v3";
+
+export const idempotencyKeyParent = task({
+  id: "idempotency-key-parent",
+  run: async (payload: { key: string }) => {
+    console.log("Hello from idempotency-key-parent");
+
+    const childTaskResponse = await idempotencyKeyChild.triggerAndWait({
+      payload: {
+        key: payload.key,
+        forceError: true,
+      },
+      options: {
+        idempotencyKey: payload.key,
+      },
+    });
+
+    return {
+      key: payload.key,
+      childTaskResponse,
+    };
+  },
+});
+
+export const idempotencyKeyChild = task({
+  id: "idempotency-key-child",
+  run: async (payload: { forceError: boolean; key: string }) => {
+    console.log("Hello from idempotency-key-child", payload.key);
+
+    await wait.for({ seconds: 5 });
+
+    if (payload.forceError) {
+      throw new Error("This is a forced error in idempotency-key-child");
+    }
+
+    return payload;
+  },
+});
+
+export const idempotencyKeyBatchParent = task({
+  id: "idempotency-key-batch-parent",
+  run: async (payload: { keyPrefix: string; itemCount: number }) => {
+    console.log("Hello from idempotency-key-batch-parent");
+
+    const childTaskResponse = await idempotencyKeyBatchChild.batchTriggerAndWait({
+      items: Array.from({ length: payload.itemCount }).map((_, index) => ({
+        payload: {
+          key: `${payload.keyPrefix}-${index}`,
+          forceError: index % 2 === 0,
+          waitSeconds: 5 * index,
+        },
+        options: {
+          idempotencyKey: `${payload.keyPrefix}-${index}`,
+        },
+      })),
+    });
+
+    return {
+      keyPrefix: payload.keyPrefix,
+      childTaskResponse,
+    };
+  },
+});
+
+export const idempotencyKeyBatchChild = task({
+  id: "idempotency-key-batch-child",
+  run: async (payload: { forceError: boolean; key: string; waitSeconds: number }) => {
+    console.log("idempotency-key-batch-child", payload.key);
+
+    await wait.for({ seconds: payload.waitSeconds });
+
+    if (payload.forceError) {
+      throw new Error(`This is a forced error in idempotency-key-batch-child ${payload.key}`);
+    }
+
+    return payload;
+  },
+});


### PR DESCRIPTION
Fixes various issues with triggerAndWait and batchTriggerAndWait

When using idempotency keys, triggerAndWait and batchTriggerAndWait will still work even if the existing runs have already been completed (or even partially completed, in the case of batchTriggerAndWait)

- TaskRunExecutionResult.id is now the run friendlyId, not the attempt friendlyId
- A single TaskRun can now have many batchItems, in the case of batchTriggerAndWait while using idempotency keys
- A run’s idempotencyKey is now added to the ctx as well as the TaskEvent and displayed in the span view
- When resolving batchTriggerAndWait, the runtimes no longer reject promises, leading to an error in the parent task

Additionally, this PR contains a fix for tasks getting incorrectly throttled because of the default queue concurrency in `MarQS`, which has now been removed (if a task queue does not have a concurrency limit set, then it will be limited by either the env concurrency limit or the org concurrency limit)