### PR TITLE
Exclude body req for `GET`/`HEAD` according to fetch api

### DIFF
--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -55,10 +55,13 @@ function convertToStandardRequest(req: HonoRequest): Request {
     headers[key] = value;
   }
 
+  // https://developer.mozilla.org/en-US/docs/Web/API/fetch#body
+  const includeBody = ["GET", "HEAD"].includes(req.raw.method);
+
   return new Request(req.raw.url, {
     method: req.raw.method,
     headers,
-    body: req.raw.body,
+    body: includeBody ? req.raw.body : undefined,
     // @ts-ignore
     duplex: "half",
   });

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -70,12 +70,15 @@ async function convertToStandardRequest(nextReq: NextApiRequest): Promise<Reques
     headers.set(key, value as string);
   });
 
+  // https://developer.mozilla.org/en-US/docs/Web/API/fetch#body
+  const includeBody = !!method && ["GET", "HEAD"].includes(method);
+
   // Create a new Request object (hardcode the url because it doesn't really matter what it is)
   const webReq = new Request("https://next.js/api/trigger", {
     headers,
     method,
     // @ts-ignore
-    body: nextReq,
+    body: includeBody ? nextReq : undefined,
     duplex: "half",
   });
 


### PR DESCRIPTION
Closes #1031 


Some requests end up sending a body for GET/HEAD requests, which triggers the `Request with GET/HEAD method cannot have body,` causing some jobs to fail.
In my case, it happens during `io.sendEvent`.

This solution adheres to the fetch API specifications by removing the body. Although another solution is to identify the source of the problematic request, it cannot guarantee that such an issue will not occur in the future. Additionally, other packages that utilize `convertToStandardRequest` may require the same fix.

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

_[Describe the steps you took to test this change]_

---

## Changelog

_[Short description of what has changed]_

---

## Screenshots
<img width="1228" alt="image" src="https://github.com/triggerdotdev/trigger.dev/assets/9632910/418838fe-b9b6-4d1c-b5dc-0d5e38456df9">




💯
