### PR TITLE
v3: misc prod fixes

### DIFF
--- a/.changeset/eighty-wombats-sneeze.md
+++ b/.changeset/eighty-wombats-sneeze.md
@@ -1,0 +1,6 @@
+---
+"trigger.dev": patch
+"@trigger.dev/core": patch
+---
+
+Detect and handle unrecoverable worker errors

--- a/.changeset/eighty-wombats-sneeze.md
+++ b/.changeset/eighty-wombats-sneeze.md
@@ -3,4 +3,12 @@
 "@trigger.dev/core": patch
 ---
 
-Detect and handle unrecoverable worker errors
+- Clear paused states before retry
+- Detect and handle unrecoverable worker errors
+- Remove checkpoints after successful push
+- Permanently switch to DO hosted busybox image
+- Fix IPC timeout issue, or at least handle it more gracefully
+- Handle checkpoint failures
+- Basic chaos monkey for checkpoint testing
+- Stack traces are back in the dashboard
+- Display final errors on root span

--- a/.changeset/warm-olives-provide.md
+++ b/.changeset/warm-olives-provide.md
@@ -1,5 +1,0 @@
----
-"@trigger.dev/core": patch
----
-
-Improve handling of IPC timeouts and fix checkpoint cancellation after failures

--- a/.changeset/warm-olives-provide.md
+++ b/.changeset/warm-olives-provide.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Improve handling of IPC timeouts and fix checkpoint cancellation after failures

--- a/apps/coordinator/src/index.ts
+++ b/apps/coordinator/src/index.ts
@@ -33,6 +33,10 @@ const SECURE_CONNECTION = ["1", "true"].includes(process.env.SECURE_CONNECTION ?
 
 const logger = new SimpleLogger(`[${NODE_NAME}]`);
 
+if (CHAOS_MONKEY_ENABLED) {
+  logger.log("🍌 Chaos monkey enabled");
+}
+
 type CheckpointerInitializeReturn = {
   canCheckpoint: boolean;
   willSimulate: boolean;
@@ -224,6 +228,22 @@ class Checkpointer {
     const $$ = $({ signal: controller.signal });
 
     try {
+      if (CHAOS_MONKEY_ENABLED) {
+        console.log("🍌 Chaos monkey wreaking havoc");
+
+        const random = Math.random();
+
+        if (random < 0.33) {
+          // Fake long checkpoint duration
+          await $$`sleep 300`;
+        } else if (random < 0.66) {
+          // Fake checkpoint error
+          await $$`false`;
+        } else {
+          // no-op
+        }
+      }
+
       const shortCode = nanoid(8);
       const imageRef = this.#getImageRef(projectRef, deploymentVersion, shortCode);
       const exportLocation = this.#getExportLocation(projectRef, deploymentVersion, shortCode);

--- a/apps/coordinator/src/index.ts
+++ b/apps/coordinator/src/index.ts
@@ -286,9 +286,8 @@ class Checkpointer {
         await $$`rm ${exportLocation}`;
         this.#logger.log("Deleted checkpoint archive", { exportLocation });
 
-        // Disabled for now as this will increase restore time by having to pull the image again
-        // await $`buildah rmi ${imageRef}`;
-        // this.#logger.log("Deleted checkpoint image", { imageRef });
+        await $`buildah rmi ${imageRef}`;
+        this.#logger.log("Deleted checkpoint image", { imageRef });
       } catch (error) {
         this.#logger.error("Failed during checkpoint cleanup", { exportLocation });
         this.#logger.debug(error);

--- a/apps/coordinator/src/index.ts
+++ b/apps/coordinator/src/index.ts
@@ -916,6 +916,20 @@ class TaskCoordinator {
             error: message.error,
           });
         });
+
+        socket.on("UNRECOVERABLE_ERROR", async (message) => {
+          logger.log("[UNRECOVERABLE_ERROR]", message);
+
+          this.#platformSocket?.send("RUN_CRASHED", {
+            version: "v1",
+            runId: socket.data.runId,
+            error: message.error,
+          });
+
+          socket.emit("REQUEST_EXIT", {
+            version: "v1",
+          });
+        });
       },
       onDisconnect: async (socket, handler, sender, logger) => {
         this.#platformSocket?.send("LOG", {

--- a/apps/kubernetes-provider/src/index.ts
+++ b/apps/kubernetes-provider/src/index.ts
@@ -212,7 +212,7 @@ class KubernetesTaskOperations implements TaskOperations {
             },
             {
               name: "populate-taskinfo",
-              image: "docker.io/library/busybox",
+              image: "registry.digitalocean.com/trigger/busybox",
               imagePullPolicy: "IfNotPresent",
               command: ["/bin/sh", "-c"],
               args: ["printenv COORDINATOR_HOST | tee /etc/taskinfo/coordinator-host"],

--- a/apps/webapp/app/v3/eventRepository.server.ts
+++ b/apps/webapp/app/v3/eventRepository.server.ts
@@ -149,6 +149,7 @@ export type UpdateEventOptions = {
   attributes: TraceAttributes;
   endTime?: Date;
   immediate?: boolean;
+  events?: SpanEvents;
 };
 
 export class EventRepository {
@@ -219,7 +220,7 @@ export class EventRepository {
       isCancelled: false,
       status: options?.attributes.isError ? "ERROR" : "OK",
       links: event.links ?? [],
-      events: event.events ?? [],
+      events: event.events ?? (options?.events as any) ?? [],
       duration: calculateDurationFromStart(event.startTime, options?.endTime),
       properties: event.properties as Attributes,
       metadata: event.metadata as Attributes,

--- a/apps/webapp/app/v3/eventRepository.server.ts
+++ b/apps/webapp/app/v3/eventRepository.server.ts
@@ -414,6 +414,7 @@ export class EventRepository {
       },
       select: {
         traceId: true,
+        environmentType: true,
       },
     });
 
@@ -481,7 +482,11 @@ export class EventRepository {
       });
     }
 
-    const events = transformEvents(span.data.events, fullEvent.metadata as Attributes);
+    const events = transformEvents(
+      span.data.events,
+      fullEvent.metadata as Attributes,
+      traceSearch.environmentType === "DEVELOPMENT"
+    );
 
     return {
       ...fullEvent,
@@ -1073,16 +1078,16 @@ function removePrivateProperties(
   return result;
 }
 
-function transformEvents(events: SpanEvents, properties: Attributes): SpanEvents {
-  return (events ?? []).map((event) => transformEvent(event, properties));
+function transformEvents(events: SpanEvents, properties: Attributes, isDev: boolean): SpanEvents {
+  return (events ?? []).map((event) => transformEvent(event, properties, isDev));
 }
 
-function transformEvent(event: SpanEvent, properties: Attributes): SpanEvent {
+function transformEvent(event: SpanEvent, properties: Attributes, isDev: boolean): SpanEvent {
   if (isExceptionSpanEvent(event)) {
     return {
       ...event,
       properties: {
-        exception: transformException(event.properties.exception, properties),
+        exception: transformException(event.properties.exception, properties, isDev),
       },
     };
   }
@@ -1092,11 +1097,12 @@ function transformEvent(event: SpanEvent, properties: Attributes): SpanEvent {
 
 function transformException(
   exception: ExceptionEventProperties,
-  properties: Attributes
+  properties: Attributes,
+  isDev: boolean
 ): ExceptionEventProperties {
   const projectDirAttributeValue = properties[SemanticInternalAttributes.PROJECT_DIR];
 
-  if (typeof projectDirAttributeValue !== "string") {
+  if (projectDirAttributeValue !== undefined && typeof projectDirAttributeValue !== "string") {
     return exception;
   }
 
@@ -1105,6 +1111,7 @@ function transformException(
     stacktrace: exception.stacktrace
       ? correctErrorStackTrace(exception.stacktrace, projectDirAttributeValue, {
           removeFirstLine: true,
+          isDev,
         })
       : undefined,
   };

--- a/apps/webapp/app/v3/handleSocketIo.server.ts
+++ b/apps/webapp/app/v3/handleSocketIo.server.ts
@@ -137,7 +137,19 @@ function createCoordinatorNamespace(io: Server) {
 
           await service.call(message.deploymentId, message.error);
         } catch (e) {
-          logger.error("Error while indexing", { error: e });
+          logger.error("Error while processing index failure", { error: e });
+        }
+      },
+      RUN_CRASHED: async (message) => {
+        try {
+          const service = new CrashTaskRunService();
+
+          await service.call(message.runId, {
+            reason: `${message.error.name}: ${message.error.message}`,
+            logs: message.error.stack,
+          });
+        } catch (e) {
+          logger.error("Error while processing run failure", { error: e });
         }
       },
     },

--- a/apps/webapp/app/v3/services/completeAttempt.server.ts
+++ b/apps/webapp/app/v3/services/completeAttempt.server.ts
@@ -57,6 +57,8 @@ export class CompleteAttemptService extends BaseService {
         },
       });
 
+      // No attempt, so there's no message to ACK
+
       return "COMPLETED";
     }
 
@@ -142,6 +144,8 @@ export class CompleteAttemptService extends BaseService {
         "Cancelled by user",
         env
       );
+
+      // The cancel service handles ACK
 
       return "COMPLETED";
     }
@@ -230,6 +234,8 @@ export class CompleteAttemptService extends BaseService {
             status: "SYSTEM_FAILURE",
           },
         });
+
+        await marqs?.acknowledgeMessage(taskRunAttempt.taskRunId);
 
         return "COMPLETED";
       }

--- a/packages/cli-v3/src/workers/prod/entry-point.ts
+++ b/packages/cli-v3/src/workers/prod/entry-point.ts
@@ -258,6 +258,9 @@ class ProdWorker {
       await this.#exitGracefully();
     }
 
+    // Clear state for next execution
+    this.paused = false;
+    this.waitForPostStart = false;
     this.executing = false;
     this.attemptFriendlyId = undefined;
 

--- a/packages/cli-v3/src/workers/prod/entry-point.ts
+++ b/packages/cli-v3/src/workers/prod/entry-point.ts
@@ -111,6 +111,15 @@ class ProdWorker {
     this.#backgroundWorker.onWaitForDuration.attach(async (message) => {
       if (!this.attemptFriendlyId) {
         logger.error("Failed to send wait message, attempt friendly ID not set", { message });
+
+        this.#coordinatorSocket.socket.emit("UNRECOVERABLE_ERROR", {
+          version: "v1",
+          error: {
+            name: "NoAttemptId",
+            message: "Attempt ID not set before waiting for duration",
+          },
+        });
+
         return;
       }
 
@@ -128,6 +137,15 @@ class ProdWorker {
     this.#backgroundWorker.onWaitForTask.attach(async (message) => {
       if (!this.attemptFriendlyId) {
         logger.error("Failed to send wait message, attempt friendly ID not set", { message });
+
+        this.#coordinatorSocket.socket.emit("UNRECOVERABLE_ERROR", {
+          version: "v1",
+          error: {
+            name: "NoAttemptId",
+            message: "Attempt ID not set before waiting for task",
+          },
+        });
+
         return;
       }
 
@@ -145,6 +163,15 @@ class ProdWorker {
     this.#backgroundWorker.onWaitForBatch.attach(async (message) => {
       if (!this.attemptFriendlyId) {
         logger.error("Failed to send wait message, attempt friendly ID not set", { message });
+
+        this.#coordinatorSocket.socket.emit("UNRECOVERABLE_ERROR", {
+          version: "v1",
+          error: {
+            name: "NoAttemptId",
+            message: "Attempt ID not set before waiting for batch",
+          },
+        });
+
         return;
       }
 
@@ -454,11 +481,28 @@ class ProdWorker {
 
         if (this.paused) {
           if (!this.nextResumeAfter) {
+            this.#coordinatorSocket.socket.emit("UNRECOVERABLE_ERROR", {
+              version: "v1",
+              error: {
+                name: "NoNextResume",
+                message: "Next resume reason not set while resuming from paused state",
+              },
+            });
+
             return;
           }
 
           if (!this.attemptFriendlyId) {
             logger.error("Missing friendly ID");
+
+            this.#coordinatorSocket.socket.emit("UNRECOVERABLE_ERROR", {
+              version: "v1",
+              error: {
+                name: "NoAttemptId",
+                message: "Attempt ID not set while resuming from paused state",
+              },
+            });
+
             return;
           }
 

--- a/packages/core/src/v3/errors.ts
+++ b/packages/core/src/v3/errors.ts
@@ -84,13 +84,13 @@ export function createJsonErrorObject(error: TaskRunError) {
 export function correctErrorStackTrace(
   stackTrace: string,
   projectDir?: string,
-  options?: { removeFirstLine?: boolean }
+  options?: { removeFirstLine?: boolean; isDev?: boolean }
 ) {
   const [errorLine, ...traceLines] = stackTrace.split("\n");
 
   return [
     options?.removeFirstLine ? undefined : errorLine,
-    ...traceLines.map((line) => correctStackTraceLine(line, projectDir)),
+    ...traceLines.map((line) => correctStackTraceLine(line, projectDir, options?.isDev)),
   ]
     .filter(Boolean)
     .join("\n");
@@ -102,17 +102,21 @@ const LINES_TO_IGNORE = [
   /TaskExecutor/,
   /EXECUTE_TASK_RUN/,
   /@trigger.dev\/core/,
+  /packages\/core\/src\/v3/,
   /safeJsonProcess/,
   /__entryPoint.ts/,
+  /ZodIpc/,
+  /startActiveSpan/,
+  /processTicksAndRejections/,
 ];
 
-function correctStackTraceLine(line: string, projectDir?: string) {
+function correctStackTraceLine(line: string, projectDir?: string, isDev?: boolean) {
   if (LINES_TO_IGNORE.some((regex) => regex.test(line))) {
     return;
   }
 
   // Check to see if the path is inside the project directory
-  if (projectDir && !line.includes(projectDir)) {
+  if (isDev && projectDir && !line.includes(projectDir)) {
     return;
   }
 

--- a/packages/core/src/v3/runtime/prodRuntimeManager.ts
+++ b/packages/core/src/v3/runtime/prodRuntimeManager.ts
@@ -55,10 +55,14 @@ export class ProdRuntimeManager implements RuntimeManager {
       this._waitForDuration = { resolve, reject };
     });
 
-    const { willCheckpointAndRestore } = await this.ipc.sendWithAck("WAIT_FOR_DURATION", {
-      ms,
-      now,
-    });
+    const { willCheckpointAndRestore } = await this.ipc.sendWithAck(
+      "WAIT_FOR_DURATION",
+      {
+        ms,
+        now,
+      },
+      31_000
+    );
 
     if (!willCheckpointAndRestore) {
       await internalTimeout;
@@ -74,18 +78,24 @@ export class ProdRuntimeManager implements RuntimeManager {
     // Resets the clock to the current time
     clock.reset();
 
-    // The coordinator should cancel any in-progress checkpoints
-    const { checkpointCanceled, version } = await this.ipc.sendWithAck(
-      "CANCEL_CHECKPOINT",
-      {
-        version: "v2",
-        reason: "WAIT_FOR_DURATION",
-      },
-      31_000
-    );
+    try {
+      // The coordinator should cancel any in-progress checkpoints
+      const { checkpointCanceled, version } = await this.ipc.sendWithAck(
+        "CANCEL_CHECKPOINT",
+        {
+          version: "v2",
+          reason: "WAIT_FOR_DURATION",
+        },
+        31_000
+      );
 
-    if (checkpointCanceled) {
-      // There won't be a checkpoint or external resume and we've already completed our internal timeout
+      if (checkpointCanceled) {
+        // There won't be a checkpoint or external resume and we've already completed our internal timeout
+        return;
+      }
+    } catch (error) {
+      // If the cancellation times out, we will proceed as if the checkpoint was canceled
+      logger.debug("Checkpoint cancellation timed out", { error });
       return;
     }
 

--- a/packages/core/src/v3/schemas/messages.ts
+++ b/packages/core/src/v3/schemas/messages.ts
@@ -490,6 +490,17 @@ export const CoordinatorToPlatformMessages = {
       }),
     }),
   },
+  RUN_CRASHED: {
+    message: z.object({
+      version: z.literal("v1").default("v1"),
+      runId: z.string(),
+      error: z.object({
+        name: z.string(),
+        message: z.string(),
+        stack: z.string().optional(),
+      }),
+    }),
+  },
 };
 
 export const PlatformToCoordinatorMessages = {
@@ -679,6 +690,16 @@ export const ProdWorkerToCoordinatorMessages = {
     message: z.object({
       version: z.literal("v1").default("v1"),
       deploymentId: z.string(),
+      error: z.object({
+        name: z.string(),
+        message: z.string(),
+        stack: z.string().optional(),
+      }),
+    }),
+  },
+  UNRECOVERABLE_ERROR: {
+    message: z.object({
+      version: z.literal("v1").default("v1"),
       error: z.object({
         name: z.string(),
         message: z.string(),


### PR DESCRIPTION
Various small fixes:
- Clear paused states before retry
- Detect and handle unrecoverable worker errors
- Remove checkpoints after successful push
- Permanently switch to DO hosted busybox image
- Fix IPC timeout issue, or at least handle it more gracefully
- Handle checkpoint failures
- Basic chaos monkey for checkpoint testing
- Stack traces are back in the dashboard
- Display final errors on root span