### PR TITLE
Speed up the Run log queries

### DIFF
--- a/apps/webapp/app/db.server.ts
+++ b/apps/webapp/app/db.server.ts
@@ -70,7 +70,9 @@ export { Prisma };
 
 export const prisma = singleton("prisma", getClient);
 
-export const $replica: Omit<PrismaClient, "$transaction"> = singleton(
+export type PrismaReplicaClient = Omit<PrismaClient, "$transaction">;
+
+export const $replica: PrismaReplicaClient = singleton(
   "replica",
   () => getReplicaClient() ?? prisma
 );

--- a/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
@@ -1,17 +1,12 @@
 import { prettyPrintPacket } from "@trigger.dev/core/v3";
 import { PrismaClient, prisma } from "~/db.server";
 import { eventRepository } from "~/v3/eventRepository.server";
+import { BasePresenter } from "./basePresenter.server";
 
 type Result = Awaited<ReturnType<SpanPresenter["call"]>>;
 export type Span = NonNullable<Result>["event"];
 
-export class SpanPresenter {
-  #prismaClient: PrismaClient;
-
-  constructor(prismaClient: PrismaClient = prisma) {
-    this.#prismaClient = prismaClient;
-  }
-
+export class SpanPresenter extends BasePresenter {
   public async call({
     userId,
     projectSlug,
@@ -25,7 +20,7 @@ export class SpanPresenter {
     spanId: string;
     runFriendlyId: string;
   }) {
-    const project = await this.#prismaClient.project.findUnique({
+    const project = await this._replica.project.findUnique({
       where: {
         slug: projectSlug,
       },
@@ -35,7 +30,7 @@ export class SpanPresenter {
       throw new Error("Project not found");
     }
 
-    const run = await this.#prismaClient.taskRun.findFirst({
+    const run = await this._replica.taskRun.findFirst({
       select: {
         traceId: true,
       },

--- a/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
@@ -17,11 +17,13 @@ export class SpanPresenter {
     projectSlug,
     organizationSlug,
     spanId,
+    runFriendlyId,
   }: {
     userId: string;
     projectSlug: string;
     organizationSlug: string;
     spanId: string;
+    runFriendlyId: string;
   }) {
     const project = await this.#prismaClient.project.findUnique({
       where: {
@@ -33,7 +35,20 @@ export class SpanPresenter {
       throw new Error("Project not found");
     }
 
-    const span = await eventRepository.getSpan(spanId);
+    const run = await this.#prismaClient.taskRun.findFirst({
+      select: {
+        traceId: true,
+      },
+      where: {
+        friendlyId: runFriendlyId,
+      },
+    });
+
+    if (!run) {
+      return;
+    }
+
+    const span = await eventRepository.getSpan(spanId, run.traceId);
 
     if (!span) {
       return;

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -4,11 +4,11 @@ import {
   QueueListIcon,
   StopCircleIcon,
 } from "@heroicons/react/20/solid";
-import { useFetcher, useParams } from "@remix-run/react";
+import { useParams } from "@remix-run/react";
 import { LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { formatDurationNanoseconds, nanosecondsToMilliseconds } from "@trigger.dev/core/v3";
 import { useEffect } from "react";
-import { typedjson, useTypedFetcher, useTypedLoaderData } from "remix-typedjson";
+import { typedjson, useTypedFetcher } from "remix-typedjson";
 import { ExitIcon } from "~/assets/icons/ExitIcon";
 import { CodeBlock } from "~/components/code/CodeBlock";
 import { EnvironmentLabel } from "~/components/environments/EnvironmentLabel";
@@ -46,6 +46,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     organizationSlug,
     projectSlug: projectParam,
     spanId: spanParam,
+    runFriendlyId: runParam,
   });
 
   if (!span) {

--- a/packages/database/prisma/migrations/20240523135511_added_task_event_trace_id_index/migration.sql
+++ b/packages/database/prisma/migrations/20240523135511_added_task_event_trace_id_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "TaskEvent_traceId_idx" ON "TaskEvent"("traceId");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1898,6 +1898,9 @@ model TaskEvent {
   payloadType String?
 
   createdAt DateTime @default(now())
+
+  /// Used on the run page
+  @@index([traceId])
 }
 
 enum TaskEventLevel {


### PR DESCRIPTION
- Added traceId index to Postgres
- Only select the data we need for the spans
- Use the read replica for the run log view