### PR TITLE
Improvement: Added more context to Shopify webhook registering errors

### DIFF
--- a/.changeset/blue-pumas-whisper.md
+++ b/.changeset/blue-pumas-whisper.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/shopify": patch
+---
+
+improved error messages when a shopify webhook fails to register

--- a/integrations/shopify/src/index.ts
+++ b/integrations/shopify/src/index.ts
@@ -63,6 +63,26 @@ export class Shopify implements TriggerIntegration {
       throw `Can't create Shopify integration (${options.id}) as apiKey was undefined`;
     }
 
+    if (Object.keys(options).includes("apiSecretKey") && !options.apiSecretKey) {
+      throw `Can't create Shopify integration (${options.id}) as apiSecretKey was undefined`;
+    }
+
+    if (Object.keys(options).includes("adminAccessToken") && !options.adminAccessToken) {
+      throw `Can't create Shopify integration (${options.id}) as adminAccessToken was undefined`;
+    }
+
+    if (Object.keys(options).includes("hostName") && !options.hostName) {
+      throw `Can't create Shopify integration (${options.id}) as hostName was undefined`;
+    }
+
+    // Regular expression to ensure the hostname ends with `.myshopify.com`
+    const shopifyDomainPattern = /^[a-zA-Z0-9-]+\.myshopify\.com$/;
+
+    // Verify that the user has entered the .myshopify.com domain and not a custom primary domain
+    if (!shopifyDomainPattern.test(options.hostName)) {
+      throw `Can't create Shopify integration (${options.id}) because hostName should be a ".myshopify.com" domain, not a custom primary domain.`;
+    }
+
     this._options = options;
     this._shopDomain = this._options.hostName.replace("http://", "").replace("https://", "");
   }

--- a/integrations/shopify/src/index.ts
+++ b/integrations/shopify/src/index.ts
@@ -75,16 +75,18 @@ export class Shopify implements TriggerIntegration {
       throw `Can't create Shopify integration (${options.id}) as hostName was undefined`;
     }
 
-    // Regular expression to ensure the hostname ends with `.myshopify.com`
+    this._options = options;
+    // Extract the shop domain if user has entered the full URL
+    this._shopDomain = this._options.hostName
+      .replace(/^https?:\/\//, "") // Remove http:// or https://
+      .replace(/\/$/, ""); // Remove trailing slash if it exists (e.g. `example.myshopify.com/`)
+
+    // Regular expression to ensure the shopDomain is a valid `.myshopify.com` domain
     const shopifyDomainPattern = /^[a-zA-Z0-9-]+\.myshopify\.com$/;
 
-    // Verify that the user has entered the .myshopify.com domain and not a custom primary domain
-    if (!shopifyDomainPattern.test(options.hostName)) {
-      throw `Can't create Shopify integration (${options.id}) because hostName should be a ".myshopify.com" domain, not a custom primary domain.`;
+    if (!shopifyDomainPattern.test(this._shopDomain)) {
+      throw `Can't create Shopify integration (${options.id}) because hostName should be a valid ".myshopify.com" domain, not a custom primary domain. For example: my-domain.myshopify.com`;
     }
-
-    this._options = options;
-    this._shopDomain = this._options.hostName.replace("http://", "").replace("https://", "");
   }
 
   get authSource() {

--- a/integrations/shopify/src/webhooks.ts
+++ b/integrations/shopify/src/webhooks.ts
@@ -95,6 +95,12 @@ export function createWebhookEventSource(integration: Shopify) {
             },
           });
 
+          if (!webhook.id) {
+            throw new Error(
+              "Could not subscribe endpoint to webhook. Make sure your shopfiy client configuration is correct. (you have the right permissions and are using the primary myshopify domain)"
+            );
+          }
+
           const clientSecret = await io.integration.runTask(
             "get-client-secret",
             async (client) => client.config.apiSecretKey

--- a/integrations/shopify/src/webhooks.ts
+++ b/integrations/shopify/src/webhooks.ts
@@ -97,7 +97,7 @@ export function createWebhookEventSource(integration: Shopify) {
 
           if (!webhook.id) {
             throw new Error(
-              "Could not subscribe endpoint to webhook. Make sure your shopfiy client configuration is correct. (you have the right permissions and are using the primary myshopify domain)"
+              "Failed to create webhook. Ensure your Shopfiy client configuration is correct. Have you set the correct access scopes? Are you using the primary myshopify.com domain?"
             );
           }
 
@@ -109,7 +109,11 @@ export function createWebhookEventSource(integration: Shopify) {
           await io.store.job.set("set-id", "webhook-id", webhook.id);
           await io.store.job.set("set-secret", "webhook-secret", clientSecret);
         } catch (error) {
-          await io.logger.error(`Failed to create webhook: ${(error as Error).message}`);
+          if (error instanceof Error) {
+            await io.logger.error(`Failed to create webhook: ${error.message}`);
+          } else {
+            await io.logger.error("Failed to create webhook", { rawError: error });
+          }
           throw error;
         }
       },
@@ -125,7 +129,11 @@ export function createWebhookEventSource(integration: Shopify) {
             id: webhookId,
           });
         } catch (error) {
-          await io.logger.error(`Failed to delete webhook: ${(error as Error).message}`);
+          if (error instanceof Error) {
+            await io.logger.error(`Failed to delete webhook: ${error.message}`);
+          } else {
+            await io.logger.error("Failed to delete webhook", { rawError: error });
+          }
           throw error;
         }
 
@@ -144,7 +152,11 @@ export function createWebhookEventSource(integration: Shopify) {
             },
           });
         } catch (error) {
-          await io.logger.error(`Failed to update webhook: ${(error as Error).message}`);
+          if (error instanceof Error) {
+            await io.logger.error(`Failed to update webhook: ${error.message}`);
+          } else {
+            await io.logger.error("Failed to update webhook", { rawError: error });
+          }
           throw error;
         }
       },

--- a/references/job-catalog/src/shopify.ts
+++ b/references/job-catalog/src/shopify.ts
@@ -35,12 +35,32 @@ client.defineJob({
 });
 
 client.defineJob({
-  id: "shopify-products-delete",
-  name: "Shopify: products/delete",
+  id: "shopify-locations-create",
+  name: "Shopify: locations/create",
   version: "0.1.0",
-  trigger: shopify.on("products/delete"),
+  trigger: shopify.on("locations/create"),
   run: async (payload, io, ctx) => {
-    await io.logger.log(`product deleted: ${payload.id}`);
+    await io.logger.log(`location created: ${payload.id}`);
+  },
+});
+
+client.defineJob({
+  id: "shopify-locations-update",
+  name: "Shopify: locations/update",
+  version: "0.1.0",
+  trigger: shopify.on("locations/update"),
+  run: async (payload, io, ctx) => {
+    await io.logger.log(`location updated: ${payload.id}`);
+  },
+});
+
+client.defineJob({
+  id: "shopify-locations-delete",
+  name: "Shopify: locations/delete",
+  version: "0.1.0",
+  trigger: shopify.on("locations/delete"),
+  run: async (payload, io, ctx) => {
+    await io.logger.log(`location updated: ${payload.id}`);
   },
 });
 

--- a/references/job-catalog/src/shopify.ts
+++ b/references/job-catalog/src/shopify.ts
@@ -35,32 +35,12 @@ client.defineJob({
 });
 
 client.defineJob({
-  id: "shopify-locations-create",
-  name: "Shopify: locations/create",
+  id: "shopify-products-delete",
+  name: "Shopify: products/delete",
   version: "0.1.0",
-  trigger: shopify.on("locations/create"),
+  trigger: shopify.on("products/delete"),
   run: async (payload, io, ctx) => {
-    await io.logger.log(`location created: ${payload.id}`);
-  },
-});
-
-client.defineJob({
-  id: "shopify-locations-update",
-  name: "Shopify: locations/update",
-  version: "0.1.0",
-  trigger: shopify.on("locations/update"),
-  run: async (payload, io, ctx) => {
-    await io.logger.log(`location updated: ${payload.id}`);
-  },
-});
-
-client.defineJob({
-  id: "shopify-locations-delete",
-  name: "Shopify: locations/delete",
-  version: "0.1.0",
-  trigger: shopify.on("locations/delete"),
-  run: async (payload, io, ctx) => {
-    await io.logger.log(`location updated: ${payload.id}`);
+    await io.logger.log(`product deleted: ${payload.id}`);
   },
 });
 


### PR DESCRIPTION
## About Issue

When initializing the Shopify Client with invalid parameters (excluding apiKey), errors are not explicitly thrown, resulting in a silent failure in the background. The user only sees an error message stating, "Error: Missing webhook ID for delete operation." This occurs because the current logic attempts to delete a webhook subscription first if its creation fails, possibly to avoid the "address already in use" exception. However, this logic is poorly documented, and only users running a trigger client with verbose mode enabled will see the debug message, "ERROR CREATING WEBHOOK RESTARTING WITH DELETE FIRST." In cases of invalid secret keys, this approach is ineffective and does not resolve the issue.


## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Localhost & Shopify Dev Store

---

## Changelog

- Added input validation for constructor parameters to ensure required arguments are correct.
- Verified that the store domain uses the .myshopify.com domain instead of a custom primary domain.
- Integrated logger.error statements into the webhook created/update/delete logic for improved error tracking.

---

## Screenshots
### Old Behaviour
![image](https://github.com/triggerdotdev/trigger.dev/assets/55840806/d7c144dc-1bc9-4939-8739-288062277011)
### New Behaviour
![image](https://github.com/triggerdotdev/trigger.dev/assets/55840806/57e36043-e727-49ff-85ec-ab38d3f12dd1)


💯
