### PR TITLE
New TaskRunNumberCounter that uses taskIdentifier + environmentId

### DIFF
--- a/apps/webapp/app/v3/services/triggerTask.server.ts
+++ b/apps/webapp/app/v3/services/triggerTask.server.ts
@@ -100,10 +100,15 @@ export class TriggerTaskService extends BaseService {
                 })
               : undefined;
 
-            const counter = await tx.taskRunCounter.upsert({
-              where: { taskIdentifier: taskId },
+            const counter = await tx.taskRunNumberCounter.upsert({
+              where: {
+                taskIdentifier_environmentId: {
+                  taskIdentifier: taskId,
+                  environmentId: environment.id,
+                },
+              },
               update: { lastNumber: { increment: 1 } },
-              create: { taskIdentifier: taskId, lastNumber: 1 },
+              create: { taskIdentifier: taskId, environmentId: environment.id, lastNumber: 1 },
               select: { lastNumber: true },
             });
 

--- a/packages/database/prisma/migrations/20240523081426_added_task_run_number_counter_with_environment_as_well_as_task_identifier/migration.sql
+++ b/packages/database/prisma/migrations/20240523081426_added_task_run_number_counter_with_environment_as_well_as_task_identifier/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "TaskRunNumberCounter" (
+    "id" TEXT NOT NULL,
+    "taskIdentifier" TEXT NOT NULL,
+    "environmentId" TEXT NOT NULL,
+    "lastNumber" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "TaskRunNumberCounter_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TaskRunNumberCounter_taskIdentifier_environmentId_key" ON "TaskRunNumberCounter"("taskIdentifier", "environmentId");
+
+-- AddForeignKey
+ALTER TABLE "TaskRunNumberCounter" ADD CONSTRAINT "TaskRunNumberCounter_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "RuntimeEnvironment"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20240523082748_drop_old_task_run_counter_table/migration.sql
+++ b/packages/database/prisma/migrations/20240523082748_drop_old_task_run_counter_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the `TaskRunCounter` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "TaskRunCounter";

--- a/packages/database/prisma/migrations/20240523082748_drop_old_task_run_counter_table/migration.sql
+++ b/packages/database/prisma/migrations/20240523082748_drop_old_task_run_counter_table/migration.sql
@@ -1,8 +1,0 @@
-/*
-  Warnings:
-
-  - You are about to drop the `TaskRunCounter` table. If the table is not empty, all the data it contains will be lost.
-
-*/
--- DropTable
-DROP TABLE "TaskRunCounter";

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1731,12 +1731,6 @@ model TaskRunDependency {
   updatedAt DateTime @updatedAt
 }
 
-/// deprecated, we hadn't included the project id in the unique constraint
-model TaskRunCounter {
-  taskIdentifier String @id
-  lastNumber     Int    @default(0)
-}
-
 /// Used for the TaskRun number (e.g. #1,421)
 model TaskRunNumberCounter {
   id String @id @default(cuid())

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1731,6 +1731,12 @@ model TaskRunDependency {
   updatedAt DateTime @updatedAt
 }
 
+/// deprecated, we hadn't included the project id in the unique constraint
+model TaskRunCounter {
+  taskIdentifier String @id
+  lastNumber     Int    @default(0)
+}
+
 /// Used for the TaskRun number (e.g. #1,421)
 model TaskRunNumberCounter {
   id String @id @default(cuid())

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -406,9 +406,10 @@ model RuntimeEnvironment {
   taskScheduleInstances      TaskScheduleInstance[]
   alerts                     ProjectAlert[]
 
-  sessions         RuntimeEnvironmentSession[]
-  currentSession   RuntimeEnvironmentSession?  @relation("currentSession", fields: [currentSessionId], references: [id], onDelete: SetNull, onUpdate: Cascade)
-  currentSessionId String?
+  sessions             RuntimeEnvironmentSession[]
+  currentSession       RuntimeEnvironmentSession?  @relation("currentSession", fields: [currentSessionId], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  currentSessionId     String?
+  taskRunNumberCounter TaskRunNumberCounter[]
 
   @@unique([projectId, slug, orgMemberId])
   @@unique([projectId, shortcode])
@@ -1730,9 +1731,23 @@ model TaskRunDependency {
   updatedAt DateTime @updatedAt
 }
 
+/// deprecated, we hadn't included the project id in the unique constraint
 model TaskRunCounter {
   taskIdentifier String @id
   lastNumber     Int    @default(0)
+}
+
+/// Used for the TaskRun number (e.g. #1,421)
+model TaskRunNumberCounter {
+  id String @id @default(cuid())
+
+  taskIdentifier String
+  environment    RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  environmentId  String
+
+  lastNumber Int @default(0)
+
+  @@unique([taskIdentifier, environmentId])
 }
 
 model TaskTag {


### PR DESCRIPTION
There was a bug where the task numbers were just looking at the taskIdentifier (the user-defined string in their tasks). This meant that if two tasks across different users had the same id (pretty likely) then the numbers wouldn't be correct.

This wasn't a security issue, it was purely used to increment the number for the TaskRun table. But obviously it's wrong so now the number is unique to the taskIdentifier + environmentId.