### PR TITLE
v3: fix for fresh CLI logins after CLI token revoke

### DIFF
--- a/.changeset/rich-kangaroos-unite.md
+++ b/.changeset/rich-kangaroos-unite.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Fix a bug where revoking the CLI token would prevent you from ever logging in again with the CLI.

--- a/apps/webapp/app/services/personalAccessToken.server.ts
+++ b/apps/webapp/app/services/personalAccessToken.server.ts
@@ -210,6 +210,18 @@ export async function createPersonalAccessTokenFromAuthorizationCode(
       },
     });
 
+    if (existingCliPersonalAccessToken.revokedAt) {
+      // re-activate revoked CLI PAT so we can use it again
+      await prisma.personalAccessToken.update({
+        where: {
+          id: existingCliPersonalAccessToken.id,
+        },
+        data: {
+          revokedAt: null,
+        },
+      });
+    }
+
     //we don't return the decrypted token
     return {
       id: existingCliPersonalAccessToken.id,

--- a/apps/webapp/app/services/personalAccessToken.server.ts
+++ b/apps/webapp/app/services/personalAccessToken.server.ts
@@ -134,19 +134,26 @@ export async function authenticatePersonalAccessToken(
 
   const hashedToken = hashToken(token);
 
-  const personalAccessToken = await prisma.personalAccessToken.update({
+  const personalAccessToken = await prisma.personalAccessToken.findFirst({
     where: {
       hashedToken,
       revokedAt: null,
+    },
+  });
+
+  if (!personalAccessToken) {
+    // The token may have been revoked or is entirely invalid
+    return;
+  }
+
+  await prisma.personalAccessToken.update({
+    where: {
+      id: personalAccessToken.id,
     },
     data: {
       lastAccessedAt: new Date(),
     },
   });
-
-  if (!personalAccessToken) {
-    return;
-  }
 
   const decryptedToken = decryptPersonalAccessToken(personalAccessToken);
 

--- a/packages/cli-v3/src/commands/login.ts
+++ b/packages/cli-v3/src/commands/login.ts
@@ -13,7 +13,7 @@ import {
   tracer,
   wrapCommandAction,
 } from "../cli/common.js";
-import { chalkLink } from "../utilities/cliOutput.js";
+import { chalkLink, prettyError } from "../utilities/cliOutput.js";
 import { readAuthConfigProfile, writeAuthConfigProfile } from "../utilities/configFiles.js";
 import { getVersion } from "../utilities/getVersion.js";
 import { printInitialBanner } from "../utilities/initialBanner.js";
@@ -109,10 +109,16 @@ export async function login(options?: LoginOptions): Promise<LoginResult> {
             skipTelemetry: !span.isRecording(),
             logLevel: logger.loggerLevel,
           },
-          opts.embedded
+          true
         );
 
         if (!whoAmIResult.success) {
+          prettyError("Whoami failed", whoAmIResult.error);
+
+          if (!opts.embedded) {
+            outro("Login failed");
+          }
+
           throw new Error(whoAmIResult.error);
         } else {
           if (!opts.embedded) {

--- a/packages/cli-v3/src/commands/whoami.ts
+++ b/packages/cli-v3/src/commands/whoami.ts
@@ -1,4 +1,4 @@
-import { intro, note } from "@clack/prompts";
+import { intro, note, outro } from "@clack/prompts";
 import { chalkLink } from "../utilities/cliOutput.js";
 import { logger } from "../utilities/logger.js";
 import { isLoggedIn } from "../utilities/session.js";
@@ -66,11 +66,20 @@ export async function whoAmI(
     if (authentication.error === "fetch failed") {
       loadingSpinner.stop("Fetch failed. Platform down?");
     } else {
-      loadingSpinner.stop(
-        `You must login first. Use \`trigger.dev login --profile ${
-          options?.profile ?? "default"
-        }\` to login.`
-      );
+      if (embedded) {
+        loadingSpinner.stop(
+          `Failed to check account details. You may want to run \`trigger.dev logout --profile ${
+            options?.profile ?? "default"
+          }\` and try again.`
+        );
+      } else {
+        loadingSpinner.stop(
+          `You must login first. Use \`trigger.dev login --profile ${
+            options?.profile ?? "default"
+          }\` to login.`
+        );
+        outro("Whoami failed");
+      }
     }
 
     return {

--- a/packages/cli-v3/src/utilities/cliOutput.ts
+++ b/packages/cli-v3/src/utilities/cliOutput.ts
@@ -65,6 +65,29 @@ export function prettyPrintDate(date: Date = new Date()) {
   return formattedDate;
 }
 
+export function prettyError(header: string, body?: string, footer?: string) {
+  const prefix = "Error: ";
+  const indent = Array(prefix.length).fill(" ").join("");
+  const spacing = "\n\n";
+
+  const prettyPrefix = chalkError(prefix);
+
+  const withIndents = (text?: string) =>
+    text
+      ?.split("\n")
+      .map((line) => `${indent}${line}`)
+      .join("\n");
+
+  const prettyBody = withIndents(body);
+  const prettyFooter = withIndents(footer);
+
+  log.error(
+    `${prettyPrefix}${header}${prettyBody ? `${spacing}${prettyBody}` : ""}${
+      prettyFooter ? `${spacing}${prettyFooter}` : ""
+    }`
+  );
+}
+
 export function prettyWarning(header: string, body?: string, footer?: string) {
   const prefix = "Warning: ";
   const indent = Array(prefix.length).fill(" ").join("");


### PR DESCRIPTION
The token would forever be stuck in the revoked state, so you could never login again. Even after confirming via the auth code page and getting a lovely "success" message. That's been fixed, and login command output was improved.