### PR TITLE
Fix missing logs when client includes their own @opentelemetry/api

### DIFF
--- a/.changeset/cool-comics-burn.md
+++ b/.changeset/cool-comics-burn.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Fixing missing logs when importing client @opentelemetry/api

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -1117,7 +1117,9 @@ async function compileProject(
         .replace("__TASKS__", createTaskFileImports(taskFiles))
         .replace(
           "__WORKER_SETUP__",
-          `import { tracingSDK } from "${escapeImportPath(workerSetupPath)}";`
+          `import { tracingSDK, otelTracer, otelLogger } from "${escapeImportPath(
+            workerSetupPath
+          )}";`
         );
 
       if (configPath) {

--- a/packages/cli-v3/src/commands/dev.tsx
+++ b/packages/cli-v3/src/commands/dev.tsx
@@ -364,7 +364,9 @@ function useDev({
         .replace("__TASKS__", createTaskFileImports(taskFiles))
         .replace(
           "__WORKER_SETUP__",
-          `import { tracingSDK, sender } from "${escapeImportPath(workerSetupPath)}";`
+          `import { tracingSDK, otelTracer, otelLogger, sender } from "${escapeImportPath(
+            workerSetupPath
+          )}";`
         );
 
       if (configPath) {

--- a/packages/cli-v3/src/workers/dev/backgroundWorker.ts
+++ b/packages/cli-v3/src/workers/dev/backgroundWorker.ts
@@ -323,6 +323,7 @@ export class BackgroundWorker {
     const fullEnv = {
       ...this.params.env,
       ...this.#readEnvVars(),
+      ...(this.params.debugOtel ? { OTEL_LOG_LEVEL: "debug" } : {}),
     };
 
     logger.debug("Initializing worker", { path: this.path, cwd, fullEnv });

--- a/packages/cli-v3/src/workers/dev/worker-facade.ts
+++ b/packages/cli-v3/src/workers/dev/worker-facade.ts
@@ -26,9 +26,8 @@ declare const handleError: HandleErrorFunction | undefined;
 
 declare const __PROJECT_CONFIG__: Config;
 declare const tracingSDK: TracingSDK;
-
-const otelTracer = tracingSDK.getTracer("trigger-dev-worker", packageJson.version);
-const otelLogger = tracingSDK.getLogger("trigger-dev-worker", packageJson.version);
+declare const otelTracer: Tracer;
+declare const otelLogger: Logger;
 
 import {
   TaskRunErrorCodes,
@@ -45,7 +44,8 @@ import {
   ZodMessageSender,
   ZodSchemaParsedError,
 } from "@trigger.dev/core/v3/zodMessageHandler";
-import * as packageJson from "../../../package.json";
+import type { Tracer } from "@opentelemetry/api";
+import type { Logger } from "@opentelemetry/api-logs";
 
 declare const sender: ZodMessageSender<typeof childToWorkerMessages>;
 

--- a/packages/cli-v3/src/workers/dev/worker-setup.ts
+++ b/packages/cli-v3/src/workers/dev/worker-setup.ts
@@ -1,17 +1,14 @@
-import "source-map-support/register.js";
-import { Resource } from "@opentelemetry/resources";
+import type { Tracer } from "@opentelemetry/api";
+import type { Logger } from "@opentelemetry/api-logs";
+import { ProjectConfig, childToWorkerMessages, taskCatalog } from "@trigger.dev/core/v3";
 import {
-  ProjectConfig,
-  SemanticInternalAttributes,
-  childToWorkerMessages,
-  taskCatalog,
-} from "@trigger.dev/core/v3";
-import {
+  StandardTaskCatalog,
   TracingDiagnosticLogLevel,
   TracingSDK,
-  StandardTaskCatalog,
 } from "@trigger.dev/core/v3/workers";
 import { ZodMessageSender } from "@trigger.dev/core/v3/zodMessageHandler";
+import "source-map-support/register.js";
+import * as packageJson from "../../../package.json";
 
 __SETUP_IMPORTED_PROJECT_CONFIG__;
 declare const __SETUP_IMPORTED_PROJECT_CONFIG__: unknown;
@@ -19,12 +16,12 @@ declare const setupImportedConfig: ProjectConfig | undefined;
 
 export const tracingSDK = new TracingSDK({
   url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? "http://0.0.0.0:4318",
-  resource: new Resource({
-    [SemanticInternalAttributes.CLI_VERSION]: "3.0.0",
-  }),
   instrumentations: setupImportedConfig?.instrumentations ?? [],
   diagLogLevel: (process.env.OTEL_LOG_LEVEL as TracingDiagnosticLogLevel) ?? "none",
 });
+
+export const otelTracer: Tracer = tracingSDK.getTracer("trigger-dev-worker", packageJson.version);
+export const otelLogger: Logger = tracingSDK.getLogger("trigger-dev-worker", packageJson.version);
 
 export const sender = new ZodMessageSender({
   schema: childToWorkerMessages,

--- a/packages/cli-v3/src/workers/prod/worker-facade.ts
+++ b/packages/cli-v3/src/workers/prod/worker-facade.ts
@@ -31,9 +31,8 @@ declare const handleError: HandleErrorFunction | undefined;
 
 declare const __PROJECT_CONFIG__: Config;
 declare const tracingSDK: TracingSDK;
-
-const otelTracer = tracingSDK.getTracer("trigger-prod-worker", packageJson.version);
-const otelLogger = tracingSDK.getLogger("trigger-prod-worker", packageJson.version);
+declare const otelTracer: Tracer;
+declare const otelLogger: Logger;
 
 import {
   TaskRunErrorCodes,
@@ -43,7 +42,8 @@ import {
   runtime,
 } from "@trigger.dev/core/v3";
 import { ProdRuntimeManager } from "@trigger.dev/core/v3/prod";
-import * as packageJson from "../../../package.json";
+import type { Tracer } from "@opentelemetry/api";
+import type { Logger } from "@opentelemetry/api-logs";
 
 const durableClock = new DurableClock();
 clock.setGlobalClock(durableClock);

--- a/packages/cli-v3/src/workers/prod/worker-setup.ts
+++ b/packages/cli-v3/src/workers/prod/worker-setup.ts
@@ -1,10 +1,12 @@
-import { Resource } from "@opentelemetry/resources";
-import { ProjectConfig, SemanticInternalAttributes, taskCatalog } from "@trigger.dev/core/v3";
+import type { Tracer } from "@opentelemetry/api";
+import * as packageJson from "../../../package.json";
+import { ProjectConfig, taskCatalog } from "@trigger.dev/core/v3";
 import {
   TracingDiagnosticLogLevel,
   TracingSDK,
   StandardTaskCatalog,
 } from "@trigger.dev/core/v3/workers";
+import type { Logger } from "@opentelemetry/api-logs";
 
 __SETUP_IMPORTED_PROJECT_CONFIG__;
 declare const __SETUP_IMPORTED_PROJECT_CONFIG__: unknown;
@@ -12,11 +14,11 @@ declare const setupImportedConfig: ProjectConfig | undefined;
 
 export const tracingSDK = new TracingSDK({
   url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? "http://0.0.0.0:4318",
-  resource: new Resource({
-    [SemanticInternalAttributes.CLI_VERSION]: "3.0.0",
-  }),
   instrumentations: setupImportedConfig?.instrumentations ?? [],
   diagLogLevel: (process.env.OTEL_LOG_LEVEL as TracingDiagnosticLogLevel) ?? "none",
 });
+
+export const otelTracer: Tracer = tracingSDK.getTracer("trigger-prod-worker", packageJson.version);
+export const otelLogger: Logger = tracingSDK.getLogger("trigger-prod-worker", packageJson.version);
 
 taskCatalog.setGlobalTaskCatalog(new StandardTaskCatalog());

--- a/packages/core/src/v3/otel/tracingSDK.ts
+++ b/packages/core/src/v3/otel/tracingSDK.ts
@@ -40,6 +40,7 @@ import {
 import { SemanticInternalAttributes } from "../semanticInternalAttributes";
 import { TaskContextLogProcessor, TaskContextSpanProcessor } from "../taskContext/otelProcessors";
 import { getEnvVar } from "../utils/getEnv";
+import { version } from "../../../package.json";
 
 class AsyncResourceDetector implements DetectorSync {
   private _promise: Promise<ResourceAttributes>;
@@ -111,6 +112,7 @@ export class TracingSDK {
         new Resource({
           [SemanticResourceAttributes.CLOUD_PROVIDER]: "trigger.dev",
           [SemanticInternalAttributes.TRIGGER]: true,
+          [SemanticInternalAttributes.CLI_VERSION]: version,
         })
       )
       .merge(config.resource ?? new Resource({}))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3066,8 +3066,8 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2
       '@opentelemetry/api':
-        specifier: ^1.8.0
-        version: 1.8.0
+        specifier: 1.4.1
+        version: 1.4.1
       '@react-email/components':
         specifier: ^0.0.17
         version: 0.0.17(@types/react@18.3.1)(react@18.2.0)
@@ -3079,7 +3079,7 @@ importers:
         version: 2.2.1
       '@traceloop/instrumentation-openai':
         specifier: ^0.3.9
-        version: 0.3.9(@opentelemetry/api@1.8.0)
+        version: 0.3.9(@opentelemetry/api@1.4.1)
       '@trigger.dev/core':
         specifier: workspace:^3.0.0-beta.0
         version: link:../../packages/core
@@ -3125,43 +3125,43 @@ importers:
     devDependencies:
       '@opentelemetry/core':
         specifier: ^1.22.0
-        version: 1.22.0(@opentelemetry/api@1.8.0)
+        version: 1.22.0(@opentelemetry/api@1.4.1)
       '@opentelemetry/exporter-logs-otlp-http':
         specifier: ^0.49.1
-        version: 0.49.1(@opentelemetry/api@1.8.0)
+        version: 0.49.1(@opentelemetry/api@1.4.1)
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.49.1
-        version: 0.49.1(@opentelemetry/api@1.8.0)
+        version: 0.49.1(@opentelemetry/api@1.4.1)
       '@opentelemetry/instrumentation':
         specifier: ^0.49.1
-        version: 0.49.1(@opentelemetry/api@1.8.0)
+        version: 0.49.1(@opentelemetry/api@1.4.1)
       '@opentelemetry/instrumentation-express':
         specifier: ^0.36.1
-        version: 0.36.1(@opentelemetry/api@1.8.0)
+        version: 0.36.1(@opentelemetry/api@1.4.1)
       '@opentelemetry/instrumentation-fetch':
         specifier: ^0.49.1
-        version: 0.49.1(@opentelemetry/api@1.8.0)
+        version: 0.49.1(@opentelemetry/api@1.4.1)
       '@opentelemetry/instrumentation-http':
         specifier: ^0.49.1
-        version: 0.49.1(@opentelemetry/api@1.8.0)
+        version: 0.49.1(@opentelemetry/api@1.4.1)
       '@opentelemetry/instrumentation-undici':
         specifier: 0.2.0
-        version: 0.2.0(@opentelemetry/api@1.8.0)
+        version: 0.2.0(@opentelemetry/api@1.4.1)
       '@opentelemetry/resources':
         specifier: ^1.22.0
-        version: 1.22.0(@opentelemetry/api@1.8.0)
+        version: 1.22.0(@opentelemetry/api@1.4.1)
       '@opentelemetry/sdk-logs':
         specifier: ^0.49.1
-        version: 0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.8.0)
+        version: 0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.4.1)
       '@opentelemetry/sdk-node':
         specifier: ^0.49.1
-        version: 0.49.1(@opentelemetry/api@1.8.0)
+        version: 0.49.1(@opentelemetry/api@1.4.1)
       '@opentelemetry/sdk-trace-base':
         specifier: ^1.22.0
-        version: 1.22.0(@opentelemetry/api@1.8.0)
+        version: 1.22.0(@opentelemetry/api@1.4.1)
       '@opentelemetry/sdk-trace-node':
         specifier: ^1.22.0
-        version: 1.22.0(@opentelemetry/api@1.8.0)
+        version: 1.22.0(@opentelemetry/api@1.4.1)
       '@opentelemetry/semantic-conventions':
         specifier: ^1.22.0
         version: 1.22.0
@@ -9290,9 +9290,22 @@ packages:
       '@opentelemetry/api': 1.8.0
     dev: true
 
+  /@opentelemetry/api@1.4.1:
+    resolution: {integrity: sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==}
+    engines: {node: '>=8.0.0'}
+
   /@opentelemetry/api@1.8.0:
     resolution: {integrity: sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==}
     engines: {node: '>=8.0.0'}
+
+  /@opentelemetry/context-async-hooks@1.22.0(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-Nfdxyg8YtWqVWkyrCukkundAjPhUXi93JtVQmqDT1mZRVKqA7e2r7eJCrI+F651XUBMp0hsOJSGiFk3QSpaIJw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+    dev: true
 
   /@opentelemetry/context-async-hooks@1.22.0(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-Nfdxyg8YtWqVWkyrCukkundAjPhUXi93JtVQmqDT1mZRVKqA7e2r7eJCrI+F651XUBMp0hsOJSGiFk3QSpaIJw==}
@@ -9301,6 +9314,16 @@ packages:
       '@opentelemetry/api': '>=1.0.0 <1.9.0'
     dependencies:
       '@opentelemetry/api': 1.8.0
+    dev: false
+
+  /@opentelemetry/core@1.22.0(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-0VoAlT6x+Xzik1v9goJ3pZ2ppi6+xd3aUfg4brfrLkDBHRIVjMP0eBHrKrhB+NKcDyMAg8fAbGL3Npg/F6AwWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/semantic-conventions': 1.22.0
 
   /@opentelemetry/core@1.22.0(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-0VoAlT6x+Xzik1v9goJ3pZ2ppi6+xd3aUfg4brfrLkDBHRIVjMP0eBHrKrhB+NKcDyMAg8fAbGL3Npg/F6AwWA==}
@@ -9310,6 +9333,21 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.8.0
       '@opentelemetry/semantic-conventions': 1.22.0
+    dev: false
+
+  /@opentelemetry/exporter-logs-otlp-http@0.49.1(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-3QoBnIGCmEkujynUP0mK155QtOM0MSf9FNrEw7u9ieCFsoMiyatg2hPp+alEDONJ8N8wGEK+wP2q3icgXBiggw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/api-logs': 0.49.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/otlp-exporter-base': 0.49.1(@opentelemetry/api@1.4.1)
+      '@opentelemetry/otlp-transformer': 0.49.1(@opentelemetry/api@1.4.1)
+      '@opentelemetry/sdk-logs': 0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.4.1)
+    dev: true
 
   /@opentelemetry/exporter-logs-otlp-http@0.49.1(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-3QoBnIGCmEkujynUP0mK155QtOM0MSf9FNrEw7u9ieCFsoMiyatg2hPp+alEDONJ8N8wGEK+wP2q3icgXBiggw==}
@@ -9323,6 +9361,22 @@ packages:
       '@opentelemetry/otlp-exporter-base': 0.49.1(@opentelemetry/api@1.8.0)
       '@opentelemetry/otlp-transformer': 0.49.1(@opentelemetry/api@1.8.0)
       '@opentelemetry/sdk-logs': 0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.8.0)
+    dev: false
+
+  /@opentelemetry/exporter-trace-otlp-grpc@0.49.1(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-Zbd7f3zF7fI2587MVhBizaW21cO/SordyrZGtMtvhoxU6n4Qb02Gx71X4+PzXH620e0+JX+Pcr9bYb1HTeVyJA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@grpc/grpc-js': 1.8.17
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.49.1(@opentelemetry/api@1.4.1)
+      '@opentelemetry/otlp-transformer': 0.49.1(@opentelemetry/api@1.4.1)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.4.1)
+    dev: true
 
   /@opentelemetry/exporter-trace-otlp-grpc@0.49.1(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-Zbd7f3zF7fI2587MVhBizaW21cO/SordyrZGtMtvhoxU6n4Qb02Gx71X4+PzXH620e0+JX+Pcr9bYb1HTeVyJA==}
@@ -9337,6 +9391,21 @@ packages:
       '@opentelemetry/otlp-transformer': 0.49.1(@opentelemetry/api@1.8.0)
       '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.8.0)
+    dev: false
+
+  /@opentelemetry/exporter-trace-otlp-http@0.49.1(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-KOLtZfZvIrpGZLVvblKsiVQT7gQUZNKcUUH24Zz6Xbi7LJb9Vt6xtUZFYdR5IIjvt47PIqBKDWUQlU0o1wAsRw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/otlp-exporter-base': 0.49.1(@opentelemetry/api@1.4.1)
+      '@opentelemetry/otlp-transformer': 0.49.1(@opentelemetry/api@1.4.1)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.4.1)
+    dev: true
 
   /@opentelemetry/exporter-trace-otlp-http@0.49.1(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-KOLtZfZvIrpGZLVvblKsiVQT7gQUZNKcUUH24Zz6Xbi7LJb9Vt6xtUZFYdR5IIjvt47PIqBKDWUQlU0o1wAsRw==}
@@ -9350,6 +9419,22 @@ packages:
       '@opentelemetry/otlp-transformer': 0.49.1(@opentelemetry/api@1.8.0)
       '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.8.0)
+    dev: false
+
+  /@opentelemetry/exporter-trace-otlp-proto@0.49.1(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-n8ON/c9pdMyYAfSFWKkgsPwjYoxnki+6Olzo+klKfW7KqLWoyEkryNkbcMIYnGGNXwdkMIrjoaP0VxXB26Oxcg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/otlp-exporter-base': 0.49.1(@opentelemetry/api@1.4.1)
+      '@opentelemetry/otlp-proto-exporter-base': 0.49.1(@opentelemetry/api@1.4.1)
+      '@opentelemetry/otlp-transformer': 0.49.1(@opentelemetry/api@1.4.1)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.4.1)
+    dev: true
 
   /@opentelemetry/exporter-trace-otlp-proto@0.49.1(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-n8ON/c9pdMyYAfSFWKkgsPwjYoxnki+6Olzo+klKfW7KqLWoyEkryNkbcMIYnGGNXwdkMIrjoaP0VxXB26Oxcg==}
@@ -9364,6 +9449,20 @@ packages:
       '@opentelemetry/otlp-transformer': 0.49.1(@opentelemetry/api@1.8.0)
       '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.8.0)
+    dev: false
+
+  /@opentelemetry/exporter-zipkin@1.22.0(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-XcFs6rGvcTz0qW5uY7JZDYD0yNEXdekXAb6sFtnZgY/cHY6BQ09HMzOjv9SX+iaXplRDcHr1Gta7VQKM1XXM6g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/semantic-conventions': 1.22.0
+    dev: true
 
   /@opentelemetry/exporter-zipkin@1.22.0(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-XcFs6rGvcTz0qW5uY7JZDYD0yNEXdekXAb6sFtnZgY/cHY6BQ09HMzOjv9SX+iaXplRDcHr1Gta7VQKM1XXM6g==}
@@ -9376,6 +9475,21 @@ packages:
       '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/semantic-conventions': 1.22.0
+    dev: false
+
+  /@opentelemetry/instrumentation-express@0.36.1(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-ltIE4kIMa+83QjW/p7oe7XCESF29w3FQ9/T1VgShdX7fzm56K2a0xfEX1vF8lnHRGERYxIWX9D086C6gJOjVGA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/instrumentation': 0.49.1(@opentelemetry/api@1.4.1)
+      '@opentelemetry/semantic-conventions': 1.22.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@opentelemetry/instrumentation-express@0.36.1(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-ltIE4kIMa+83QjW/p7oe7XCESF29w3FQ9/T1VgShdX7fzm56K2a0xfEX1vF8lnHRGERYxIWX9D086C6gJOjVGA==}
@@ -9389,6 +9503,22 @@ packages:
       '@opentelemetry/semantic-conventions': 1.22.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-fetch@0.49.1(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-hizhULZXlq02y8YC0vPQ4WtUWiXcwxPdEqHBy8p75jzF9rAuP/ldrVr0Oxvz5Xr9qQcdEOFLvEl0ZxbVL76WKw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/instrumentation': 0.49.1(@opentelemetry/api@1.4.1)
+      '@opentelemetry/sdk-trace-web': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/semantic-conventions': 1.22.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@opentelemetry/instrumentation-fetch@0.49.1(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-hizhULZXlq02y8YC0vPQ4WtUWiXcwxPdEqHBy8p75jzF9rAuP/ldrVr0Oxvz5Xr9qQcdEOFLvEl0ZxbVL76WKw==}
@@ -9403,6 +9533,22 @@ packages:
       '@opentelemetry/semantic-conventions': 1.22.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /@opentelemetry/instrumentation-http@0.49.1(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-Yib5zrW2s0V8wTeUK/B3ZtpyP4ldgXj9L3Ws/axXrW1dW0/mEFKifK50MxMQK9g5NNJQS9dWH7rvcEGZdWdQDA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/instrumentation': 0.49.1(@opentelemetry/api@1.4.1)
+      '@opentelemetry/semantic-conventions': 1.22.0
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@opentelemetry/instrumentation-http@0.49.1(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-Yib5zrW2s0V8wTeUK/B3ZtpyP4ldgXj9L3Ws/axXrW1dW0/mEFKifK50MxMQK9g5NNJQS9dWH7rvcEGZdWdQDA==}
@@ -9417,27 +9563,28 @@ packages:
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
-  /@opentelemetry/instrumentation-undici@0.2.0(@opentelemetry/api@1.8.0):
+  /@opentelemetry/instrumentation-undici@0.2.0(@opentelemetry/api@1.4.1):
     resolution: {integrity: sha512-RH9WdVRtpnyp8kvya2RYqKsJouPxvHl7jKPsIfrbL8u2QCKloAGi0uEqDHoOS15ZRYPQTDXZ7d8jSpUgSQmvpA==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.7.0
     dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.4.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@opentelemetry/instrumentation@0.48.0(@opentelemetry/api@1.8.0):
+  /@opentelemetry/instrumentation@0.48.0(@opentelemetry/api@1.4.1):
     resolution: {integrity: sha512-sjtZQB5PStIdCw5ovVTDGwnmQC+GGYArJNgIcydrDSqUTdYBnMrN9P4pwQZgS3vTGIp+TU1L8vMXGe51NVmIKQ==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
     dependencies:
-      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/api': 1.4.1
       '@types/shimmer': 1.0.2
       import-in-the-middle: 1.7.1
       require-in-the-middle: 7.1.1
@@ -9446,6 +9593,23 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+
+  /@opentelemetry/instrumentation@0.49.1(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-0DLtWtaIppuNNRRllSD4bjU8ZIiLp1cDXvJEbp752/Zf+y3gaLNaoGRGIlX4UHhcsrmtL+P2qxi3Hodi8VuKiQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/api-logs': 0.49.1
+      '@types/shimmer': 1.0.2
+      import-in-the-middle: 1.7.1
+      require-in-the-middle: 7.1.1
+      semver: 7.5.4
+      shimmer: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@opentelemetry/instrumentation@0.49.1(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-0DLtWtaIppuNNRRllSD4bjU8ZIiLp1cDXvJEbp752/Zf+y3gaLNaoGRGIlX4UHhcsrmtL+P2qxi3Hodi8VuKiQ==}
@@ -9462,14 +9626,15 @@ packages:
       shimmer: 1.2.1
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
-  /@opentelemetry/instrumentation@0.51.1(@opentelemetry/api@1.8.0):
+  /@opentelemetry/instrumentation@0.51.1(@opentelemetry/api@1.4.1):
     resolution: {integrity: sha512-JIrvhpgqY6437QIqToyozrUG1h5UhwHkaGK/WAX+fkrpyPtc+RO5FkRtUd9BH0MibabHHvqsnBGKfKVijbmp8w==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
     dependencies:
-      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/api': 1.4.1
       '@opentelemetry/api-logs': 0.51.1
       '@types/shimmer': 1.0.2
       import-in-the-middle: 1.7.4
@@ -9480,6 +9645,16 @@ packages:
       - supports-color
     dev: true
 
+  /@opentelemetry/otlp-exporter-base@0.49.1(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-z6sHliPqDgJU45kQatAettY9/eVF58qVPaTuejw9YWfSRqid9pXPYeegDCSdyS47KAUgAtm+nC28K3pfF27HWg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+    dev: true
+
   /@opentelemetry/otlp-exporter-base@0.49.1(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-z6sHliPqDgJU45kQatAettY9/eVF58qVPaTuejw9YWfSRqid9pXPYeegDCSdyS47KAUgAtm+nC28K3pfF27HWg==}
     engines: {node: '>=14'}
@@ -9488,6 +9663,20 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.8.0
       '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+    dev: false
+
+  /@opentelemetry/otlp-grpc-exporter-base@0.49.1(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-DNDNUWmOqtKTFJAyOyHHKotVox0NQ/09ETX8fUOeEtyNVHoGekAVtBbvIA3AtK+JflP7LC0PTjlLfruPM3Wy6w==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@grpc/grpc-js': 1.8.17
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/otlp-exporter-base': 0.49.1(@opentelemetry/api@1.4.1)
+      protobufjs: 7.2.6
+    dev: true
 
   /@opentelemetry/otlp-grpc-exporter-base@0.49.1(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-DNDNUWmOqtKTFJAyOyHHKotVox0NQ/09ETX8fUOeEtyNVHoGekAVtBbvIA3AtK+JflP7LC0PTjlLfruPM3Wy6w==}
@@ -9500,6 +9689,19 @@ packages:
       '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/otlp-exporter-base': 0.49.1(@opentelemetry/api@1.8.0)
       protobufjs: 7.2.6
+    dev: false
+
+  /@opentelemetry/otlp-proto-exporter-base@0.49.1(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-x1qB4EUC7KikUl2iNuxCkV8yRzrSXSyj4itfpIO674H7dhI7Zv37SFaOJTDN+8Z/F50gF2ISFH9CWQ4KCtGm2A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/otlp-exporter-base': 0.49.1(@opentelemetry/api@1.4.1)
+      protobufjs: 7.2.6
+    dev: true
 
   /@opentelemetry/otlp-proto-exporter-base@0.49.1(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-x1qB4EUC7KikUl2iNuxCkV8yRzrSXSyj4itfpIO674H7dhI7Zv37SFaOJTDN+8Z/F50gF2ISFH9CWQ4KCtGm2A==}
@@ -9511,6 +9713,22 @@ packages:
       '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/otlp-exporter-base': 0.49.1(@opentelemetry/api@1.8.0)
       protobufjs: 7.2.6
+    dev: false
+
+  /@opentelemetry/otlp-transformer@0.49.1(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-Z+koA4wp9L9e3jkFacyXTGphSWTbOKjwwXMpb0CxNb0kjTHGUxhYRN8GnkLFsFo5NbZPjP07hwAqeEG/uCratQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.9.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/api-logs': 0.49.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/sdk-logs': 0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.4.1)
+      '@opentelemetry/sdk-metrics': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.4.1)
+    dev: true
 
   /@opentelemetry/otlp-transformer@0.49.1(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-Z+koA4wp9L9e3jkFacyXTGphSWTbOKjwwXMpb0CxNb0kjTHGUxhYRN8GnkLFsFo5NbZPjP07hwAqeEG/uCratQ==}
@@ -9525,6 +9743,17 @@ packages:
       '@opentelemetry/sdk-logs': 0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.8.0)
       '@opentelemetry/sdk-metrics': 1.22.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.8.0)
+    dev: false
+
+  /@opentelemetry/propagator-b3@1.22.0(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-qBItJm9ygg/jCB5rmivyGz1qmKZPsL/sX715JqPMFgq++Idm0x+N9sLQvWFHFt2+ZINnCSojw7FVBgFW6izcXA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+    dev: true
 
   /@opentelemetry/propagator-b3@1.22.0(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-qBItJm9ygg/jCB5rmivyGz1qmKZPsL/sX715JqPMFgq++Idm0x+N9sLQvWFHFt2+ZINnCSojw7FVBgFW6izcXA==}
@@ -9534,6 +9763,17 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.8.0
       '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+    dev: false
+
+  /@opentelemetry/propagator-jaeger@1.22.0(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-pMLgst3QIwrUfepraH5WG7xfpJ8J3CrPKrtINK0t7kBkuu96rn+HDYQ8kt3+0FXvrZI8YJE77MCQwnJWXIrgpA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+    dev: true
 
   /@opentelemetry/propagator-jaeger@1.22.0(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-pMLgst3QIwrUfepraH5WG7xfpJ8J3CrPKrtINK0t7kBkuu96rn+HDYQ8kt3+0FXvrZI8YJE77MCQwnJWXIrgpA==}
@@ -9543,6 +9783,18 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.8.0
       '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
+    dev: false
+
+  /@opentelemetry/resources@1.22.0(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/semantic-conventions': 1.22.0
+    dev: true
 
   /@opentelemetry/resources@1.22.0(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==}
@@ -9553,6 +9805,7 @@ packages:
       '@opentelemetry/api': 1.8.0
       '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/semantic-conventions': 1.22.0
+    dev: false
 
   /@opentelemetry/sdk-logs@0.49.1(@opentelemetry/api-logs@0.48.0)(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-gCzYWsJE0h+3cuh3/cK+9UwlVFyHvj3PReIOCDOmdeXOp90ZjKRoDOJBc3mvk1LL6wyl1RWIivR8Rg9OToyesw==}
@@ -9567,6 +9820,19 @@ packages:
       '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
     dev: false
 
+  /@opentelemetry/sdk-logs@0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-gCzYWsJE0h+3cuh3/cK+9UwlVFyHvj3PReIOCDOmdeXOp90ZjKRoDOJBc3mvk1LL6wyl1RWIivR8Rg9OToyesw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.9.0'
+      '@opentelemetry/api-logs': '>=0.39.1'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/api-logs': 0.49.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.4.1)
+    dev: true
+
   /@opentelemetry/sdk-logs@0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-gCzYWsJE0h+3cuh3/cK+9UwlVFyHvj3PReIOCDOmdeXOp90ZjKRoDOJBc3mvk1LL6wyl1RWIivR8Rg9OToyesw==}
     engines: {node: '>=14'}
@@ -9578,6 +9844,19 @@ packages:
       '@opentelemetry/api-logs': 0.49.1
       '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
+    dev: false
+
+  /@opentelemetry/sdk-metrics@1.22.0(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-k6iIx6H3TZ+BVMr2z8M16ri2OxWaljg5h8ihGJxi/KQWcjign6FEaEzuigXt5bK9wVEhqAcWLCfarSftaNWkkg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.9.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.4.1)
+      lodash.merge: 4.6.2
+    dev: true
 
   /@opentelemetry/sdk-metrics@1.22.0(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-k6iIx6H3TZ+BVMr2z8M16ri2OxWaljg5h8ihGJxi/KQWcjign6FEaEzuigXt5bK9wVEhqAcWLCfarSftaNWkkg==}
@@ -9589,6 +9868,31 @@ packages:
       '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
       lodash.merge: 4.6.2
+    dev: false
+
+  /@opentelemetry/sdk-node@0.49.1(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-feBIT85ndiSHXsQ2gfGpXC/sNeX4GCHLksC4A9s/bfpUbbgbCSl0RvzZlmEpCHarNrkZMwFRi4H0xFfgvJEjrg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.9.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/api-logs': 0.49.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.49.1(@opentelemetry/api@1.4.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.49.1(@opentelemetry/api@1.4.1)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.49.1(@opentelemetry/api@1.4.1)
+      '@opentelemetry/exporter-zipkin': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/instrumentation': 0.49.1(@opentelemetry/api@1.4.1)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/sdk-logs': 0.49.1(@opentelemetry/api-logs@0.49.1)(@opentelemetry/api@1.4.1)
+      '@opentelemetry/sdk-metrics': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/sdk-trace-node': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/semantic-conventions': 1.22.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@opentelemetry/sdk-node@0.49.1(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-feBIT85ndiSHXsQ2gfGpXC/sNeX4GCHLksC4A9s/bfpUbbgbCSl0RvzZlmEpCHarNrkZMwFRi4H0xFfgvJEjrg==}
@@ -9612,6 +9916,19 @@ packages:
       '@opentelemetry/semantic-conventions': 1.22.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /@opentelemetry/sdk-trace-base@1.22.0(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-pfTuSIpCKONC6vkTpv6VmACxD+P1woZf4q0K46nSUvXFvOFqjBYKFaAMkKD3M1mlKUUh0Oajwj35qNjMl80m1Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/semantic-conventions': 1.22.0
+    dev: true
 
   /@opentelemetry/sdk-trace-base@1.22.0(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-pfTuSIpCKONC6vkTpv6VmACxD+P1woZf4q0K46nSUvXFvOFqjBYKFaAMkKD3M1mlKUUh0Oajwj35qNjMl80m1Q==}
@@ -9623,6 +9940,22 @@ packages:
       '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/resources': 1.22.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/semantic-conventions': 1.22.0
+    dev: false
+
+  /@opentelemetry/sdk-trace-node@1.22.0(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-gTGquNz7ue8uMeiWPwp3CU321OstQ84r7PCDtOaCicjbJxzvO8RZMlEC4geOipTeiF88kss5n6w+//A0MhP1lQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/context-async-hooks': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/propagator-b3': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/propagator-jaeger': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.4.1)
+      semver: 7.5.4
+    dev: true
 
   /@opentelemetry/sdk-trace-node@1.22.0(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-gTGquNz7ue8uMeiWPwp3CU321OstQ84r7PCDtOaCicjbJxzvO8RZMlEC4geOipTeiF88kss5n6w+//A0MhP1lQ==}
@@ -9637,6 +9970,19 @@ packages:
       '@opentelemetry/propagator-jaeger': 1.22.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.8.0)
       semver: 7.5.4
+    dev: false
+
+  /@opentelemetry/sdk-trace-web@1.22.0(@opentelemetry/api@1.4.1):
+    resolution: {integrity: sha512-id5bUhWYg475xbm4hjwWA4PnWM4duNK1EyFRkZxa3BZNuCITwiKCLvDkVhlE9RK2kvuDOPmcRxgSbU1apF9/1w==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.9.0'
+    dependencies:
+      '@opentelemetry/api': 1.4.1
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/semantic-conventions': 1.22.0
+    dev: true
 
   /@opentelemetry/sdk-trace-web@1.22.0(@opentelemetry/api@1.8.0):
     resolution: {integrity: sha512-id5bUhWYg475xbm4hjwWA4PnWM4duNK1EyFRkZxa3BZNuCITwiKCLvDkVhlE9RK2kvuDOPmcRxgSbU1apF9/1w==}
@@ -9648,6 +9994,7 @@ packages:
       '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/sdk-trace-base': 1.22.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/semantic-conventions': 1.22.0
+    dev: false
 
   /@opentelemetry/semantic-conventions@1.22.0:
     resolution: {integrity: sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw==}
@@ -14878,12 +15225,12 @@ packages:
     engines: {node: '>=14'}
     dev: false
 
-  /@traceloop/instrumentation-openai@0.3.9(@opentelemetry/api@1.8.0):
+  /@traceloop/instrumentation-openai@0.3.9(@opentelemetry/api@1.4.1):
     resolution: {integrity: sha512-Ru2QBK6crx0dtWXd4aMyFNRP9cA2WF+8Rjt2ctOgu/R7M7fmNvtcXveY0qXZ1doKYzzt0+icZqs0ahJEn8WYcQ==}
     engines: {node: '>=14'}
     dependencies:
-      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation': 0.48.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/core': 1.22.0(@opentelemetry/api@1.4.1)
+      '@opentelemetry/instrumentation': 0.48.0(@opentelemetry/api@1.4.1)
       '@opentelemetry/semantic-conventions': 1.22.0
       '@traceloop/ai-semantic-conventions': 0.3.8
     transitivePeerDependencies:

--- a/references/v3-catalog/package.json
+++ b/references/v3-catalog/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@ffprobe-installer/ffprobe": "^2.1.2",
-    "@opentelemetry/api": "^1.8.0",
+    "@opentelemetry/api": "1.4.1",
     "@react-email/components": "^0.0.17",
     "@react-email/render": "^0.0.7",
     "@sindresorhus/slugify": "^2.2.1",
@@ -30,27 +30,27 @@
     "yt-dlp-wrap": "^2.3.12"
   },
   "devDependencies": {
-    "@trigger.dev/tsconfig": "workspace:*",
-    "@types/node": "20.4.2",
-    "@types/react": "^18.3.1",
-    "trigger.dev": "workspace:*",
-    "ts-node": "^10.9.2",
-    "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.3.0",
     "@opentelemetry/api": "^1.8.0",
     "@opentelemetry/core": "^1.22.0",
     "@opentelemetry/exporter-logs-otlp-http": "^0.49.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.49.1",
     "@opentelemetry/instrumentation": "^0.49.1",
     "@opentelemetry/instrumentation-express": "^0.36.1",
+    "@opentelemetry/instrumentation-fetch": "^0.49.1",
     "@opentelemetry/instrumentation-http": "^0.49.1",
+    "@opentelemetry/instrumentation-undici": "0.2.0",
     "@opentelemetry/resources": "^1.22.0",
     "@opentelemetry/sdk-logs": "^0.49.1",
     "@opentelemetry/sdk-node": "^0.49.1",
     "@opentelemetry/sdk-trace-base": "^1.22.0",
     "@opentelemetry/sdk-trace-node": "^1.22.0",
     "@opentelemetry/semantic-conventions": "^1.22.0",
-    "@opentelemetry/instrumentation-fetch": "^0.49.1",
-    "@opentelemetry/instrumentation-undici": "0.2.0"
+    "@trigger.dev/tsconfig": "workspace:*",
+    "@types/node": "20.4.2",
+    "@types/react": "^18.3.1",
+    "trigger.dev": "workspace:*",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^5.3.0"
   }
 }

--- a/references/v3-catalog/src/telemetry.ts
+++ b/references/v3-catalog/src/telemetry.ts
@@ -1,0 +1,13 @@
+import { trace } from "@opentelemetry/api";
+
+export const tracer = trace.getTracer("v3-catalog", "3.0.0.dp.1");
+
+export function traceAsync<T>(name: string, fn: () => Promise<T>): Promise<T> {
+  return tracer.startActiveSpan(name, async (span) => {
+    try {
+      return await fn();
+    } finally {
+      span.end();
+    }
+  });
+}

--- a/references/v3-catalog/src/trigger/simple.ts
+++ b/references/v3-catalog/src/trigger/simple.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { logger, task, wait } from "@trigger.dev/sdk/v3";
+import { traceAsync } from "@/telemetry";
 
 export const simplestTask = task({
   id: "fetch-post-task",
@@ -20,6 +21,10 @@ export const simplestTask = task({
 export const taskWithSpecialCharacters = task({
   id: "admin:special-characters",
   run: async (payload: { url: string }) => {
+    await traceAsync("taskWithSpecialCharacters", async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    });
+
     return {
       message: "This task has special characters in its ID",
     };


### PR DESCRIPTION
If a user has their own `@opentelemetry/api` package, which is a different version from ours, then task logs will fail to be sent to the platform because opentelemetry will fail to register our tracing API with the following error message:

```
Error: @opentelemetry/api: Registration of version v1.8.0 for trace does not match previously registered API v1.4.1
```

The solution was to make sure the user's `@opentelemetry/api` was not imported by the worker prior to our trace API registration. Removing the `@opentelemetry/resources` import from `worker-setup.ts` was enough to solve this problem because it imports `@opentelemetry/api`, and the top-level `@opentelemetry/api` inside node_modules is the users, not the one inside `@trigger.dev/core`.