### PR TITLE
v2: When a run hits the rate limit reschedule the re-execution

### DIFF
--- a/.changeset/strong-owls-know.md
+++ b/.changeset/strong-owls-know.md
@@ -1,0 +1,6 @@
+---
+"@trigger.dev/sdk": patch
+"@trigger.dev/core": patch
+---
+
+When a v2 run hits the rate limit, reschedule with the reset date

--- a/apps/webapp/app/services/apiRateLimit.server.ts
+++ b/apps/webapp/app/services/apiRateLimit.server.ts
@@ -157,16 +157,18 @@ export function authorizationRateLimitMiddleware({
     }
 
     res.setHeader("Content-Type", "application/problem+json");
+    const secondsUntilReset = Math.max(0, (reset - new Date().getTime()) / 1000);
     return res.status(429).send(
       JSON.stringify(
         {
           title: "Rate Limit Exceeded",
           status: 429,
           type: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429",
-          detail: `Rate limit exceeded ${remaining}/${limit} requests remaining. Retry after ${reset} seconds.`,
-          reset: reset,
-          limit: limit,
-          error: `Rate limit exceeded ${remaining}/${limit} requests remaining. Retry after ${reset} seconds.`,
+          detail: `Rate limit exceeded ${remaining}/${limit} requests remaining. Retry in ${secondsUntilReset} seconds.`,
+          reset,
+          limit,
+          secondsUntilReset,
+          error: `Rate limit exceeded ${remaining}/${limit} requests remaining. Retry in ${secondsUntilReset} seconds.`,
         },
         null,
         2

--- a/apps/webapp/app/services/runs/performRunExecutionV3.server.ts
+++ b/apps/webapp/app/services/runs/performRunExecutionV3.server.ts
@@ -441,6 +441,10 @@ export class PerformRunExecutionV3Service {
           await this.#resumeAutoYieldedRunWithCompletedTask(run, safeBody.data, durationInMs);
           break;
         }
+        case "AUTO_YIELD_RATE_LIMIT": {
+          await this.#rescheduleRun(run, safeBody.data.reset, durationInMs);
+          break;
+        }
         case "RESUME_WITH_PARALLEL_TASK": {
           await this.#resumeParallelRunWithTask(run, safeBody.data, durationInMs);
 
@@ -667,6 +671,10 @@ export class PerformRunExecutionV3Service {
 
           break;
         }
+        case "AUTO_YIELD_RATE_LIMIT": {
+          await this.#rescheduleRun(run, childError.reset, durationInMs);
+          break;
+        }
         case "CANCELED": {
           break;
         }
@@ -801,9 +809,9 @@ export class PerformRunExecutionV3Service {
     });
   }
 
-  async #resumeAutoYieldedRun(
+  async #rescheduleRun(
     run: FoundRun,
-    data: AutoYieldMetadata,
+    reset: number,
     durationInMs: number,
     executionCount: number = 1
   ) {
@@ -820,16 +828,6 @@ export class PerformRunExecutionV3Service {
           executionCount: {
             increment: executionCount,
           },
-          autoYieldExecution: {
-            create: [
-              {
-                location: data.location,
-                timeRemaining: data.timeRemaining,
-                timeElapsed: data.timeElapsed,
-                limit: data.limit ?? 0,
-              },
-            ],
-          },
           forceYieldImmediately: false,
         },
         select: {
@@ -837,7 +835,7 @@ export class PerformRunExecutionV3Service {
         },
       });
 
-      await ResumeRunService.enqueue(run, tx);
+      await ResumeRunService.enqueue(run, tx, new Date(reset));
     });
   }
 
@@ -882,6 +880,46 @@ export class PerformRunExecutionV3Service {
       await service.call(run.environment, run.id, data.id, {
         properties: data.properties,
         output: data.output ? (JSON.parse(data.output) as any) : undefined,
+      });
+
+      await ResumeRunService.enqueue(run, tx);
+    });
+  }
+
+  async #resumeAutoYieldedRun(
+    run: FoundRun,
+    data: AutoYieldMetadata,
+    durationInMs: number,
+    executionCount: number = 1
+  ) {
+    await $transaction(this.#prismaClient, async (tx) => {
+      await tx.jobRun.update({
+        where: {
+          id: run.id,
+        },
+        data: {
+          status: "WAITING_TO_EXECUTE",
+          executionDuration: {
+            increment: durationInMs,
+          },
+          executionCount: {
+            increment: executionCount,
+          },
+          autoYieldExecution: {
+            create: [
+              {
+                location: data.location,
+                timeRemaining: data.timeRemaining,
+                timeElapsed: data.timeElapsed,
+                limit: data.limit ?? 0,
+              },
+            ],
+          },
+          forceYieldImmediately: false,
+        },
+        select: {
+          executionCount: true,
+        },
       });
 
       await ResumeRunService.enqueue(run, tx);

--- a/packages/core/src/schemas/api.ts
+++ b/packages/core/src/schemas/api.ts
@@ -671,6 +671,13 @@ export type RunJobAutoYieldWithCompletedTaskExecutionError = z.infer<
   typeof RunJobAutoYieldWithCompletedTaskExecutionErrorSchema
 >;
 
+export const RunJobAutoYieldRateLimitErrorSchema = z.object({
+  status: z.literal("AUTO_YIELD_RATE_LIMIT"),
+  reset: z.coerce.number(),
+});
+
+export type RunJobAutoYieldRateLimitError = z.infer<typeof RunJobAutoYieldRateLimitErrorSchema>;
+
 export const RunJobInvalidPayloadErrorSchema = z.object({
   status: z.literal("INVALID_PAYLOAD"),
   errors: z.array(SchemaErrorSchema),
@@ -719,6 +726,7 @@ export const RunJobErrorResponseSchema = z.union([
   RunJobAutoYieldExecutionErrorSchema,
   RunJobAutoYieldWithCompletedTaskExecutionErrorSchema,
   RunJobYieldExecutionErrorSchema,
+  RunJobAutoYieldRateLimitErrorSchema,
   RunJobErrorSchema,
   RunJobUnresolvedAuthErrorSchema,
   RunJobInvalidPayloadErrorSchema,
@@ -741,6 +749,7 @@ export const RunJobResponseSchema = z.discriminatedUnion("status", [
   RunJobAutoYieldExecutionErrorSchema,
   RunJobAutoYieldWithCompletedTaskExecutionErrorSchema,
   RunJobYieldExecutionErrorSchema,
+  RunJobAutoYieldRateLimitErrorSchema,
   RunJobErrorSchema,
   RunJobUnresolvedAuthErrorSchema,
   RunJobInvalidPayloadErrorSchema,

--- a/packages/trigger-sdk/src/apiClient.ts
+++ b/packages/trigger-sdk/src/apiClient.ts
@@ -904,7 +904,7 @@ async function zodfetchWithVersions<
       body: versionedSchema.parse(jsonBody),
     };
   } catch (error) {
-    if (error instanceof UnknownVersionError) {
+    if (error instanceof UnknownVersionError || error instanceof AutoYieldRateLimitError) {
       throw error;
     }
 
@@ -1031,6 +1031,10 @@ async function zodfetch<TResponseSchema extends z.ZodTypeAny, TOptional extends 
 
     return schema.parse(jsonBody);
   } catch (error) {
+    if (error instanceof AutoYieldRateLimitError) {
+      throw error;
+    }
+
     if (retryCount < MAX_RETRIES) {
       // retry with exponential backoff and jitter
       const delay = exponentialBackoff(retryCount + 1);

--- a/packages/trigger-sdk/src/errors.ts
+++ b/packages/trigger-sdk/src/errors.ts
@@ -45,6 +45,10 @@ export class AutoYieldWithCompletedTaskExecutionError {
   ) {}
 }
 
+export class AutoYieldRateLimitError {
+  constructor(public resetAtTimestamp: number) {}
+}
+
 export class ParsedPayloadSchemaError {
   constructor(public schemaErrors: SchemaError[]) {}
 }
@@ -56,6 +60,7 @@ export type TriggerInternalError =
   | YieldExecutionError
   | AutoYieldExecutionError
   | AutoYieldWithCompletedTaskExecutionError
+  | AutoYieldRateLimitError
   | ResumeWithParallelTaskError;
 
 /** Use this function if you're using a `try/catch` block to catch errors.
@@ -72,6 +77,7 @@ export function isTriggerError(err: unknown): err is TriggerInternalError {
     err instanceof YieldExecutionError ||
     err instanceof AutoYieldExecutionError ||
     err instanceof AutoYieldWithCompletedTaskExecutionError ||
+    err instanceof AutoYieldRateLimitError ||
     err instanceof ResumeWithParallelTaskError
   );
 }

--- a/packages/trigger-sdk/src/io.ts
+++ b/packages/trigger-sdk/src/io.ts
@@ -28,6 +28,7 @@ import { webcrypto } from "node:crypto";
 import { ApiClient } from "./apiClient";
 import {
   AutoYieldExecutionError,
+  AutoYieldRateLimitError,
   AutoYieldWithCompletedTaskExecutionError,
   CanceledWithTaskError,
   ErrorWithTask,
@@ -1460,6 +1461,14 @@ export class IO {
         cachedTasksCursor: this._cachedTasksCursor,
       });
     } catch (error) {
+      if (error instanceof AutoYieldRateLimitError) {
+        this._logger.debug("AutoYieldRateLimitError", {
+          error,
+        });
+
+        throw error;
+      }
+
       return;
     }
   }

--- a/packages/trigger-sdk/src/triggerClient.ts
+++ b/packages/trigger-sdk/src/triggerClient.ts
@@ -52,6 +52,7 @@ import { ApiClient } from "./apiClient";
 import { ConcurrencyLimit, ConcurrencyLimitOptions } from "./concurrencyLimit";
 import {
   AutoYieldExecutionError,
+  AutoYieldRateLimitError,
   AutoYieldWithCompletedTaskExecutionError,
   CanceledWithTaskError,
   ErrorWithTask,
@@ -1232,6 +1233,13 @@ export class TriggerClient {
           ...error.data,
           limit: body.runChunkExecutionLimit,
         },
+      };
+    }
+
+    if (error instanceof AutoYieldRateLimitError) {
+      return {
+        status: "AUTO_YIELD_RATE_LIMIT",
+        reset: error.resetAtTimestamp,
       };
     }
 

--- a/references/job-catalog/src/stressTest.ts
+++ b/references/job-catalog/src/stressTest.ts
@@ -22,14 +22,14 @@ client.defineJob({
       await io.runTask(
         `task-${i}`,
         async (task) => {
+          await new Promise((resolve) => setTimeout(resolve, 2000));
+
           return {
             output: "a".repeat(30),
           };
         },
         { name: `Task ${i}` }
       );
-
-      await new Promise((resolve) => setTimeout(resolve, 2000));
     }
 
     // Now do a wait for 5 seconds


### PR DESCRIPTION
If your run code hits the API rate limit in v2 it failed the run.

Now it throws a special error that the backend uses to reschedule the run execution for when the rate limit window has reset.