### PR TITLE
feature: add no-trigger-core-import

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-trigger-core-import.md
+++ b/packages/eslint-plugin/docs/rules/no-trigger-core-import.md
@@ -1,0 +1,69 @@
+# Prevent importing from `@trigger.dev/core` directly (`trigger-dev/no-trigger-core-import`)
+
+<!-- end auto-generated rule header -->
+
+Due to [this Remix bug](https://github.com/remix-run/remix/issues/9597), the web app is very sensitive to importing server-side code when it's bundling for the client side. If a route imports from a barrel file that ALSO exports server-side code, it will break the webapp's client side navigation and the page simply refreshes. This only happens during development.
+
+## Rule Details
+
+This rule prevents importing from `@trigger.dev/core` and `@trigger.dev/core/v3` directly, which are barrel files that export server-side code.
+
+It forces direct imports from the most specific file that exports a particular module and will autocorrect it.
+
+Examples of **incorrect** code for this rule:
+
+```ts
+import { ScheduledTaskPayload, parsePacket, prettyPrintPacket } from "@trigger.dev/core/v3";
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+import { ScheduledTaskPayload } from "@trigger.dev/core/v3/schemas";
+import { parsePacket, prettyPrintPacket } from "@trigger.dev/core/v3/utils/ioSerialization";
+```
+
+## When Not To Use It
+
+This rule prevents issues when client-side navigating to routes that import from `@trigger.dev/core` or `@trigger.dev/core/v3`. If there will be no client-side navigation during development, this rule is not needed.
+
+If [this bug](https://github.com/remix-run/remix/issues/9597) is fixed, this rule can be removed.
+
+## Workflow
+
+This rule runs in several steps
+
+```ts
+import { ScheduledTaskPayload, parsePacket, prettyPrintPacket } from "@trigger.dev/core/v3";
+```
+
+First it splits Core imports into one line per import
+
+```ts
+import { ScheduledTaskPayload } from "@trigger.dev/core/v3";
+import { parsePacket } from "@trigger.dev/core/v3";
+import { prettyPrintPacket } from "@trigger.dev/core/v3";
+```
+
+Then refines each down to their most specific exported file
+
+```ts
+import { ScheduledTaskPayload } from "@trigger.dev/core/v3/schemas/api";
+import { parsePacket } from "@trigger.dev/core/v3/utils/ioSerialization";
+import { prettyPrintPacket } from "@trigger.dev/core/v3/utils/ioSerialization";
+```
+
+if that exported file is downstream of an allowed barrel file (set to the schemas folders right now), it returns the export from the barrel instead
+
+```ts
+import { ScheduledTaskPayload } from "@trigger.dev/core/v3/schemas";
+import { parsePacket } from "@trigger.dev/core/v3/utils/ioSerialization";
+import { prettyPrintPacket } from "@trigger.dev/core/v3/utils/ioSerialization";
+```
+
+then the normal lint plugin for merging multiple imports from the same file will run and merge any that are the same
+
+```ts
+import { ScheduledTaskPayload } from "@trigger.dev/core/v3/schemas";
+import { parsePacket, prettyPrintPacket } from "@trigger.dev/core/v3/utils/ioSerialization";
+```

--- a/packages/eslint-plugin/lib/rules/no-trigger-core-import.js
+++ b/packages/eslint-plugin/lib/rules/no-trigger-core-import.js
@@ -1,0 +1,235 @@
+/**
+ * @fileoverview Prevent importing from `@trigger.dev/core` directly
+ */
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const parser = require("@babel/parser");
+const traverse = require("@babel/traverse").default;
+const tsconfigPaths = require("tsconfig-paths");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const blockedImportSources = ["@trigger.dev/core", "@trigger.dev/core/v3"];
+const allowedBarrelFiles = ["@trigger.dev/core/schemas", "@trigger.dev/core/v3/schemas"];
+
+function resolveSpecifier(importSource, specifier, context) {
+  const corePath = resolveModulePath(importSource);
+  const coreDir = path.dirname(corePath);
+
+  const resolvedPath = resolveExport(coreDir, specifier);
+  if (resolvedPath) {
+    const baseName = "@trigger.dev/core";
+    const relativePath = resolvedPath.split("packages/core/src/")[1].replace(/\\/g, "/");
+    const finalPath = `${baseName}/${relativePath}`;
+
+    // Check if the resolved path should map to an allowed barrel file
+    for (const barrelFile of allowedBarrelFiles) {
+      if (finalPath.startsWith(barrelFile)) {
+        return barrelFile;
+      }
+    }
+
+    return removeExtensionAndIndex(finalPath);
+  }
+  return null;
+}
+
+function resolveExport(fileOrDir, specifier) {
+  const filePath = fs.lstatSync(fileOrDir).isDirectory()
+    ? path.join(fileOrDir, "index.ts")
+    : fileOrDir;
+
+  if (!fs.existsSync(filePath)) return null;
+
+  const code = fs.readFileSync(filePath, "utf8");
+  const ast = parser.parse(code, { sourceType: "module", plugins: ["typescript"] });
+
+  let foundPath = null;
+
+  traverse(ast, {
+    ExportNamedDeclaration({ node }) {
+      if (node.declaration) {
+        if (
+          node.declaration.type === "VariableDeclaration" &&
+          node.declaration.declarations.some((decl) => decl.id.name === specifier)
+        ) {
+          foundPath = filePath;
+          return;
+        }
+
+        if (
+          node.declaration.type === "FunctionDeclaration" &&
+          node.declaration.id.name === specifier
+        ) {
+          foundPath = filePath;
+          return;
+        }
+
+        if (
+          node.declaration.type === "ClassDeclaration" &&
+          node.declaration.id.name === specifier
+        ) {
+          foundPath = filePath;
+          return;
+        }
+      } else if (node.specifiers) {
+        for (const exportSpecifier of node.specifiers) {
+          if (exportSpecifier.exported.name === specifier) {
+            const sourcePath = node.source.value;
+            const dir = fs.lstatSync(fileOrDir).isDirectory() ? fileOrDir : path.dirname(fileOrDir);
+            const resolvedSourcePath = tryResolveSourcePath(dir, sourcePath);
+
+            if (resolvedSourcePath) {
+              const resolvedExport = resolveExport(resolvedSourcePath, specifier);
+              if (resolvedExport) {
+                foundPath = resolvedExport;
+                return;
+              }
+            }
+          }
+        }
+      }
+    },
+    ExportAllDeclaration({ node }) {
+      const sourcePath = node.source.value;
+      const dir = fs.lstatSync(fileOrDir).isDirectory() ? fileOrDir : path.dirname(fileOrDir);
+      const resolvedSourcePath = tryResolveSourcePath(dir, sourcePath);
+
+      if (resolvedSourcePath) {
+        const resolvedExport = resolveExport(resolvedSourcePath, specifier);
+        if (resolvedExport) {
+          foundPath = resolvedExport;
+        }
+      }
+    },
+  });
+
+  return foundPath ? foundPath : null;
+}
+
+function tryResolveSourcePath(baseDir, sourcePath) {
+  const possibleExtensions = ["", ".ts", ".tsx", ".js", ".jsx"];
+  const possibleIndexFiles = ["index.ts", "index.tsx", "index.js", "index.jsx"];
+
+  for (const ext of possibleExtensions) {
+    const fullPath = path.resolve(baseDir, `${sourcePath}${ext}`);
+    if (fs.existsSync(fullPath)) {
+      return fullPath;
+    }
+  }
+
+  const dirPath = path.resolve(baseDir, sourcePath);
+  if (fs.existsSync(dirPath) && fs.lstatSync(dirPath).isDirectory()) {
+    for (const indexFile of possibleIndexFiles) {
+      const indexPath = path.join(dirPath, indexFile);
+      if (fs.existsSync(indexPath)) {
+        return indexPath;
+      }
+    }
+  }
+
+  return null;
+}
+
+function removeExtensionAndIndex(filePath) {
+  return filePath
+    .replace(/\/index(\.ts|\.tsx|\.js|\.jsx)$/, "")
+    .replace(/(\.ts|\.tsx|\.js|\.jsx)$/, "");
+}
+
+// Configure tsconfig-paths
+function resolveModulePath(sourcePath) {
+  const cwd = path.resolve(process.cwd());
+  const tsconfigPath = path.resolve(cwd, "tsconfig.json");
+  const tsconfig = require(tsconfigPath);
+  const { absoluteBaseUrl, paths } = tsconfigPaths.loadConfig(tsconfigPath);
+
+  if (!absoluteBaseUrl || !paths) {
+    throw new Error("Could not load tsconfig paths");
+  }
+
+  const matchPath = tsconfigPaths.createMatchPath(absoluteBaseUrl, paths);
+
+  let resolvedPath = matchPath(sourcePath, undefined, undefined, [".ts", ".tsx", ".js", ".jsx"]);
+
+  if (resolvedPath) {
+    if (fs.existsSync(resolvedPath) && fs.lstatSync(resolvedPath).isDirectory()) {
+      const indexResolvedPath = path.join(resolvedPath, "index.ts");
+      if (fs.existsSync(indexResolvedPath)) {
+        resolvedPath = indexResolvedPath;
+      }
+    }
+
+    return path.resolve(resolvedPath);
+  }
+
+  return path.resolve(sourcePath);
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Prevent importing from `@trigger.dev/core` or `@trigger.dev/core/v3` directly",
+      recommended: true,
+      url: null,
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      noTriggerCoreImport: "{{name}} should be imported from '{{resolvedPath}}'",
+    },
+  },
+
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        const importSource = node.source.value;
+
+        if (blockedImportSources.includes(importSource)) {
+          const specifierFixes = node.specifiers
+            .map((specifier) => {
+              const resolvedPath = resolveSpecifier(importSource, specifier.local.name, context);
+              if (resolvedPath) {
+                return {
+                  name: specifier.local.name,
+                  path: resolvedPath,
+                };
+              }
+              return null;
+            })
+            .filter(Boolean);
+
+          if (specifierFixes.length > 0) {
+            const fixes = specifierFixes
+              .map((fix) => {
+                return `import { ${fix.name} } from '${fix.path}';`;
+              })
+              .join("\n");
+
+            context.report({
+              node,
+              messageId: "noTriggerCoreImport",
+              data: {
+                name: node.specifiers.map((spec) => spec.local.name).join(", "),
+                resolvedPath: fixes,
+              },
+              fix(fixer) {
+                return fixer.replaceText(node, fixes);
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -18,9 +18,13 @@
     "update:eslint-docs": "eslint-doc-generator"
   },
   "dependencies": {
-    "requireindex": "^1.2.0"
+    "requireindex": "^1.2.0",
+    "tsconfig-paths": "^4.2.0"
   },
   "devDependencies": {
+    "@babel/parser": "^7.24.7",
+    "@babel/traverse": "^7.24.7",
+    "@types/babel__traverse": "^7.20.6",
     "eslint": "^8.19.0",
     "eslint-doc-generator": "^1.0.0",
     "eslint-plugin-eslint-plugin": "^5.0.0",

--- a/packages/eslint-plugin/tests/lib/rules/no-trigger-core-import.js
+++ b/packages/eslint-plugin/tests/lib/rules/no-trigger-core-import.js
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Prevent importing from `@trigger.dev/core` directly
+ * @author
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-trigger-core-import"),
+  RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: "module",
+    ecmaVersion: 2020,
+  },
+});
+ruleTester.run("no-trigger-core-import", rule, {
+  valid: [
+    {
+      code: `import { conditionallyImportPacket, parsePacket } from "@trigger.dev/core/v3/utils/ioSerialization";`,
+    },
+  ],
+
+  invalid: [
+    {
+      code: `import { parsePacket } from '@trigger.dev/core/v3';`,
+      output: `import { parsePacket } from '@trigger.dev/core/v3/utils/ioSerialization';`,
+      errors: [
+        {
+          messageId: "noTriggerCoreImport",
+        },
+      ],
+    },
+    {
+      code: `import { CreateBackgroundWorkerRequestBody, TaskResource } from '@trigger.dev/core/v3';`,
+      output: `import { CreateBackgroundWorkerRequestBody } from '@trigger.dev/core/v3/schemas';
+import { TaskResource } from '@trigger.dev/core/v3/schemas';`,
+      errors: [
+        {
+          messageId: "noTriggerCoreImport",
+        },
+      ],
+    },
+    {
+      code: `import { CreateBackgroundWorkerRequestBody, stringifyIO } from '@trigger.dev/core/v3';`,
+      output: `import { CreateBackgroundWorkerRequestBody } from '@trigger.dev/core/v3/schemas';
+import { stringifyIO } from '@trigger.dev/core/v3/utils/ioSerialization';`,
+      errors: [
+        {
+          messageId: "noTriggerCoreImport",
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  "include": ["**/*.ts", "**/*.tsx"],
+  "compilerOptions": {
+    "types": ["vitest/globals"],
+    "lib": ["ES2019"],
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
+    "resolveJsonModule": true,
+    "target": "ES2019",
+    "strict": true,
+    "allowJs": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "baseUrl": ".",
+    // Need paths for the no-trigger-core-import plugin
+    "paths": {
+      "~/*": ["./app/*"],
+      "@/*": ["./*"],
+      "@trigger.dev/sdk": ["../../packages/trigger-sdk/src/index"],
+      "@trigger.dev/sdk/*": ["../../packages/trigger-sdk/src/*"],
+      "@trigger.dev/core": ["../../packages/core/src/index"],
+      "@trigger.dev/core/*": ["../../packages/core/src/*"],
+      "@trigger.dev/core-backend": ["../../packages/core-backend/src/index"],
+      "@trigger.dev/core-backend/*": ["../../packages/core-backend/src/*"],
+      "@trigger.dev/database": ["../../packages/database/src/index"],
+      "@trigger.dev/database/*": ["../../packages/database/src/*"],
+      "@trigger.dev/yalt": ["../../packages/yalt/src/index"],
+      "@trigger.dev/yalt/*": ["../../packages/yalt/src/*"],
+      "@trigger.dev/otlp-importer": ["../../packages/otlp-importer/src/index"],
+      "@trigger.dev/otlp-importer/*": ["../../packages/otlp-importer/src/*"],
+      "emails": ["../../packages/emails/src/index"],
+      "emails/*": ["../../packages/emails/src/*"]
+    },
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
Disallows importing from `@trigger.dev/core` and `@trigger.dev/core/v3` directly (favouring more specific exports) and autofixes it

## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [ ] The PR title follows the convention.
- [ ] I ran and tested the code works

---

## Testing

_[Describe the steps you took to test this change]_

---

## Changelog

_[Short description of what has changed]_

---

## Screenshots

_[Screenshots]_

💯
