### PR TITLE
v3: Fix issues with posting alerts to public slack channels

### DIFF
--- a/apps/webapp/app/components/environments/EnvironmentLabel.tsx
+++ b/apps/webapp/app/components/environments/EnvironmentLabel.tsx
@@ -9,6 +9,30 @@ const variants = {
   large: "h-6 text-xs px-1.5 rounded",
 };
 
+export function EnvironmentTypeLabel({
+  environment,
+  size = "small",
+  className,
+}: {
+  environment: Environment;
+  size?: keyof typeof variants;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "text-midnight-900 inline-flex items-center justify-center whitespace-nowrap border font-medium uppercase tracking-wider",
+        environmentBorderClassName(environment),
+        environmentTextClassName(environment),
+        variants[size],
+        className
+      )}
+    >
+      {environmentTypeTitle(environment)}
+    </span>
+  );
+}
+
 export function EnvironmentLabel({
   environment,
   size = "small",
@@ -111,6 +135,19 @@ export function environmentTitle(environment: Environment, username?: string) {
       return "Staging";
     case "DEVELOPMENT":
       return username ? `Dev: ${username}` : "Dev: You";
+    case "PREVIEW":
+      return "Preview";
+  }
+}
+
+export function environmentTypeTitle(environment: Environment) {
+  switch (environment.type) {
+    case "PRODUCTION":
+      return "Prod";
+    case "STAGING":
+      return "Staging";
+    case "DEVELOPMENT":
+      return "Dev";
     case "PREVIEW":
       return "Preview";
   }

--- a/apps/webapp/app/models/orgIntegration.server.ts
+++ b/apps/webapp/app/models/orgIntegration.server.ts
@@ -27,7 +27,7 @@ type SlackSecret = z.infer<typeof SlackSecretSchema>;
 
 const REDIRECT_AFTER_AUTH_KEY = "redirect-back-after-auth";
 
-type OrganizationIntegrationForService<TService extends IntegrationService> = Omit<
+export type OrganizationIntegrationForService<TService extends IntegrationService> = Omit<
   AuthenticatableIntegration,
   "service"
 > & {
@@ -83,7 +83,14 @@ export class OrgIntegrationRepository {
 
   static slackAuthorizationUrl(
     state: string,
-    scopes: string[] = ["channels:read", "groups:read", "im:read", "mpim:read", "chat:write"],
+    scopes: string[] = [
+      "channels:read",
+      "groups:read",
+      "im:read",
+      "mpim:read",
+      "chat:write",
+      "chat:write.public",
+    ],
     userScopes: string[] = ["channels:read", "groups:read", "im:read", "mpim:read", "chat:write"]
   ) {
     return `https://slack.com/oauth/v2/authorize?client_id=${

--- a/apps/webapp/app/presenters/v3/ApiAlertChannelPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ApiAlertChannelPresenter.server.ts
@@ -16,6 +16,10 @@ export const ApiAlertType = z.enum(["attempt_failure", "deployment_failure", "de
 
 export type ApiAlertType = z.infer<typeof ApiAlertType>;
 
+export const ApiAlertEnvironmentType = z.enum(["STAGING", "PRODUCTION"]);
+
+export type ApiAlertEnvironmentType = z.infer<typeof ApiAlertEnvironmentType>;
+
 export const ApiAlertChannel = z.enum(["email", "webhook"]);
 
 export type ApiAlertChannel = z.infer<typeof ApiAlertChannel>;
@@ -34,6 +38,7 @@ export const ApiCreateAlertChannel = z.object({
   channel: ApiAlertChannel,
   channelData: ApiAlertChannelData,
   deduplicationKey: z.string().optional(),
+  environmentTypes: ApiAlertEnvironmentType.array().default(["STAGING", "PRODUCTION"]),
 });
 
 export type ApiCreateAlertChannel = z.infer<typeof ApiCreateAlertChannel>;

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.alerts.new/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.alerts.new/route.tsx
@@ -376,27 +376,7 @@ export default function Page() {
 
               <FormError id={alertTypes.errorId}>{alertTypes.error}</FormError>
             </InputGroup>
-            <InputGroup>
-              <Label>Environments</Label>
-              <Checkbox
-                name="environments"
-                id="production"
-                value="production"
-                variant="simple/small"
-                label="PROD"
-                defaultChecked
-                disabled
-              />
-              <Checkbox
-                name="environments"
-                id="staging"
-                value="staging"
-                variant="simple/small"
-                label="STAGING"
-                defaultChecked
-                disabled
-              />
-            </InputGroup>
+
             <FormError>{form.error}</FormError>
             <div className="border-t border-grid-bright pt-3">
               <FormButtons

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.alerts.new/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.alerts.new/route.tsx
@@ -41,6 +41,10 @@ const FormSchema = z
       .array(z.enum(["TASK_RUN_ATTEMPT", "DEPLOYMENT_FAILURE", "DEPLOYMENT_SUCCESS"]))
       .min(1)
       .or(z.enum(["TASK_RUN_ATTEMPT", "DEPLOYMENT_FAILURE", "DEPLOYMENT_SUCCESS"])),
+    environmentTypes: z
+      .array(z.enum(["STAGING", "PRODUCTION"]))
+      .min(1)
+      .or(z.enum(["STAGING", "PRODUCTION"])),
     type: z.enum(["WEBHOOK", "SLACK", "EMAIL"]).default("EMAIL"),
     channelValue: z.string().nonempty(),
     integrationId: z.string().optional(),
@@ -82,6 +86,9 @@ function formDataToCreateAlertChannelOptions(
         alertTypes: Array.isArray(formData.alertTypes)
           ? formData.alertTypes
           : [formData.alertTypes],
+        environmentTypes: Array.isArray(formData.environmentTypes)
+          ? formData.environmentTypes
+          : [formData.environmentTypes],
         channel: {
           type: "WEBHOOK",
           url: formData.channelValue,
@@ -94,6 +101,9 @@ function formDataToCreateAlertChannelOptions(
         alertTypes: Array.isArray(formData.alertTypes)
           ? formData.alertTypes
           : [formData.alertTypes],
+        environmentTypes: Array.isArray(formData.environmentTypes)
+          ? formData.environmentTypes
+          : [formData.environmentTypes],
         channel: {
           type: "EMAIL",
           email: formData.channelValue,
@@ -108,6 +118,9 @@ function formDataToCreateAlertChannelOptions(
         alertTypes: Array.isArray(formData.alertTypes)
           ? formData.alertTypes
           : [formData.alertTypes],
+        environmentTypes: Array.isArray(formData.environmentTypes)
+          ? formData.environmentTypes
+          : [formData.environmentTypes],
         channel: {
           type: "SLACK",
           channelId,
@@ -205,15 +218,16 @@ export default function Page() {
     navigation.formMethod === "post" &&
     navigation.formData?.get("action") === "create";
 
-  const [form, { channelValue: channelValue, alertTypes, type, integrationId }] = useForm({
-    id: "create-alert",
-    // TODO: type this
-    lastSubmission: lastSubmission as any,
-    onValidate({ formData }) {
-      return parse(formData, { schema: FormSchema });
-    },
-    shouldRevalidate: "onSubmit",
-  });
+  const [form, { channelValue: channelValue, alertTypes, environmentTypes, type, integrationId }] =
+    useForm({
+      id: "create-alert",
+      // TODO: type this
+      lastSubmission: lastSubmission as any,
+      onValidate({ formData }) {
+        return parse(formData, { schema: FormSchema });
+      },
+      shouldRevalidate: "onSubmit",
+    });
 
   useEffect(() => {
     setIsOpen(true);
@@ -376,7 +390,27 @@ export default function Page() {
 
               <FormError id={alertTypes.errorId}>{alertTypes.error}</FormError>
             </InputGroup>
+            <InputGroup>
+              <Label>Environments</Label>
+              <Checkbox
+                name={environmentTypes.name}
+                id="PRODUCTION"
+                value="PRODUCTION"
+                variant="simple/small"
+                label="PROD"
+                defaultChecked
+              />
+              <Checkbox
+                name={environmentTypes.name}
+                id="STAGING"
+                value="STAGING"
+                variant="simple/small"
+                label="STAGING"
+                defaultChecked
+              />
 
+              <FormError id={environmentTypes.errorId}>{environmentTypes.error}</FormError>
+            </InputGroup>
             <FormError>{form.error}</FormError>
             <div className="border-t border-grid-bright pt-3">
               <FormButtons

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.alerts.new/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.alerts.new/route.tsx
@@ -194,6 +194,12 @@ export default function Page() {
   const project = useProject();
   const [currentAlertChannel, setCurrentAlertChannel] = useState<string | null>(option ?? "EMAIL");
 
+  const [selectedSlackChannelValue, setSelectedSlackChannelValue] = useState<string | undefined>();
+
+  const selectedSlackChannel = slack.channels?.find(
+    (s) => selectedSlackChannelValue === `${s.id}/${s.name}`
+  );
+
   const isLoading =
     navigation.state !== "idle" &&
     navigation.formMethod === "post" &&
@@ -272,6 +278,9 @@ export default function Page() {
                       dropdownIcon
                       variant="tertiary/medium"
                       items={slack.channels}
+                      setValue={(value) => {
+                        typeof value === "string" && setSelectedSlackChannelValue(value);
+                      }}
                       filter={(channel, search) =>
                         channel.name?.toLowerCase().includes(search.toLowerCase()) ?? false
                       }
@@ -291,10 +300,16 @@ export default function Page() {
                         </>
                       )}
                     </Select>
-                    <Hint className="leading-relaxed">
-                      If selecting a private channel, you will need to invite the bot to the channel
-                      using <InlineCode variant="extra-small">/invite @Trigger.dev</InlineCode>
-                    </Hint>
+                    {selectedSlackChannel && selectedSlackChannel.is_private && (
+                      <Callout variant="warning">
+                        Heads up! To receive alerts in the{" "}
+                        <InlineCode variant="extra-small">{selectedSlackChannel.name}</InlineCode>{" "}
+                        channel, you will need to invite the @Trigger.dev Slack Bot. You can do this
+                        by visiting the channel in your Slack workspace issue the following command:{" "}
+                        <InlineCode variant="extra-small">/invite @Trigger.dev</InlineCode>.
+                      </Callout>
+                    )}
+
                     <FormError id={channelValue.errorId}>{channelValue.error}</FormError>
                     <input type="hidden" name="integrationId" value={slack.integrationId} />
                   </>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.alerts/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.alerts/route.tsx
@@ -18,7 +18,7 @@ import { ProjectAlertChannelType, ProjectAlertType } from "@trigger.dev/database
 import assertNever from "assert-never";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { z } from "zod";
-import { EnvironmentLabel } from "~/components/environments/EnvironmentLabel";
+import { EnvironmentTypeLabel } from "~/components/environments/EnvironmentLabel";
 import { PageBody, PageContainer } from "~/components/layout/AppLayout";
 import { Button, LinkButton } from "~/components/primitives/Buttons";
 import { ClipboardField } from "~/components/primitives/ClipboardField";
@@ -204,8 +204,12 @@ export default function Page() {
                     <TableCell
                       className={cn("space-x-2", alertChannel.enabled ? "" : "opacity-50")}
                     >
-                      <EnvironmentLabel environment={{ type: "PRODUCTION" }} />
-                      <EnvironmentLabel environment={{ type: "STAGING" }} />
+                      {alertChannel.environmentTypes.map((environmentType) => (
+                        <EnvironmentTypeLabel
+                          key={environmentType}
+                          environment={{ type: environmentType }}
+                        />
+                      ))}
                     </TableCell>
                     <TableCell className={alertChannel.enabled ? "" : "opacity-50"}>
                       <AlertChannelDetails alertChannel={alertChannel} />

--- a/apps/webapp/app/routes/api.v1.projects.$projectRef.alertChannels.ts
+++ b/apps/webapp/app/routes/api.v1.projects.$projectRef.alertChannels.ts
@@ -54,6 +54,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           email: body.data.channelData.email,
         },
         deduplicationKey: body.data.deduplicationKey,
+        environmentTypes: body.data.environmentTypes,
       });
 
       return json(await ApiAlertChannelPresenter.alertChannelToApi(alertChannel));
@@ -75,6 +76,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           secret: body.data.channelData.secret,
         },
         deduplicationKey: body.data.deduplicationKey,
+        environmentTypes: body.data.environmentTypes,
       });
 
       return json(await ApiAlertChannelPresenter.alertChannelToApi(alertChannel));

--- a/apps/webapp/app/v3/services/alerts/performDeploymentAlerts.server.ts
+++ b/apps/webapp/app/v3/services/alerts/performDeploymentAlerts.server.ts
@@ -9,6 +9,9 @@ export class PerformDeploymentAlertsService extends BaseService {
   public async call(deploymentId: string) {
     const deployment = await this._prisma.workerDeployment.findUnique({
       where: { id: deploymentId },
+      include: {
+        environment: true,
+      },
     });
 
     if (!deployment) {
@@ -24,6 +27,9 @@ export class PerformDeploymentAlertsService extends BaseService {
         projectId: deployment.projectId,
         alertTypes: {
           has: alertType,
+        },
+        environmentTypes: {
+          has: deployment.environment.type,
         },
         enabled: true,
       },

--- a/apps/webapp/app/v3/services/alerts/performTaskAttemptAlerts.server.ts
+++ b/apps/webapp/app/v3/services/alerts/performTaskAttemptAlerts.server.ts
@@ -26,16 +26,15 @@ export class PerformTaskAttemptAlertsService extends BaseService {
       return;
     }
 
-    if (taskAttempt.runtimeEnvironment.type === "DEVELOPMENT") {
-      return;
-    }
-
     // Find all the alert channels
     const alertChannels = await this._prisma.projectAlertChannel.findMany({
       where: {
         projectId: taskAttempt.taskRun.projectId,
         alertTypes: {
           has: "TASK_RUN_ATTEMPT",
+        },
+        environmentTypes: {
+          has: taskAttempt.runtimeEnvironment.type,
         },
         enabled: true,
       },

--- a/packages/database/prisma/migrations/20240517105021_add_environment_types_to_alert_channel/migration.sql
+++ b/packages/database/prisma/migrations/20240517105021_add_environment_types_to_alert_channel/migration.sql
@@ -1,0 +1,5 @@
+-- AlterEnum
+ALTER TYPE "ProjectAlertType" ADD VALUE 'TEST';
+
+-- AlterTable
+ALTER TABLE "ProjectAlertChannel" ADD COLUMN     "environmentTypes" "RuntimeEnvironmentType"[] DEFAULT ARRAY['STAGING', 'PRODUCTION']::"RuntimeEnvironmentType"[];

--- a/packages/database/prisma/migrations/20240517105224_remove_test_alert_type/migration.sql
+++ b/packages/database/prisma/migrations/20240517105224_remove_test_alert_type/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - The values [TEST] on the enum `ProjectAlertType` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "ProjectAlertType_new" AS ENUM ('TASK_RUN_ATTEMPT', 'DEPLOYMENT_FAILURE', 'DEPLOYMENT_SUCCESS');
+ALTER TABLE "ProjectAlertChannel" ALTER COLUMN "alertTypes" TYPE "ProjectAlertType_new"[] USING ("alertTypes"::text::"ProjectAlertType_new"[]);
+ALTER TABLE "ProjectAlert" ALTER COLUMN "type" TYPE "ProjectAlertType_new" USING ("type"::text::"ProjectAlertType_new");
+ALTER TABLE "ProjectAlertStorage" ALTER COLUMN "alertType" TYPE "ProjectAlertType_new" USING ("alertType"::text::"ProjectAlertType_new");
+ALTER TYPE "ProjectAlertType" RENAME TO "ProjectAlertType_old";
+ALTER TYPE "ProjectAlertType_new" RENAME TO "ProjectAlertType";
+DROP TYPE "ProjectAlertType_old";
+COMMIT;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2241,10 +2241,11 @@ model ProjectAlertChannel {
 
   enabled Boolean @default(true)
 
-  type       ProjectAlertChannelType
-  name       String
-  properties Json
-  alertTypes ProjectAlertType[]
+  type             ProjectAlertChannelType
+  name             String
+  properties       Json
+  alertTypes       ProjectAlertType[]
+  environmentTypes RuntimeEnvironmentType[] @default([STAGING, PRODUCTION])
 
   project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   projectId String


### PR DESCRIPTION
- We we're missing the `chat:write.public` scope which caused slack alerts to fail to post into public channels, unless the `@Trigger.dev` slack bot was explicitly invited to the channel.
- We'll need to add the `chat:write.public` scope to the list of bot scopes to our Slack apps @matt-aitken 
- There's currently no way for existing "OrganizationIntegrations" to re-authorize their slack connection to get the new scope, outside of them being deleted in the database and reconnected (we need to build a section of the dashboard for OrganizationIntegrations.
- We're now showing a much stronger warning message when selecting a private channel:

![CleanShot 2024-05-17 at 14 14 52](https://github.com/triggerdotdev/trigger.dev/assets/534/33417f74-f98e-4c4b-8040-5c15175887c9)
