### PR TITLE
Support custom queue when triggering a task

### DIFF
--- a/.changeset/itchy-chairs-itch.md
+++ b/.changeset/itchy-chairs-itch.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+Fix for calling trigger and passing a custom queue

--- a/apps/webapp/app/v3/marqs/index.server.ts
+++ b/apps/webapp/app/v3/marqs/index.server.ts
@@ -82,6 +82,10 @@ export class MarQS {
     return this.redis.set(this.keys.queueConcurrencyLimitKey(env, queue), concurrency);
   }
 
+  public async removeQueueConcurrencyLimits(env: AuthenticatedEnvironment, queue: string) {
+    return this.redis.del(this.keys.queueConcurrencyLimitKey(env, queue));
+  }
+
   public async updateEnvConcurrencyLimits(env: AuthenticatedEnvironment) {
     await this.#callUpdateGlobalConcurrencyLimits({
       envConcurrencyLimitKey: this.keys.envConcurrencyLimitKey(env),

--- a/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
@@ -179,6 +179,8 @@ export async function createBackgroundTasks(
           taskQueue.name,
           taskQueue.concurrencyLimit
         );
+      } else {
+        await marqs?.removeQueueConcurrencyLimits(environment, taskQueue.name);
       }
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {

--- a/apps/webapp/app/v3/services/triggerTask.server.ts
+++ b/apps/webapp/app/v3/services/triggerTask.server.ts
@@ -219,6 +219,8 @@ export class TriggerTaskService extends BaseService {
                   taskQueue.name,
                   taskQueue.concurrencyLimit
                 );
+              } else {
+                await marqs?.removeQueueConcurrencyLimits(environment, taskQueue.name);
               }
             }
 

--- a/packages/trigger-sdk/src/v3/shared.ts
+++ b/packages/trigger-sdk/src/v3/shared.ts
@@ -353,7 +353,7 @@ export function createTask<TInput = void, TOutput = unknown, TInitOutput extends
             {
               payload: payloadPacket.data,
               options: {
-                queue: params.queue,
+                queue: options?.queue ?? params.queue,
                 concurrencyKey: options?.concurrencyKey,
                 test: taskContext.ctx?.run.isTest,
                 payloadType: payloadPacket.dataType,
@@ -482,7 +482,7 @@ export function createTask<TInput = void, TOutput = unknown, TInitOutput extends
             options: {
               dependentAttempt: ctx.attempt.id,
               lockToVersion: taskContext.worker?.version, // Lock to current version because we're waiting for it to finish
-              queue: params.queue,
+              queue: options?.queue ?? params.queue,
               concurrencyKey: options?.concurrencyKey,
               test: taskContext.ctx?.run.isTest,
               payloadType: payloadPacket.dataType,

--- a/references/v3-catalog/package.json
+++ b/references/v3-catalog/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev:trigger": "triggerdev dev",
-    "management": "ts-node -r tsconfig-paths/register ./src/management.ts"
+    "management": "ts-node -r tsconfig-paths/register ./src/management.ts",
+    "queues": "ts-node -r tsconfig-paths/register ./src/queues.ts"
   },
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",

--- a/references/v3-catalog/src/queues.ts
+++ b/references/v3-catalog/src/queues.ts
@@ -1,5 +1,6 @@
 import dotenv from "dotenv";
 import { simpleChildTask } from "./trigger/subtasks";
+import { wait } from "@trigger.dev/sdk/v3";
 
 dotenv.config();
 
@@ -54,6 +55,18 @@ export async function run() {
       },
     },
   ]);
+
+  await wait.for({ seconds: 5 });
+
+  //this should set the concurrencyLimit back to none
+  await simpleChildTask.trigger(
+    { message: "Simple alt queue 2" },
+    {
+      queue: {
+        name: "queue-concurrency-3",
+      },
+    }
+  );
 }
 
 run().catch(console.error);

--- a/references/v3-catalog/src/queues.ts
+++ b/references/v3-catalog/src/queues.ts
@@ -6,11 +6,20 @@ dotenv.config();
 export async function run() {
   await simpleChildTask.trigger({ message: "Regular queue" });
   await simpleChildTask.trigger(
-    { message: "Alt queue" },
+    { message: "Simple alt queue 1" },
     {
       queue: {
         name: "queue-concurrency-3",
-        concurrencyLimit: 3,
+        concurrencyLimit: 1,
+      },
+    }
+  );
+  await simpleChildTask.trigger(
+    { message: "Simple alt queue 2" },
+    {
+      queue: {
+        name: "queue-concurrency-3",
+        concurrencyLimit: 1,
       },
     }
   );
@@ -18,11 +27,29 @@ export async function run() {
   await simpleChildTask.batchTrigger([{ payload: { message: "Regular queue" } }]);
   await simpleChildTask.batchTrigger([
     {
-      payload: { message: "Regular queue" },
+      payload: { message: "Batched alt queue 1" },
       options: {
         queue: {
           name: "queue-concurrency-3",
-          concurrencyLimit: 3,
+          concurrencyLimit: 1,
+        },
+      },
+    },
+    {
+      payload: { message: "Batched alt queue 2" },
+      options: {
+        queue: {
+          name: "queue-concurrency-3",
+          concurrencyLimit: 1,
+        },
+      },
+    },
+    {
+      payload: { message: "Batched alt queue 3" },
+      options: {
+        queue: {
+          name: "queue-concurrency-3",
+          concurrencyLimit: 1,
         },
       },
     },

--- a/references/v3-catalog/src/queues.ts
+++ b/references/v3-catalog/src/queues.ts
@@ -1,6 +1,7 @@
 import dotenv from "dotenv";
 import { simpleChildTask } from "./trigger/subtasks";
 import { wait } from "@trigger.dev/sdk/v3";
+import { setTimeout } from "timers/promises";
 
 dotenv.config();
 
@@ -56,7 +57,7 @@ export async function run() {
     },
   ]);
 
-  await wait.for({ seconds: 5 });
+  await setTimeout(10_000);
 
   //this should set the concurrencyLimit back to none
   await simpleChildTask.trigger(

--- a/references/v3-catalog/src/queues.ts
+++ b/references/v3-catalog/src/queues.ts
@@ -1,0 +1,32 @@
+import dotenv from "dotenv";
+import { simpleChildTask } from "./trigger/subtasks";
+
+dotenv.config();
+
+export async function run() {
+  await simpleChildTask.trigger({ message: "Regular queue" });
+  await simpleChildTask.trigger(
+    { message: "Alt queue" },
+    {
+      queue: {
+        name: "queue-concurrency-3",
+        concurrencyLimit: 3,
+      },
+    }
+  );
+
+  await simpleChildTask.batchTrigger([{ payload: { message: "Regular queue" } }]);
+  await simpleChildTask.batchTrigger([
+    {
+      payload: { message: "Regular queue" },
+      options: {
+        queue: {
+          name: "queue-concurrency-3",
+          concurrencyLimit: 3,
+        },
+      },
+    },
+  ]);
+}
+
+run().catch(console.error);


### PR DESCRIPTION
Closes #1137 

When calling trigger or batchTrigger (and their await variants) you can pass in a custom queue. This wasn't properly supported before.

This PR includes a test script (queues) that can be run in the v3-catalog.