### PR TITLE
marqs: add parent queue global concurrency limits

### DIFF
--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -83,6 +83,7 @@ const EnvironmentSchema = z.object({
 
   DEFAULT_ENV_EXECUTION_CONCURRENCY_LIMIT: z.coerce.number().int().default(10),
   DEFAULT_ORG_EXECUTION_CONCURRENCY_LIMIT: z.coerce.number().int().default(10),
+  DEFAULT_PARENT_QUEUE_EXECUTION_CONCURRENCY_LIMIT: z.coerce.number().int().default(250),
   DEFAULT_DEV_ENV_EXECUTION_ATTEMPTS: z.coerce.number().int().positive().default(1),
 
   TUNNEL_HOST: z.string().optional(),

--- a/apps/webapp/app/routes/admin.api.v1.environments.$environmentId.ts
+++ b/apps/webapp/app/routes/admin.api.v1.environments.$environmentId.ts
@@ -2,7 +2,7 @@ import { ActionFunctionArgs, json } from "@remix-run/server-runtime";
 import { z } from "zod";
 import { prisma } from "~/db.server";
 import { authenticateApiRequestWithPersonalAccessToken } from "~/services/personalAccessToken.server";
-import { marqs } from "~/v3/marqs/index.server";
+import { marqsv3 } from "~/v3/marqs/v3.server";
 
 const ParamsSchema = z.object({
   environmentId: z.string(),
@@ -60,7 +60,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     },
   });
 
-  await marqs?.updateEnvConcurrencyLimits(environment);
+  await marqsv3?.updateEnvConcurrencyLimits(environment);
 
   return json({ success: true });
 }

--- a/apps/webapp/app/routes/admin.api.v1.marqs.ts
+++ b/apps/webapp/app/routes/admin.api.v1.marqs.ts
@@ -1,7 +1,7 @@
 import { LoaderFunctionArgs, json } from "@remix-run/server-runtime";
 import { prisma } from "~/db.server";
 import { authenticateApiRequestWithPersonalAccessToken } from "~/services/personalAccessToken.server";
-import { marqs } from "~/v3/marqs/index.server";
+import { marqsv3 } from "~/v3/marqs/v3.server";
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   // Next authenticate the request
@@ -25,7 +25,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     return json({ error: "You must be an admin to perform this action" }, { status: 403 });
   }
 
-  const details = await marqs?.getSharedQueueDetails();
+  const details = await marqsv3?.getSharedQueueDetails();
 
   return json(details);
 }

--- a/apps/webapp/app/v3/failedTaskRun.server.ts
+++ b/apps/webapp/app/v3/failedTaskRun.server.ts
@@ -1,6 +1,6 @@
 import { TaskRunFailedExecutionResult } from "@trigger.dev/core/v3";
 import { logger } from "~/services/logger.server";
-import { marqs } from "~/v3/marqs/index.server";
+import { marqsv3 } from "~/v3/marqs/v3.server";
 
 import { TaskRunStatus } from "@trigger.dev/database";
 import { createExceptionPropertiesFromError, eventRepository } from "./eventRepository.server";
@@ -35,7 +35,7 @@ export class FailedTaskRunService extends BaseService {
     // No more retries, we need to fail the task run
     logger.debug("[FailedTaskRunService] Failing task run", { taskRun, completion });
 
-    await marqs?.acknowledgeMessage(taskRun.id);
+    await marqsv3?.acknowledgeMessage(taskRun.id);
 
     // Now we need to "complete" the task run event/span
     await eventRepository.completeEvent(taskRun.spanId, {

--- a/apps/webapp/app/v3/marqs/concurrencyMonitor.server.ts
+++ b/apps/webapp/app/v3/marqs/concurrencyMonitor.server.ts
@@ -135,6 +135,10 @@ export class MarqsConcurrencyMonitor {
     pipeline.srem(key, ...completedRunIds);
     pipeline.srem(orgKey, ...completedRunIds);
     pipeline.srem(envKey, ...completedRunIds);
+    pipeline.srem(
+      this.keys.parentQueueCurrentConcurrencyKey(this.keys.sharedQueueKey()),
+      ...completedRunIds
+    );
 
     try {
       await pipeline.exec();

--- a/apps/webapp/app/v3/marqs/concurrencyMonitor.server.ts
+++ b/apps/webapp/app/v3/marqs/concurrencyMonitor.server.ts
@@ -2,7 +2,7 @@ import { Logger } from "@trigger.dev/core-backend";
 import { Redis } from "ioredis";
 import { prisma } from "~/db.server";
 import { logger } from "~/services/logger.server";
-import { MarQS, marqs as marqsv3 } from "./index.server";
+import { MarQS, marqs as marqsv3 } from "./queue.server";
 import { env } from "~/env.server";
 import { marqsv2 } from "./v2.server";
 

--- a/apps/webapp/app/v3/marqs/concurrencyMonitor.server.ts
+++ b/apps/webapp/app/v3/marqs/concurrencyMonitor.server.ts
@@ -2,7 +2,8 @@ import { Logger } from "@trigger.dev/core-backend";
 import { Redis } from "ioredis";
 import { prisma } from "~/db.server";
 import { logger } from "~/services/logger.server";
-import { MarQS, marqs as marqsv3 } from "./queue.server";
+import { MarQS } from "./queue.server";
+import { marqsv3 } from "./v3.server";
 import { env } from "~/env.server";
 import { marqsv2 } from "./v2.server";
 

--- a/apps/webapp/app/v3/marqs/marqsKeyProducer.server.ts
+++ b/apps/webapp/app/v3/marqs/marqsKeyProducer.server.ts
@@ -13,7 +13,7 @@ const constants = {
 } as const;
 
 export class MarQSShortKeyProducer implements MarQSKeyProducer {
-  constructor(private _prefix: string) { }
+  constructor(private _prefix: string) {}
 
   sharedQueueScanPattern() {
     return `${this._prefix}*${constants.SHARED_QUEUE}`;
@@ -87,6 +87,14 @@ export class MarQSShortKeyProducer implements MarQSKeyProducer {
     return [this.queueKey(env, queue, concurrencyKey), constants.CURRENT_CONCURRENCY_PART].join(
       ":"
     );
+  }
+
+  parentQueueConcurrencyLimitKey(parentQueue: string): string {
+    return `${parentQueue}:${constants.CONCURRENCY_LIMIT_PART}`;
+  }
+
+  parentQueueCurrentConcurrencyKey(parentQueue: string): string {
+    return `${parentQueue}:${constants.CURRENT_CONCURRENCY_PART}`;
   }
 
   orgConcurrencyLimitKeyFromQueue(queue: string) {

--- a/apps/webapp/app/v3/marqs/queue.server.ts
+++ b/apps/webapp/app/v3/marqs/queue.server.ts
@@ -1118,18 +1118,6 @@ export class MarQS {
     parentQueueConcurrencyLimitKey: string;
     parentQueueCurrentConcurrencyKey: string;
   }): Promise<QueueCapacities> {
-    logger.debug("Calling calculateMessageQueueCapacities", {
-      currentConcurrencyKey,
-      currentEnvConcurrencyKey,
-      currentOrgConcurrencyKey,
-      concurrencyLimitKey,
-      envConcurrencyLimitKey,
-      orgConcurrencyLimitKey,
-      parentQueueConcurrencyLimitKey,
-      parentQueueCurrentConcurrencyKey,
-      service: this.name,
-    });
-
     const capacities = await this.redis.calculateMessageQueueCapacities(
       currentConcurrencyKey,
       currentEnvConcurrencyKey,

--- a/apps/webapp/app/v3/marqs/requeueV2Message.server.ts
+++ b/apps/webapp/app/v3/marqs/requeueV2Message.server.ts
@@ -1,9 +1,7 @@
-import { logger } from "~/services/logger.server";
-import { marqs } from "~/v3/marqs/index.server";
-
-import { BaseService } from "../services/baseService.server";
 import { PrismaClientOrTransaction } from "~/db.server";
+import { logger } from "~/services/logger.server";
 import { workerQueue } from "~/services/worker.server";
+import { BaseService } from "../services/baseService.server";
 import { marqsv2 } from "./v2.server";
 
 export class RequeueV2Message extends BaseService {

--- a/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
+++ b/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
@@ -424,7 +424,7 @@ export class SharedQueueConsumer {
         });
 
         if (!lockedTaskRun) {
-          logger.warn("Failed to lock task run", {
+          logger.error("Failed to lock task run", {
             taskRun: existingTaskRun.id,
             taskIdentifier: existingTaskRun.taskIdentifier,
             deployment: deployment.id,
@@ -446,13 +446,13 @@ export class SharedQueueConsumer {
         });
 
         if (!queue) {
-          logger.debug("SharedQueueConsumer queue not found, so nacking message", {
+          logger.error("SharedQueueConsumer queue not found, so acking message", {
             queueMessage: message,
             taskRunQueue: lockedTaskRun.queue,
             runtimeEnvironmentId: lockedTaskRun.runtimeEnvironmentId,
           });
 
-          await this.#nackAndDoMoreWork(message.messageId, this._options.nextTickInterval);
+          await this.#ackAndDoMoreWork(message.messageId);
           return;
         }
 

--- a/apps/webapp/app/v3/marqs/simpleWeightedPriorityStrategy.server.ts
+++ b/apps/webapp/app/v3/marqs/simpleWeightedPriorityStrategy.server.ts
@@ -1,4 +1,3 @@
-import { RedisOptions } from "ioredis";
 import { nanoid } from "nanoid";
 import {
   MarQSQueuePriorityStrategy,
@@ -92,7 +91,8 @@ function filterQueuesAtCapacity(queues: QueueWithScores[]) {
     (queue) =>
       queue.capacities.queue.current < queue.capacities.queue.limit &&
       queue.capacities.env.current < queue.capacities.env.limit &&
-      queue.capacities.org.current < queue.capacities.org.limit
+      queue.capacities.org.current < queue.capacities.org.limit &&
+      queue.capacities.parentQueue.current < queue.capacities.parentQueue.limit
   );
 }
 

--- a/apps/webapp/app/v3/marqs/types.ts
+++ b/apps/webapp/app/v3/marqs/types.ts
@@ -10,6 +10,7 @@ export type QueueCapacities = {
   queue: QueueCapacity;
   env: QueueCapacity;
   org: QueueCapacity;
+  parentQueue: QueueCapacity;
 };
 
 export type QueueWithScores = {
@@ -43,6 +44,8 @@ export interface MarQSKeyProducer {
   envCurrentConcurrencyKeyFromQueue(queue: string): string;
   orgCurrentConcurrencyKey(env: AuthenticatedEnvironment): string;
   envCurrentConcurrencyKey(env: AuthenticatedEnvironment): string;
+  parentQueueConcurrencyLimitKey(parentQueue: string): string;
+  parentQueueCurrentConcurrencyKey(parentQueue: string): string;
   messageKey(messageId: string): string;
   stripKeyPrefix(key: string): string;
 }

--- a/apps/webapp/app/v3/marqs/v2.server.ts
+++ b/apps/webapp/app/v3/marqs/v2.server.ts
@@ -8,7 +8,7 @@ import { logger } from "~/services/logger.server";
 import { PerformRunExecutionV3Service } from "~/services/runs/performRunExecutionV3.server";
 import { singleton } from "~/utils/singleton";
 import { generateFriendlyId } from "../friendlyIdentifiers";
-import { MarQS } from "./index.server";
+import { MarQS } from "./queue.server";
 import { MarQSShortKeyProducer } from "./marqsKeyProducer.server";
 import { RequeueV2Message } from "./requeueV2Message.server";
 import {

--- a/apps/webapp/app/v3/marqs/v2.server.ts
+++ b/apps/webapp/app/v3/marqs/v2.server.ts
@@ -82,6 +82,7 @@ function getMarQSClient() {
     defaultEnvConcurrency: env.V2_MARQS_DEFAULT_ENV_CONCURRENCY, // this is so we aren't limited by the environment concurrency
     defaultOrgConcurrency: env.DEFAULT_ORG_EXECUTION_CONCURRENCY_LIMIT,
     visibilityTimeoutInMs: env.V2_MARQS_VISIBILITY_TIMEOUT_MS, // 15 minutes
+    defaultParentQueueConcurrency: env.DEFAULT_PARENT_QUEUE_EXECUTION_CONCURRENCY_LIMIT,
     enableRebalancing: env.V2_MARQS_CONSUMER_POOL_ENABLED === "1",
   });
 }

--- a/apps/webapp/app/v3/marqs/v3.server.ts
+++ b/apps/webapp/app/v3/marqs/v3.server.ts
@@ -1,0 +1,48 @@
+import { trace } from "@opentelemetry/api";
+import { env } from "~/env.server";
+import { singleton } from "~/utils/singleton";
+import { MarQSShortKeyProducer } from "./marqsKeyProducer.server";
+import { MarQS } from "./queue.server";
+import { SimpleWeightedChoiceStrategy } from "./simpleWeightedPriorityStrategy.server";
+import { V3VisibilityTimeout } from "./v3VisibilityTimeout.server";
+
+const KEY_PREFIX = "marqs:";
+
+export const marqsv3 = singleton("marqsv3", getMarQSClient);
+
+function getMarQSClient() {
+  if (env.V3_ENABLED) {
+    if (env.REDIS_HOST && env.REDIS_PORT) {
+      const redisOptions = {
+        keyPrefix: KEY_PREFIX,
+        port: env.REDIS_PORT,
+        host: env.REDIS_HOST,
+        username: env.REDIS_USERNAME,
+        password: env.REDIS_PASSWORD,
+        enableAutoPipelining: true,
+        ...(env.REDIS_TLS_DISABLED === "true" ? {} : { tls: {} }),
+      };
+
+      return new MarQS({
+        name: "marqs",
+        tracer: trace.getTracer("marqs"),
+        keysProducer: new MarQSShortKeyProducer(KEY_PREFIX),
+        visibilityTimeoutStrategy: new V3VisibilityTimeout(),
+        queuePriorityStrategy: new SimpleWeightedChoiceStrategy({ queueSelectionCount: 36 }),
+        envQueuePriorityStrategy: new SimpleWeightedChoiceStrategy({ queueSelectionCount: 12 }),
+        workers: 1,
+        redis: redisOptions,
+        defaultEnvConcurrency: env.DEFAULT_ENV_EXECUTION_CONCURRENCY_LIMIT,
+        defaultOrgConcurrency: env.DEFAULT_ORG_EXECUTION_CONCURRENCY_LIMIT,
+        defaultParentQueueConcurrency: env.DEFAULT_PARENT_QUEUE_EXECUTION_CONCURRENCY_LIMIT,
+        visibilityTimeoutInMs: 120 * 1000, // 2 minutes,
+        enableRebalancing: !env.MARQS_DISABLE_REBALANCING,
+        verbose: false,
+      });
+    } else {
+      console.warn(
+        "Could not initialize MarQS because process.env.REDIS_HOST and process.env.REDIS_PORT are required to be set. Trigger.dev v3 will not work without this."
+      );
+    }
+  }
+}

--- a/apps/webapp/app/v3/requeueTaskRun.server.ts
+++ b/apps/webapp/app/v3/requeueTaskRun.server.ts
@@ -1,5 +1,5 @@
 import { logger } from "~/services/logger.server";
-import { marqs } from "~/v3/marqs/index.server";
+import { marqsv3 } from "~/v3/marqs/v3.server";
 
 import assertNever from "assert-never";
 import { FailedTaskRunService } from "./failedTaskRun.server";
@@ -25,7 +25,7 @@ export class RequeueTaskRunService extends BaseService {
       case "PENDING": {
         logger.debug("[RequeueTaskRunService] Requeueing task run", { taskRun });
 
-        await marqs?.nackMessage(taskRun.id);
+        await marqsv3?.nackMessage(taskRun.id);
 
         break;
       }
@@ -51,7 +51,7 @@ export class RequeueTaskRunService extends BaseService {
       case "WAITING_FOR_DEPLOY": {
         logger.debug("[RequeueTaskRunService] Removing task run from queue", { taskRun });
 
-        await marqs?.acknowledgeMessage(taskRun.id);
+        await marqsv3?.acknowledgeMessage(taskRun.id);
 
         break;
       }
@@ -59,7 +59,7 @@ export class RequeueTaskRunService extends BaseService {
       case "PAUSED": {
         logger.debug("[RequeueTaskRunService] Requeueing task run", { taskRun });
 
-        await marqs?.nackMessage(taskRun.id);
+        await marqsv3?.nackMessage(taskRun.id);
 
         break;
       }
@@ -71,7 +71,7 @@ export class RequeueTaskRunService extends BaseService {
       case "CANCELED": {
         logger.debug("[RequeueTaskRunService] Task run is completed", { taskRun });
 
-        await marqs?.acknowledgeMessage(taskRun.id);
+        await marqsv3?.acknowledgeMessage(taskRun.id);
 
         break;
       }

--- a/apps/webapp/app/v3/services/cancelAttempt.server.ts
+++ b/apps/webapp/app/v3/services/cancelAttempt.server.ts
@@ -1,6 +1,6 @@
 import { AuthenticatedEnvironment } from "~/services/apiAuth.server";
 import { eventRepository } from "../eventRepository.server";
-import { marqs } from "~/v3/marqs/index.server";
+import { marqsv3 } from "~/v3/marqs/v3.server";
 import { BaseService } from "./baseService.server";
 import { logger } from "~/services/logger.server";
 
@@ -43,7 +43,7 @@ export class CancelAttemptService extends BaseService {
         return;
       }
 
-      await marqs?.acknowledgeMessage(taskRunId);
+      await marqsv3?.acknowledgeMessage(taskRunId);
 
       await this._prisma.taskRunAttempt.update({
         where: {

--- a/apps/webapp/app/v3/services/cancelTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/cancelTaskRun.server.ts
@@ -1,7 +1,7 @@
 import { Prisma, TaskRun, TaskRunAttemptStatus, TaskRunStatus } from "@trigger.dev/database";
 import assertNever from "assert-never";
 import { logger } from "~/services/logger.server";
-import { marqs } from "~/v3/marqs/index.server";
+import { marqsv3 } from "~/v3/marqs/v3.server";
 import { eventRepository } from "../eventRepository.server";
 import { socketIo } from "../handleSocketIo.server";
 import { devPubSub } from "../marqs/devPubSub.server";
@@ -58,7 +58,7 @@ export class CancelTaskRunService extends BaseService {
     }
 
     // Remove the task run from the queue if it's there for some reason
-    await marqs?.acknowledgeMessage(taskRun.id);
+    await marqsv3?.acknowledgeMessage(taskRun.id);
 
     // Set the task run status to cancelled
     const cancelledTaskRun = await this._prisma.taskRun.update({

--- a/apps/webapp/app/v3/services/crashTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/crashTaskRun.server.ts
@@ -5,7 +5,7 @@ import {
   TaskRunStatus,
 } from "@trigger.dev/database";
 import { eventRepository } from "../eventRepository.server";
-import { marqs } from "~/v3/marqs/index.server";
+import { marqsv3 } from "~/v3/marqs/v3.server";
 import { BaseService } from "./baseService.server";
 import { logger } from "~/services/logger.server";
 import { AuthenticatedEnvironment } from "~/services/apiAuth.server";
@@ -57,7 +57,7 @@ export class CrashTaskRunService extends BaseService {
     }
 
     // Remove the task run from the queue if it's there for some reason
-    await marqs?.acknowledgeMessage(taskRun.id);
+    await marqsv3?.acknowledgeMessage(taskRun.id);
 
     // Set the task run status to crashed
     const crashedTaskRun = await this._prisma.taskRun.update({
@@ -136,7 +136,7 @@ export class CrashTaskRunService extends BaseService {
       span.setAttribute("taskRunId", run.id);
       span.setAttribute("attemptId", attempt.id);
 
-      await marqs?.acknowledgeMessage(run.id);
+      await marqsv3?.acknowledgeMessage(run.id);
 
       await this._prisma.taskRunAttempt.update({
         where: {

--- a/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
@@ -3,7 +3,8 @@ import type { BackgroundWorker } from "@trigger.dev/database";
 import { Prisma, PrismaClientOrTransaction } from "~/db.server";
 import { AuthenticatedEnvironment } from "~/services/apiAuth.server";
 import { logger } from "~/services/logger.server";
-import { marqs, sanitizeQueueName } from "~/v3/marqs/index.server";
+import { marqsv3 } from "~/v3/marqs/v3.server";
+import { sanitizeQueueName } from "~/v3/marqs/queue.server";
 import { generateFriendlyId } from "../friendlyIdentifiers";
 import { calculateNextBuildVersion } from "../utils/calculateNextBuildVersion";
 import { BaseService } from "./baseService.server";
@@ -83,7 +84,7 @@ export class CreateBackgroundWorkerService extends BaseService {
           }
         );
 
-        await marqs?.updateEnvConcurrencyLimits(environment);
+        await marqsv3?.updateEnvConcurrencyLimits(environment);
       } catch (err) {
         logger.error(
           "Error publishing WORKER_CREATED event or updating global concurrency limits",
@@ -174,13 +175,13 @@ export async function createBackgroundTasks(
       });
 
       if (typeof taskQueue.concurrencyLimit === "number") {
-        await marqs?.updateQueueConcurrencyLimits(
+        await marqsv3?.updateQueueConcurrencyLimits(
           environment,
           taskQueue.name,
           taskQueue.concurrencyLimit
         );
       } else {
-        await marqs?.removeQueueConcurrencyLimits(environment, taskQueue.name);
+        await marqsv3?.removeQueueConcurrencyLimits(environment, taskQueue.name);
       }
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {

--- a/apps/webapp/app/v3/services/createCheckpoint.server.ts
+++ b/apps/webapp/app/v3/services/createCheckpoint.server.ts
@@ -7,7 +7,7 @@ import type {
 } from "@trigger.dev/database";
 import { logger } from "~/services/logger.server";
 import { generateFriendlyId } from "../friendlyIdentifiers";
-import { marqs } from "~/v3/marqs/index.server";
+import { marqsv3 } from "~/v3/marqs/v3.server";
 import { CreateCheckpointRestoreEventService } from "./createCheckpointRestoreEvent.server";
 import { BaseService } from "./baseService.server";
 import { CrashTaskRunService } from "./crashTaskRun.server";
@@ -131,7 +131,7 @@ export class CreateCheckpointService extends BaseService {
           dependencyFriendlyRunId: reason.friendlyId,
         });
 
-        await marqs?.acknowledgeMessage(attempt.taskRunId);
+        await marqsv3?.acknowledgeMessage(attempt.taskRunId);
         break;
       }
       case "WAIT_FOR_BATCH": {
@@ -140,7 +140,7 @@ export class CreateCheckpointService extends BaseService {
           batchDependencyFriendlyId: reason.batchFriendlyId,
         });
 
-        await marqs?.acknowledgeMessage(attempt.taskRunId);
+        await marqsv3?.acknowledgeMessage(attempt.taskRunId);
         break;
       }
       case "RETRYING_AFTER_FAILURE": {
@@ -161,12 +161,12 @@ export class CreateCheckpointService extends BaseService {
         attemptId: attempt.id,
         checkpointId: checkpoint.id,
       });
-      await marqs?.acknowledgeMessage(attempt.taskRunId);
+      await marqsv3?.acknowledgeMessage(attempt.taskRunId);
       return;
     }
 
     if (reason.type === "WAIT_FOR_DURATION") {
-      await marqs?.replaceMessage(
+      await marqsv3?.replaceMessage(
         attempt.taskRunId,
         {
           type: "RESUME_AFTER_DURATION",

--- a/apps/webapp/app/v3/services/createDeployedBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createDeployedBackgroundWorker.server.ts
@@ -6,7 +6,7 @@ import { BaseService } from "./baseService.server";
 import { createBackgroundTasks } from "./createBackgroundWorker.server";
 import { CURRENT_DEPLOYMENT_LABEL } from "~/consts";
 import { projectPubSub } from "./projectPubSub.server";
-import { marqs } from "~/v3/marqs/index.server";
+import { marqsv3 } from "~/v3/marqs/v3.server";
 import { logger } from "~/services/logger.server";
 import { ExecuteTasksWaitingForDeployService } from "./executeTasksWaitingForDeploy";
 import { PerformDeploymentAlertsService } from "./alerts/performDeploymentAlerts.server";
@@ -94,7 +94,7 @@ export class CreateDeployedBackgroundWorkerService extends BaseService {
             type: "deployed",
           }
         );
-        await marqs?.updateEnvConcurrencyLimits(environment);
+        await marqsv3?.updateEnvConcurrencyLimits(environment);
       } catch (err) {
         logger.error("Failed to publish WORKER_CREATED event", { err });
       }

--- a/apps/webapp/app/v3/services/executeTasksWaitingForDeploy.ts
+++ b/apps/webapp/app/v3/services/executeTasksWaitingForDeploy.ts
@@ -1,6 +1,6 @@
 import { PrismaClientOrTransaction } from "~/db.server";
 import { workerQueue } from "~/services/worker.server";
-import { marqs } from "~/v3/marqs/index.server";
+import { marqsv3 } from "~/v3/marqs/v3.server";
 import { BaseService } from "./baseService.server";
 import { logger } from "~/services/logger.server";
 
@@ -63,7 +63,7 @@ export class ExecuteTasksWaitingForDeployService extends BaseService {
       });
     }
 
-    if (!marqs) {
+    if (!marqsv3) {
       return;
     }
 
@@ -72,7 +72,7 @@ export class ExecuteTasksWaitingForDeployService extends BaseService {
 
     for (const run of runsWaitingForDeploy) {
       enqueues.push(
-        marqs.enqueueMessage(
+        marqsv3.enqueueMessage(
           backgroundWorker.runtimeEnvironment,
           run.queue,
           run.id,

--- a/apps/webapp/app/v3/services/resumeAttempt.server.ts
+++ b/apps/webapp/app/v3/services/resumeAttempt.server.ts
@@ -7,7 +7,7 @@ import {
 import type { InferSocketMessageSchema } from "@trigger.dev/core/v3/zodSocket";
 import { $transaction, PrismaClientOrTransaction } from "~/db.server";
 import { logger } from "~/services/logger.server";
-import { marqs } from "~/v3/marqs/index.server";
+import { marqsv3 } from "~/v3/marqs/v3.server";
 import { socketIo } from "../handleSocketIo.server";
 import { SharedQueueMessageBody, sharedQueueTasks } from "../marqs/sharedQueueConsumer.server";
 import { BaseService } from "./baseService.server";
@@ -189,7 +189,7 @@ export class ResumeAttemptService extends BaseService {
           attemptId: attempt.id,
           completedAttemptId,
         });
-        await marqs?.acknowledgeMessage(attempt.taskRunId);
+        await marqsv3?.acknowledgeMessage(attempt.taskRunId);
         return;
       }
 
@@ -202,7 +202,7 @@ export class ResumeAttemptService extends BaseService {
           attemptId: attempt.id,
           completedAttemptId,
         });
-        await marqs?.acknowledgeMessage(attempt.taskRunId);
+        await marqsv3?.acknowledgeMessage(attempt.taskRunId);
         return;
       }
 
@@ -217,7 +217,7 @@ export class ResumeAttemptService extends BaseService {
           attemptId: attempt.id,
           completedAttemptId,
         });
-        await marqs?.acknowledgeMessage(attempt.taskRunId);
+        await marqsv3?.acknowledgeMessage(attempt.taskRunId);
         return;
       }
 
@@ -255,7 +255,7 @@ export class ResumeAttemptService extends BaseService {
   }
 
   async #replaceResumeWithFailMessage(messageId: string, waitReason: WaitReason) {
-    const currentMessage = await marqs?.readMessage(messageId);
+    const currentMessage = await marqsv3?.readMessage(messageId);
 
     if (!currentMessage) {
       logger.debug("No message to replace", { messageId, waitReason });
@@ -297,6 +297,6 @@ export class ResumeAttemptService extends BaseService {
       reason,
     };
 
-    return await marqs?.replaceMessage(messageId, failMessage, undefined, true);
+    return await marqsv3?.replaceMessage(messageId, failMessage, undefined, true);
   }
 }

--- a/apps/webapp/app/v3/services/resumeBatchRun.server.ts
+++ b/apps/webapp/app/v3/services/resumeBatchRun.server.ts
@@ -1,6 +1,6 @@
 import { PrismaClientOrTransaction } from "~/db.server";
 import { workerQueue } from "~/services/worker.server";
-import { marqs } from "~/v3/marqs/index.server";
+import { marqsv3 } from "~/v3/marqs/v3.server";
 import { BaseService } from "./baseService.server";
 import { logger } from "~/services/logger.server";
 
@@ -67,11 +67,11 @@ export class ResumeBatchRunService extends BaseService {
           batchRunId: batchRun.id,
         });
 
-        await marqs?.acknowledgeMessage(dependentRun.id);
+        await marqsv3?.acknowledgeMessage(dependentRun.id);
         return;
       }
 
-      await marqs?.enqueueMessage(
+      await marqsv3?.enqueueMessage(
         environment,
         dependentRun.queue,
         dependentRun.id,
@@ -84,7 +84,7 @@ export class ResumeBatchRunService extends BaseService {
         dependentRun.concurrencyKey ?? undefined
       );
     } else {
-      await marqs?.replaceMessage(dependentRun.id, {
+      await marqsv3?.replaceMessage(dependentRun.id, {
         type: "RESUME",
         completedAttemptIds: batchRun.items.map((item) => item.taskRunAttemptId).filter(Boolean),
         resumableAttemptId: batchRun.dependentTaskAttempt.id,

--- a/apps/webapp/app/v3/services/resumeTaskDependency.server.ts
+++ b/apps/webapp/app/v3/services/resumeTaskDependency.server.ts
@@ -1,6 +1,6 @@
 import { PrismaClientOrTransaction } from "~/db.server";
 import { workerQueue } from "~/services/worker.server";
-import { marqs } from "~/v3/marqs/index.server";
+import { marqsv3 } from "~/v3/marqs/v3.server";
 import { BaseService } from "./baseService.server";
 import { logger } from "~/services/logger.server";
 
@@ -44,11 +44,11 @@ export class ResumeTaskDependencyService extends BaseService {
           attemptId: dependency.id,
         });
 
-        await marqs?.acknowledgeMessage(dependentRun.id);
+        await marqsv3?.acknowledgeMessage(dependentRun.id);
         return;
       }
 
-      await marqs?.enqueueMessage(
+      await marqsv3?.enqueueMessage(
         dependency.taskRun.runtimeEnvironment,
         dependentRun.queue,
         dependentRun.id,
@@ -61,7 +61,7 @@ export class ResumeTaskDependencyService extends BaseService {
         dependentRun.concurrencyKey ?? undefined
       );
     } else {
-      await marqs?.replaceMessage(dependentRun.id, {
+      await marqsv3?.replaceMessage(dependentRun.id, {
         type: "RESUME",
         completedAttemptIds: [sourceTaskAttemptId],
         resumableAttemptId: dependency.dependentAttempt.id,

--- a/apps/webapp/app/v3/services/triggerTask.server.ts
+++ b/apps/webapp/app/v3/services/triggerTask.server.ts
@@ -7,7 +7,8 @@ import {
 import { prisma } from "~/db.server";
 import { AuthenticatedEnvironment } from "~/services/apiAuth.server";
 import { autoIncrementCounter } from "~/services/autoIncrementCounter.server";
-import { marqs, sanitizeQueueName } from "~/v3/marqs/index.server";
+import { marqsv3 } from "~/v3/marqs/v3.server";
+import { sanitizeQueueName } from "~/v3/marqs/queue.server";
 import { eventRepository } from "../eventRepository.server";
 import { generateFriendlyId } from "../friendlyIdentifiers";
 import { uploadToObjectStore } from "../r2.server";
@@ -202,13 +203,13 @@ export class TriggerTaskService extends BaseService {
                 });
 
                 if (typeof taskQueue.concurrencyLimit === "number") {
-                  await marqs?.updateQueueConcurrencyLimits(
+                  await marqsv3?.updateQueueConcurrencyLimits(
                     environment,
                     taskQueue.name,
                     taskQueue.concurrencyLimit
                   );
                 } else {
-                  await marqs?.removeQueueConcurrencyLimits(environment, taskQueue.name);
+                  await marqsv3?.removeQueueConcurrencyLimits(environment, taskQueue.name);
                 }
               }
 
@@ -235,7 +236,7 @@ export class TriggerTaskService extends BaseService {
           }
 
           // We need to enqueue the task run into the appropriate queue. This is done after the tx completes to prevent a race condition where the task run hasn't been created yet by the time we dequeue.
-          await marqs?.enqueueMessage(
+          await marqsv3?.enqueueMessage(
             environment,
             run.queue,
             run.id,


### PR DESCRIPTION
This allows configuring a global concurrency limit for a parent queue (e.g. `marqs:sharedQueue`). If a value is not set in `marqs:sharedQueue:concurrency`, the value from `process.env.DEFAULT_PARENT_QUEUE_EXECUTION_CONCURRENCY_LIMIT` will be used, with a default of 250.