### PR TITLE
fix: allow command login to read api url from cli args

### DIFF
--- a/.changeset/strong-phones-smoke.md
+++ b/.changeset/strong-phones-smoke.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+fix: allow command login to read api url from cli args

--- a/packages/cli-v3/src/commands/login.ts
+++ b/packages/cli-v3/src/commands/login.ts
@@ -78,7 +78,7 @@ export async function login(options?: LoginOptions): Promise<LoginResult> {
       if (accessTokenFromEnv) {
         const auth = {
           accessToken: accessTokenFromEnv,
-          apiUrl: process.env.TRIGGER_API_URL ?? "https://api.trigger.dev",
+          apiUrl: process.env.TRIGGER_API_URL ?? opts.defaultApiUrl ?? "https://api.trigger.dev",
         };
         const apiClient = new CliApiClient(auth.apiUrl, auth.accessToken);
         const userData = await apiClient.whoAmI();


### PR DESCRIPTION
I'm new to trigger.dev and want to start with v3. I was playing with the self-hosted version since i don't have access for v3  cloud version. 

During my setup, I noticed that the login command (triggered by deploy) does not respect the --api-url argument. To work around this, I have to set TRIGGER_API_URL in the GitHub Action step environment. However, this is not mentioned in the GitHub Action guide. https://trigger.dev/docs/v3/github-actions



This fix allows the login command to respect the --api-url argument.

Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

_[Describe the steps you took to test this change]_

---

## Changelog

allow login command to read api url from cli args


## Screenshots

_[Screenshots]_

💯
