### PR TITLE
v3: Cancel awaited subtasks and reliable rate-limit recovery

### DIFF
--- a/.changeset/lemon-sloths-hide.md
+++ b/.changeset/lemon-sloths-hide.md
@@ -1,0 +1,6 @@
+---
+"@trigger.dev/sdk": patch
+"@trigger.dev/core": patch
+---
+
+v3: recover from server rate limiting errors in a more reliable way

--- a/apps/webapp/app/components/runs/v3/CancelRunDialog.tsx
+++ b/apps/webapp/app/components/runs/v3/CancelRunDialog.tsx
@@ -23,8 +23,7 @@ export function CancelRunDialog({ runFriendlyId, redirectPath }: CancelRunDialog
     <DialogContent key="cancel">
       <DialogHeader>Cancel this run?</DialogHeader>
       <DialogDescription>
-        Canceling a run will stop execution. If you want to run this later you will have to replay
-        the entire run with the original payload.
+        Canceling a run will stop execution, along with any executing subtasks.
       </DialogDescription>
       <DialogFooter>
         <Form action={`/resources/taskruns/${runFriendlyId}/cancel`} method="post">

--- a/apps/webapp/app/entry.server.tsx
+++ b/apps/webapp/app/entry.server.tsx
@@ -185,6 +185,7 @@ export { apiRateLimiter } from "./services/apiRateLimit.server";
 export { socketIo } from "./v3/handleSocketIo.server";
 export { wss } from "./v3/handleWebsockets.server";
 export { registryProxy } from "./v3/registryProxy.server";
+export { runWithHttpContext } from "./services/httpAsyncStorage.server";
 import { eventLoopMonitor } from "./eventLoopMonitor.server";
 import { env } from "./env.server";
 

--- a/apps/webapp/app/entry.server.tsx
+++ b/apps/webapp/app/entry.server.tsx
@@ -16,7 +16,6 @@ import {
 } from "./components/primitives/OperatingSystemProvider";
 import { getSharedSqsEventConsumer } from "./services/events/sqsEventConsumer";
 import { singleton } from "./utils/singleton";
-import { logger } from "./services/logger.server";
 
 const ABORT_DELAY = 30000;
 

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -97,8 +97,9 @@ const EnvironmentSchema = z.object({
    * @example "1000ms"
    * @example "1000s"
    */
-  API_RATE_LIMIT_WINDOW: z.string().default("60s"),
-  API_RATE_LIMIT_MAX: z.coerce.number().int().default(600),
+  API_RATE_LIMIT_REFILL_INTERVAL: z.string().default("10s"), // refill 250 tokens every 10 seconds
+  API_RATE_LIMIT_MAX: z.coerce.number().int().default(750), // allow bursts of 750 requests
+  API_RATE_LIMIT_REFILL_RATE: z.coerce.number().int().default(250), // refix 250 tokens every 10 seconds
   API_RATE_LIMIT_REQUEST_LOGS_ENABLED: z.string().default("0"),
   API_RATE_LIMIT_REJECTION_LOGS_ENABLED: z.string().default("1"),
 

--- a/apps/webapp/app/routes/api.v1.tasks.$taskId.trigger.ts
+++ b/apps/webapp/app/routes/api.v1.tasks.$taskId.trigger.ts
@@ -6,6 +6,7 @@ import { env } from "~/env.server";
 import { authenticateApiRequest } from "~/services/apiAuth.server";
 import { logger } from "~/services/logger.server";
 import { parseRequestJsonAsync } from "~/utils/parseRequestJson.server";
+import { ServiceValidationError } from "~/v3/services/baseService.server";
 import { TriggerTaskService } from "~/v3/services/triggerTask.server";
 import { startActiveSpan } from "~/v3/tracer.server";
 
@@ -92,18 +93,12 @@ export async function action({ request, params }: ActionFunctionArgs) {
       traceContext,
     });
 
-    const run = await service.call(
-      taskId,
-      authenticationResult.environment,
-      { ...body.data },
-      // { ...body.data, payload: (anyBody as any).payload },
-      {
-        idempotencyKey: idempotencyKey ?? undefined,
-        triggerVersion: triggerVersion ?? undefined,
-        traceContext,
-        spanParentAsLink: spanParentAsLink === 1,
-      }
-    );
+    const run = await service.call(taskId, authenticationResult.environment, body.data, {
+      idempotencyKey: idempotencyKey ?? undefined,
+      triggerVersion: triggerVersion ?? undefined,
+      traceContext,
+      spanParentAsLink: spanParentAsLink === 1,
+    });
 
     if (!run) {
       return json({ error: "Task not found" }, { status: 404 });
@@ -113,7 +108,9 @@ export async function action({ request, params }: ActionFunctionArgs) {
       id: run.friendlyId,
     });
   } catch (error) {
-    if (error instanceof Error) {
+    if (error instanceof ServiceValidationError) {
+      return json({ error: error.message }, { status: 422 });
+    } else if (error instanceof Error) {
       return json({ error: error.message }, { status: 400 });
     }
 

--- a/apps/webapp/app/routes/metrics.ts
+++ b/apps/webapp/app/routes/metrics.ts
@@ -1,7 +1,10 @@
 import { LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { metricsRegister } from "~/metrics.server";
+import { logger } from "~/services/logger.server";
 
 export async function loader({ request }: LoaderFunctionArgs) {
+  logger.debug("Getting metrics from the metrics register");
+
   return new Response(await metricsRegister.metrics(), {
     headers: {
       "Content-Type": metricsRegister.contentType,

--- a/apps/webapp/app/routes/metrics.ts
+++ b/apps/webapp/app/routes/metrics.ts
@@ -1,10 +1,7 @@
 import { LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { metricsRegister } from "~/metrics.server";
-import { logger } from "~/services/logger.server";
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  logger.debug("Getting metrics from the metrics register");
-
   return new Response(await metricsRegister.metrics(), {
     headers: {
       "Content-Type": metricsRegister.contentType,

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -261,7 +261,7 @@ function RunActionButtons({ span }: { span: Span }) {
 
   if (span.isPartial) {
     return (
-      <Dialog>
+      <Dialog key="in-progress">
         <LinkButton
           to={v3RunDownloadLogsPath({ friendlyId: runParam })}
           LeadingIcon={CloudArrowDownIcon}
@@ -290,7 +290,7 @@ function RunActionButtons({ span }: { span: Span }) {
   }
 
   return (
-    <Dialog>
+    <Dialog key="complete">
       <LinkButton
         to={v3RunDownloadLogsPath({ friendlyId: runParam })}
         LeadingIcon={CloudArrowDownIcon}

--- a/apps/webapp/app/services/httpAsyncStorage.server.ts
+++ b/apps/webapp/app/services/httpAsyncStorage.server.ts
@@ -1,0 +1,19 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type HttpLocalStorage = {
+  requestId: string;
+  path: string;
+  host: string;
+};
+
+const httpLocalStorage = new AsyncLocalStorage<HttpLocalStorage>();
+
+export type RunWithHttpContextFunction = <T>(context: HttpLocalStorage, fn: () => T) => T;
+
+export function runWithHttpContext<T>(context: HttpLocalStorage, fn: () => T): T {
+  return httpLocalStorage.run(context, fn);
+}
+
+export function getHttpContext(): HttpLocalStorage | undefined {
+  return httpLocalStorage.getStore();
+}

--- a/apps/webapp/app/services/logger.server.ts
+++ b/apps/webapp/app/services/logger.server.ts
@@ -2,6 +2,7 @@ import type { LogLevel } from "@trigger.dev/core-backend";
 import { Logger } from "@trigger.dev/core-backend";
 import { sensitiveDataReplacer } from "./sensitiveDataReplacer";
 import { AsyncLocalStorage } from "async_hooks";
+import { getHttpContext } from "./httpAsyncStorage.server";
 
 const currentFieldsStore = new AsyncLocalStorage<Record<string, unknown>>();
 
@@ -16,7 +17,8 @@ export const logger = new Logger(
   sensitiveDataReplacer,
   () => {
     const fields = currentFieldsStore.getStore();
-    return fields ? { ...fields } : {};
+    const httpContext = getHttpContext();
+    return { ...fields, http: httpContext };
   }
 );
 

--- a/apps/webapp/app/v3/eventRepository.server.ts
+++ b/apps/webapp/app/v3/eventRepository.server.ts
@@ -1411,7 +1411,9 @@ function filteredAttributes(attributes: Attributes, prefix: string): Attributes 
 }
 
 function calculateDurationFromStart(startTime: bigint, endTime: Date = new Date()) {
-  return Number(BigInt(endTime.getTime() * 1_000_000) - startTime);
+  const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
+
+  return Number(BigInt($endtime.getTime() * 1_000_000) - startTime);
 }
 
 function getNowInNanoseconds(): bigint {

--- a/apps/webapp/app/v3/services/baseService.server.ts
+++ b/apps/webapp/app/v3/services/baseService.server.ts
@@ -18,6 +18,10 @@ export abstract class BaseService {
         try {
           return await fn(span);
         } catch (e) {
+          if (e instanceof ServiceValidationError) {
+            throw e;
+          }
+
           if (e instanceof Error) {
             span.recordException(e);
           } else {

--- a/apps/webapp/app/v3/services/batchTriggerTask.server.ts
+++ b/apps/webapp/app/v3/services/batchTriggerTask.server.ts
@@ -34,7 +34,11 @@ export class BatchTriggerTaskService extends BaseService {
             include: {
               items: {
                 include: {
-                  taskRun: true,
+                  taskRun: {
+                    select: {
+                      friendlyId: true,
+                    },
+                  },
                 },
               },
             },
@@ -53,7 +57,12 @@ export class BatchTriggerTaskService extends BaseService {
         ? await this._prisma.taskRunAttempt.findUnique({
             where: { friendlyId: body.dependentAttempt },
             include: {
-              taskRun: true,
+              taskRun: {
+                select: {
+                  id: true,
+                  status: true,
+                },
+              },
             },
           })
         : undefined;

--- a/apps/webapp/app/v3/services/batchTriggerTask.server.ts
+++ b/apps/webapp/app/v3/services/batchTriggerTask.server.ts
@@ -26,9 +26,10 @@ export class BatchTriggerTaskService extends BaseService {
       const existingBatch = options.idempotencyKey
         ? await this._prisma.batchTaskRun.findUnique({
             where: {
-              runtimeEnvironmentId_idempotencyKey: {
+              runtimeEnvironmentId_taskIdentifier_idempotencyKey: {
                 runtimeEnvironmentId: environment.id,
                 idempotencyKey: options.idempotencyKey,
+                taskIdentifier: taskId,
               },
             },
             include: {

--- a/apps/webapp/app/v3/services/cancelAttempt.server.ts
+++ b/apps/webapp/app/v3/services/cancelAttempt.server.ts
@@ -1,12 +1,12 @@
 import { AuthenticatedEnvironment } from "~/services/apiAuth.server";
-import { eventRepository } from "../eventRepository.server";
-import { marqs } from "~/v3/marqs/index.server";
-import { BaseService } from "./baseService.server";
 import { logger } from "~/services/logger.server";
+import { marqs } from "~/v3/marqs/index.server";
+import { eventRepository } from "../eventRepository.server";
+import { BaseService } from "./baseService.server";
 
 import { PrismaClientOrTransaction, prisma } from "~/db.server";
-import { ResumeTaskRunDependenciesService } from "./resumeTaskRunDependencies.server";
 import { isCancellableRunStatus } from "../taskStatus";
+import { ResumeTaskRunDependenciesService } from "./resumeTaskRunDependencies.server";
 
 export class CancelAttemptService extends BaseService {
   public async call(
@@ -40,6 +40,14 @@ export class CancelAttemptService extends BaseService {
       });
 
       if (!taskRunAttempt) {
+        return;
+      }
+
+      if (taskRunAttempt.status === "CANCELED") {
+        logger.warn("Task run attempt is already cancelled", {
+          attemptId,
+        });
+
         return;
       }
 

--- a/apps/webapp/app/v3/services/cancelTaskAttemptDependencies.server.ts
+++ b/apps/webapp/app/v3/services/cancelTaskAttemptDependencies.server.ts
@@ -1,0 +1,55 @@
+import { PrismaClientOrTransaction } from "~/db.server";
+import { workerQueue } from "~/services/worker.server";
+import { BaseService } from "./baseService.server";
+import { logger } from "~/services/logger.server";
+import { CancelTaskRunService } from "./cancelTaskRun.server";
+
+export class CancelTaskAttemptDependenciesService extends BaseService {
+  public async call(attemptId: string) {
+    const taskAttempt = await this._prisma.taskRunAttempt.findUnique({
+      where: { id: attemptId },
+      include: {
+        dependencies: {
+          include: {
+            taskRun: true,
+          },
+        },
+      },
+    });
+
+    if (!taskAttempt) {
+      return;
+    }
+
+    if (!taskAttempt.dependencies.length) {
+      return;
+    }
+
+    if (taskAttempt.status !== "CANCELED") {
+      logger.debug("Task attempt is not cancelled, continuing anyway", {
+        attemptId,
+        status: taskAttempt.status,
+      });
+    }
+
+    const cancelRunService = new CancelTaskRunService();
+
+    for (const dependency of taskAttempt.dependencies) {
+      await cancelRunService.call(dependency.taskRun);
+    }
+  }
+
+  static async enqueue(attemptId: string, tx: PrismaClientOrTransaction, runAt?: Date) {
+    return await workerQueue.enqueue(
+      "v3.cancelTaskAttemptDependencies",
+      {
+        attemptId,
+      },
+      {
+        tx,
+        runAt,
+        jobKey: `cancelTaskAttemptDependencies:${attemptId}`,
+      }
+    );
+  }
+}

--- a/apps/webapp/app/v3/services/cancelTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/cancelTaskRun.server.ts
@@ -104,18 +104,6 @@ export class CancelTaskRunService extends BaseService {
       await this.#cancelRemainingRunWorkers(cancelledTaskRun);
     }
 
-    const cancelService = new CancelTaskRunService();
-
-    // Cancel any dependent task runs
-    for (const attempt of cancelledTaskRun.attempts) {
-      for (const dependency of attempt.dependencies) {
-        await cancelService.call(dependency.taskRun, {
-          ...opts,
-          reason: `Parent task run was cancelled`,
-        });
-      }
-    }
-
     return {
       id: cancelledTaskRun.id,
     };

--- a/apps/webapp/app/v3/services/createTaskRunAttempt.server.ts
+++ b/apps/webapp/app/v3/services/createTaskRunAttempt.server.ts
@@ -52,7 +52,14 @@ export class CreateTaskRunAttemptService extends BaseService {
           },
           lockedBy: {
             include: {
-              worker: true,
+              worker: {
+                select: {
+                  id: true,
+                  version: true,
+                  sdkVersion: true,
+                  cliVersion: true,
+                },
+              },
             },
           },
           batchItems: {
@@ -185,6 +192,7 @@ export class CreateTaskRunAttemptService extends BaseService {
           durationMs: taskRun.usageDurationMs,
           costInCents: taskRun.costInCents,
           baseCostInCents: taskRun.baseCostInCents,
+          maxAttempts: taskRun.maxAttempts ?? undefined,
         },
         queue: {
           id: queue.friendlyId,

--- a/apps/webapp/app/v3/services/createTaskRunAttempt.server.ts
+++ b/apps/webapp/app/v3/services/createTaskRunAttempt.server.ts
@@ -58,6 +58,7 @@ export class CreateTaskRunAttemptService extends BaseService {
                   version: true,
                   sdkVersion: true,
                   cliVersion: true,
+                  supportsLazyAttempts: true,
                 },
               },
             },
@@ -125,10 +126,6 @@ export class CreateTaskRunAttemptService extends BaseService {
             status: setToExecuting ? "EXECUTING" : "PENDING",
             queueId: queue.id,
             runtimeEnvironmentId: environment.id,
-          },
-          include: {
-            backgroundWorker: true,
-            backgroundWorkerTask: true,
           },
         });
 

--- a/apps/webapp/app/v3/services/testTask.server.ts
+++ b/apps/webapp/app/v3/services/testTask.server.ts
@@ -1,9 +1,8 @@
+import { stringifyIO } from "@trigger.dev/core/v3";
 import { findEnvironmentById } from "~/models/runtimeEnvironment.server";
+import { TestTaskData } from "../testTask";
 import { BaseService } from "./baseService.server";
 import { TriggerTaskService } from "./triggerTask.server";
-import { TestTaskData } from "../testTask";
-import { nextScheduledTimestamps } from "../utils/calculateNextSchedule.server";
-import { stringifyIO } from "@trigger.dev/core/v3";
 
 export class TestTaskService extends BaseService {
   public async call(userId: string, data: TestTaskData) {

--- a/apps/webapp/app/v3/services/triggerTask.server.ts
+++ b/apps/webapp/app/v3/services/triggerTask.server.ts
@@ -48,15 +48,16 @@ export class TriggerTaskService extends BaseService {
       const existingRun = idempotencyKey
         ? await this._prisma.taskRun.findUnique({
             where: {
-              runtimeEnvironmentId_idempotencyKey: {
+              runtimeEnvironmentId_taskIdentifier_idempotencyKey: {
                 runtimeEnvironmentId: environment.id,
                 idempotencyKey,
+                taskIdentifier: taskId,
               },
             },
           })
         : undefined;
 
-      if (existingRun && existingRun.taskIdentifier === taskId) {
+      if (existingRun) {
         span.setAttribute("runId", existingRun.friendlyId);
 
         return existingRun;

--- a/apps/webapp/app/v3/services/triggerTask.server.ts
+++ b/apps/webapp/app/v3/services/triggerTask.server.ts
@@ -206,6 +206,7 @@ export class TriggerTaskService extends BaseService {
                   isTest: body.options?.test ?? false,
                   delayUntil,
                   queuedAt: delayUntil ? undefined : new Date(),
+                  maxAttempts: body.options?.maxAttempts,
                   ttl,
                 },
               });

--- a/apps/webapp/app/v3/services/triggerTask.server.ts
+++ b/apps/webapp/app/v3/services/triggerTask.server.ts
@@ -13,7 +13,9 @@ import { eventRepository } from "../eventRepository.server";
 import { generateFriendlyId } from "../friendlyIdentifiers";
 import { uploadToObjectStore } from "../r2.server";
 import { startActiveSpan } from "../tracer.server";
-import { BaseService } from "./baseService.server";
+import { BaseService, ServiceValidationError } from "./baseService.server";
+import { logger } from "~/services/logger.server";
+import { isFinalAttemptStatus, isFinalRunStatus } from "../taskStatus";
 
 export type TriggerTaskServiceOptions = {
   idempotencyKey?: string;
@@ -68,6 +70,71 @@ export class TriggerTaskService extends BaseService {
         runFriendlyId,
         environment
       );
+
+      const dependentAttempt = body.options?.dependentAttempt
+        ? await this._prisma.taskRunAttempt.findUnique({
+            where: { friendlyId: body.options.dependentAttempt },
+            include: {
+              taskRun: true,
+            },
+          })
+        : undefined;
+
+      if (
+        dependentAttempt &&
+        (isFinalAttemptStatus(dependentAttempt.status) ||
+          isFinalRunStatus(dependentAttempt.taskRun.status))
+      ) {
+        logger.debug("Dependent attempt or run is in a terminal state", {
+          dependentAttempt: dependentAttempt,
+        });
+
+        if (isFinalAttemptStatus(dependentAttempt.status)) {
+          throw new ServiceValidationError(
+            `Cannot trigger ${taskId} as the parent attempt has a status of ${dependentAttempt.status}`
+          );
+        } else {
+          throw new ServiceValidationError(
+            `Cannot trigger ${taskId} as the parent run has a status of ${dependentAttempt.taskRun.status}`
+          );
+        }
+      }
+
+      const dependentBatchRun = body.options?.dependentBatch
+        ? await this._prisma.batchTaskRun.findUnique({
+            where: { friendlyId: body.options.dependentBatch },
+            include: {
+              dependentTaskAttempt: {
+                include: {
+                  taskRun: true,
+                },
+              },
+            },
+          })
+        : undefined;
+
+      if (
+        dependentBatchRun &&
+        dependentBatchRun.dependentTaskAttempt &&
+        (isFinalAttemptStatus(dependentBatchRun.dependentTaskAttempt.status) ||
+          isFinalRunStatus(dependentBatchRun.dependentTaskAttempt.taskRun.status))
+      ) {
+        logger.debug("Dependent batch run task attempt or run has been canceled", {
+          dependentBatchRunId: dependentBatchRun.id,
+          status: dependentBatchRun.status,
+          attempt: dependentBatchRun.dependentTaskAttempt,
+        });
+
+        if (isFinalAttemptStatus(dependentBatchRun.dependentTaskAttempt.status)) {
+          throw new ServiceValidationError(
+            `Cannot trigger ${taskId} as the parent attempt has a status of ${dependentBatchRun.dependentTaskAttempt.status}`
+          );
+        } else {
+          throw new ServiceValidationError(
+            `Cannot trigger ${taskId} as the parent run has a status of ${dependentBatchRun.dependentTaskAttempt.taskRun.status}`
+          );
+        }
+      }
 
       return await eventRepository.traceEvent(
         taskId,
@@ -159,32 +226,20 @@ export class TriggerTaskService extends BaseService {
               event.setAttribute("runId", taskRun.friendlyId);
               span.setAttribute("runId", taskRun.friendlyId);
 
-              if (body.options?.dependentAttempt) {
-                const dependentAttempt = await tx.taskRunAttempt.findUnique({
-                  where: { friendlyId: body.options.dependentAttempt },
+              if (dependentAttempt) {
+                await tx.taskRunDependency.create({
+                  data: {
+                    taskRunId: taskRun.id,
+                    dependentAttemptId: dependentAttempt.id,
+                  },
                 });
-
-                if (dependentAttempt) {
-                  await tx.taskRunDependency.create({
-                    data: {
-                      taskRunId: taskRun.id,
-                      dependentAttemptId: dependentAttempt.id,
-                    },
-                  });
-                }
-              } else if (body.options?.dependentBatch) {
-                const dependentBatchRun = await tx.batchTaskRun.findUnique({
-                  where: { friendlyId: body.options.dependentBatch },
+              } else if (dependentBatchRun) {
+                await tx.taskRunDependency.create({
+                  data: {
+                    taskRunId: taskRun.id,
+                    dependentBatchRunId: dependentBatchRun.id,
+                  },
                 });
-
-                if (dependentBatchRun) {
-                  await tx.taskRunDependency.create({
-                    data: {
-                      taskRunId: taskRun.id,
-                      dependentBatchRunId: dependentBatchRun.id,
-                    },
-                  });
-                }
               }
 
               if (body.options?.queue) {

--- a/apps/webapp/app/v3/services/triggerTask.server.ts
+++ b/apps/webapp/app/v3/services/triggerTask.server.ts
@@ -75,7 +75,12 @@ export class TriggerTaskService extends BaseService {
         ? await this._prisma.taskRunAttempt.findUnique({
             where: { friendlyId: body.options.dependentAttempt },
             include: {
-              taskRun: true,
+              taskRun: {
+                select: {
+                  id: true,
+                  status: true,
+                },
+              },
             },
           })
         : undefined;
@@ -106,7 +111,12 @@ export class TriggerTaskService extends BaseService {
             include: {
               dependentTaskAttempt: {
                 include: {
-                  taskRun: true,
+                  taskRun: {
+                    select: {
+                      id: true,
+                      status: true,
+                    },
+                  },
                 },
               },
             },

--- a/docs/v3/errors-retrying.mdx
+++ b/docs/v3/errors-retrying.mdx
@@ -255,11 +255,39 @@ export const openaiTask = task({
 });
 ```
 
-## Using try/catch to prevent retries
+## Preventing retries
+
+### Using `AbortTaskRunError`
+
+You can prevent retries by throwing an `AbortTaskRunError`. This will fail the task attempt and disable retrying.
+
+```ts /trigger/myTasks.ts
+import { task, AbortTaskRunError } from "@trigger.dev/sdk/v3";
+
+export const openaiTask = task({
+  id: "openai-task",
+  run: async (payload: { prompt: string }) => {
+    //if this fails, it will throw an error and stop retrying
+    const chatCompletion = await openai.chat.completions.create({
+      messages: [{ role: "user", content: payload.prompt }],
+      model: "gpt-3.5-turbo",
+    });
+
+    if (chatCompletion.choices[0]?.message.content === undefined) {
+      // If OpenAI returns an empty response, abort retrying
+      throw new AbortTaskRunError("OpenAI call failed");
+    }
+
+    return chatCompletion.choices[0].message.content;
+  },
+});
+```
+
+### Using try/catch
 
 Sometimes you want to catch an error and don't want to retry the task. You can use try/catch as you normally would. In this example we fallback to using Replicate if OpenAI fails.
 
-```ts /trigger/
+```ts /trigger/myTasks.ts
 import { task } from "@trigger.dev/sdk/v3";
 
 export const openaiTask = task({

--- a/docs/v3/idempotency.mdx
+++ b/docs/v3/idempotency.mdx
@@ -3,4 +3,101 @@ title: "Idempotency"
 description: "An API call or operation is “idempotent” if it has the same result when called more than once."
 ---
 
-<Snippet file="incomplete-docs.mdx" />
+We currently support idempotency at the task level, meaning that if you trigger a task with the same `idempotencyKey` twice, the second request will not create a new task run.
+
+## `idempotencyKey` option
+
+You can provide an `idempotencyKey` to ensure that a task is only triggered once with the same key. This is useful if you are triggering a task within another task that might be retried:
+
+```typescript
+import { idempotencyKeys, task } from "@trigger.dev/sdk/v3";
+
+export const myTask = task({
+  id: "my-task",
+  retry: {
+    maxAttempts: 4,
+  },
+  run: async (payload: any) => {
+    const idempotencyKey = await idempotencyKeys.create("my-task-key");
+
+    // childTask will only be triggered once with the same idempotency key
+    await childTask.triggerAndWait(payload, { idempotencyKey });
+
+    // Do something else, that may throw an error and cause the task to be retried
+  },
+});
+```
+
+You can use the `idempotencyKeys.create` SDK function to create an idempotency key before passing it to the `options` object.
+
+<Note>
+  We automatically inject the run ID when generating the idempotency key when running inside a task.
+</Note>
+
+If you are triggering a task from your backend code, you can use the `idempotencyKeys.create` SDK function to create an idempotency key.
+
+```typescript
+import { idempotencyKeys, tasks } from "@trigger.dev/sdk/v3";
+
+// You can also pass an array of strings to create a idempotency key
+const idempotencyKey = await idempotenceKeys.create([myUser.id, "my-task"]);
+await tasks.trigger("my-task", { some: "data" }, { idempotencyKey });
+```
+
+You can also pass a string to the `idempotencyKey` option, without first creating it with `idempotencyKeys.create`.
+
+```typescript
+import { myTask } from "./trigger/myTasks";
+
+// You can also pass an array of strings to create a idempotency key
+await myTask.trigger({ some: "data" }, { idempotencyKey: myUser.id });
+```
+
+<Note>Make sure you provide sufficiently unique keys to avoid collisions.</Note>
+
+You can pass the `idempotencyKey` when calling `batchTrigger` as well:
+
+```typescript
+import { tasks } from "@trigger.dev/sdk/v3";
+
+await tasks.batchTrigger("my-task", [
+  {
+    payload: { some: "data" },
+    options: { idempotencyKey: await idempotenceKeys.create([myUser.id, "my-task"]) },
+  },
+]);
+```
+
+## Payload-based idempotency
+
+We don't currently support payload-based idempotency, but you can implement it yourself by hashing the payload and using the hash as the idempotency key.
+
+```typescript
+import { idempotencyKeys, task } from "@trigger.dev/sdk/v3";
+import { createHash } from "node:crypto";
+
+export const myTask = task({
+  id: "my-task",
+  retry: {
+    maxAttempts: 4,
+  },
+  run: async (payload: any) => {
+    const childPayload = { ...payload, some: "data" };
+
+    const idempotencyKey = await idempotencyKeys.create(hash(childPayload));
+
+    // childTask will only be triggered once with the same idempotency key
+    await childTask.triggerAndWait(payload, { idempotencyKey });
+
+    // Do something else, that may throw an error and cause the task to be retried
+  },
+});
+
+// Create a hash of the payload using Node.js crypto
+// Ideally, you'd do a stable serialization of the payload before hashing, to ensure the same payload always results in the same hash
+function hash(payload: any): string {
+  const hash = createHash("sha256");
+  hash.update(JSON.stringify(payload));
+  return hash.digest("hex");
+}
+```

--- a/docs/v3/idempotency.mdx
+++ b/docs/v3/idempotency.mdx
@@ -18,6 +18,7 @@ export const myTask = task({
     maxAttempts: 4,
   },
   run: async (payload: any) => {
+    // By default, idempotency keys generated are unique to the run, to prevent retries from duplicating child tasks
     const idempotencyKey = await idempotencyKeys.create("my-task-key");
 
     // childTask will only be triggered once with the same idempotency key
@@ -30,9 +31,28 @@ export const myTask = task({
 
 You can use the `idempotencyKeys.create` SDK function to create an idempotency key before passing it to the `options` object.
 
-<Note>
-  We automatically inject the run ID when generating the idempotency key when running inside a task.
-</Note>
+We automatically inject the run ID when generating the idempotency key when running inside a task by default. You can turn it off by passing the `scope` option to `idempotencyKeys.create`:
+
+```typescript
+import { idempotencyKeys, task } from "@trigger.dev/sdk/v3";
+
+export const myTask = task({
+  id: "my-task",
+  retry: {
+    maxAttempts: 4,
+  },
+  run: async (payload: any) => {
+    // This idempotency key will be the same for all runs of this task
+    const idempotencyKey = await idempotencyKeys.create("my-task-key", { scope: "global" });
+
+    // childTask will only be triggered once with the same idempotency key
+    await childTask.triggerAndWait(payload, { idempotencyKey });
+
+    // This is the same as the above
+    await childTask.triggerAndWait(payload, { idempotencyKey: "my-task-key" });
+  },
+});
+```
 
 If you are triggering a task from your backend code, you can use the `idempotencyKeys.create` SDK function to create an idempotency key.
 
@@ -63,7 +83,7 @@ import { tasks } from "@trigger.dev/sdk/v3";
 await tasks.batchTrigger("my-task", [
   {
     payload: { some: "data" },
-    options: { idempotencyKey: await idempotenceKeys.create([myUser.id, "my-task"]) },
+    options: { idempotencyKey: await idempotenceKeys.create(myUser.id) },
   },
 ]);
 ```
@@ -76,22 +96,10 @@ We don't currently support payload-based idempotency, but you can implement it y
 import { idempotencyKeys, task } from "@trigger.dev/sdk/v3";
 import { createHash } from "node:crypto";
 
-export const myTask = task({
-  id: "my-task",
-  retry: {
-    maxAttempts: 4,
-  },
-  run: async (payload: any) => {
-    const childPayload = { ...payload, some: "data" };
-
-    const idempotencyKey = await idempotencyKeys.create(hash(childPayload));
-
-    // childTask will only be triggered once with the same idempotency key
-    await childTask.triggerAndWait(payload, { idempotencyKey });
-
-    // Do something else, that may throw an error and cause the task to be retried
-  },
-});
+// Somewhere in your code
+const idempotencyKey = await idempotencyKeys.create(hash(childPayload));
+// childTask will only be triggered once with the same idempotency key
+await tasks.trigger("child-task", { some: "payload" }, { idempotencyKey });
 
 // Create a hash of the payload using Node.js crypto
 // Ideally, you'd do a stable serialization of the payload before hashing, to ensure the same payload always results in the same hash
@@ -101,3 +109,9 @@ function hash(payload: any): string {
   return hash.digest("hex");
 }
 ```
+
+## Important notes
+
+Idempotency keys, even the ones scoped globally, are actually scoped to the task and the environment. This means that you cannot collide with keys from other environments (e.g. dev will never collide with prod), or to other projects and orgs.
+
+If you use the same idempotency key for triggering different tasks, the tasks will not be idempotent, and both tasks will be triggered. There's currently no way to make multiple tasks idempotent with the same key.

--- a/docs/v3/introduction.mdx
+++ b/docs/v3/introduction.mdx
@@ -4,8 +4,8 @@ description: "Welcome to the Trigger.dev v3 documentation."
 ---
 
 <Warning>
-  The Trigger.dev v3 Developer Preview is currently in invite-only early access. [Sign up here to
-  request access](https://trigger.dev/v3-early-access).
+  The Trigger.dev v3 Cloud Developer Preview is currently in invite-only early access. [Sign up here
+  to request access](https://trigger.dev/v3-early-access).
 </Warning>
 
 ## What is Trigger.dev (v3)?

--- a/docs/v3/management/overview.mdx
+++ b/docs/v3/management/overview.mdx
@@ -161,6 +161,47 @@ async function main() {
 }
 ```
 
+## Retries
+
+The SDK will automatically retry requests that fail due to network errors or server errors. By default, the SDK will retry requests up to 3 times, with an exponential backoff delay between retries.
+
+You can customize the retry behavior by passing a `requestOptions` option to the `configure` function:
+
+```ts
+import { configure } from "@trigger.dev/sdk/v3";
+
+configure({
+  requestOptions: {
+    retry: {
+      maxAttempts: 5,
+      minTimeoutInMs: 1000,
+      maxTimeoutInMs: 5000,
+      factor: 1.8,
+      randomize: true,
+    },
+  },
+});
+```
+
+All SDK functions also take a `requestOptions` parameter as the last argument, which can be used to customize the request options. You can use this to disable retries for a specific request:
+
+```ts
+import { runs } from "@trigger.dev/sdk/v3";
+
+async function main() {
+  const run = await runs.retrieve("run_1234", {
+    retry: {
+      maxAttempts: 1, // Disable retries
+    },
+  });
+}
+```
+
+<Note>
+  When running inside a task, the SDK ignores customized retry options for certain functions (e.g.,
+  `task.trigger`, `task.batchTrigger`), and uses retry settings optimized for task execution.
+</Note>
+
 ## Auto-pagination
 
 All list endpoints in the management API support auto-pagination.

--- a/docs/v3/triggering.mdx
+++ b/docs/v3/triggering.mdx
@@ -531,31 +531,18 @@ export const myTask = task({
     maxAttempts: 4,
   },
   run: async (payload: any) => {
+    // By default, idempotency keys generated are unique to the run, to prevent retries from duplicating child tasks
     const idempotencyKey = await idempotencyKeys.create("my-task-key");
 
     // childTask will only be triggered once with the same idempotency key
     await childTask.triggerAndWait(payload, { idempotencyKey });
+
+    // Do something else, that may throw an error and cause the task to be retried
   },
 });
 ```
 
-You can use the `idempotencyKeys.create` SDK function to create an idempotency key before passing it to the `options` object.
-
-<Note>
-  We automatically inject the run ID when generating the idempotency key when running inside a task.
-</Note>
-
-If you are triggering a task from your backend code, you can use the `idempotencyKeys.create` SDK function to create an idempotency key.
-
-```typescript
-import { idempotencyKeys, tasks } from "@trigger.dev/sdk/v3";
-
-// You can also pass an array of strings to create a idempotency key
-const idempotencyKey = await idempotenceKeys.create([myUser.id, "my-task"]);
-await tasks.trigger("my-task", { some: "data" }, { idempotencyKey });
-```
-
-<Note>Make sure you provide sufficiently unique keys to avoid collisions.</Note>
+For more information, see our [Idempotency](/v3/idempotency) documentation.
 
 ### `queue`
 

--- a/docs/v3/triggering.mdx
+++ b/docs/v3/triggering.mdx
@@ -148,6 +148,11 @@ export const myTask = task({
 
 ### Task.triggerAndWait()
 
+<Warning>
+  This method should only be used inside a task. If you use it outside a task, it will throw an
+  error.
+</Warning>
+
 This is where it gets interesting. You can trigger a task and then wait for the result. This is useful when you need to call a different task and then use the result to continue with your task.
 
 <Accordion title="Don't use this in parallel, e.g. with `Promise.all()`">
@@ -205,6 +210,11 @@ export const parentTask = task({
 ```
 
 ### Task.batchTriggerAndWait()
+
+<Warning>
+  This method should only be used inside a task. If you use it outside a task, it will throw an
+  error.
+</Warning>
 
 You can batch trigger a task and wait for all the results. This is useful for the fan-out pattern, where you need to call a task multiple times and then wait for all the results to continue with your task.
 
@@ -408,134 +418,246 @@ export async function POST(request: Request) {
   this way as it will block the request until the task is complete.
 </Note>
 
-### runs.retrieve()
+## Options
 
-You can retrieve a run by its handle using the `runs.retrieve()` function.
+All of the above functions accept an options object:
 
-<CodeGroup>
+```ts
+await myTask.trigger({ some: "data" }, { delay: "1h", ttl: "1h" });
+await myTask.batchTrigger([{ payload: { some: "data" }, options: { delay: "1h" } }]);
+```
 
-```ts Next.js API route
-import { tasks, runs } from "@trigger.dev/sdk/v3";
-import type { emailSequence } from "~/trigger/emails";
-//     👆 **type-only** import
+The following options are available:
 
-//app/email/route.ts
+### `delay`
+
+When you want to trigger a task now, but have it run at a later time, you can use the `delay` option:
+
+```ts
+// Delay the task run by 1 hour
+await myTask.trigger({ some: "data" }, { delay: "1h" });
+// Delay the task run by 88 seconds
+await myTask.trigger({ some: "data" }, { delay: "88s" });
+// Delay the task run by 1 hour and 52 minutes and 18 seconds
+await myTask.trigger({ some: "data" }, { delay: "1h52m18s" });
+// Delay until a specific time
+await myTask.trigger({ some: "data" }, { delay: "2024-12-01T00:00:00" });
+// Delay using a Date object
+await myTask.trigger({ some: "data" }, { delay: new Date(Date.now() + 1000 * 60 * 60) });
+```
+
+Runs that are delayed and have not been enqueued yet will display in the dashboard with a "Delayed" status:
+
+![Delayed run in the dashboard](/images/v3/delayed-runs.png)
+
+<Note>
+  Delayed runs will be enqueued at the time specified, and will run as soon as possible after that
+  time, just as a normally triggered run would.
+</Note>
+
+You can cancel a delayed run using the `runs.cancel` SDK function:
+
+```ts
+import { runs } from "@trigger.dev/sdk/v3";
+
+await runs.cancel("run_1234");
+```
+
+You can also reschedule a delayed run using the `runs.reschedule` SDK function:
+
+```ts
+import { runs } from "@trigger.dev/sdk/v3";
+
+// The delay option here takes the same format as the trigger delay option
+await runs.reschedule("run_1234", { delay: "1h" });
+```
+
+The `delay` option is also available when using `batchTrigger`:
+
+```ts
+await myTask.batchTrigger([{ payload: { some: "data" }, options: { delay: "1h" } }]);
+```
+
+### `ttl`
+
+You can set a TTL (time to live) when triggering a task, which will automatically expire the run if it hasn't started within the specified time. This is useful for ensuring that a run doesn't get stuck in the queue for too long.
+
+<Note>
+  All runs in development have a default `ttl` of 10 minutes. You can disable this by setting the
+  `ttl` option.
+</Note>
+
+```ts
+import { myTask } from "./trigger/myTasks";
+
+// Expire the run if it hasn't started within 1 hour
+await myTask.trigger({ some: "data" }, { ttl: "1h" });
+
+// If you specify a number, it will be treated as seconds
+await myTask.trigger({ some: "data" }, { ttl: 3600 }); // 1 hour
+```
+
+When a run is expired, it will be marked as "Expired" in the dashboard:
+
+![Expired runs in the dashboard](/images/v3/expired-runs.png)
+
+When you use both `delay` and `ttl`, the TTL will start counting down from the time the run is enqueued, not from the time the run is triggered.
+
+So for example, when using the following code:
+
+```ts
+await myTask.trigger({ some: "data" }, { delay: "10m", ttl: "1h" });
+```
+
+The timeline would look like this:
+
+1. The run is created at 12:00:00
+2. The run is enqueued at 12:10:00
+3. The TTL starts counting down from 12:10:00
+4. If the run hasn't started by 13:10:00, it will be expired
+
+For this reason, the `ttl` option only accepts durations and not absolute timestamps.
+
+### `idempotencyKey`
+
+You can provide an `idempotencyKey` to ensure that a task is only triggered once with the same key. This is useful if you are triggering a task within another task that might be retried:
+
+```typescript
+import { idempotencyKeys, task } from "@trigger.dev/sdk/v3";
+
+export const myTask = task({
+  id: "my-task",
+  retry: {
+    maxAttempts: 4,
+  },
+  run: async (payload: any) => {
+    const idempotencyKey = await idempotencyKeys.create("my-task-key");
+
+    // childTask will only be triggered once with the same idempotency key
+    await childTask.triggerAndWait(payload, { idempotencyKey });
+  },
+});
+```
+
+You can use the `idempotencyKeys.create` SDK function to create an idempotency key before passing it to the `options` object.
+
+<Note>
+  We automatically inject the run ID when generating the idempotency key when running inside a task.
+</Note>
+
+If you are triggering a task from your backend code, you can use the `idempotencyKeys.create` SDK function to create an idempotency key.
+
+```typescript
+import { idempotencyKeys, tasks } from "@trigger.dev/sdk/v3";
+
+// You can also pass an array of strings to create a idempotency key
+const idempotencyKey = await idempotenceKeys.create([myUser.id, "my-task"]);
+await tasks.trigger("my-task", { some: "data" }, { idempotencyKey });
+```
+
+<Note>Make sure you provide sufficiently unique keys to avoid collisions.</Note>
+
+### `queue`
+
+When you trigger a task you can override the concurrency limit. This is really useful if you sometimes have high priority runs.
+
+The task:
+
+```ts /trigger/override-concurrency.ts
+const generatePullRequest = task({
+  id: "generate-pull-request",
+  queue: {
+    //normally when triggering this task it will be limited to 1 run at a time
+    concurrencyLimit: 1,
+  },
+  run: async (payload) => {
+    //todo generate a PR using OpenAI
+  },
+});
+```
+
+Triggering from your backend and overriding the concurrency:
+
+```ts app/api/push/route.ts
+import { generatePullRequest } from "~/trigger/override-concurrency";
+
 export async function POST(request: Request) {
-  //get the JSON from the request
   const data = await request.json();
 
-  // Pass the task type to `trigger()` as a generic argument, giving you full type checking
-  const handle = await tasks.trigger<typeof emailSequence>("email-sequence", {
-    to: data.email,
-    name: data.name,
-  });
-
-  const run = await runs.retrieve(handle);
-
-  // run.output will be correctly typed as the return value of the task
-  return Response.json(run.output);
-}
-```
-
-</CodeGroup>
-
-### runs.poll()
-
-You can poll a run by its handle using the `runs.poll()` function.
-
-<CodeGroup>
-
-```ts Next.js API route
-import { tasks, runs } from "@trigger.dev/sdk/v3";
-import type { emailSequence } from "~/trigger/emails";
-//     👆 **type-only** import
-
-//app/email/route.ts
-export async function POST(request: Request) {
-  //get the JSON from the request
-  const data = await request.json();
-
-  // Pass the task type to `trigger()` as a generic argument, giving you full type checking
-  const handle = await tasks.trigger<typeof emailSequence>("email-sequence", {
-    to: data.email,
-    name: data.name,
-  });
-
-  // Poll the run until it's complete
-  const run = await runs.poll(handle, { pollIntervalMs: 5000 });
-
-  // run.output will be correctly typed as the return value of the task
-  return Response.json(run.output);
-}
-```
-
-</CodeGroup>
-
-## Next.js Server Actions
-
-Server Actions allow you to call your backend code without creating API routes. This is very useful for triggering tasks but you need to be careful you don't accidentally bundle the Trigger.dev SDK into your frontend code.
-
-If you see an error like this then you've bundled `@trigger.dev/sdk/v3` into your frontend code:
-
-```bash
-Module build failed: UnhandledSchemeError: Reading from "node:crypto" is not handled by plugins (Unhandled scheme).
-Module build failed: UnhandledSchemeError: Reading from "node:process" is not handled by plugins (Unhandled scheme).
-Webpack supports "data:" and "file:" URIs by default.
-You may need an additional plugin to handle "node:" URIs.
-```
-
-When you use server actions that use `@trigger.dev/sdk/v3`:
-
-- The file can't have any React components in it.
-- The file should have `"use server"` on the first line.
-
-Here's an example of how to do it with a component that calls the server action and the actions file:
-
-<CodeGroup>
-
-```tsx app/page.tsx
-"use client";
-
-import { create } from "@/app/actions";
-
-export default function Home() {
-  return (
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
-      <button
-        onClick={async () => {
-          const handle = await create();
-          console.log(handle);
-        }}
-      >
-        Create a thing
-      </button>
-    </main>
-  );
-}
-```
-
-```tsx app/actions.ts
-"use server";
-
-import { createAvatar } from "@/trigger/create-avatar";
-
-export async function create() {
-  try {
-    const handle = await createAvatar.trigger({
-      userImage: "http://...",
+  if (data.branch === "main") {
+    //trigger the task, with a different queue
+    const handle = await generatePullRequest.trigger(data, {
+      queue: {
+        //the "main-branch" queue will have a concurrency limit of 10
+        //this triggered run will use that queue
+        name: "main-branch",
+        concurrencyLimit: 10,
+      },
     });
 
-    return { handle };
-  } catch (error) {
-    console.error(error);
-    return {
-      error: "something went wrong",
-    };
+    return Response.json(handle);
+  } else {
+    //triggered with the default (concurrency of 1)
+    const handle = await generatePullRequest.trigger(data);
+    return Response.json(handle);
   }
 }
 ```
 
-</CodeGroup>
+### `concurrencyKey`
+
+If you're building an application where you want to run tasks for your users, you might want a separate queue for each of your users. (It doesn't have to be users, it can be any entity you want to separately limit the concurrency for.)
+
+You can do this by using `concurrencyKey`. It creates a separate queue for each value of the key.
+
+Your backend code:
+
+```ts app/api/pr/route.ts
+import { generatePullRequest } from "~/trigger/override-concurrency";
+
+export async function POST(request: Request) {
+  const data = await request.json();
+
+  if (data.isFreeUser) {
+    //free users can only have 1 PR generated at a time
+    const handle = await generatePullRequest.trigger(data, {
+      queue: {
+        //every free user gets a queue with a concurrency limit of 1
+        name: "free-users",
+        concurrencyLimit: 1,
+      },
+      concurrencyKey: data.userId,
+    });
+
+    //return a success response with the handle
+    return Response.json(handle);
+  } else {
+    //trigger the task, with a different queue
+    const handle = await generatePullRequest.trigger(data, {
+      queue: {
+        //every paid user gets a queue with a concurrency limit of 10
+        name: "paid-users",
+        concurrencyLimit: 10,
+      },
+      concurrencyKey: data.userId,
+    });
+
+    //return a success response with the handle
+    return Response.json(handle);
+  }
+}
+```
+
+### `maxAttempts`
+
+You can set the maximum number of attempts for a task run. If the run fails, it will be retried up to the number of attempts you specify.
+
+```ts
+await myTask.trigger({ some: "data" }, { maxAttempts: 3 });
+await myTask.trigger({ some: "data" }, { maxAttempts: 1 }); // no retries
+```
+
+This will override the `retry.maxAttempts` value set in the task definition.
 
 ## Large Payloads
 
@@ -620,93 +742,68 @@ export const myTask = task({
 
 When using `batchTrigger` or `batchTriggerAndWait`, the total size of all payloads cannot exceed 10MB. This means if you are doing a batch of 100 runs, each payload should be less than 100KB.
 
-## Delayed runs
+## Next.js Server Actions
 
-When you want to trigger a task now, but have it run at a later time, you can use the `delay` option:
+Server Actions allow you to call your backend code without creating API routes. This is very useful for triggering tasks but you need to be careful you don't accidentally bundle the Trigger.dev SDK into your frontend code.
 
-```ts
-// Delay the task run by 1 hour
-await myTask.trigger({ some: "data" }, { delay: "1h" });
-// Delay the task run by 88 seconds
-await myTask.trigger({ some: "data" }, { delay: "88s" });
-// Delay the task run by 1 hour and 52 minutes and 18 seconds
-await myTask.trigger({ some: "data" }, { delay: "1h52m18s" });
-// Delay until a specific time
-await myTask.trigger({ some: "data" }, { delay: "2024-12-01T00:00:00" });
-// Delay using a Date object
-await myTask.trigger({ some: "data" }, { delay: new Date(Date.now() + 1000 * 60 * 60) });
+If you see an error like this then you've bundled `@trigger.dev/sdk/v3` into your frontend code:
+
+```bash
+Module build failed: UnhandledSchemeError: Reading from "node:crypto" is not handled by plugins (Unhandled scheme).
+Module build failed: UnhandledSchemeError: Reading from "node:process" is not handled by plugins (Unhandled scheme).
+Webpack supports "data:" and "file:" URIs by default.
+You may need an additional plugin to handle "node:" URIs.
 ```
 
-Runs that are delayed and have not been enqueued yet will display in the dashboard with a "Delayed" status:
+When you use server actions that use `@trigger.dev/sdk/v3`:
 
-![Delayed run in the dashboard](/images/v3/delayed-runs.png)
+- The file can't have any React components in it.
+- The file should have `"use server"` on the first line.
 
-<Note>
-  Delayed runs will be enqueued at the time specified, and will run as soon as possible after that
-  time, just as a normally triggered run would.
-</Note>
+Here's an example of how to do it with a component that calls the server action and the actions file:
 
-You can cancel a delayed run using the `runs.cancel` SDK function:
+<CodeGroup>
 
-```ts
-import { runs } from "@trigger.dev/sdk/v3";
+```tsx app/page.tsx
+"use client";
 
-await runs.cancel("run_1234");
+import { create } from "@/app/actions";
+
+export default function Home() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-between p-24">
+      <button
+        onClick={async () => {
+          const handle = await create();
+          console.log(handle);
+        }}
+      >
+        Create a thing
+      </button>
+    </main>
+  );
+}
 ```
 
-You can also reschedule a delayed run using the `runs.reschedule` SDK function:
+```tsx app/actions.ts
+"use server";
 
-```ts
-import { runs } from "@trigger.dev/sdk/v3";
+import { createAvatar } from "@/trigger/create-avatar";
 
-// The delay option here takes the same format as the trigger delay option
-await runs.reschedule("run_1234", { delay: "1h" });
+export async function create() {
+  try {
+    const handle = await createAvatar.trigger({
+      userImage: "http://...",
+    });
+
+    return { handle };
+  } catch (error) {
+    console.error(error);
+    return {
+      error: "something went wrong",
+    };
+  }
+}
 ```
 
-The `delay` option is also available when using `batchTrigger`:
-
-```ts
-await myTask.batchTrigger([{ payload: { some: "data" }, options: { delay: "1h" } }]);
-```
-
-## TTL
-
-You can set a TTL (time to live) when triggering a task, which will automatically expire the run if it hasn't started within the specified time. This is useful for ensuring that a run doesn't get stuck in the queue for too long.
-
-<Note>
-  All runs in development have a default `ttl` of 10 minutes. You can disable this by setting the
-  `ttl` option.
-</Note>
-
-```ts
-import { myTask } from "./trigger/myTasks";
-
-// Expire the run if it hasn't started within 1 hour
-await myTask.trigger({ some: "data" }, { ttl: "1h" });
-
-// If you specify a number, it will be treated as seconds
-await myTask.trigger({ some: "data" }, { ttl: 3600 }); // 1 hour
-```
-
-When a run is expired, it will be marked as "Expired" in the dashboard:
-
-![Expired runs in the dashboard](/images/v3/expired-runs.png)
-
-### Delayed runs and TTL
-
-When you use both `delay` and `ttl`, the TTL will start counting down from the time the run is enqueued, not from the time the run is triggered.
-
-So for example, when using the following code:
-
-```ts
-await myTask.trigger({ some: "data" }, { delay: "10m", ttl: "1h" });
-```
-
-The timeline would look like this:
-
-1. The run is created at 12:00:00
-2. The run is enqueued at 12:10:00
-3. The TTL starts counting down from 12:10:00
-4. If the run hasn't started by 13:10:00, it will be expired
-
-For this reason, the `ttl` option only accepts durations and not absolute timestamps.
+</CodeGroup>

--- a/packages/core/src/v3/apiClientManager/types.ts
+++ b/packages/core/src/v3/apiClientManager/types.ts
@@ -1,4 +1,7 @@
+import { ApiRequestOptions } from "../apiClient";
+
 export type ApiClientConfiguration = {
   baseURL?: string;
   secretKey?: string;
+  requestOptions?: ApiRequestOptions;
 };

--- a/packages/core/src/v3/errors.ts
+++ b/packages/core/src/v3/errors.ts
@@ -1,6 +1,12 @@
 import { z } from "zod";
 import { TaskRunError } from "./schemas/common";
-import nodePath from "node:path";
+
+export class AbortTaskRunError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AbortTaskRunError";
+  }
+}
 
 export function parseError(error: unknown): TaskRunError {
   if (error instanceof Error) {

--- a/packages/core/src/v3/schemas/api.ts
+++ b/packages/core/src/v3/schemas/api.ts
@@ -70,6 +70,7 @@ export const TriggerTaskRequestBody = z.object({
       payloadType: z.string().optional(),
       delay: z.string().or(z.coerce.date()).optional(),
       ttl: z.string().or(z.number().nonnegative().int()).optional(),
+      maxAttempts: z.number().int().optional(),
     })
     .optional(),
 });

--- a/packages/core/src/v3/schemas/common.ts
+++ b/packages/core/src/v3/schemas/common.ts
@@ -133,6 +133,7 @@ export const TaskRun = z.object({
   createdAt: z.coerce.date(),
   startedAt: z.coerce.date().default(() => new Date()),
   idempotencyKey: z.string().optional(),
+  maxAttempts: z.number().optional(),
   durationMs: z.number().default(0),
   costInCents: z.number().default(0),
   baseCostInCents: z.number().default(0),

--- a/packages/core/src/v3/semanticInternalAttributes.ts
+++ b/packages/core/src/v3/semanticInternalAttributes.ts
@@ -48,4 +48,7 @@ export const SemanticInternalAttributes = {
   IDEMPOTENCY_KEY: "ctx.run.idempotencyKey",
   USAGE_DURATION_MS: "$usage.durationMs",
   USAGE_COST_IN_CENTS: "$usage.costInCents",
+  RATE_LIMIT_LIMIT: "response.rateLimit.limit",
+  RATE_LIMIT_REMAINING: "response.rateLimit.remaining",
+  RATE_LIMIT_RESET: "response.rateLimit.reset",
 };

--- a/packages/database/prisma/migrations/20240702131302_add_max_attempts_to_task_run/migration.sql
+++ b/packages/database/prisma/migrations/20240702131302_add_max_attempts_to_task_run/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "TaskRun" ADD COLUMN     "maxAttempts" INTEGER;

--- a/packages/database/prisma/migrations/20240704170301_scope_idempotency_key_to_task_identifier/migration.sql
+++ b/packages/database/prisma/migrations/20240704170301_scope_idempotency_key_to_task_identifier/migration.sql
@@ -1,0 +1,26 @@
+/*
+ Warnings:
+ 
+ - A unique constraint covering the columns `[runtimeEnvironmentId,taskIdentifier,idempotencyKey]` on the table `BatchTaskRun` will be added. If there are existing duplicate values, this will fail.
+ - A unique constraint covering the columns `[runtimeEnvironmentId,taskIdentifier,idempotencyKey]` on the table `TaskRun` will be added. If there are existing duplicate values, this will fail.
+ 
+ */
+-- CreateIndex
+CREATE UNIQUE INDEX "BatchTaskRun_runtimeEnvironmentId_taskIdentifier_idempotenc_key" ON "BatchTaskRun"(
+  "runtimeEnvironmentId",
+  "taskIdentifier",
+  "idempotencyKey"
+);
+
+-- DropIndex
+DROP INDEX "BatchTaskRun_runtimeEnvironmentId_idempotencyKey_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TaskRun_runtimeEnvironmentId_taskIdentifier_idempotencyKey_key" ON "TaskRun"(
+  "runtimeEnvironmentId",
+  "taskIdentifier",
+  "idempotencyKey"
+);
+
+-- DropIndex
+DROP INDEX "TaskRun_runtimeEnvironmentId_idempotencyKey_key";

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1679,7 +1679,7 @@ model TaskRun {
   sourceBulkActionItems      BulkActionItem[] @relation("SourceActionItemRun")
   destinationBulkActionItems BulkActionItem[] @relation("DestinationActionItemRun")
 
-  @@unique([runtimeEnvironmentId, idempotencyKey])
+  @@unique([runtimeEnvironmentId, taskIdentifier, idempotencyKey])
   // Task activity graph
   @@index([projectId, createdAt, taskIdentifier])
   //Runs list
@@ -2022,7 +2022,7 @@ model BatchTaskRun {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  @@unique([runtimeEnvironmentId, idempotencyKey])
+  @@unique([runtimeEnvironmentId, taskIdentifier, idempotencyKey])
 }
 
 enum BatchTaskRunStatus {

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1660,10 +1660,11 @@ model TaskRun {
 
   concurrencyKey String?
 
-  delayUntil DateTime?
-  queuedAt   DateTime?
-  ttl        String?
-  expiredAt  DateTime?
+  delayUntil  DateTime?
+  queuedAt    DateTime?
+  ttl         String?
+  expiredAt   DateTime?
+  maxAttempts Int?
 
   batchItems             BatchTaskRunItem[]
   dependency             TaskRunDependency?

--- a/packages/trigger-sdk/src/v3/errors.ts
+++ b/packages/trigger-sdk/src/v3/errors.ts
@@ -1,0 +1,1 @@
+export { AbortTaskRunError } from "@trigger.dev/core/v3";

--- a/packages/trigger-sdk/src/v3/idempotencyKeys.ts
+++ b/packages/trigger-sdk/src/v3/idempotencyKeys.ts
@@ -1,0 +1,62 @@
+import { taskContext } from "@trigger.dev/core/v3";
+
+export const idempotencyKeys = {
+  create: createIdempotencyKey,
+};
+
+declare const __brand: unique symbol;
+type Brand<B> = { [__brand]: B };
+type Branded<T, B> = T & Brand<B>;
+
+export type IdempotencyKey = Branded<string, "IdempotencyKey">;
+
+export function isIdempotencyKey(value: string | IdempotencyKey): value is IdempotencyKey {
+  // Cannot check the brand at runtime because it doesn't exist (it's a TypeScript-only construct)
+  return typeof value === "string" && value.length === 64;
+}
+
+/**
+ * Creates a deterministic idempotency key based on the provided key material.
+ *
+ * If running inside a task, the task run ID is automatically included in the key material, giving you a unique key per task run.
+ * This ensures that a given child task is only triggered once per task run, even if the parent task is retried.
+ *
+ * @param {string | string[]} key The key material to create the idempotency key from.
+ *
+ * @returns {Promise<IdempotencyKey>} The idempotency key as a branded string.
+ *
+ * @example
+ *
+ * ```typescript
+ * import { idempotencyKeys, task } from "@trigger.dev/sdk/v3";
+ *
+ * export const myTask = task({
+ *  id: "my-task",
+ *  run: async (payload: any) => {
+ *   const idempotencyKey = await idempotencyKeys.create("my-task-key");
+ *
+ *   // Use the idempotency key when triggering child tasks
+ *   await childTask.triggerAndWait(payload, { idempotencyKey });
+ *  }
+ * });
+ * ```
+ */
+async function createIdempotencyKey(key: string | string[]): Promise<IdempotencyKey> {
+  const idempotencyKey = await generateIdempotencyKey(
+    [...(Array.isArray(key) ? key : [key])].concat(taskContext?.ctx ? [taskContext.ctx.run.id] : [])
+  );
+
+  return idempotencyKey as IdempotencyKey;
+}
+
+async function generateIdempotencyKey(keyMaterial: string[]) {
+  const hash = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(keyMaterial.join("-"))
+  );
+
+  // Return a hex string, using cross-runtime compatible methods
+  return Array.from(new Uint8Array(hash))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/packages/trigger-sdk/src/v3/idempotencyKeys.ts
+++ b/packages/trigger-sdk/src/v3/idempotencyKeys.ts
@@ -10,7 +10,9 @@ type Branded<T, B> = T & Brand<B>;
 
 export type IdempotencyKey = Branded<string, "IdempotencyKey">;
 
-export function isIdempotencyKey(value: string | IdempotencyKey): value is IdempotencyKey {
+export function isIdempotencyKey(
+  value: string | string[] | IdempotencyKey
+): value is IdempotencyKey {
   // Cannot check the brand at runtime because it doesn't exist (it's a TypeScript-only construct)
   return typeof value === "string" && value.length === 64;
 }
@@ -22,6 +24,8 @@ export function isIdempotencyKey(value: string | IdempotencyKey): value is Idemp
  * This ensures that a given child task is only triggered once per task run, even if the parent task is retried.
  *
  * @param {string | string[]} key The key material to create the idempotency key from.
+ * @param {object} [options] Additional options.
+ * @param {"run" | "attempt" | "global"} [options.scope="run"] The scope of the idempotency key.
  *
  * @returns {Promise<IdempotencyKey>} The idempotency key as a branded string.
  *
@@ -40,13 +44,40 @@ export function isIdempotencyKey(value: string | IdempotencyKey): value is Idemp
  *  }
  * });
  * ```
+ *
+ * You can also use the `scope` parameter to create a key that is unique per task run, task run attempts (retries of the same run), or globally:
+ *
+ * ```typescript
+ *  await idempotencyKeys.create("my-task-key", { scope: "attempt" }); // Creates a key that is unique per task run attempt
+ *  await idempotencyKeys.create("my-task-key", { scope: "global" }); // Skips including the task run ID
+ * ```
  */
-async function createIdempotencyKey(key: string | string[]): Promise<IdempotencyKey> {
+async function createIdempotencyKey(
+  key: string | string[],
+  options?: { scope?: "run" | "attempt" | "global" }
+): Promise<IdempotencyKey> {
   const idempotencyKey = await generateIdempotencyKey(
-    [...(Array.isArray(key) ? key : [key])].concat(taskContext?.ctx ? [taskContext.ctx.run.id] : [])
+    [...(Array.isArray(key) ? key : [key])].concat(injectScope(options?.scope ?? "run"))
   );
 
   return idempotencyKey as IdempotencyKey;
+}
+
+function injectScope(scope: "run" | "attempt" | "global"): string[] {
+  switch (scope) {
+    case "run": {
+      if (taskContext?.ctx) {
+        return [taskContext.ctx.run.id];
+      }
+    }
+    case "attempt": {
+      if (taskContext?.ctx) {
+        return [taskContext.ctx.attempt.id];
+      }
+    }
+  }
+
+  return [];
 }
 
 async function generateIdempotencyKey(keyMaterial: string[]) {

--- a/packages/trigger-sdk/src/v3/index.ts
+++ b/packages/trigger-sdk/src/v3/index.ts
@@ -5,6 +5,7 @@ export { queue } from "./shared";
 export * from "./tasks";
 export * from "./wait";
 export * from "./usage";
+export * from "./idempotencyKeys";
 export type { Context };
 
 import type { Context } from "./shared";

--- a/packages/trigger-sdk/src/v3/retry.ts
+++ b/packages/trigger-sdk/src/v3/retry.ts
@@ -77,6 +77,12 @@ function onThrow<T>(
 
           innerSpan.setStatus({ code: SpanStatusCode.ERROR });
 
+          if (e instanceof Error && e.name === "AbortTaskRunError") {
+            innerSpan.end();
+
+            throw e;
+          }
+
           const nextRetryDelay = calculateNextRetryDelay(opts, attempt);
 
           if (!nextRetryDelay) {

--- a/packages/trigger-sdk/src/v3/runs.ts
+++ b/packages/trigger-sdk/src/v3/runs.ts
@@ -1,4 +1,5 @@
 import type {
+  ApiRequestOptions,
   ListProjectRunsQueryParams,
   ListRunsQueryParams,
   RescheduleRunRequestBody,
@@ -10,9 +11,14 @@ import {
   ListRunResponseItem,
   ReplayRunResponse,
   RetrieveRunResponse,
+  accessoryAttributes,
   apiClientManager,
+  flattenAttributes,
+  isRequestOptions,
+  mergeRequestOptions,
 } from "@trigger.dev/core/v3";
 import { Prettify, RunHandle, apiClientMissingError } from "./shared";
+import { tracer } from "./tracer";
 
 export type RetrieveRunResult<TOutput> = Prettify<
   TOutput extends RunHandle<infer THandleOutput>
@@ -33,12 +39,17 @@ export type ListRunsItem = ListRunResponseItem;
 
 function listRuns(
   projectRef: string,
-  params?: ListProjectRunsQueryParams
+  params?: ListProjectRunsQueryParams,
+  requestOptions?: ApiRequestOptions
 ): CursorPagePromise<typeof ListRunResponseItem>;
-function listRuns(params?: ListRunsQueryParams): CursorPagePromise<typeof ListRunResponseItem>;
+function listRuns(
+  params?: ListRunsQueryParams,
+  requestOptions?: ApiRequestOptions
+): CursorPagePromise<typeof ListRunResponseItem>;
 function listRuns(
   paramsOrProjectRef?: ListRunsQueryParams | string,
-  params?: ListRunsQueryParams | ListProjectRunsQueryParams
+  paramsOrOptions?: ListRunsQueryParams | ListProjectRunsQueryParams | ApiRequestOptions,
+  requestOptions?: ApiRequestOptions
 ): CursorPagePromise<typeof ListRunResponseItem> {
   const apiClient = apiClientManager.client;
 
@@ -46,15 +57,91 @@ function listRuns(
     throw apiClientMissingError();
   }
 
+  const $requestOptions = listRunsRequestOptions(
+    paramsOrProjectRef,
+    paramsOrOptions,
+    requestOptions
+  );
+
   if (typeof paramsOrProjectRef === "string") {
-    return apiClient.listProjectRuns(paramsOrProjectRef, params);
+    if (isRequestOptions(paramsOrOptions)) {
+      return apiClient.listProjectRuns(paramsOrProjectRef, {}, $requestOptions);
+    } else {
+      return apiClient.listProjectRuns(paramsOrProjectRef, paramsOrOptions, $requestOptions);
+    }
   }
 
-  return apiClient.listRuns(params);
+  return apiClient.listRuns(paramsOrProjectRef, $requestOptions);
+}
+
+function listRunsRequestOptions(
+  paramsOrProjectRef?: ListRunsQueryParams | string,
+  paramsOrOptions?: ListRunsQueryParams | ListProjectRunsQueryParams | ApiRequestOptions,
+  requestOptions?: ApiRequestOptions
+): ApiRequestOptions {
+  if (typeof paramsOrProjectRef === "string") {
+    if (isRequestOptions(paramsOrOptions)) {
+      return mergeRequestOptions(
+        {
+          tracer,
+          name: "runs.list()",
+          icon: "runs",
+          attributes: {
+            projectRef: paramsOrProjectRef,
+            ...accessoryAttributes({
+              items: [
+                {
+                  text: paramsOrProjectRef,
+                  variant: "normal",
+                },
+              ],
+              style: "codepath",
+            }),
+          },
+        },
+        paramsOrOptions
+      );
+    } else {
+      return mergeRequestOptions(
+        {
+          tracer,
+          name: "runs.list()",
+          icon: "runs",
+          attributes: {
+            projectRef: paramsOrProjectRef,
+            ...flattenAttributes(paramsOrOptions as Record<string, unknown>, "queryParams"),
+            ...accessoryAttributes({
+              items: [
+                {
+                  text: paramsOrProjectRef,
+                  variant: "normal",
+                },
+              ],
+              style: "codepath",
+            }),
+          },
+        },
+        requestOptions
+      );
+    }
+  }
+
+  return mergeRequestOptions(
+    {
+      tracer,
+      name: "runs.list()",
+      icon: "runs",
+      attributes: {
+        ...flattenAttributes(paramsOrProjectRef as Record<string, unknown>, "queryParams"),
+      },
+    },
+    isRequestOptions(paramsOrOptions) ? paramsOrOptions : requestOptions
+  );
 }
 
 function retrieveRun<TRunId extends RunHandle<any> | string>(
-  runId: TRunId
+  runId: TRunId,
+  requestOptions?: ApiRequestOptions
 ): ApiPromise<RetrieveRunResult<TRunId>> {
   const apiClient = apiClientManager.client;
 
@@ -62,36 +149,108 @@ function retrieveRun<TRunId extends RunHandle<any> | string>(
     throw apiClientMissingError();
   }
 
+  const $requestOptions = mergeRequestOptions(
+    {
+      tracer,
+      name: "runs.retrieve()",
+      icon: "runs",
+      attributes: {
+        runId: typeof runId === "string" ? runId : runId.id,
+        ...accessoryAttributes({
+          items: [
+            {
+              text: typeof runId === "string" ? runId : runId.id,
+              variant: "normal",
+            },
+          ],
+          style: "codepath",
+        }),
+      },
+    },
+    requestOptions
+  );
+
   if (typeof runId === "string") {
-    return apiClient.retrieveRun(runId) as ApiPromise<RetrieveRunResult<TRunId>>;
+    return apiClient.retrieveRun(runId, $requestOptions) as ApiPromise<RetrieveRunResult<TRunId>>;
   } else {
-    return apiClient.retrieveRun(runId.id) as ApiPromise<RetrieveRunResult<TRunId>>;
+    return apiClient.retrieveRun(runId.id, $requestOptions) as ApiPromise<
+      RetrieveRunResult<TRunId>
+    >;
   }
 }
 
-function replayRun(runId: string): ApiPromise<ReplayRunResponse> {
+function replayRun(
+  runId: string,
+  requestOptions?: ApiRequestOptions
+): ApiPromise<ReplayRunResponse> {
   const apiClient = apiClientManager.client;
 
   if (!apiClient) {
     throw apiClientMissingError();
   }
 
-  return apiClient.replayRun(runId);
+  const $requestOptions = mergeRequestOptions(
+    {
+      tracer,
+      name: "runs.replay()",
+      icon: "runs",
+      attributes: {
+        runId,
+        ...accessoryAttributes({
+          items: [
+            {
+              text: runId,
+              variant: "normal",
+            },
+          ],
+          style: "codepath",
+        }),
+      },
+    },
+    requestOptions
+  );
+
+  return apiClient.replayRun(runId, $requestOptions);
 }
 
-function cancelRun(runId: string): ApiPromise<CanceledRunResponse> {
+function cancelRun(
+  runId: string,
+  requestOptions?: ApiRequestOptions
+): ApiPromise<CanceledRunResponse> {
   const apiClient = apiClientManager.client;
 
   if (!apiClient) {
     throw apiClientMissingError();
   }
 
-  return apiClient.cancelRun(runId);
+  const $requestOptions = mergeRequestOptions(
+    {
+      tracer,
+      name: "runs.cancel()",
+      icon: "runs",
+      attributes: {
+        runId,
+        ...accessoryAttributes({
+          items: [
+            {
+              text: runId,
+              variant: "normal",
+            },
+          ],
+          style: "codepath",
+        }),
+      },
+    },
+    requestOptions
+  );
+
+  return apiClient.cancelRun(runId, $requestOptions);
 }
 
 function rescheduleRun(
   runId: string,
-  body: RescheduleRunRequestBody
+  body: RescheduleRunRequestBody,
+  requestOptions?: ApiRequestOptions
 ): ApiPromise<RetrieveRunResponse> {
   const apiClient = apiClientManager.client;
 
@@ -99,17 +258,43 @@ function rescheduleRun(
     throw apiClientMissingError();
   }
 
-  return apiClient.rescheduleRun(runId, body);
+  const $requestOptions = mergeRequestOptions(
+    {
+      tracer,
+      name: "runs.reschedule()",
+      icon: "runs",
+      attributes: {
+        runId,
+        ...accessoryAttributes({
+          items: [
+            {
+              text: runId,
+              variant: "normal",
+            },
+          ],
+          style: "codepath",
+        }),
+      },
+    },
+    requestOptions
+  );
+
+  return apiClient.rescheduleRun(runId, body, $requestOptions);
 }
 
 export type PollOptions = { pollIntervalMs?: number };
 
+const MAX_POLL_ATTEMPTS = 500;
+
 async function poll<TRunHandle extends RunHandle<any> | string>(
   handle: TRunHandle,
-  options?: { pollIntervalMs?: number }
+  options?: { pollIntervalMs?: number },
+  requestOptions?: ApiRequestOptions
 ) {
-  while (true) {
-    const run = await runs.retrieve(handle);
+  let attempts = 0;
+
+  while (attempts++ < MAX_POLL_ATTEMPTS) {
+    const run = await runs.retrieve(handle, requestOptions);
 
     if (run.isCompleted) {
       return run;
@@ -117,4 +302,6 @@ async function poll<TRunHandle extends RunHandle<any> | string>(
 
     await new Promise((resolve) => setTimeout(resolve, options?.pollIntervalMs ?? 1000));
   }
+
+  throw new Error(`Run ${handle} did not complete after ${MAX_POLL_ATTEMPTS} attempts`);
 }

--- a/packages/trigger-sdk/src/v3/schedules/index.ts
+++ b/packages/trigger-sdk/src/v3/schedules/index.ts
@@ -1,16 +1,20 @@
 import {
   ApiPromise,
+  ApiRequestOptions,
   DeletedScheduleObject,
   InitOutput,
   OffsetLimitPagePromise,
   ScheduleObject,
   TimezonesResult,
+  accessoryAttributes,
   apiClientManager,
+  mergeRequestOptions,
   taskCatalog,
 } from "@trigger.dev/core/v3";
 import { zodfetch } from "@trigger.dev/core/v3/zodfetch";
 import { Task, TaskOptions, apiClientMissingError, createTask } from "../shared";
 import * as SchedulesAPI from "./api";
+import { tracer } from "../tracer";
 
 export function task<TIdentifier extends string, TOutput, TInitOutput extends InitOutput>(
   params: TaskOptions<TIdentifier, SchedulesAPI.ScheduledTaskPayload, TOutput, TInitOutput>
@@ -34,14 +38,37 @@ export function task<TIdentifier extends string, TOutput, TInitOutput extends In
  * @param options.deduplicationKey - An optional deduplication key for the schedule
  * @returns The created schedule
  */
-export function create(options: SchedulesAPI.CreateScheduleOptions): ApiPromise<ScheduleObject> {
+export function create(
+  options: SchedulesAPI.CreateScheduleOptions,
+  requestOptions?: ApiRequestOptions
+): ApiPromise<ScheduleObject> {
   const apiClient = apiClientManager.client;
 
   if (!apiClient) {
     throw apiClientMissingError();
   }
 
-  return apiClient.createSchedule(options);
+  const $requestOptions = mergeRequestOptions(
+    {
+      tracer,
+      name: "schedules.create()",
+      icon: "clock",
+      attributes: {
+        ...accessoryAttributes({
+          items: [
+            {
+              text: options.cron,
+              variant: "normal",
+            },
+          ],
+          style: "codepath",
+        }),
+      },
+    },
+    requestOptions
+  );
+
+  return apiClient.createSchedule(options, $requestOptions);
 }
 
 /**
@@ -49,14 +76,38 @@ export function create(options: SchedulesAPI.CreateScheduleOptions): ApiPromise<
  * @param scheduleId - The ID of the schedule to retrieve
  * @returns The retrieved schedule
  */
-export function retrieve(scheduleId: string): ApiPromise<ScheduleObject> {
+export function retrieve(
+  scheduleId: string,
+  requestOptions?: ApiRequestOptions
+): ApiPromise<ScheduleObject> {
   const apiClient = apiClientManager.client;
 
   if (!apiClient) {
     throw apiClientMissingError();
   }
 
-  return apiClient.retrieveSchedule(scheduleId);
+  const $requestOptions = mergeRequestOptions(
+    {
+      tracer,
+      name: "schedules.retrieve()",
+      icon: "clock",
+      attributes: {
+        scheduleId,
+        ...accessoryAttributes({
+          items: [
+            {
+              text: scheduleId,
+              variant: "normal",
+            },
+          ],
+          style: "codepath",
+        }),
+      },
+    },
+    requestOptions
+  );
+
+  return apiClient.retrieveSchedule(scheduleId, $requestOptions);
 }
 
 /**
@@ -71,7 +122,8 @@ export function retrieve(scheduleId: string): ApiPromise<ScheduleObject> {
  */
 export function update(
   scheduleId: string,
-  options: SchedulesAPI.UpdateScheduleOptions
+  options: SchedulesAPI.UpdateScheduleOptions,
+  requestOptions?: ApiRequestOptions
 ): ApiPromise<ScheduleObject> {
   const apiClient = apiClientManager.client;
 
@@ -79,49 +131,142 @@ export function update(
     throw apiClientMissingError();
   }
 
-  return apiClient.updateSchedule(scheduleId, options);
+  const $requestOptions = mergeRequestOptions(
+    {
+      tracer,
+      name: "schedules.update()",
+      icon: "clock",
+      attributes: {
+        scheduleId,
+        ...accessoryAttributes({
+          items: [
+            {
+              text: scheduleId,
+              variant: "normal",
+            },
+          ],
+          style: "codepath",
+        }),
+      },
+    },
+    requestOptions
+  );
+
+  return apiClient.updateSchedule(scheduleId, options, $requestOptions);
 }
 
 /**
  * Deletes a schedule
  * @param scheduleId - The ID of the schedule to delete
  */
-export function del(scheduleId: string): ApiPromise<DeletedScheduleObject> {
+export function del(
+  scheduleId: string,
+  requestOptions?: ApiRequestOptions
+): ApiPromise<DeletedScheduleObject> {
   const apiClient = apiClientManager.client;
 
   if (!apiClient) {
     throw apiClientMissingError();
   }
 
-  return apiClient.deleteSchedule(scheduleId);
+  const $requestOptions = mergeRequestOptions(
+    {
+      tracer,
+      name: "schedules.delete()",
+      icon: "clock",
+      attributes: {
+        scheduleId,
+        ...accessoryAttributes({
+          items: [
+            {
+              text: scheduleId,
+              variant: "normal",
+            },
+          ],
+          style: "codepath",
+        }),
+      },
+    },
+    requestOptions
+  );
+
+  return apiClient.deleteSchedule(scheduleId, $requestOptions);
 }
 
 /**
  * Deactivates a schedule
  * @param scheduleId - The ID of the schedule to deactivate
  */
-export function deactivate(scheduleId: string): ApiPromise<ScheduleObject> {
+export function deactivate(
+  scheduleId: string,
+  requestOptions?: ApiRequestOptions
+): ApiPromise<ScheduleObject> {
   const apiClient = apiClientManager.client;
 
   if (!apiClient) {
     throw apiClientMissingError();
   }
 
-  return apiClient.deactivateSchedule(scheduleId);
+  const $requestOptions = mergeRequestOptions(
+    {
+      tracer,
+      name: "schedules.deactivate()",
+      icon: "clock",
+      attributes: {
+        scheduleId,
+        ...accessoryAttributes({
+          items: [
+            {
+              text: scheduleId,
+              variant: "normal",
+            },
+          ],
+          style: "codepath",
+        }),
+      },
+    },
+    requestOptions
+  );
+
+  return apiClient.deactivateSchedule(scheduleId, $requestOptions);
 }
 
 /**
  * Activates a schedule
  * @param scheduleId - The ID of the schedule to activate
  */
-export function activate(scheduleId: string): ApiPromise<ScheduleObject> {
+export function activate(
+  scheduleId: string,
+  requestOptions?: ApiRequestOptions
+): ApiPromise<ScheduleObject> {
   const apiClient = apiClientManager.client;
 
   if (!apiClient) {
     throw apiClientMissingError();
   }
 
-  return apiClient.activateSchedule(scheduleId);
+  const $requestOptions = mergeRequestOptions(
+    {
+      tracer,
+      name: "schedules.activate()",
+      icon: "clock",
+      attributes: {
+        scheduleId,
+        ...accessoryAttributes({
+          items: [
+            {
+              text: scheduleId,
+              variant: "normal",
+            },
+          ],
+          style: "codepath",
+        }),
+      },
+    },
+    requestOptions
+  );
+
+  return apiClient.activateSchedule(scheduleId, $requestOptions);
 }
 
 /**
@@ -132,7 +277,8 @@ export function activate(scheduleId: string): ApiPromise<ScheduleObject> {
  * @returns The list of schedules
  */
 export function list(
-  options?: SchedulesAPI.ListScheduleOptions
+  options?: SchedulesAPI.ListScheduleOptions,
+  requestOptions?: ApiRequestOptions
 ): OffsetLimitPagePromise<typeof ScheduleObject> {
   const apiClient = apiClientManager.client;
 
@@ -140,7 +286,16 @@ export function list(
     throw apiClientMissingError();
   }
 
-  return apiClient.listSchedules(options);
+  const $requestOptions = mergeRequestOptions(
+    {
+      tracer,
+      name: "schedules.list()",
+      icon: "clock",
+    },
+    requestOptions
+  );
+
+  return apiClient.listSchedules(options, $requestOptions);
 }
 
 /**

--- a/references/v3-catalog/src/handleError.ts
+++ b/references/v3-catalog/src/handleError.ts
@@ -1,5 +1,9 @@
 import { logger, type HandleErrorFunction } from "@trigger.dev/sdk/v3";
 
-export const handleError: HandleErrorFunction = async (payload, error, { ctx, retry }) => {
-  logger.log("handling error", { error });
+export const handleError: HandleErrorFunction = async (
+  payload,
+  error,
+  { ctx, retry, retryAt, retryDelayInMs }
+) => {
+  logger.log("handling error", { error, retry, retryAt, retryDelayInMs });
 };

--- a/references/v3-catalog/src/trigger/idempotencyKeys.ts
+++ b/references/v3-catalog/src/trigger/idempotencyKeys.ts
@@ -1,4 +1,5 @@
-import { logger, task, wait } from "@trigger.dev/sdk/v3";
+import { AbortTaskRunError } from "@trigger.dev/core/v3";
+import { idempotencyKeys, logger, task, wait } from "@trigger.dev/sdk/v3";
 
 export const idempotencyKeyParent = task({
   id: "idempotency-key-parent",
@@ -11,7 +12,7 @@ export const idempotencyKeyParent = task({
         forceError: true,
       },
       {
-        idempotencyKey: payload.key,
+        idempotencyKey: await idempotencyKeys.create(payload.key),
       }
     );
 
@@ -33,10 +34,10 @@ export const idempotencyKeyChild = task({
   run: async (payload: { forceError: boolean; key: string }) => {
     console.log("Hello from idempotency-key-child", payload.key);
 
-    await wait.for({ seconds: 5 });
+    await wait.for({ seconds: 2 });
 
     if (payload.forceError) {
-      throw new Error("This is a forced error in idempotency-key-child");
+      throw new AbortTaskRunError("This is a forced error in idempotency-key-child");
     }
 
     return payload;
@@ -49,16 +50,18 @@ export const idempotencyKeyBatchParent = task({
     console.log("Hello from idempotency-key-batch-parent");
 
     const childTaskResponse = await idempotencyKeyBatchChild.batchTriggerAndWait(
-      Array.from({ length: payload.itemCount }).map((_, index) => ({
-        payload: {
-          key: `${payload.keyPrefix}-${index}`,
-          forceError: index % 2 === 0,
-          waitSeconds: 5 * index,
-        },
-        options: {
-          idempotencyKey: `${payload.keyPrefix}-${index}`,
-        },
-      }))
+      await Promise.all(
+        Array.from({ length: payload.itemCount }).map(async (_, index) => ({
+          payload: {
+            key: `${payload.keyPrefix}-${index}`,
+            forceError: index % 2 === 0,
+            waitSeconds: 5 * index,
+          },
+          options: {
+            idempotencyKey: await idempotencyKeys.create([payload.keyPrefix, String(index)]),
+          },
+        }))
+      )
     );
 
     return {
@@ -80,5 +83,43 @@ export const idempotencyKeyBatchChild = task({
     }
 
     return payload;
+  },
+});
+
+export const idempotencyKeyParentUsage = task({
+  id: "idempotency-key-parent-usage",
+  run: async (payload: any, { ctx }) => {
+    console.log(`Hello from idempotency-key-parent-usage, attempt #${ctx.attempt.number}`);
+
+    const idempotencyKey = await idempotencyKeys.create("💚");
+
+    console.log(`Generated idempotency key: ${idempotencyKey}`);
+
+    const childTaskResponse = await idempotencyKeyChild.triggerAndWait(
+      {
+        key: idempotencyKey,
+        forceError: true,
+      },
+      {
+        idempotencyKey,
+      }
+    );
+
+    if (childTaskResponse.ok) {
+      logger.log("Child task response", { output: childTaskResponse.output });
+    } else {
+      logger.error("Child task error", { error: childTaskResponse.error });
+
+      if (ctx.attempt.number > 1) {
+        throw new AbortTaskRunError("Child task failed on retry, exiting parent task");
+      } else {
+        throw new Error("Child task failed");
+      }
+    }
+
+    return {
+      key: payload.key,
+      childTaskResponse,
+    };
   },
 });

--- a/references/v3-catalog/src/trigger/retries.ts
+++ b/references/v3-catalog/src/trigger/retries.ts
@@ -1,6 +1,8 @@
-import { logger, retry, task, wait } from "@trigger.dev/sdk/v3";
+import { logger, retry, runs, task, wait } from "@trigger.dev/sdk/v3";
 import { cache } from "./utils/cache";
 import { interceptor } from "./utils/interceptor";
+import { join } from "node:path";
+import { mkdir, writeFile } from "node:fs/promises";
 
 export const taskWithRetries = task({
   id: "task-with-retries",
@@ -131,3 +133,128 @@ export const taskWithFetchRetries = task({
     };
   },
 });
+
+export const taskWithRateLimitRetries = task({
+  id: "task-with-rate-limit-retries",
+  retry: {
+    maxAttempts: 5,
+    minTimeoutInMs: 500,
+    maxTimeoutInMs: 30_000,
+    factor: 1.8,
+  },
+  run: async (payload: { runId: string }, { ctx }) => {
+    for (let i = 0; i < 100; i++) {
+      const { response } = await runs.retrieve(payload.runId).withResponse();
+
+      const limit = response.headers.get("x-ratelimit-limit");
+      const remaining = response.headers.get("x-ratelimit-remaining");
+      const reset = response.headers.get("x-ratelimit-reset");
+
+      console.log(
+        `Rate limit: ${remaining}/${limit} remaining. Reset at ${new Date(
+          parseInt(reset!, 10)
+        ).toISOString()}`
+      );
+
+      if (remaining === "0") {
+        // break out of the loop
+        break;
+      }
+    }
+
+    console.log("Rate limit almost breached, triggering child task to test rate limit.");
+
+    // Now we want to trigger a subtask to test the rate limit
+    await childTaskWithRateLimitRetries.trigger({ runId: payload.runId });
+  },
+});
+
+export const childTaskWithRateLimitRetries = task({
+  id: "child-task-with-rate-limit-retries",
+  run: async (payload: { runId: string }, { ctx }) => {
+    return runs.retrieve(payload.runId);
+  },
+});
+
+export const taskRetriesAfterRateLimitError = task({
+  id: "task-retries-after-rate-limit-error",
+  retry: {
+    maxAttempts: 5,
+    minTimeoutInMs: 500,
+    maxTimeoutInMs: 30_000,
+    factor: 1.8,
+  },
+  run: async (payload: { runId: string }, { ctx }) => {
+    for (let i = 0; i < 100; i++) {
+      const { response } = await runs.retrieve(payload.runId).withResponse();
+
+      const limit = response.headers.get("x-ratelimit-limit");
+      const remaining = response.headers.get("x-ratelimit-remaining");
+      const reset = response.headers.get("x-ratelimit-reset");
+
+      console.log(
+        `Rate limit: ${remaining}/${limit} remaining. Reset at ${new Date(
+          parseInt(reset!, 10)
+        ).toISOString()}`
+      );
+
+      if (remaining === "0") {
+        // break out of the loop
+        break;
+      }
+    }
+
+    console.log("Rate limit almost breached, triggering child task to test rate limit.");
+
+    // Now we are going to cause a rate limit error to test the retry mechanism
+    await runs.retrieve(payload.runId, {
+      retry: {
+        maxAttempts: 1,
+      },
+    });
+  },
+});
+
+export const spamRateLimiter = task({
+  id: "spam-rate-limiter",
+  retry: {
+    maxAttempts: 5,
+    minTimeoutInMs: 500,
+    maxTimeoutInMs: 30_000,
+    factor: 1.8,
+  },
+  run: async (payload: { runId: string }, { ctx }) => {
+    const requestStats = {
+      total: 0,
+    };
+
+    while (requestStats.total < 100) {
+      const { response } = await runs.retrieve(payload.runId).withResponse();
+
+      const remaining = response.headers.get("x-ratelimit-remaining");
+
+      await logRequest("runs/spam-run-test-3", ctx.run.id, remaining!);
+
+      requestStats.total++;
+    }
+
+    return requestStats;
+  },
+});
+
+// Write out a log entry for the request
+async function logRequest(dir: string, file: string, remaining: string, ts: Date = new Date()) {
+  const log = {
+    ts,
+    remaining,
+  };
+
+  const $dir = join(process.cwd(), dir);
+
+  // Create the dir if it doesn't exist
+  await mkdir($dir, { recursive: true });
+
+  // Make sure to swap '/path/to/request/logs/' with an actual directory path
+  const filePath = join($dir, `${file}-${log.ts.toISOString()}.json`);
+  await writeFile(filePath, JSON.stringify(log, null, 2));
+}

--- a/references/v3-catalog/src/trigger/sdkUsage.ts
+++ b/references/v3-catalog/src/trigger/sdkUsage.ts
@@ -1,0 +1,128 @@
+import { task, tasks, runs, logger, schedules, envvars } from "@trigger.dev/sdk/v3";
+
+export const sdkUsage = task({
+  id: "sdk-usage",
+  run: async (payload: any, { ctx }) => {
+    const $runs = await runs.list({
+      limit: 10,
+      status: "COMPLETED",
+    });
+
+    const $firstRun = await runs.retrieve($runs.data[0].id);
+
+    const handle = await tasks.trigger<typeof sdkChild>("sdk-child", {
+      run: $firstRun,
+    });
+
+    await tasks.triggerAndPoll<typeof sdkChild>("sdk-child", {
+      handle,
+    });
+
+    const replayedRun = await runs.replay($firstRun.id);
+
+    await runs.cancel(replayedRun.id);
+
+    const delayed = await tasks.trigger<typeof sdkChild>(
+      "sdk-child",
+      {
+        delay: "1h",
+      },
+      {
+        delay: "1h",
+      }
+    );
+
+    await runs.reschedule(delayed.id, {
+      delay: "1m",
+    });
+
+    for await (const run of runs.list({
+      limit: 10,
+      period: "1d",
+    })) {
+      logger.log(run.id, { run });
+    }
+
+    const batchHandle = await sdkChild.batchTrigger([
+      {
+        payload: {},
+      },
+    ]);
+
+    const waitResult = await sdkChild.triggerAndWait({
+      payload: {},
+    });
+
+    await sdkChild.batchTriggerAndWait([
+      {
+        payload: {},
+      },
+    ]);
+
+    await tasks.batchTrigger<typeof sdkChild>("sdk-child", [
+      {
+        payload: {},
+      },
+    ]);
+
+    const schedule = await schedules.create({
+      cron: "0 0 * * *", // every day at midnight
+      deduplicationKey: ctx.run.id,
+      externalId: ctx.run.id,
+      task: "sdk-schedule",
+    });
+
+    await schedules.retrieve(schedule.id);
+
+    await schedules.del(schedule.id);
+
+    await envvars.upload({
+      variables: {
+        INSIDE_RUN: "true",
+      },
+      override: true,
+    });
+
+    await envvars.list({
+      retry: {
+        maxAttempts: 3,
+      },
+    });
+
+    await envvars.create(
+      {
+        name: "INSIDE_RUN_2",
+        value: "true",
+      },
+      {
+        retry: {
+          maxAttempts: 3,
+        },
+      }
+    );
+
+    await envvars.retrieve("INSIDE_RUN_2");
+
+    await envvars.update(
+      "INSIDE_RUN_2",
+      {
+        value: "false",
+      },
+      {
+        retry: {
+          maxAttempts: 3,
+        },
+      }
+    );
+  },
+});
+
+export const sdkChild = task({
+  id: "sdk-child",
+  run: async (payload: any) => {},
+});
+
+export const sdkSchedule = schedules.task({
+  id: "sdk-schedule",
+  run: async (payload: any) => {},
+});


### PR DESCRIPTION
- When cancelling a task that has in progress or queued subtasks (using `triggerAndWait` or `batchTriggerAndWait`), those subtasks will now also be cancelled (and any of their subtasks). Tasks triggered with `trigger` or `batchTrigger` will not be cancelled.
- Changing from sliding window to token bucket in the API rate limiter, to help smooth out traffic
- Adding spans to the API Client core & SDK functions
- Added waiting spans when retrying in the API Client
- Retrying in the API Client now respects the x-ratelimit-reset
- Retrying ApiError’s in tasks now respects the x-ratelimit-reset
- Added AbortTaskRunError that when thrown will stop retries
- Added idempotency keys SDK functions and automatically injecting the run ID when inside a task
- Added the ability to configure ApiRequestOptions (retries only for now) globally and on specific calls
- Implement the maxAttempts TaskRunOption (it wasn’t doing anything before)