### PR TITLE
Fix for sendEvent same id causing multiple runs

### DIFF
--- a/apps/webapp/app/services/events/deliverEvent.server.ts
+++ b/apps/webapp/app/services/events/deliverEvent.server.ts
@@ -115,7 +115,7 @@ export class DeliverEventService {
     }
     catch (error) {
       if (error instanceof AlreadyDeliveredError) {
-        logger.debug("Event already delivered", {
+        logger.debug("Event already delivered, AlreadyDeliveredError", {
           eventRecord: id,
         });
 

--- a/apps/webapp/app/services/events/deliverEvent.server.ts
+++ b/apps/webapp/app/services/events/deliverEvent.server.ts
@@ -6,6 +6,12 @@ import { $transaction, PrismaClientOrTransaction, prisma } from "~/db.server";
 import { logger } from "~/services/logger.server";
 import { workerQueue } from "../worker.server";
 
+class AlreadyDeliveredError extends Error {
+  constructor() {
+    super("Event already delivered");
+  }
+}
+
 export class DeliverEventService {
   #prismaClient: PrismaClientOrTransaction;
 
@@ -14,95 +20,111 @@ export class DeliverEventService {
   }
 
   public async call(id: string) {
-    await $transaction(
-      this.#prismaClient,
-      async (tx) => {
-        const eventRecord = await tx.eventRecord.findUniqueOrThrow({
-          where: {
-            id,
-          },
-          include: {
-            environment: {
-              include: {
-                organization: true,
-                project: true,
+    try {
+      await $transaction(
+        this.#prismaClient,
+        async (tx) => {
+          const eventRecord = await tx.eventRecord.findUniqueOrThrow({
+            where: {
+              id,
+            },
+            include: {
+              environment: {
+                include: {
+                  organization: true,
+                  project: true,
+                },
               },
             },
-          },
-        });
+          });
 
-        if (eventRecord.deliveredAt) {
-          logger.debug("Event already delivered", {
+          if (eventRecord.deliveredAt) {
+            logger.debug("Event already delivered", {
+              eventRecord: eventRecord.id,
+            });
+
+            return;
+          }
+
+          const possibleEventDispatchers = await tx.eventDispatcher.findMany({
+            where: {
+              environmentId: eventRecord.environmentId,
+              event: {
+                has: eventRecord.name,
+              },
+              source: eventRecord.source,
+              enabled: true,
+              manual: false,
+            },
+          });
+
+          logger.debug("Found possible event dispatchers", {
+            possibleEventDispatchers,
             eventRecord: eventRecord.id,
           });
 
-          return;
-        }
+          const matchingEventDispatchers = possibleEventDispatchers.filter((eventDispatcher) =>
+            this.#evaluateEventRule(eventDispatcher, eventRecord)
+          );
 
-        const possibleEventDispatchers = await tx.eventDispatcher.findMany({
-          where: {
-            environmentId: eventRecord.environmentId,
-            event: {
-              has: eventRecord.name,
-            },
-            source: eventRecord.source,
-            enabled: true,
-            manual: false,
-          },
-        });
+          if (matchingEventDispatchers.length === 0) {
+            logger.debug("No matching event dispatchers", {
+              eventRecord: eventRecord.id,
+            });
 
-        logger.debug("Found possible event dispatchers", {
-          possibleEventDispatchers,
-          eventRecord: eventRecord.id,
-        });
+            return;
+          }
 
-        const matchingEventDispatchers = possibleEventDispatchers.filter((eventDispatcher) =>
-          this.#evaluateEventRule(eventDispatcher, eventRecord)
-        );
-
-        if (matchingEventDispatchers.length === 0) {
-          logger.debug("No matching event dispatchers", {
+          logger.debug("Found matching event dispatchers", {
+            matchingEventDispatchers,
             eventRecord: eventRecord.id,
           });
 
-          return;
-        }
-
-        logger.debug("Found matching event dispatchers", {
-          matchingEventDispatchers,
-          eventRecord: eventRecord.id,
-        });
-
-        await Promise.all(
-          matchingEventDispatchers.map((eventDispatcher) =>
-            workerQueue.enqueue(
-              "events.invokeDispatcher",
-              {
-                id: eventDispatcher.id,
-                eventRecordId: eventRecord.id,
-              },
-              { tx }
+          await Promise.all(
+            matchingEventDispatchers.map((eventDispatcher) =>
+              workerQueue.enqueue(
+                "events.invokeDispatcher",
+                {
+                  id: eventDispatcher.id,
+                  eventRecordId: eventRecord.id,
+                },
+                { tx }
+              )
             )
-          )
-        );
+          );
 
-        // Optimistically mark the event as delivered
-        const lockedRecord = await tx.eventRecord.updateMany({
-          where: {
-            id: eventRecord.id,
-            deliveredAt: null,
-          },
-          data: {
-            deliveredAt: new Date(),
-          },
+          // Optimistically mark the event as delivered
+          const lockedRecord = await tx.eventRecord.updateMany({
+            where: {
+              id: eventRecord.id,
+              deliveredAt: null,
+            },
+            data: {
+              deliveredAt: new Date(),
+            },
+          });
+
+          if (lockedRecord.count === 0) {
+            //this means we've already delivered it, because there were no records with deliveredAt = null
+            //by throwing it will rollback the transaction, stopping the queue from processing the event again
+            throw new AlreadyDeliveredError();
+          }
+        },
+        { timeout: 10000 }
+      );
+    }
+    catch (error) {
+      if (error instanceof AlreadyDeliveredError) {
+        logger.debug("Event already delivered", {
+          eventRecord: id,
         });
 
-        if (lockedRecord.count === 0) {
-          throw new Error("Event already delivered");
-        }
-      },
-      { timeout: 10000 }
-    );
+        //we swallow the error because we don't want to retry
+        return;
+      }
+
+      throw error;
+    }
   }
 
   #evaluateEventRule(dispatcher: EventDispatcher, eventRecord: EventRecord): boolean {

--- a/apps/webapp/app/services/events/ingestSendEvent.server.ts
+++ b/apps/webapp/app/services/events/ingestSendEvent.server.ts
@@ -110,6 +110,14 @@ export class IngestSendEvent {
           },
         });
 
+        if (existingEventLog?.deliveredAt) {
+          logger.debug("Event already delivered", {
+            eventRecordId: existingEventLog.id,
+            deliveredAt: existingEventLog.deliveredAt,
+          });
+          return;
+        }
+
         const eventLog = await (existingEventLog
           ? this.updateEvent({ tx, existingEventLog, reqEvent: event, deliverAt })
           : this.createEvent({

--- a/apps/webapp/app/services/events/ingestSendEvent.server.ts
+++ b/apps/webapp/app/services/events/ingestSendEvent.server.ts
@@ -115,7 +115,7 @@ export class IngestSendEvent {
             eventRecordId: existingEventLog.id,
             deliveredAt: existingEventLog.deliveredAt,
           });
-          return;
+          return existingEventLog;
         }
 
         const eventLog = await (existingEventLog
@@ -134,6 +134,15 @@ export class IngestSendEvent {
       });
 
       if (!createdEvent) return;
+
+      if (createdEvent.deliveredAt) {
+        logger.debug("Event already delivered", {
+          eventRecordId: createdEvent.id,
+          deliveredAt: createdEvent.deliveredAt,
+        });
+        //return the event if it was already delivered, don't enqueue it again
+        return createdEvent;
+      }
 
       //rate limit
       const result = await rateLimiter?.limit(environment.organizationId);

--- a/references/job-catalog/src/events.ts
+++ b/references/job-catalog/src/events.ts
@@ -175,4 +175,38 @@ client.defineJob({
   },
 });
 
+client.defineJob({
+  id: "same-event-id",
+  name: "Save event id",
+  version: "1.0.0",
+  trigger: eventTrigger({
+    name: "same.event.id",
+  }),
+  run: async (payload: { id: string }, io, ctx) => {
+    const event = await io.sendEvent("send-event", {
+      name: "same.event.child",
+      id: payload.id,
+      payload: { payload, ctx },
+    });
+
+    const event2 = await io.sendEvent("send-event-2", {
+      name: "same.event.child",
+      id: payload.id,
+      payload: { payload, ctx },
+    });
+  },
+});
+
+client.defineJob({
+  id: "same-event-id-child",
+  name: "Save event id: child",
+  version: "1.0.0",
+  trigger: eventTrigger({
+    name: "same.event.child",
+  }),
+  run: async (payload, io, ctx) => {
+    await io.logger.info(`payloadId: ${payload.id}`);
+  },
+});
+
 createExpressServer(client);


### PR DESCRIPTION
If you have SQS setup it's possible that they deliver the same event multiple times. In this case it was possible that we triggered the same run again with the same event id.

There are two changes that prevent this
- `DeliverEventService` will fail if the event is already delivered, preventing any Graphile jobs from being enqueued.
- `IngestSendEvent` will return the original event and won't enqueue a Graphile job if the event is already delivered.

## Testing

- [x] Check that IngestSendEvent logs out "Event already delivered" if sending a duplicate
- [x] Check that DeliverEventService logs out "Event already delivered, AlreadyDeliveredError" if trying to deliever a duplicate. This is harder to test.