### PR TITLE
Fix TypeScript inclusion in tsconfig.json for `cli-v3 init`

### DIFF
--- a/.changeset/hot-fishes-retire.md
+++ b/.changeset/hot-fishes-retire.md
@@ -1,0 +1,5 @@
+---
+trigger.dev: patch
+---
+
+Fix TypeScript inclusion in tsconfig.json for `cli-v3 init`

--- a/packages/cli-v3/src/commands/init.ts
+++ b/packages/cli-v3/src/commands/init.ts
@@ -5,7 +5,7 @@ import { recordSpanException } from "@trigger.dev/core/v3/workers";
 import chalk from "chalk";
 import { Command } from "commander";
 import { execa } from "execa";
-import { applyEdits, modify } from "jsonc-parser";
+import { applyEdits, modify, findNodeAtLocation, parseTree, getNodeValue } from "jsonc-parser";
 import { writeFile } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 import terminalLink from "terminal-link";
@@ -329,8 +329,29 @@ async function addConfigFileToTsConfig(dir: string, options: InitCommandOptions)
       });
 
       const tsconfigContent = await readFile(tsconfigPath);
+      const tsconfigContentTree = parseTree(tsconfigContent, undefined);
+      if (!tsconfigContentTree) {
+        span.end();
 
-      const edits = modify(tsconfigContent, ["include", -1], "trigger.config.ts", {
+        return;
+      }
+
+      const tsconfigIncludeOption = findNodeAtLocation(tsconfigContentTree, ["include"]);
+      if (!tsconfigIncludeOption) {
+        span.end();
+
+        return;
+      }
+
+      const tsConfigFileName = "trigger.config.ts";
+      const tsconfigIncludeOptionValue: string[] = getNodeValue(tsconfigIncludeOption);
+      if (tsconfigIncludeOptionValue.includes(tsConfigFileName)) {
+        span.end();
+
+        return;
+      }
+
+      const edits = modify(tsconfigContent, ["include", -1], tsConfigFileName, {
         isArrayInsertion: true,
         formattingOptions: {
           tabSize: 2,


### PR DESCRIPTION
Closes #1017

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

1. Ensure that the `tsconfig.json` file does not contain an explicit `include` directive.
2. Run `pnpm exec triggerdev init`.
3. Verify if the `trigger.config.ts` file is not included in the `include` tsconfig directive.
4. Next, manually add an `include` directive to the `tsconfig.json` file.
5. Once the `include` directive is added, run  `pnpm exec triggerdev init` again.
6. Check if `trigger.config.ts` is included in the `include` directive tsconfig, as it should be based on the presence of the include directive.
---

## Changelog

This pull request addresses an issue specific to the `cli-v3 init` where TypeScript files were mistakenly included in the project directory when no include directive was present in `tsconfig.json`. Previously, the cli init added `trigger.config.ts` to the inclusion list by default, resulting in TypeScript compilation errors for other files within the project.

To resolve this issue, the proposed fix ensures that `trigger.config.ts` is only added to the inclusion list if there's an existing include directive present in `tsconfig.json`. This prevents unintended TypeScript compilation errors for other files and maintains the expected behavior of the TypeScript compiler.

---

💯
