### PR TITLE
v3: fix websocket timeouts

### DIFF
--- a/.changeset/curly-monkeys-tell.md
+++ b/.changeset/curly-monkeys-tell.md
@@ -1,0 +1,6 @@
+---
+"trigger.dev": patch
+"@trigger.dev/core": patch
+---
+
+Add ping/pong mechanism initiated by dev CLI to keep TCP connections alive

--- a/.changeset/curly-monkeys-tell.md
+++ b/.changeset/curly-monkeys-tell.md
@@ -3,4 +3,5 @@
 "@trigger.dev/core": patch
 ---
 
-Add ping/pong mechanism initiated by dev CLI to keep TCP connections alive
+- Prevent uncaught exceptions when handling WebSocket messages
+- Improve CLI dev command WebSocket debug and error logging

--- a/apps/webapp/app/v3/authenticatedSocketConnection.server.ts
+++ b/apps/webapp/app/v3/authenticatedSocketConnection.server.ts
@@ -91,6 +91,13 @@ export class AuthenticatedSocketConnection {
             }
           }
         },
+        PING: async () => {
+          logger.debug("[AuthenticatedSocketConnection] Received ping", {
+            id: this.id,
+            envId: this.authenticatedEnv.id,
+          });
+          await this._sender.send("PONG", {});
+        },
       },
     });
   }

--- a/apps/webapp/app/v3/authenticatedSocketConnection.server.ts
+++ b/apps/webapp/app/v3/authenticatedSocketConnection.server.ts
@@ -126,13 +126,6 @@ export class AuthenticatedSocketConnection {
             }
           }
         },
-        PING: async () => {
-          logger.debug("[AuthenticatedSocketConnection] Received ping", {
-            id: this.id,
-            envId: this.authenticatedEnv.id,
-          });
-          await this._sender.send("PONG", {});
-        },
       },
     });
   }

--- a/apps/webapp/app/v3/authenticatedSocketConnection.server.ts
+++ b/apps/webapp/app/v3/authenticatedSocketConnection.server.ts
@@ -84,6 +84,7 @@ export class AuthenticatedSocketConnection {
         ws.ping();
       },
     });
+    this._pingService.start();
 
     this._messageHandler = new ZodMessageHandler({
       schema: clientWebsocketMessages,

--- a/apps/webapp/app/v3/services/heartbeatService.server.ts
+++ b/apps/webapp/app/v3/services/heartbeatService.server.ts
@@ -1,0 +1,49 @@
+type HeartbeatServiceOptions = {
+  heartbeat: () => Promise<void>;
+  pingIntervalInMs?: number;
+  leadingEdge?: boolean;
+};
+
+export class HeartbeatService {
+  private _heartbeat: () => Promise<void>;
+  private _heartbeatIntervalInMs: number;
+  private _nextHeartbeat: NodeJS.Timeout | undefined;
+  private _leadingEdge: boolean;
+
+  constructor(opts: HeartbeatServiceOptions) {
+    this._heartbeat = opts.heartbeat;
+    this._heartbeatIntervalInMs = opts.pingIntervalInMs ?? 45_000;
+    this._nextHeartbeat = undefined;
+    this._leadingEdge = opts.leadingEdge ?? false;
+  }
+
+  start() {
+    if (this._leadingEdge) {
+      this.#doHeartbeat();
+    } else {
+      this.#scheduleNextHeartbeat();
+    }
+  }
+
+  stop() {
+    this.#clearNextHeartbeat();
+  }
+
+  #doHeartbeat = async () => {
+    this.#clearNextHeartbeat();
+
+    await this._heartbeat();
+
+    this.#scheduleNextHeartbeat();
+  };
+
+  #clearNextHeartbeat() {
+    if (this._nextHeartbeat) {
+      clearTimeout(this._nextHeartbeat);
+    }
+  }
+
+  #scheduleNextHeartbeat() {
+    this._nextHeartbeat = setTimeout(this.#doHeartbeat, this._heartbeatIntervalInMs);
+  }
+}

--- a/apps/webapp/app/v3/sharedSocketConnection.ts
+++ b/apps/webapp/app/v3/sharedSocketConnection.ts
@@ -96,6 +96,7 @@ export class SharedSocketConnection {
 
     this._messageHandler = new ZodMessageHandler({
       schema: clientWebsocketMessages,
+      logger,
       messages: {
         READY_FOR_TASKS: async (payload) => {
           this._sharedQueueConsumerPool.start();

--- a/apps/webapp/app/v3/utils/zodPubSub.server.ts
+++ b/apps/webapp/app/v3/utils/zodPubSub.server.ts
@@ -39,6 +39,7 @@ class RedisZodSubscriber<TMessageCatalog extends ZodMessageCatalogSchema>
     this._subscriber = new Redis(_options.redis);
     this._messageHandler = new ZodMessageHandler({
       schema: _options.schema,
+      logger: this._logger,
     });
   }
 
@@ -76,20 +77,26 @@ class RedisZodSubscriber<TMessageCatalog extends ZodMessageCatalogSchema>
 
     const message = this._messageHandler.parseMessage(parsedMessage);
 
-    if (typeof message.type !== "string") {
+    if (!message.success) {
+      this._logger.error(`Failed to parse message: ${message.error}`, { parsedMessage });
       return;
     }
 
-    const listener = this._listeners.get(message.type);
+    if (typeof message.data.type !== "string") {
+      this._logger.error(`Failed to parse message: invalid type`, { parsedMessage });
+      return;
+    }
+
+    const listener = this._listeners.get(message.data.type);
 
     if (!listener) {
-      this._logger.debug(`No listener for message type: ${message.type}`, { parsedMessage });
+      this._logger.debug(`No listener for message type: ${message.data.type}`, { parsedMessage });
 
       return;
     }
 
     try {
-      await listener(message.payload);
+      await listener(message.data.payload);
     } catch (error) {
       this._logger.error("Error handling message", { error, message });
     }

--- a/packages/cli-v3/src/commands/dev.tsx
+++ b/packages/cli-v3/src/commands/dev.tsx
@@ -293,9 +293,18 @@ function useDev({
       `${dashboardUrl}/projects/v3/${config.project}`
     );
 
-    websocket.addEventListener("open", async (event) => {});
-    websocket.addEventListener("close", (event) => {});
-    websocket.addEventListener("error", (event) => {});
+    websocket.addEventListener("open", async (event) => {
+      logger.debug("WebSocket opened", { event });
+    });
+
+    websocket.addEventListener("close", (event) => {
+      logger.debug("WebSocket closed", { event });
+    });
+
+    websocket.addEventListener("error", (event) => {
+      logger.log(`${chalkError("WebSocketError:")} ${event.error.message}`);
+      logger.debug("WebSocket error", { event, rawError: event.error });
+    });
 
     // This is the deprecated task heart beat that uses the friendly attempt ID
     // It will only be used if the worker does not support lazy attempts

--- a/packages/cli-v3/src/commands/dev.tsx
+++ b/packages/cli-v3/src/commands/dev.tsx
@@ -371,31 +371,42 @@ function useDev({
     });
 
     websocket.addEventListener("message", async (event) => {
-      const data = JSON.parse(
-        typeof event.data === "string" ? event.data : new TextDecoder("utf-8").decode(event.data)
-      );
+      try {
+        const data = JSON.parse(
+          typeof event.data === "string" ? event.data : new TextDecoder("utf-8").decode(event.data)
+        );
 
-      const messageHandler = new ZodMessageHandler({
-        schema: serverWebsocketMessages,
-        messages: {
-          SERVER_READY: async (payload) => {
-            for (const worker of backgroundWorkerCoordinator.currentWorkers) {
-              await sender.send("READY_FOR_TASKS", {
-                backgroundWorkerId: worker.id,
-                inProgressRuns: worker.worker.inProgressRuns,
-              });
-            }
+        const messageHandler = new ZodMessageHandler({
+          schema: serverWebsocketMessages,
+          messages: {
+            SERVER_READY: async (payload) => {
+              for (const worker of backgroundWorkerCoordinator.currentWorkers) {
+                await sender.send("READY_FOR_TASKS", {
+                  backgroundWorkerId: worker.id,
+                  inProgressRuns: worker.worker.inProgressRuns,
+                });
+              }
+            },
+            BACKGROUND_WORKER_MESSAGE: async (payload) => {
+              await backgroundWorkerCoordinator.handleMessage(
+                payload.backgroundWorkerId,
+                payload.data
+              );
+            },
           },
-          BACKGROUND_WORKER_MESSAGE: async (payload) => {
-            await backgroundWorkerCoordinator.handleMessage(
-              payload.backgroundWorkerId,
-              payload.data
-            );
-          },
-        },
-      });
+        });
 
-      await messageHandler.handleMessage(data);
+        await messageHandler.handleMessage(data);
+      } catch (error) {
+        if (error instanceof Error) {
+          logger.error("Error while handling websocket message", { error: error.message });
+        } else {
+          logger.error(
+            "Unkown error while handling websocket message, use `-l debug` for additional output"
+          );
+          logger.debug("Error while handling websocket message", { error });
+        }
+      }
     });
 
     let ctx: BuildContext | undefined;

--- a/packages/cli-v3/src/commands/dev.tsx
+++ b/packages/cli-v3/src/commands/dev.tsx
@@ -293,65 +293,9 @@ function useDev({
       `${dashboardUrl}/projects/v3/${config.project}`
     );
 
-    const messageHandler = new ZodMessageHandler({
-      schema: serverWebsocketMessages,
-      messages: {
-        SERVER_READY: async (payload) => {
-          for (const worker of backgroundWorkerCoordinator.currentWorkers) {
-            await sender.send("READY_FOR_TASKS", {
-              backgroundWorkerId: worker.id,
-              inProgressRuns: worker.worker.inProgressRuns,
-            });
-          }
-        },
-        BACKGROUND_WORKER_MESSAGE: async (payload) => {
-          await backgroundWorkerCoordinator.handleMessage(payload.backgroundWorkerId, payload.data);
-        },
-        PONG: async () => {
-          logger.debug("Received pong", { timestamp: Date.now() });
-        },
-      },
-    });
-
-    websocket.addEventListener("message", async (event) => {
-      const data = JSON.parse(
-        typeof event.data === "string" ? event.data : new TextDecoder("utf-8").decode(event.data)
-      );
-
-      await messageHandler.handleMessage(data);
-    });
-
-    const ping = new WebsocketPing({
-      callback: async () => {
-        if (websocket.readyState !== WebSocket.OPEN) {
-          logger.debug("Websocket not open, skipping ping");
-          return;
-        }
-
-        logger.debug("Sending ping", { timestamp: Date.now() });
-
-        await sender.send("PING", {});
-      },
-    });
-
-    websocket.addEventListener("open", async (event) => {
-      logger.debug("Websocket opened", { event });
-
-      ping.start();
-    });
-
-    websocket.addEventListener("close", (event) => {
-      logger.debug("Websocket closed", { event });
-
-      ping.stop();
-    });
-
-    websocket.addEventListener("error", (event) => {
-      logger.log(`${chalkError("Websocket Error:")} ${event.error.message}`);
-      logger.debug("Websocket error", { event, rawError: event.error });
-
-      ping.stop();
-    });
+    websocket.addEventListener("open", async (event) => {});
+    websocket.addEventListener("close", (event) => {});
+    websocket.addEventListener("error", (event) => {});
 
     // This is the deprecated task heart beat that uses the friendly attempt ID
     // It will only be used if the worker does not support lazy attempts
@@ -415,6 +359,34 @@ function useDev({
       await sender.send("BACKGROUND_WORKER_DEPRECATED", {
         backgroundWorkerId: id,
       });
+    });
+
+    websocket.addEventListener("message", async (event) => {
+      const data = JSON.parse(
+        typeof event.data === "string" ? event.data : new TextDecoder("utf-8").decode(event.data)
+      );
+
+      const messageHandler = new ZodMessageHandler({
+        schema: serverWebsocketMessages,
+        messages: {
+          SERVER_READY: async (payload) => {
+            for (const worker of backgroundWorkerCoordinator.currentWorkers) {
+              await sender.send("READY_FOR_TASKS", {
+                backgroundWorkerId: worker.id,
+                inProgressRuns: worker.worker.inProgressRuns,
+              });
+            }
+          },
+          BACKGROUND_WORKER_MESSAGE: async (payload) => {
+            await backgroundWorkerCoordinator.handleMessage(
+              payload.backgroundWorkerId,
+              payload.data
+            );
+          },
+        },
+      });
+
+      await messageHandler.handleMessage(data);
     });
 
     let ctx: BuildContext | undefined;
@@ -998,36 +970,5 @@ function createResolveEnvironmentVariablesFunction(configModule?: any) {
     }
 
     return resolvedEnvVars;
-  };
-}
-
-type WebsocketPingOptions = {
-  callback: () => Promise<void>;
-  pingIntervalInMs?: number;
-};
-
-class WebsocketPing {
-  private _callback: () => Promise<void>;
-  private _pingIntervalInMs: number;
-  private _nextPingIteration: NodeJS.Timeout | undefined;
-
-  constructor(opts: WebsocketPingOptions) {
-    this._callback = opts.callback;
-    this._pingIntervalInMs = opts.pingIntervalInMs ?? 45_000;
-    this._nextPingIteration = undefined;
-  }
-
-  start() {
-    this.#sendPing();
-  }
-
-  stop() {
-    clearTimeout(this._nextPingIteration);
-  }
-
-  #sendPing = async () => {
-    await this._callback();
-
-    this._nextPingIteration = setTimeout(this.#sendPing, this._pingIntervalInMs);
   };
 }

--- a/packages/core/src/v3/schemas/messages.ts
+++ b/packages/core/src/v3/schemas/messages.ts
@@ -57,6 +57,9 @@ export const serverWebsocketMessages = {
     backgroundWorkerId: z.string(),
     data: BackgroundWorkerServerMessages,
   }),
+  PONG: z.object({
+    version: z.literal("v1").default("v1"),
+  }),
 };
 
 export const BackgroundWorkerClientMessages = z.discriminatedUnion("type", [
@@ -107,6 +110,9 @@ export const clientWebsocketMessages = {
     version: z.literal("v1").default("v1"),
     backgroundWorkerId: z.string(),
     data: BackgroundWorkerClientMessages,
+  }),
+  PING: z.object({
+    version: z.literal("v1").default("v1"),
   }),
 };
 

--- a/packages/core/src/v3/schemas/messages.ts
+++ b/packages/core/src/v3/schemas/messages.ts
@@ -57,9 +57,6 @@ export const serverWebsocketMessages = {
     backgroundWorkerId: z.string(),
     data: BackgroundWorkerServerMessages,
   }),
-  PONG: z.object({
-    version: z.literal("v1").default("v1"),
-  }),
 };
 
 export const BackgroundWorkerClientMessages = z.discriminatedUnion("type", [
@@ -110,9 +107,6 @@ export const clientWebsocketMessages = {
     version: z.literal("v1").default("v1"),
     backgroundWorkerId: z.string(),
     data: BackgroundWorkerClientMessages,
-  }),
-  PING: z.object({
-    version: z.literal("v1").default("v1"),
   }),
 };
 

--- a/packages/core/src/v3/schemas/messages.ts
+++ b/packages/core/src/v3/schemas/messages.ts
@@ -627,6 +627,11 @@ export const ClientToSharedQueueMessages = {
       data: BackgroundWorkerClientMessages,
     }),
   },
+  PING: {
+    message: z.object({
+      version: z.literal("v1").default("v1"),
+    }),
+  },
 };
 
 export const SharedQueueToClientMessages = {

--- a/packages/core/src/v3/zodMessageHandler.ts
+++ b/packages/core/src/v3/zodMessageHandler.ts
@@ -25,6 +25,7 @@ export type ZodMessageHandlers<TCatalogSchema extends ZodMessageCatalogSchema> =
 export type ZodMessageHandlerOptions<TMessageCatalog extends ZodMessageCatalogSchema> = {
   schema: TMessageCatalog;
   messages?: ZodMessageHandlers<TMessageCatalog>;
+  logger?: StructuredLogger;
 };
 
 export type MessageFromSchema<
@@ -52,53 +53,107 @@ export interface EventEmitterLike {
 export class ZodMessageHandler<TMessageCatalog extends ZodMessageCatalogSchema> {
   #schema: TMessageCatalog;
   #handlers: ZodMessageHandlers<TMessageCatalog> | undefined;
+  #logger: StructuredLogger | Console;
 
   constructor(options: ZodMessageHandlerOptions<TMessageCatalog>) {
     this.#schema = options.schema;
     this.#handlers = options.messages;
+    this.#logger = options.logger ?? console;
   }
 
-  public async handleMessage(message: unknown) {
+  public async handleMessage(message: unknown): Promise<
+    | {
+        success: true;
+        data: unknown;
+      }
+    | {
+        success: false;
+        error: string;
+      }
+  > {
     const parsedMessage = this.parseMessage(message);
 
-    if (!this.#handlers) {
-      throw new Error("No handlers provided");
+    if (!parsedMessage.success) {
+      this.#logger.error(parsedMessage.error, { message });
+
+      return {
+        success: false,
+        error: parsedMessage.error,
+      };
     }
 
-    const handler = this.#handlers[parsedMessage.type];
+    if (!this.#handlers) {
+      this.#logger.error("No handlers provided", { message });
+
+      return {
+        success: false,
+        error: "No handlers provided",
+      };
+    }
+
+    const handler = this.#handlers[parsedMessage.data.type];
 
     if (!handler) {
-      console.error(`No handler for message type: ${String(parsedMessage.type)}`);
-      return;
+      const error = `No handler for message type: ${String(parsedMessage.data.type)}`;
+
+      this.#logger.error(error, { message });
+
+      return {
+        success: false,
+        error,
+      };
     }
 
-    const ack = await handler(parsedMessage.payload);
+    const ack = await handler(parsedMessage.data.payload);
 
-    return ack;
+    return {
+      success: true,
+      data: ack,
+    };
   }
 
-  public parseMessage(message: unknown): MessageFromCatalog<TMessageCatalog> {
+  public parseMessage(message: unknown):
+    | {
+        success: true;
+        data: MessageFromCatalog<TMessageCatalog>;
+      }
+    | {
+        success: false;
+        error: string;
+      } {
     const parsedMessage = ZodMessageSchema.safeParse(message);
 
     if (!parsedMessage.success) {
-      throw new Error(`Failed to parse message: ${JSON.stringify(parsedMessage.error)}`);
+      return {
+        success: false,
+        error: `Failed to parse message: ${JSON.stringify(parsedMessage.error)}`,
+      };
     }
 
     const schema = this.#schema[parsedMessage.data.type];
 
     if (!schema) {
-      throw new Error(`Unknown message type: ${parsedMessage.data.type}`);
+      return {
+        success: false,
+        error: `Unknown message type: ${parsedMessage.data.type}`,
+      };
     }
 
     const parsedPayload = schema.safeParse(parsedMessage.data.payload);
 
     if (!parsedPayload.success) {
-      throw new Error(`Failed to parse message payload: ${JSON.stringify(parsedPayload.error)}`);
+      return {
+        success: false,
+        error: `Failed to parse message payload: ${JSON.stringify(parsedPayload.error)}`,
+      };
     }
 
     return {
-      type: parsedMessage.data.type,
-      payload: parsedPayload.data,
+      success: true,
+      data: {
+        type: parsedMessage.data.type,
+        payload: parsedPayload.data,
+      },
     };
   }
 
@@ -117,7 +172,7 @@ export class ZodMessageHandler<TMessageCatalog extends ZodMessageCatalogSchema> 
           hasCallback: !!callback,
         });
 
-        let ack;
+        let ack: Awaited<ReturnType<ZodMessageHandler<TMessageCatalog>["handleMessage"]>>;
 
         // FIXME: this only works if the message doesn't have genuine payload prop
         if ("payload" in message) {
@@ -129,7 +184,13 @@ export class ZodMessageHandler<TMessageCatalog extends ZodMessageCatalogSchema> 
         }
 
         if (callback && typeof callback === "function") {
-          callback(ack);
+          if (!ack.success) {
+            // We don't know the callback type, so we can't do anything else - not all callbacks may accept a success prop
+            log.error("Failed to handle message, skipping callback", { message, error: ack.error });
+            return;
+          }
+
+          callback(ack.data);
         }
       });
     }


### PR DESCRIPTION
WebSockets could previously time out when no messages were sent for a period of 60s. This is due to load balancer connection timeouts. The only real fix here was to add a ping / pong mechanism that will keep connections alive during periods of rest, e.g. when waiting within or between attempts.

Pings will be automatically sent from the server every 45s. Clients will reply with pongs, but we just log those for now.

Whenever a dev CLI disconnects it will also cancel all in-progress dev runs. This shouldn't happen anymore.

This fix also prevents uncaught exceptions related to schema parsing.