### PR TITLE
v2 IngestSendEvent rate limit

### DIFF
--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -102,7 +102,7 @@ const EnvironmentSchema = z.object({
 
   //Ingesting event rate limit
   INGEST_EVENT_RATE_LIMIT_WINDOW: z.string().default("60s"),
-  INGEST_EVENT_RATE_LIMIT_MAX: z.coerce.number().int().default(1_000),
+  INGEST_EVENT_RATE_LIMIT_MAX: z.coerce.number().int().optional(),
 
   //v3
   V3_ENABLED: z.string().default("false"),

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -100,6 +100,10 @@ const EnvironmentSchema = z.object({
   API_RATE_LIMIT_REQUEST_LOGS_ENABLED: z.string().default("0"),
   API_RATE_LIMIT_REJECTION_LOGS_ENABLED: z.string().default("1"),
 
+  //Ingesting event rate limit
+  INGEST_EVENT_RATE_LIMIT_WINDOW: z.string().default("60s"),
+  INGEST_EVENT_RATE_LIMIT_MAX: z.coerce.number().int().default(1_000),
+
   //v3
   V3_ENABLED: z.string().default("false"),
   PROVIDER_SECRET: z.string().default("provider-secret"),

--- a/apps/webapp/app/services/apiRateLimit.server.ts
+++ b/apps/webapp/app/services/apiRateLimit.server.ts
@@ -145,7 +145,7 @@ export function authorizationRateLimitMiddleware({
 }
 
 export const apiRateLimiter = authorizationRateLimitMiddleware({
-  keyPrefix: "ratelimit:api",
+  keyPrefix: "api",
   limiter: Ratelimit.slidingWindow(env.API_RATE_LIMIT_MAX, env.API_RATE_LIMIT_WINDOW as Duration),
   pathMatchers: [/^\/api/],
   // Allow /api/v1/tasks/:id/callback/:secret

--- a/apps/webapp/app/services/apiRateLimit.server.ts
+++ b/apps/webapp/app/services/apiRateLimit.server.ts
@@ -30,14 +30,6 @@ export function authorizationRateLimitMiddleware({
     requests: true,
   },
 }: Options) {
-  // const rateLimiter = new Ratelimit({
-  //   redis: createRedisRateLimitClient(redis),
-  //   limiter: limiter,
-  //   ephemeralCache: new Map(),
-  //   analytics: false,
-  //   prefix: keyPrefix,
-  // });
-
   const rateLimiter = new RateLimiter({
     redis,
     keyPrefix,

--- a/apps/webapp/app/services/events/ingestSendEvent.server.ts
+++ b/apps/webapp/app/services/events/ingestSendEvent.server.ts
@@ -122,6 +122,7 @@ export class IngestSendEvent {
           await this.enqueueWorkerEvent(tx, eventLog);
         } else {
           logger.info("IngestSendEvent: Rate limit exceeded", {
+            eventRecordId: eventLog.id,
             organizationId: environment.organizationId,
             reset,
             limit,

--- a/apps/webapp/app/services/events/ingestSendEvent.server.ts
+++ b/apps/webapp/app/services/events/ingestSendEvent.server.ts
@@ -131,7 +131,7 @@ export class IngestSendEvent {
           reset: result.reset,
           limit: result.limit,
         });
-        return createdEvent;
+        return;
       }
 
       await this.enqueueWorkerEvent(this.#prismaClient, createdEvent);

--- a/apps/webapp/app/services/rateLimiter.server.ts
+++ b/apps/webapp/app/services/rateLimiter.server.ts
@@ -51,7 +51,8 @@ export class RateLimiter {
       });
     }
 
-    if (!success && this.options.logFailure) {
+    //log these by default
+    if (!success && this.options.logFailure !== false) {
       logger.info(`RateLimiter (${this.options.keyPrefix}): rate limit exceeded`, {
         limit,
         reset,

--- a/apps/webapp/app/services/rateLimiter.server.ts
+++ b/apps/webapp/app/services/rateLimiter.server.ts
@@ -20,6 +20,7 @@ export class RateLimiter {
 
   constructor(private readonly options: Options) {
     const { redis, keyPrefix, limiter } = options;
+    const prefix = `ratelimit:${keyPrefix}`;
     this.#ratelimit = new Ratelimit({
       redis: createRedisRateLimitClient(
         redis ?? {
@@ -34,7 +35,12 @@ export class RateLimiter {
       limiter,
       ephemeralCache: new Map(),
       analytics: false,
-      prefix: `ratelimit:${keyPrefix}`,
+      prefix,
+    });
+
+    logger.info(`RateLimiter (${keyPrefix}): initialized`, {
+      keyPrefix,
+      redisKeyspace: prefix,
     });
   }
 

--- a/apps/webapp/app/services/rateLimiter.server.ts
+++ b/apps/webapp/app/services/rateLimiter.server.ts
@@ -34,7 +34,7 @@ export class RateLimiter {
       limiter,
       ephemeralCache: new Map(),
       analytics: false,
-      prefix: keyPrefix,
+      prefix: `ratelimit:${keyPrefix}`,
     });
   }
 

--- a/apps/webapp/app/services/rateLimiter.server.ts
+++ b/apps/webapp/app/services/rateLimiter.server.ts
@@ -1,0 +1,98 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import Redis, { RedisOptions } from "ioredis";
+import { env } from "~/env.server";
+import { logger } from "./logger.server";
+
+type Options = {
+  redis?: RedisOptions;
+  keyPrefix: string;
+  limiter: Limiter;
+  logSuccess?: boolean;
+  logFailure?: boolean;
+};
+
+export type Limiter = ConstructorParameters<typeof Ratelimit>[0]["limiter"];
+export type Duration = Parameters<typeof Ratelimit.slidingWindow>[1];
+export type RateLimitResponse = Awaited<ReturnType<Ratelimit["limit"]>>;
+
+export class RateLimiter {
+  #ratelimit: Ratelimit;
+
+  constructor(private readonly options: Options) {
+    const { redis, keyPrefix, limiter } = options;
+    this.#ratelimit = new Ratelimit({
+      redis: createRedisRateLimitClient(
+        redis ?? {
+          port: env.REDIS_PORT,
+          host: env.REDIS_HOST,
+          username: env.REDIS_USERNAME,
+          password: env.REDIS_PASSWORD,
+          enableAutoPipelining: true,
+          ...(env.REDIS_TLS_DISABLED === "true" ? {} : { tls: {} }),
+        }
+      ),
+      limiter,
+      ephemeralCache: new Map(),
+      analytics: false,
+      prefix: keyPrefix,
+    });
+  }
+
+  async limit(identifier: string, rate = 1): Promise<RateLimitResponse> {
+    const result = this.#ratelimit.limit(identifier, { rate });
+    const { success, limit, reset, remaining } = await result;
+
+    if (success && this.options.logSuccess) {
+      logger.info(`RateLimiter (${this.options.keyPrefix}): under rate limit`, {
+        limit,
+        reset,
+        remaining,
+        identifier,
+      });
+    }
+
+    if (!success && this.options.logFailure) {
+      logger.info(`RateLimiter (${this.options.keyPrefix}): rate limit exceeded`, {
+        limit,
+        reset,
+        remaining,
+        identifier,
+      });
+    }
+
+    return result;
+  }
+}
+
+export function createRedisRateLimitClient(
+  redisOptions: RedisOptions
+): ConstructorParameters<typeof Ratelimit>[0]["redis"] {
+  const redis = new Redis(redisOptions);
+
+  return {
+    sadd: async <TData>(key: string, ...members: TData[]): Promise<number> => {
+      return redis.sadd(key, members as (string | number | Buffer)[]);
+    },
+    hset: <TValue>(
+      key: string,
+      obj: {
+        [key: string]: TValue;
+      }
+    ): Promise<number> => {
+      return redis.hset(key, obj);
+    },
+    eval: <TArgs extends unknown[], TData = unknown>(
+      ...args: [script: string, keys: string[], args: TArgs]
+    ): Promise<TData> => {
+      const script = args[0];
+      const keys = args[1];
+      const argsArray = args[2];
+      return redis.eval(
+        script,
+        keys.length,
+        ...keys,
+        ...(argsArray as (string | Buffer | number)[])
+      ) as Promise<TData>;
+    },
+  };
+}

--- a/apps/webapp/app/services/worker.server.ts
+++ b/apps/webapp/app/services/worker.server.ts
@@ -309,7 +309,7 @@ function getWorkerQueue() {
       },
       "events.deliverScheduled": {
         priority: 0, // smaller number = higher priority
-        maxAttempts: 5,
+        maxAttempts: 8,
         handler: async ({ id, payload }, job) => {
           const service = new DeliverScheduledEventService();
 

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -101,7 +101,7 @@
     "@trigger.dev/yalt": "workspace:*",
     "@types/pg": "8.6.6",
     "@uiw/react-codemirror": "^4.19.5",
-    "@upstash/ratelimit": "^1.0.1",
+    "@upstash/ratelimit": "^1.1.3",
     "@whatwg-node/fetch": "^0.9.14",
     "assert-never": "^1.2.1",
     "aws4fetch": "^1.0.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,8 +412,8 @@ importers:
         specifier: ^4.19.5
         version: 4.19.5(@babel/runtime@7.24.5)(@codemirror/autocomplete@6.4.0)(@codemirror/language@6.3.2)(@codemirror/lint@6.4.2)(@codemirror/search@6.2.3)(@codemirror/state@6.2.0)(@codemirror/theme-one-dark@6.1.0)(@codemirror/view@6.7.2)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0)
       '@upstash/ratelimit':
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: ^1.1.3
+        version: 1.1.3
       '@whatwg-node/fetch':
         specifier: ^0.9.14
         version: 0.9.14
@@ -16932,17 +16932,17 @@ packages:
       - '@codemirror/search'
     dev: false
 
-  /@upstash/core-analytics@0.0.7:
-    resolution: {integrity: sha512-lC2j5efqb1haX/fpTGaPUx1rue1WUkOZBVHDzCB7eMIVsRdFFp4xiHtyH/G9omiR1zj39fU5SCTWFiKJH3KOpw==}
+  /@upstash/core-analytics@0.0.8:
+    resolution: {integrity: sha512-MCJoF+Y8fkzq4NRLG7kEHjtGyMsZ2DICBdmEdwoK9umoSrfkzgBlYdZiHTIaewyt9PGaMZCHOasz0LAuMpxwxQ==}
     engines: {node: '>=16.0.0'}
     dependencies:
       '@upstash/redis': 1.29.0
     dev: false
 
-  /@upstash/ratelimit@1.0.1:
-    resolution: {integrity: sha512-G9LZ7idhlkuYknbUngCB3qzd7QnkK1xDkFG5jRtEJZuOUS5UKJ0UTKbhalCtp39eX2wu2Ubv8W7HCeaJQOWM0A==}
+  /@upstash/ratelimit@1.1.3:
+    resolution: {integrity: sha512-rl+GMvPdZJ9xPDIvIrqRl/g0nzAEaH75hwR5lXAKW8zPPplD/AeliDCHwuwcFCPIjg49FKyA1oc5H473WkVFrQ==}
     dependencies:
-      '@upstash/core-analytics': 0.0.7
+      '@upstash/core-analytics': 0.0.8
     dev: false
 
   /@upstash/redis@1.29.0:


### PR DESCRIPTION
## Changes
- Updated to Upstash's newest ratelimit package
- Made it easy to create a rate limiter
- Switch the API rate limiter to use the new `RateLimiter` class
- Added a rate limiter to IngestSendEvent. It only queues the event if we're below the rate limit

## What happens if the limit is exceeded
We return undefined from IngestSendEvent `call()` if the rate limit has been hit. 

Practically this means:
- `DeliverScheduledEvent` will throw an error causing a retry (max is 8 attempts)

For all other uses it will fail to do the runs, and will always log this message:
> "IngestSendEvent: Rate limit exceeded"
