### PR TITLE
docs: add 'retry' import in code snippet

### DIFF
--- a/docs/v3/errors-retrying.mdx
+++ b/docs/v3/errors-retrying.mdx
@@ -66,7 +66,7 @@ We provide some useful functions that you can use to retry smaller parts of a ta
 You can retry a block of code that can throw an error, with the same retry settings as a task.
 
 ```ts /trigger/retry-on-throw.ts
-import { retry } from "@trigger.dev/sdk/v3"
+import { task, logger, retry } from "@trigger.dev/sdk/v3"
 
 export const retryOnThrow = task({
   id: "retry-on-throw",

--- a/docs/v3/errors-retrying.mdx
+++ b/docs/v3/errors-retrying.mdx
@@ -66,6 +66,8 @@ We provide some useful functions that you can use to retry smaller parts of a ta
 You can retry a block of code that can throw an error, with the same retry settings as a task.
 
 ```ts /trigger/retry-on-throw.ts
+import { retry } from "@trigger.dev/sdk/v3"
+
 export const retryOnThrow = task({
   id: "retry-on-throw",
   run: async (payload: any) => {


### PR DESCRIPTION
It wasn't obvious where `retry` is coming from, this adds an import line to the snippet.

Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [ ] I ran and tested the code works

---

## Testing

Open the mintlify docs
---

## Changelog

_[Short description of what has changed]_

---

## Screenshots

_[Screenshots]_

💯
