### PR TITLE
v3: fix private package installs

### DIFF
--- a/.changeset/rotten-beers-refuse.md
+++ b/.changeset/rotten-beers-refuse.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Add git to prod worker image which fixes private package installs

--- a/packages/cli-v3/src/Containerfile.prod
+++ b/packages/cli-v3/src/Containerfile.prod
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     busybox \
     ca-certificates \
     dumb-init \
+    git \
     openssl \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Previously, including private packages in the worker image caused errors because git wasn't installed. That's been fixed!

Example error:

`
npm WARN tarball tarball data for REPOSITORY@git+https://<PAT>x-oauth-basic@github.com/<USER>/<REPOSITORY> (null) seems to be corrupted. Trying again.
`