### PR TITLE
Declarative schedules

### DIFF
--- a/.changeset/thirty-hotels-raise.md
+++ b/.changeset/thirty-hotels-raise.md
@@ -1,0 +1,6 @@
+---
+"@trigger.dev/sdk": patch
+"@trigger.dev/core": patch
+---
+
+Added declarative cron schedules

--- a/apps/webapp/app/components/runs/v3/ScheduleFilters.tsx
+++ b/apps/webapp/app/components/runs/v3/ScheduleFilters.tsx
@@ -29,7 +29,7 @@ export const ScheduleListFilters = z.object({
     .string()
     .optional()
     .transform((value) => (value ? value.split(",") : undefined)),
-  type: z.union([z.literal("static"), z.literal("dynamic")]).optional(),
+  type: z.union([z.literal("declarative"), z.literal("imperative")]).optional(),
   search: z.string().optional(),
 });
 
@@ -117,11 +117,11 @@ export function ScheduleFilters({ possibleEnvironments, possibleTasks }: Schedul
                 All types
               </Paragraph>
             </SelectItem>
-            <SelectItem value={"static"}>
-              <ScheduleTypeCombo type="STATIC" className="text-xs text-text-dimmed" />
+            <SelectItem value={"declarative"}>
+              <ScheduleTypeCombo type="DECLARATIVE" className="text-xs text-text-dimmed" />
             </SelectItem>
-            <SelectItem value={"dynamic"}>
-              <ScheduleTypeCombo type="DYNAMIC" className="text-xs text-text-dimmed" />
+            <SelectItem value={"imperative"}>
+              <ScheduleTypeCombo type="IMPERATIVE" className="text-xs text-text-dimmed" />
             </SelectItem>
           </SelectContent>
         </Select>

--- a/apps/webapp/app/components/runs/v3/ScheduleFilters.tsx
+++ b/apps/webapp/app/components/runs/v3/ScheduleFilters.tsx
@@ -1,6 +1,6 @@
 import { XMarkIcon } from "@heroicons/react/20/solid";
 import { useNavigate } from "@remix-run/react";
-import { RuntimeEnvironment } from "@trigger.dev/database";
+import { type RuntimeEnvironment } from "@trigger.dev/database";
 import { useCallback } from "react";
 import { z } from "zod";
 import { Input } from "~/components/primitives/Input";
@@ -17,6 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../../primitives/SimpleSelect";
+import { ScheduleTypeCombo } from "./ScheduleType";
 
 export const ScheduleListFilters = z.object({
   page: z.coerce.number().default(1),
@@ -28,6 +29,7 @@ export const ScheduleListFilters = z.object({
     .string()
     .optional()
     .transform((value) => (value ? value.split(",") : undefined)),
+  type: z.union([z.literal("static"), z.literal("dynamic")]).optional(),
   search: z.string().optional(),
 });
 
@@ -48,7 +50,7 @@ export function ScheduleFilters({ possibleEnvironments, possibleTasks }: Schedul
   const navigate = useNavigate();
   const location = useOptimisticLocation();
   const searchParams = new URLSearchParams(location.search);
-  const { environments, tasks, page, search } = ScheduleListFilters.parse(
+  const { environments, tasks, page, search, type } = ScheduleListFilters.parse(
     Object.fromEntries(searchParams.entries())
   );
 
@@ -71,6 +73,10 @@ export function ScheduleFilters({ possibleEnvironments, possibleTasks }: Schedul
 
   const handleEnvironmentChange = useCallback((value: string | typeof All) => {
     handleFilterChange("environments", value === "ALL" ? undefined : value);
+  }, []);
+
+  const handleTypeChange = useCallback((value: string | typeof All) => {
+    handleFilterChange("type", value === "ALL" ? undefined : value);
   }, []);
 
   const handleSearchChange = useThrottle((value: string) => {
@@ -97,6 +103,30 @@ export function ScheduleFilters({ possibleEnvironments, possibleTasks }: Schedul
         defaultValue={search}
         onChange={(e) => handleSearchChange(e.target.value)}
       />
+      <SelectGroup>
+        <Select name="type" value={type ?? "ALL"} onValueChange={handleTypeChange}>
+          <SelectTrigger size="minimal" width="full">
+            <SelectValue placeholder={"Select type"} className="ml-2 whitespace-nowrap p-0" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={"ALL"}>
+              <Paragraph
+                variant="extra-small"
+                className="whitespace-nowrap pl-0.5 transition group-hover:text-text-bright"
+              >
+                All types
+              </Paragraph>
+            </SelectItem>
+            <SelectItem value={"static"}>
+              <ScheduleTypeCombo type="STATIC" className="text-xs text-text-dimmed" />
+            </SelectItem>
+            <SelectItem value={"dynamic"}>
+              <ScheduleTypeCombo type="DYNAMIC" className="text-xs text-text-dimmed" />
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </SelectGroup>
+
       <SelectGroup>
         <Select
           name="environment"

--- a/apps/webapp/app/components/runs/v3/ScheduleType.tsx
+++ b/apps/webapp/app/components/runs/v3/ScheduleType.tsx
@@ -11,12 +11,12 @@ export function ScheduleTypeCombo({ type, className }: { type: ScheduleType; cla
   );
 }
 
-export function ScheduleTypeIcon({ type }: { type: ScheduleType }) {
+export function ScheduleTypeIcon({ type, className }: { type: ScheduleType; className?: string }) {
   switch (type) {
     case "IMPERATIVE":
-      return <ArrowsRightLeftIcon className="size-4" />;
+      return <ArrowsRightLeftIcon className={cn("size-4", className)} />;
     case "DECLARATIVE":
-      return <ArchiveBoxIcon className="size-4" />;
+      return <ArchiveBoxIcon className={cn("size-4", className)} />;
   }
 }
 export function scheduleTypeName(type: ScheduleType) {

--- a/apps/webapp/app/components/runs/v3/ScheduleType.tsx
+++ b/apps/webapp/app/components/runs/v3/ScheduleType.tsx
@@ -1,0 +1,29 @@
+import { ArchiveBoxIcon, ArrowsRightLeftIcon } from "@heroicons/react/20/solid";
+import type { ScheduleType } from "@trigger.dev/database";
+import { cn } from "~/utils/cn";
+
+export function ScheduleTypeCombo({ type, className }: { type: ScheduleType; className?: string }) {
+  return (
+    <div className={cn("flex items-center space-x-1", className)}>
+      <ScheduleTypeIcon type={type} />
+      <span>{scheduleTypeName(type)}</span>
+    </div>
+  );
+}
+
+export function ScheduleTypeIcon({ type }: { type: ScheduleType }) {
+  switch (type) {
+    case "DYNAMIC":
+      return <ArrowsRightLeftIcon className="size-4" />;
+    case "STATIC":
+      return <ArchiveBoxIcon className="size-4" />;
+  }
+}
+export function scheduleTypeName(type: ScheduleType) {
+  switch (type) {
+    case "DYNAMIC":
+      return "Dynamic";
+    case "STATIC":
+      return "Static";
+  }
+}

--- a/apps/webapp/app/components/runs/v3/ScheduleType.tsx
+++ b/apps/webapp/app/components/runs/v3/ScheduleType.tsx
@@ -13,17 +13,17 @@ export function ScheduleTypeCombo({ type, className }: { type: ScheduleType; cla
 
 export function ScheduleTypeIcon({ type }: { type: ScheduleType }) {
   switch (type) {
-    case "DYNAMIC":
+    case "IMPERATIVE":
       return <ArrowsRightLeftIcon className="size-4" />;
-    case "STATIC":
+    case "DECLARATIVE":
       return <ArchiveBoxIcon className="size-4" />;
   }
 }
 export function scheduleTypeName(type: ScheduleType) {
   switch (type) {
-    case "DYNAMIC":
-      return "Dynamic";
-    case "STATIC":
-      return "Static";
+    case "IMPERATIVE":
+      return "Imperative";
+    case "DECLARATIVE":
+      return "Declarative";
   }
 }

--- a/apps/webapp/app/components/runs/v3/TaskRunsTable.tsx
+++ b/apps/webapp/app/components/runs/v3/TaskRunsTable.tsx
@@ -230,8 +230,12 @@ export function TaskRunsTable({
                       formatDuration(new Date(run.createdAt), new Date(run.startedAt), {
                         style: "short",
                       })
-                    ) : (
+                    ) : run.isCancellable ? (
                       <LiveTimer startTime={new Date(run.createdAt)} />
+                    ) : (
+                      formatDuration(new Date(run.createdAt), new Date(run.updatedAt), {
+                        style: "short",
+                      })
                     )}
                   </div>
                 </TableCell>

--- a/apps/webapp/app/presenters/v3/EditSchedulePresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/EditSchedulePresenter.server.ts
@@ -88,6 +88,7 @@ export class EditSchedulePresenter {
     const schedule = await this.#prismaClient.taskSchedule.findFirst({
       select: {
         id: true,
+        type: true,
         friendlyId: true,
         generatorExpression: true,
         externalId: true,

--- a/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
@@ -1,4 +1,4 @@
-import { Prisma, RuntimeEnvironmentType } from "@trigger.dev/database";
+import { Prisma, RuntimeEnvironmentType, ScheduleType } from "@trigger.dev/database";
 import { ScheduleListFilters } from "~/components/runs/v3/ScheduleFilters";
 import { sqlDatabaseSchema } from "~/db.server";
 import { displayableEnvironment } from "~/models/runtimeEnvironment.server";
@@ -16,6 +16,7 @@ const DEFAULT_PAGE_SIZE = 20;
 
 export type ScheduleListItem = {
   id: string;
+  type: ScheduleType;
   friendlyId: string;
   taskIdentifier: string;
   deduplicationKey: string | null;
@@ -141,6 +142,7 @@ export class ScheduleListPresenter extends BasePresenter {
     const rawSchedules = await this._replica.taskSchedule.findMany({
       select: {
         id: true,
+        type: true,
         friendlyId: true,
         taskIdentifier: true,
         deduplicationKey: true,
@@ -215,11 +217,12 @@ export class ScheduleListPresenter extends BasePresenter {
     ON t."scheduleId" = r."scheduleId" AND t."createdAt" = r."LatestRun";`
         : [];
 
-    const schedules = rawSchedules.map((schedule) => {
+    const schedules: ScheduleListItem[] = rawSchedules.map((schedule) => {
       const latestRun = latestRuns.find((r) => r.scheduleId === schedule.id);
 
       return {
         id: schedule.id,
+        type: schedule.type,
         friendlyId: schedule.friendlyId,
         taskIdentifier: schedule.taskIdentifier,
         deduplicationKey: schedule.deduplicationKey,

--- a/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
@@ -54,7 +54,8 @@ export class ScheduleListPresenter extends BasePresenter {
       environments !== undefined ||
       (search !== undefined && search !== "");
 
-    const filterType = type === "static" ? "STATIC" : type === "dynamic" ? "DYNAMIC" : undefined;
+    const filterType =
+      type === "declarative" ? "DECLARATIVE" : type === "imperative" ? "IMPERATIVE" : undefined;
 
     // Find the project scoped to the organization
     const project = await this._replica.project.findFirstOrThrow({

--- a/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
@@ -45,10 +45,16 @@ export class ScheduleListPresenter extends BasePresenter {
     environments,
     search,
     page,
+    type,
     pageSize = DEFAULT_PAGE_SIZE,
   }: ScheduleListOptions) {
     const hasFilters =
-      tasks !== undefined || environments !== undefined || (search !== undefined && search !== "");
+      type !== undefined ||
+      tasks !== undefined ||
+      environments !== undefined ||
+      (search !== undefined && search !== "");
+
+    const filterType = type === "static" ? "STATIC" : type === "dynamic" ? "DYNAMIC" : undefined;
 
     // Find the project scoped to the organization
     const project = await this._replica.project.findFirstOrThrow({
@@ -106,6 +112,7 @@ export class ScheduleListPresenter extends BasePresenter {
             environmentId: environments ? { in: environments } : undefined,
           },
         },
+        type: filterType,
         AND: search
           ? {
               OR: [
@@ -168,6 +175,7 @@ export class ScheduleListPresenter extends BasePresenter {
               },
             }
           : undefined,
+        type: filterType,
         AND: search
           ? {
               OR: [

--- a/apps/webapp/app/presenters/v3/ViewSchedulePresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ViewSchedulePresenter.server.ts
@@ -21,6 +21,7 @@ export class ViewSchedulePresenter {
     const schedule = await this.#prismaClient.taskSchedule.findFirst({
       select: {
         id: true,
+        type: true,
         friendlyId: true,
         generatorExpression: true,
         generatorDescription: true,

--- a/apps/webapp/app/presenters/v3/ViewSchedulePresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ViewSchedulePresenter.server.ts
@@ -100,6 +100,7 @@ export class ViewSchedulePresenter {
   public toJSONResponse(result: NonNullable<Awaited<ReturnType<ViewSchedulePresenter["call"]>>>) {
     const response: ScheduleObject = {
       id: result.schedule.friendlyId,
+      type: result.schedule.type,
       task: result.schedule.taskIdentifier,
       active: result.schedule.active,
       nextRun: result.schedule.nextRuns[0],

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules.$scheduleParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules.$scheduleParam/route.tsx
@@ -311,7 +311,7 @@ export default function Page() {
             </div>
             {!isImperative && (
               <InfoPanel
-                title="Editing static schedules"
+                title="Editing declarative schedules"
                 icon={BookOpenIcon}
                 iconClassName="text-indigo-500"
                 variant="info"
@@ -319,8 +319,8 @@ export default function Page() {
                 to="https://trigger.dev/docs/v3/tasks-scheduled"
                 panelClassName="max-w-full"
               >
-                You can only edit a static schedule by updating your schedules.task and then running
-                the CLI dev and deploy commands.
+                You can only edit a declarative schedule by updating your schedules.task and then
+                running the CLI dev and deploy commands.
               </InfoPanel>
             )}
           </div>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules.$scheduleParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules.$scheduleParam/route.tsx
@@ -204,13 +204,13 @@ export default function Page() {
 
   const isUtc = schedule.timezone === "UTC";
 
-  const isDynamic = schedule.type === "DYNAMIC";
+  const isImperative = schedule.type === "IMPERATIVE";
 
   return (
     <div
       className={cn(
         "grid h-full max-h-full overflow-hidden bg-background-bright",
-        isDynamic ? "grid-rows-[2.5rem_1fr_3.25rem]" : "grid-rows-[2.5rem_1fr]"
+        isImperative ? "grid-rows-[2.5rem_1fr_3.25rem]" : "grid-rows-[2.5rem_1fr]"
       )}
     >
       <div className="mx-3 flex items-center justify-between gap-2 border-b border-grid-dimmed">
@@ -241,7 +241,7 @@ export default function Page() {
               <Property label="Environments">
                 <EnvironmentLabels size="small" environments={schedule.environments} />
               </Property>
-              {isDynamic && (
+              {isImperative && (
                 <>
                   <Property label="External ID">
                     {schedule.externalId ? schedule.externalId : "–"}
@@ -309,7 +309,7 @@ export default function Page() {
                 </TableBody>
               </Table>
             </div>
-            {!isDynamic && (
+            {!isImperative && (
               <InfoPanel
                 title="Editing static schedules"
                 icon={BookOpenIcon}
@@ -326,7 +326,7 @@ export default function Page() {
           </div>
         </div>
       </div>
-      {isDynamic && (
+      {isImperative && (
         <div className="flex items-center justify-between gap-2 border-t border-grid-dimmed px-2">
           <div className="flex items-center gap-4">
             <Form method="post">

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules.edit.$scheduleParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules.edit.$scheduleParam/route.tsx
@@ -17,7 +17,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     friendlyId: scheduleParam,
   });
 
-  if (result.schedule?.type === "STATIC") {
+  if (result.schedule?.type === "DECLARATIVE") {
     throw redirect(v3SchedulesPath({ slug: organizationSlug }, { slug: projectParam }));
   }
 

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules.edit.$scheduleParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules.edit.$scheduleParam/route.tsx
@@ -1,8 +1,8 @@
-import { LoaderFunctionArgs } from "@remix-run/server-runtime";
+import { LoaderFunctionArgs, redirect } from "@remix-run/server-runtime";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { EditSchedulePresenter } from "~/presenters/v3/EditSchedulePresenter.server";
 import { requireUserId } from "~/services/session.server";
-import { ProjectParamSchema, v3ScheduleParams } from "~/utils/pathBuilder";
+import { ProjectParamSchema, v3ScheduleParams, v3SchedulesPath } from "~/utils/pathBuilder";
 import { humanToCronSupported } from "~/v3/humanToCron.server";
 import { UpsertScheduleForm } from "../resources.orgs.$organizationSlug.projects.$projectParam.schedules.new/route";
 
@@ -16,6 +16,10 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     projectSlug: projectParam,
     friendlyId: scheduleParam,
   });
+
+  if (result.schedule?.type === "STATIC") {
+    throw redirect(v3SchedulesPath({ slug: organizationSlug }, { slug: projectParam }));
+  }
 
   return typedjson({ ...result, showGenerateField: humanToCronSupported });
 };

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules/route.tsx
@@ -10,6 +10,7 @@ import { EnvironmentLabels } from "~/components/environments/EnvironmentLabel";
 import { MainCenteredContainer, PageBody, PageContainer } from "~/components/layout/AppLayout";
 import { Button, LinkButton } from "~/components/primitives/Buttons";
 import { DateTime } from "~/components/primitives/DateTime";
+import { ScheduleTypeCombo } from "~/components/runs/v3/ScheduleType";
 import {
   Dialog,
   DialogContent,
@@ -334,6 +335,51 @@ function SchedulesTable({
         <TableRow>
           <TableHeaderCell>ID</TableHeaderCell>
           <TableHeaderCell>Task ID</TableHeaderCell>
+          <TableHeaderCell
+            tooltip={
+              <div className="flex max-w-xs flex-col gap-4 p-1">
+                <div>
+                  <div className="mb-0.5 flex items-center gap-1.5 text-sm">
+                    <ScheduleTypeCombo type="STATIC" />
+                  </div>
+                  <Paragraph variant="small" className="!text-wrap text-text-dimmed" spacing>
+                    Static schedules are defined in a{" "}
+                    <InlineCode variant="extra-small">schedules.task</InlineCode> with the{" "}
+                    <InlineCode variant="extra-small">cron</InlineCode>
+                    property.
+                  </Paragraph>
+                  <Paragraph variant="small" className="!text-wrap text-text-dimmed">
+                    They sync when you update your{" "}
+                    <InlineCode variant="extra-small">schedules.task</InlineCode> definition and run
+                    the CLI dev or deploy commands.
+                  </Paragraph>
+                </div>
+                <div>
+                  <div className="mb-0.5 flex items-center gap-1.5 text-sm">
+                    <ScheduleTypeCombo type="DYNAMIC" />
+                  </div>
+                  <Paragraph variant="small" className="!text-wrap text-text-dimmed" spacing>
+                    Dynamic schedules are defined here in the dashboard or by using the SDK
+                    functions to create or delete them.
+                  </Paragraph>
+                  <Paragraph variant="small" className="!text-wrap text-text-dimmed">
+                    They can be created, updated, disabled, and deleted from the dashboard or using
+                    the SDK.
+                  </Paragraph>
+                </div>
+                <div>
+                  <LinkButton
+                    variant="tertiary/medium"
+                    to="https://trigger.dev/docs/v3/tasks-scheduled"
+                  >
+                    View the docs
+                  </LinkButton>
+                </div>
+              </div>
+            }
+          >
+            Type
+          </TableHeaderCell>
           <TableHeaderCell>External ID</TableHeaderCell>
           <TableHeaderCell>CRON</TableHeaderCell>
           <TableHeaderCell hiddenLabel>CRON description</TableHeaderCell>
@@ -362,7 +408,14 @@ function SchedulesTable({
                   {schedule.taskIdentifier}
                 </TableCell>
                 <TableCell to={path} className={cellClass}>
-                  {schedule.externalId ? schedule.externalId : "–"}
+                  <ScheduleTypeCombo type={schedule.type} />
+                </TableCell>
+                <TableCell to={path} className={cellClass}>
+                  {schedule.type === "DYNAMIC"
+                    ? schedule.externalId
+                      ? schedule.externalId
+                      : "–"
+                    : "N/A"}
                 </TableCell>
                 <TableCell to={path} className={cellClass}>
                   {schedule.cron}
@@ -384,13 +437,21 @@ function SchedulesTable({
                   )}
                 </TableCell>
                 <TableCell to={path} className={cellClass}>
-                  {schedule.userProvidedDeduplicationKey ? schedule.deduplicationKey : "–"}
+                  {schedule.type === "DYNAMIC"
+                    ? schedule.userProvidedDeduplicationKey
+                      ? schedule.deduplicationKey
+                      : "–"
+                    : "N/A"}
                 </TableCell>
                 <TableCell to={path} className={cellClass}>
                   <EnvironmentLabels environments={schedule.environments} size="small" />
                 </TableCell>
                 <TableCell to={path}>
-                  <EnabledStatus enabled={schedule.active} />
+                  {schedule.type === "DYNAMIC" ? (
+                    <EnabledStatus enabled={schedule.active} />
+                  ) : (
+                    "N/A"
+                  )}
                 </TableCell>
               </TableRow>
             );

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules/route.tsx
@@ -340,10 +340,10 @@ function SchedulesTable({
               <div className="flex max-w-xs flex-col gap-4 p-1">
                 <div>
                   <div className="mb-0.5 flex items-center gap-1.5 text-sm">
-                    <ScheduleTypeCombo type="STATIC" />
+                    <ScheduleTypeCombo type="DECLARATIVE" />
                   </div>
                   <Paragraph variant="small" className="!text-wrap text-text-dimmed" spacing>
-                    Static schedules are defined in a{" "}
+                    Declarative schedules are defined in a{" "}
                     <InlineCode variant="extra-small">schedules.task</InlineCode> with the{" "}
                     <InlineCode variant="extra-small">cron</InlineCode>
                     property.
@@ -356,10 +356,10 @@ function SchedulesTable({
                 </div>
                 <div>
                   <div className="mb-0.5 flex items-center gap-1.5 text-sm">
-                    <ScheduleTypeCombo type="DYNAMIC" />
+                    <ScheduleTypeCombo type="IMPERATIVE" />
                   </div>
                   <Paragraph variant="small" className="!text-wrap text-text-dimmed" spacing>
-                    Dynamic schedules are defined here in the dashboard or by using the SDK
+                    Imperative schedules are defined here in the dashboard or by using the SDK
                     functions to create or delete them.
                   </Paragraph>
                   <Paragraph variant="small" className="!text-wrap text-text-dimmed">
@@ -411,7 +411,7 @@ function SchedulesTable({
                   <ScheduleTypeCombo type={schedule.type} />
                 </TableCell>
                 <TableCell to={path} className={cellClass}>
-                  {schedule.type === "DYNAMIC"
+                  {schedule.type === "IMPERATIVE"
                     ? schedule.externalId
                       ? schedule.externalId
                       : "–"
@@ -437,7 +437,7 @@ function SchedulesTable({
                   )}
                 </TableCell>
                 <TableCell to={path} className={cellClass}>
-                  {schedule.type === "DYNAMIC"
+                  {schedule.type === "IMPERATIVE"
                     ? schedule.userProvidedDeduplicationKey
                       ? schedule.deduplicationKey
                       : "–"
@@ -447,7 +447,7 @@ function SchedulesTable({
                   <EnvironmentLabels environments={schedule.environments} size="small" />
                 </TableCell>
                 <TableCell to={path}>
-                  {schedule.type === "DYNAMIC" ? (
+                  {schedule.type === "IMPERATIVE" ? (
                     <EnabledStatus enabled={schedule.active} />
                   ) : (
                     "N/A"

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules/route.tsx
@@ -10,7 +10,11 @@ import { EnvironmentLabels } from "~/components/environments/EnvironmentLabel";
 import { MainCenteredContainer, PageBody, PageContainer } from "~/components/layout/AppLayout";
 import { Button, LinkButton } from "~/components/primitives/Buttons";
 import { DateTime } from "~/components/primitives/DateTime";
-import { ScheduleTypeCombo } from "~/components/runs/v3/ScheduleType";
+import {
+  ScheduleTypeCombo,
+  ScheduleTypeIcon,
+  scheduleTypeName,
+} from "~/components/runs/v3/ScheduleType";
 import {
   Dialog,
   DialogContent,
@@ -340,31 +344,31 @@ function SchedulesTable({
               <div className="flex max-w-xs flex-col gap-4 p-1">
                 <div>
                   <div className="mb-0.5 flex items-center gap-1.5 text-sm">
-                    <ScheduleTypeCombo type="DECLARATIVE" />
+                    <div className={"flex items-center space-x-1"}>
+                      <ScheduleTypeIcon type={"DECLARATIVE"} className="text-sky-500" />
+                      <span className="font-medium">{scheduleTypeName("DECLARATIVE")}</span>
+                    </div>
                   </div>
-                  <Paragraph variant="small" className="!text-wrap text-text-dimmed" spacing>
+                  <Paragraph variant="small" className="!text-wrap text-text-dimmed">
                     Declarative schedules are defined in a{" "}
                     <InlineCode variant="extra-small">schedules.task</InlineCode> with the{" "}
                     <InlineCode variant="extra-small">cron</InlineCode>
-                    property.
-                  </Paragraph>
-                  <Paragraph variant="small" className="!text-wrap text-text-dimmed">
-                    They sync when you update your{" "}
+                    property. They sync when you update your{" "}
                     <InlineCode variant="extra-small">schedules.task</InlineCode> definition and run
                     the CLI dev or deploy commands.
                   </Paragraph>
                 </div>
                 <div>
                   <div className="mb-0.5 flex items-center gap-1.5 text-sm">
-                    <ScheduleTypeCombo type="IMPERATIVE" />
+                    <div className={"flex items-center space-x-1"}>
+                      <ScheduleTypeIcon type={"IMPERATIVE"} className="text-teal-500" />
+                      <span className="font-medium">{scheduleTypeName("IMPERATIVE")}</span>
+                    </div>
                   </div>
-                  <Paragraph variant="small" className="!text-wrap text-text-dimmed" spacing>
-                    Imperative schedules are defined here in the dashboard or by using the SDK
-                    functions to create or delete them.
-                  </Paragraph>
                   <Paragraph variant="small" className="!text-wrap text-text-dimmed">
-                    They can be created, updated, disabled, and deleted from the dashboard or using
-                    the SDK.
+                    Imperative schedules are defined here in the dashboard or by using the SDK
+                    functions to create or delete them. They can be created, updated, disabled, and
+                    deleted from the dashboard or using the SDK.
                   </Paragraph>
                 </div>
                 <div>

--- a/apps/webapp/app/routes/api.v1.schedules.$scheduleId.ts
+++ b/apps/webapp/app/routes/api.v1.schedules.$scheduleId.ts
@@ -88,6 +88,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
         const responseObject: ScheduleObject = {
           id: schedule.id,
+          type: schedule.type,
           task: schedule.task,
           active: schedule.active,
           generator: {

--- a/apps/webapp/app/routes/api.v1.schedules.ts
+++ b/apps/webapp/app/routes/api.v1.schedules.ts
@@ -50,6 +50,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
     const responseObject: ScheduleObject = {
       id: schedule.id,
+      type: schedule.type,
       task: schedule.task,
       active: schedule.active,
       generator: {

--- a/apps/webapp/app/routes/api.v1.schedules.ts
+++ b/apps/webapp/app/routes/api.v1.schedules.ts
@@ -107,6 +107,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   return {
     data: result.schedules.map((schedule) => ({
       id: schedule.friendlyId,
+      type: schedule.type,
       task: schedule.taskIdentifier,
       generator: {
         type: "CRON",

--- a/apps/webapp/app/v3/services/checkSchedule.server.ts
+++ b/apps/webapp/app/v3/services/checkSchedule.server.ts
@@ -1,0 +1,93 @@
+import { ZodError } from "zod";
+import { CronPattern } from "../schedules";
+import { BaseService, ServiceValidationError } from "./baseService.server";
+import { getLimit } from "~/services/platform.v3.server";
+import { getTimezones } from "~/utils/timezones.server";
+import { env } from "~/env.server";
+
+type Schedule = {
+  cron: string;
+  timezone?: string;
+  taskIdentifier: string;
+  friendlyId?: string;
+};
+
+export class CheckScheduleService extends BaseService {
+  public async call(projectId: string, schedule: Schedule) {
+    //validate the cron expression
+    try {
+      CronPattern.parse(schedule.cron);
+    } catch (e) {
+      if (e instanceof ZodError) {
+        throw new ServiceValidationError(`Invalid cron expression: ${e.issues[0].message}`);
+      }
+
+      throw new ServiceValidationError(
+        `Invalid cron expression: ${e instanceof Error ? e.message : JSON.stringify(e)}`
+      );
+    }
+
+    //chek it's a valid timezone
+    if (schedule.timezone) {
+      const possibleTimezones = getTimezones();
+      if (!possibleTimezones.includes(schedule.timezone)) {
+        throw new ServiceValidationError(
+          `Invalid IANA timezone: '${schedule.timezone}'. View the list of valid timezones at ${env.APP_ORIGIN}/timezones`
+        );
+      }
+    }
+
+    //check the task exists
+    const task = await this._prisma.backgroundWorkerTask.findFirst({
+      where: {
+        slug: schedule.taskIdentifier,
+        projectId: projectId,
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+
+    if (!task) {
+      throw new ServiceValidationError(
+        `Task with identifier ${schedule.taskIdentifier} not found in project.`
+      );
+    }
+
+    if (task.triggerSource !== "SCHEDULED") {
+      throw new ServiceValidationError(
+        `Task with identifier ${schedule.taskIdentifier} is not a scheduled task.`
+      );
+    }
+
+    //if creating a schedule, check they're under the limits
+    if (!schedule.friendlyId) {
+      //check they're within their limit
+      const project = await this._prisma.project.findFirst({
+        where: {
+          id: projectId,
+        },
+        select: {
+          organizationId: true,
+        },
+      });
+
+      if (!project) {
+        throw new ServiceValidationError("Project not found");
+      }
+
+      const limit = await getLimit(project.organizationId, "schedules", 500);
+      const schedulesCount = await this._prisma.taskSchedule.count({
+        where: {
+          projectId,
+        },
+      });
+
+      if (schedulesCount >= limit) {
+        throw new ServiceValidationError(
+          `You have created ${schedulesCount}/${limit} schedules so you'll need to increase your limits or delete some schedules. Increase your limits by contacting support.`
+        );
+      }
+    }
+  }
+}

--- a/apps/webapp/app/v3/services/checkSchedule.server.ts
+++ b/apps/webapp/app/v3/services/checkSchedule.server.ts
@@ -85,7 +85,7 @@ export class CheckScheduleService extends BaseService {
 
       if (schedulesCount >= limit) {
         throw new ServiceValidationError(
-          `You have created ${schedulesCount}/${limit} schedules so you'll need to increase your limits or delete some schedules. Increase your limits by contacting support.`
+          `You have created ${schedulesCount}/${limit} schedules so you'll need to increase your limits or delete some schedules.`
         );
       }
     }

--- a/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
@@ -224,11 +224,6 @@ export async function createBackgroundTasks(
   }
 }
 
-//todo syncStaticSchedules
-//1. update
-//2. create
-//delete
-// - get all static ones and see if any are missing
 export async function syncStaticSchedules(
   tasks: TaskResource[],
   worker: BackgroundWorker,

--- a/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
@@ -318,8 +318,25 @@ export async function syncStaticSchedules(
   });
 
   for (const schedule of potentiallyDeletableSchedules) {
-    const canDelete =
+    const canDeleteSchedule =
       schedule.instances.length === 0 ||
       schedule.instances.every((instance) => instance.environmentId === environment.id);
+
+    if (canDeleteSchedule) {
+      //we can delete schedules with no instances other than ones for the current environment
+      await prisma.taskSchedule.delete({
+        where: {
+          id: schedule.id,
+        },
+      });
+    } else {
+      //otherwise we delete the instance (other environments remain untouched)
+      await prisma.taskScheduleInstance.deleteMany({
+        where: {
+          taskScheduleId: schedule.id,
+          environmentId: environment.id,
+        },
+      });
+    }
   }
 }

--- a/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
@@ -284,7 +284,14 @@ export async function syncDeclarativeSchedules(
       });
 
       missingSchedules.delete(existingSchedule.id);
-      await registerNextService.call(schedule.instances[0].id);
+      const instance = schedule.instances.at(0);
+      if (instance) {
+        await registerNextService.call(instance.id);
+      } else {
+        logger.error("Missing instance for declarative schedule", {
+          schedule,
+        });
+      }
     } else {
       const newSchedule = await prisma.taskSchedule.create({
         data: {

--- a/apps/webapp/app/v3/services/createDeployedBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createDeployedBackgroundWorker.server.ts
@@ -3,7 +3,7 @@ import type { BackgroundWorker } from "@trigger.dev/database";
 import { AuthenticatedEnvironment } from "~/services/apiAuth.server";
 import { generateFriendlyId } from "../friendlyIdentifiers";
 import { BaseService } from "./baseService.server";
-import { createBackgroundTasks, syncStaticSchedules } from "./createBackgroundWorker.server";
+import { createBackgroundTasks, syncDeclarativeSchedules } from "./createBackgroundWorker.server";
 import { CURRENT_DEPLOYMENT_LABEL } from "~/consts";
 import { projectPubSub } from "./projectPubSub.server";
 import { marqs } from "~/v3/marqs/index.server";
@@ -51,7 +51,12 @@ export class CreateDeployedBackgroundWorkerService extends BaseService {
       });
 
       await createBackgroundTasks(body.metadata.tasks, backgroundWorker, environment, this._prisma);
-      await syncStaticSchedules(body.metadata.tasks, backgroundWorker, environment, this._prisma);
+      await syncDeclarativeSchedules(
+        body.metadata.tasks,
+        backgroundWorker,
+        environment,
+        this._prisma
+      );
 
       // Link the deployment with the background worker
       await this._prisma.workerDeployment.update({

--- a/apps/webapp/app/v3/services/createDeployedBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createDeployedBackgroundWorker.server.ts
@@ -3,7 +3,7 @@ import type { BackgroundWorker } from "@trigger.dev/database";
 import { AuthenticatedEnvironment } from "~/services/apiAuth.server";
 import { generateFriendlyId } from "../friendlyIdentifiers";
 import { BaseService } from "./baseService.server";
-import { createBackgroundTasks } from "./createBackgroundWorker.server";
+import { createBackgroundTasks, syncStaticSchedules } from "./createBackgroundWorker.server";
 import { CURRENT_DEPLOYMENT_LABEL } from "~/consts";
 import { projectPubSub } from "./projectPubSub.server";
 import { marqs } from "~/v3/marqs/index.server";
@@ -51,6 +51,7 @@ export class CreateDeployedBackgroundWorkerService extends BaseService {
       });
 
       await createBackgroundTasks(body.metadata.tasks, backgroundWorker, environment, this._prisma);
+      await syncStaticSchedules(body.metadata.tasks, backgroundWorker, environment, this._prisma);
 
       // Link the deployment with the background worker
       await this._prisma.workerDeployment.update({

--- a/apps/webapp/app/v3/services/createDeployedBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createDeployedBackgroundWorker.server.ts
@@ -64,6 +64,9 @@ export class CreateDeployedBackgroundWorkerService extends BaseService {
           this._prisma
         );
       } catch (error) {
+        const name = error instanceof Error ? error.name : "UnknownError";
+        const message = error instanceof Error ? error.message : JSON.stringify(error);
+
         await this._prisma.workerDeployment.update({
           where: {
             id: deployment.id,
@@ -71,7 +74,10 @@ export class CreateDeployedBackgroundWorkerService extends BaseService {
           data: {
             status: "FAILED",
             failedAt: new Date(),
-            errorData: error instanceof Error ? error.message : JSON.stringify(error),
+            errorData: {
+              name,
+              message,
+            },
           },
         });
 

--- a/apps/webapp/app/v3/services/deleteTaskSchedule.server.ts
+++ b/apps/webapp/app/v3/services/deleteTaskSchedule.server.ts
@@ -27,9 +27,24 @@ export class DeleteTaskScheduleService extends BaseService {
     }
 
     try {
+      const schedule = await this._prisma.taskSchedule.findFirst({
+        where: {
+          friendlyId,
+        },
+      });
+
+      if (!schedule) {
+        throw new Error("Schedule not found");
+      }
+
+      if (schedule.type === "STATIC") {
+        throw new Error("Cannot delete static schedules");
+      }
+
       await this._prisma.taskSchedule.delete({
         where: {
           friendlyId,
+          type: "DYNAMIC",
         },
       });
     } catch (e) {

--- a/apps/webapp/app/v3/services/deleteTaskSchedule.server.ts
+++ b/apps/webapp/app/v3/services/deleteTaskSchedule.server.ts
@@ -37,14 +37,13 @@ export class DeleteTaskScheduleService extends BaseService {
         throw new Error("Schedule not found");
       }
 
-      if (schedule.type === "STATIC") {
-        throw new Error("Cannot delete static schedules");
+      if (schedule.type === "DECLARATIVE") {
+        throw new Error("Cannot delete declarative schedules");
       }
 
       await this._prisma.taskSchedule.delete({
         where: {
           friendlyId,
-          type: "DYNAMIC",
         },
       });
     } catch (e) {

--- a/apps/webapp/app/v3/services/setActiveOnTaskSchedule.server.ts
+++ b/apps/webapp/app/v3/services/setActiveOnTaskSchedule.server.ts
@@ -38,8 +38,8 @@ export class SetActiveOnTaskScheduleService extends BaseService {
         throw new Error("Schedule not found");
       }
 
-      if (schedule.type === "STATIC") {
-        throw new Error("Cannot enable/disable static schedules");
+      if (schedule.type === "DECLARATIVE") {
+        throw new Error("Cannot enable/disable declarative schedules");
       }
 
       await this._prisma.taskSchedule.update({

--- a/apps/webapp/app/v3/services/setActiveOnTaskSchedule.server.ts
+++ b/apps/webapp/app/v3/services/setActiveOnTaskSchedule.server.ts
@@ -28,6 +28,20 @@ export class SetActiveOnTaskScheduleService extends BaseService {
     }
 
     try {
+      const schedule = await this._prisma.taskSchedule.findFirst({
+        where: {
+          friendlyId,
+        },
+      });
+
+      if (!schedule) {
+        throw new Error("Schedule not found");
+      }
+
+      if (schedule.type === "STATIC") {
+        throw new Error("Cannot enable/disable static schedules");
+      }
+
       await this._prisma.taskSchedule.update({
         where: {
           friendlyId,

--- a/apps/webapp/app/v3/services/testTask.server.ts
+++ b/apps/webapp/app/v3/services/testTask.server.ts
@@ -24,6 +24,7 @@ export class TestTaskService extends BaseService {
       case "SCHEDULED": {
         const payload = {
           scheduleId: "sched_1234",
+          type: "IMPERATIVE",
           timestamp: data.timestamp,
           lastTimestamp: data.lastTimestamp,
           timezone: data.timezone,

--- a/apps/webapp/app/v3/services/triggerScheduledTask.server.ts
+++ b/apps/webapp/app/v3/services/triggerScheduledTask.server.ts
@@ -94,6 +94,7 @@ export class TriggerScheduledTaskService extends BaseService {
 
         const payload = {
           scheduleId: instance.taskSchedule.friendlyId,
+          type: instance.taskSchedule.type,
           timestamp: instance.nextScheduledTimestamp,
           lastTimestamp: instance.lastScheduledTimestamp ?? undefined,
           externalId: instance.taskSchedule.externalId ?? undefined,

--- a/apps/webapp/app/v3/services/upsertTaskSchedule.server.ts
+++ b/apps/webapp/app/v3/services/upsertTaskSchedule.server.ts
@@ -126,6 +126,10 @@ export class UpsertTaskScheduleService extends BaseService {
           });
 
       if (existingSchedule) {
+        if (existingSchedule.type === "STATIC") {
+          throw new ServiceValidationError("Cannot update a static schedule");
+        }
+
         return await this.#updateExistingSchedule(tx, existingSchedule, schedule, projectId);
       } else {
         return await this.#createNewSchedule(tx, schedule, projectId, deduplicationKey);

--- a/apps/webapp/app/v3/services/upsertTaskSchedule.server.ts
+++ b/apps/webapp/app/v3/services/upsertTaskSchedule.server.ts
@@ -126,8 +126,8 @@ export class UpsertTaskScheduleService extends BaseService {
           });
 
       if (existingSchedule) {
-        if (existingSchedule.type === "STATIC") {
-          throw new ServiceValidationError("Cannot update a static schedule");
+        if (existingSchedule.type === "DECLARATIVE") {
+          throw new ServiceValidationError("Cannot update a declarative schedule");
         }
 
         return await this.#updateExistingSchedule(tx, existingSchedule, schedule, projectId);
@@ -321,6 +321,7 @@ export class UpsertTaskScheduleService extends BaseService {
   #createReturnObject(taskSchedule: TaskSchedule, instances: InstanceWithEnvironment[]) {
     return {
       id: taskSchedule.friendlyId,
+      type: taskSchedule.type,
       task: taskSchedule.taskIdentifier,
       active: taskSchedule.active,
       externalId: taskSchedule.externalId,

--- a/docs/v3-openapi.yaml
+++ b/docs/v3-openapi.yaml
@@ -16,7 +16,7 @@ paths:
     post:
       operationId: create_schedule_v1
       summary: Create a schedule
-      description: Create a new schedule based on the specified options.
+      description: Create a new `IMPERATIVE` schedule based on the specified options.
       requestBody:
         required: true
         content:
@@ -127,7 +127,7 @@ paths:
     put:
       operationId: update_schedule_v1
       summary: Update Schedule
-      description: Update a schedule by its ID.
+      description: Update a schedule by its ID. This will only work on `IMPERATIVE` schedules that were created in the dashboard or using the imperative SDK functions like `schedules.create()`.
       parameters:
         - in: path
           name: schedule_id
@@ -173,7 +173,7 @@ paths:
     delete:
       operationId: delete_schedule_v1
       summary: Delete Schedule
-      description: Delete a schedule by its ID.
+      description: Delete a schedule by its ID. This will only work on `IMPERATIVE` schedules that were created in the dashboard or using the imperative SDK functions like `schedules.create()`.
       parameters:
         - in: path
           name: schedule_id
@@ -203,7 +203,7 @@ paths:
     post:
       operationId: deactivate_schedule_v1
       summary: Deactivate Schedule.
-      description: Deactivate a schedule by its ID.
+      description: Deactivate a schedule by its ID. This will only work on `IMPERATIVE` schedules that were created in the dashboard or using the imperative SDK functions like `schedules.create()`.
       parameters:
         - in: path
           name: schedule_id
@@ -237,7 +237,7 @@ paths:
     post:
       operationId: activate_schedule_v1
       summary: Activate Schedule
-      description: Activate a schedule by its ID.
+      description: Activate a schedule by its ID. This will only work on `IMPERATIVE` schedules that were created in the dashboard or using the imperative SDK functions like `schedules.create()`.
       parameters:
         - in: path
           name: schedule_id
@@ -1971,6 +1971,10 @@ components:
           example: my-scheduled-task
           description: The id of the scheduled task that will be triggered by this
             schedule
+        "type":
+          type: string
+          example: IMPERATIVE
+          description: The type of schedule, `DECLARATIVE` or `IMPERATIVE`. Declarative schedules are declared in your code by setting the `cron` property on a `schedules.task`. Imperative schedules are created in the dashboard or by using the imperative SDK functions like `schedules.create()`.
         active:
           type: boolean
           example: true

--- a/docs/v3/tasks-scheduled.mdx
+++ b/docs/v3/tasks-scheduled.mdx
@@ -3,21 +3,13 @@ title: "Scheduled tasks"
 description: "A task that is triggered on a recurring schedule using CRON syntax."
 ---
 
-To use scheduled tasks you need to do two things:
-
-1. Define a task in your code using `schedules.task()`.
-2. Attach a schedule to the task either using the dashboard or the SDK.
-
-<Info>A task can have multiple schedules attached to it.</Info>
-
-Like all tasks they don't have timeouts, they should be placed inside a [/trigger folder](/v3/trigger-folder), and you [can configure them](/v3/tasks-overview#defining-a-task).
-
 ## Defining a scheduled task
+
+This task will run when any of the attached schedules trigger. They have a predefined payload with some useful properties:
 
 ```ts
 import { schedules } from "@trigger.dev/sdk/v3";
 
-//this task will run when any of the attached schedules trigger
 export const firstScheduledTask = schedules.task({
   id: "first-scheduled-task",
   run: async (payload) => {
@@ -67,6 +59,66 @@ You can see from the comments that the payload has several useful properties:
   This task will NOT get triggered on a schedule until you attach a schedule to it. Read on for how
   to do that.
 </Note>
+
+Like all tasks they don't have timeouts, they should be placed inside a [/trigger folder](/v3/trigger-folder), and you [can configure them](/v3/tasks-overview#defining-a-task).
+
+## How to attach a schedule
+
+Now that we've defined a scheduled task, we need to define when it will actually run. To do this we need to attach one or more schedules.
+
+There are two ways of doing this:
+
+- **Declarative:** defined on your `schedules.task`. They sync when you run the dev command or deploy.
+- **Imperative:** created from the dashboard or by using the imperative SDK functions like `schedules.create()`.
+
+<Info>
+  A scheduled task can have multiple schedules attached to it, including a declarative schedule
+  and/or many imperative schedules.
+</Info>
+
+### Declarative schedules
+
+These sync when you run the [dev](/v3/cli-dev) or [deploy](/v3/cli-deploy) commands.
+
+To create them you add the `cron` property to your `schedules.task()`. This property is optional and is only used if you want to add a declarative schedule to your task:
+
+```ts
+export const firstScheduledTask = schedules.task({
+  id: "first-scheduled-task",
+  //every two hours (UTC timezone)
+  cron: "0 */2 * * *",
+  run: async (payload, { ctx }) => {
+    //do something
+  },
+});
+```
+
+If you use a string it will be in UTC. Alternatively, you can specify a timezone like this:
+
+```ts
+export const secondScheduledTask = schedules.task({
+  id: "second-scheduled-task",
+  cron: {
+    //5am every day Tokyo time
+    pattern: "0 5 * * *",
+    timezone: "Asia/Tokyo",
+  },
+  run: async (payload) => {},
+});
+```
+
+When you run the [dev](/v3/cli-dev) or [deploy](/v3/cli-deploy) commands, declarative schedules will be synced. If you add, delete or edit the `cron` property it will be updated when you run these commands. You can view your schedules on the Schedules page in the dashboard.
+
+### Imperative schedules
+
+Alternatively you can explicitly attach schedules to a `schedules.task`. You can do this in the Schedules page in the dashboard by just pressing the "New schedule" button, or you can use the SDK to create schedules.
+
+The advantage of imperative schedules is that they can be created dynamically, for example, you could create a schedule for each user in your database. They can also be activated, disabled, edited, and deleted without deploying new code by using the SDK or dashboard.
+
+To use imperative schedules you need to do two things:
+
+1. Define a task in your code using `schedules.task()`.
+2. Attach 1+ schedules to the task either using the dashboard or the SDK.
 
 ## Supported CRON syntax
 

--- a/packages/core/src/v3/schemas/api.ts
+++ b/packages/core/src/v3/schemas/api.ts
@@ -226,10 +226,19 @@ export const CanceledRunResponse = z.object({
 
 export type CanceledRunResponse = z.infer<typeof CanceledRunResponse>;
 
+export const ScheduleType = z.union([z.literal("DECLARATIVE"), z.literal("IMPERATIVE")]);
+
 export const ScheduledTaskPayload = z.object({
   /** The schedule id associated with this run (you can have many schedules for the same task).
     You can use this to remove the schedule, update it, etc */
   scheduleId: z.string(),
+  /** The type of schedule – `"DECLARATIVE"` or `"IMPERATIVE"`.
+   *
+   * **DECLARATIVE** – defined inline on your `schedules.task` using the `cron` property. They can only be created, updated or deleted by modifying the `cron` property on your task.
+   *
+   * **IMPERATIVE** – created using the `schedules.create` functions or in the dashboard.
+   */
+  type: ScheduleType,
   /** When the task was scheduled to run.
    * Note this will be slightly different from `new Date()` because it takes a few ms to run the task.
    * 
@@ -315,6 +324,7 @@ export type ScheduleGenerator = z.infer<typeof ScheduleGenerator>;
 
 export const ScheduleObject = z.object({
   id: z.string(),
+  type: ScheduleType,
   task: z.string(),
   active: z.boolean(),
   deduplicationKey: z.string().nullish(),

--- a/packages/core/src/v3/schemas/resources.ts
+++ b/packages/core/src/v3/schemas/resources.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { QueueOptions, RetryOptions } from "./schemas";
+import { QueueOptions, RetryOptions, ScheduleMetadata } from "./schemas";
 import { MachineConfig } from "./common";
 
 export const TaskResource = z.object({
@@ -10,6 +10,7 @@ export const TaskResource = z.object({
   retry: RetryOptions.optional(),
   machine: MachineConfig.optional(),
   triggerSource: z.string().optional(),
+  schedule: ScheduleMetadata.optional(),
 });
 
 export type TaskResource = z.infer<typeof TaskResource>;

--- a/packages/core/src/v3/schemas/schemas.ts
+++ b/packages/core/src/v3/schemas/schemas.ts
@@ -142,6 +142,11 @@ export const QueueOptions = z.object({
 
 export type QueueOptions = z.infer<typeof QueueOptions>;
 
+export const ScheduleMetadata = z.object({
+  cron: z.string(),
+  timezone: z.string(),
+});
+
 export const TaskMetadata = z.object({
   id: z.string(),
   packageVersion: z.string(),
@@ -149,6 +154,7 @@ export const TaskMetadata = z.object({
   retry: RetryOptions.optional(),
   machine: MachineConfig.optional(),
   triggerSource: z.string().optional(),
+  schedule: ScheduleMetadata.optional(),
 });
 
 export type TaskMetadata = z.infer<typeof TaskMetadata>;
@@ -167,6 +173,7 @@ export const TaskMetadataWithFilePath = z.object({
   retry: RetryOptions.optional(),
   machine: MachineConfig.optional(),
   triggerSource: z.string().optional(),
+  schedule: ScheduleMetadata.optional(),
   filePath: z.string(),
   exportName: z.string(),
 });

--- a/packages/database/prisma/migrations/20240717101035_add_task_schedule_type_dynamic_and_static/migration.sql
+++ b/packages/database/prisma/migrations/20240717101035_add_task_schedule_type_dynamic_and_static/migration.sql
@@ -1,5 +1,6 @@
 -- CreateEnum
-CREATE TYPE "ScheduleType" AS ENUM ('STATIC', 'DYNAMIC');
+CREATE TYPE "ScheduleType" AS ENUM ('DECLARATIVE', 'IMPERATIVE');
 
 -- AlterTable
-ALTER TABLE "TaskSchedule" ADD COLUMN     "type" "ScheduleType" NOT NULL DEFAULT 'DYNAMIC';
+ALTER TABLE "TaskSchedule"
+ADD COLUMN "type" "ScheduleType" NOT NULL DEFAULT 'IMPERATIVE';

--- a/packages/database/prisma/migrations/20240717101035_add_task_schedule_type_dynamic_and_static/migration.sql
+++ b/packages/database/prisma/migrations/20240717101035_add_task_schedule_type_dynamic_and_static/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "ScheduleType" AS ENUM ('STATIC', 'DYNAMIC');
+
+-- AlterTable
+ALTER TABLE "TaskSchedule" ADD COLUMN     "type" "ScheduleType" NOT NULL DEFAULT 'DYNAMIC';

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2231,6 +2231,8 @@ model WorkerDeploymentPromotion {
 model TaskSchedule {
   id String @id @default(cuid())
 
+  type ScheduleType @default(DYNAMIC)
+
   ///users see this as `id`. They start with schedule_
   friendlyId     String @unique
   ///a reference to a task (not a foreign key because it's across versions)
@@ -2265,6 +2267,11 @@ model TaskSchedule {
   runs TaskRun[]
 
   @@unique([projectId, deduplicationKey])
+}
+
+enum ScheduleType {
+  STATIC
+  DYNAMIC
 }
 
 enum ScheduleGeneratorType {

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2231,7 +2231,7 @@ model WorkerDeploymentPromotion {
 model TaskSchedule {
   id String @id @default(cuid())
 
-  type ScheduleType @default(DYNAMIC)
+  type ScheduleType @default(IMPERATIVE)
 
   ///users see this as `id`. They start with schedule_
   friendlyId     String @unique
@@ -2270,8 +2270,10 @@ model TaskSchedule {
 }
 
 enum ScheduleType {
-  STATIC
-  DYNAMIC
+  /// defined on your task using the `cron` property
+  DECLARATIVE
+  /// explicit calls to the SDK are used to create, or using the dashboard
+  IMPERATIVE
 }
 
 enum ScheduleGeneratorType {

--- a/packages/trigger-sdk/src/v3/schedules/index.ts
+++ b/packages/trigger-sdk/src/v3/schedules/index.ts
@@ -16,13 +16,57 @@ import { Task, TaskOptions, apiClientMissingError, createTask } from "../shared"
 import * as SchedulesAPI from "./api";
 import { tracer } from "../tracer";
 
+export type ScheduleOptions<
+  TIdentifier extends string,
+  TOutput,
+  TInitOutput extends InitOutput,
+> = TaskOptions<TIdentifier, SchedulesAPI.ScheduledTaskPayload, TOutput, TInitOutput> & {
+  /** You can optionally specify a CRON schedule on your task. You can also dynamically add a schedule in the dashboard or using the SDK functions.
+   *
+   * 1. Pass a CRON pattern string
+   * ```ts
+   * "0 0 * * *"
+   * ```
+   *
+   * 2. Or an object with a pattern and an optional timezone (default is "UTC")
+   * ```ts
+   * {
+   *   pattern: "0 0 * * *",
+   *   timezone: "America/Los_Angeles"
+   * }
+   * ```
+   *
+   * @link https://trigger.dev/docs/v3/tasks-scheduled
+   */
+  cron?:
+    | string
+    | {
+        pattern: string;
+        timezone?: string;
+      };
+};
+
 export function task<TIdentifier extends string, TOutput, TInitOutput extends InitOutput>(
-  params: TaskOptions<TIdentifier, SchedulesAPI.ScheduledTaskPayload, TOutput, TInitOutput>
+  params: ScheduleOptions<TIdentifier, TOutput, TInitOutput>
 ): Task<TIdentifier, SchedulesAPI.ScheduledTaskPayload, TOutput> {
   const task = createTask(params);
 
+  const cron = params.cron
+    ? typeof params.cron === "string"
+      ? params.cron
+      : params.cron.pattern
+    : undefined;
+  const timezone =
+    (params.cron && typeof params.cron !== "string" ? params.cron.timezone : "UTC") ?? "UTC";
+
   taskCatalog.updateTaskMetadata(task.id, {
     triggerSource: "schedule",
+    schedule: cron
+      ? {
+          cron: cron,
+          timezone,
+        }
+      : undefined,
   });
 
   return task;

--- a/references/v3-catalog/src/trigger/scheduled.ts
+++ b/references/v3-catalog/src/trigger/scheduled.ts
@@ -22,7 +22,10 @@ export const firstScheduledTask = schedules.task({
 
 export const secondScheduledTask = schedules.task({
   id: "second-scheduled-task",
-  cron: "0 */3 * * *",
+  cron: {
+    pattern: "0 5 * * *",
+    timezone: "Asia/Tokyo",
+  },
   run: async (payload) => {},
 });
 

--- a/references/v3-catalog/src/trigger/scheduled.ts
+++ b/references/v3-catalog/src/trigger/scheduled.ts
@@ -2,6 +2,7 @@ import { logger, schedules, task } from "@trigger.dev/sdk/v3";
 
 export const firstScheduledTask = schedules.task({
   id: "first-scheduled-task",
+  cron: "* * * * *",
   run: async (payload) => {
     const distanceInMs =
       payload.timestamp.getTime() - (payload.lastTimestamp ?? new Date()).getTime();

--- a/references/v3-catalog/src/trigger/scheduled.ts
+++ b/references/v3-catalog/src/trigger/scheduled.ts
@@ -3,7 +3,7 @@ import { logger, schedules, task } from "@trigger.dev/sdk/v3";
 export const firstScheduledTask = schedules.task({
   id: "first-scheduled-task",
   //every other minute
-  cron: "*/4 * * * *",
+  cron: "*/6 * * * *",
   run: async (payload) => {
     const distanceInMs =
       payload.timestamp.getTime() - (payload.lastTimestamp ?? new Date()).getTime();
@@ -18,6 +18,12 @@ export const firstScheduledTask = schedules.task({
 
     logger.log(formatted);
   },
+});
+
+export const secondScheduledTask = schedules.task({
+  id: "second-scheduled-task",
+  cron: "0 */3 * * *",
+  run: async (payload) => {},
 });
 
 export const manageSchedules = task({

--- a/references/v3-catalog/src/trigger/scheduled.ts
+++ b/references/v3-catalog/src/trigger/scheduled.ts
@@ -2,7 +2,8 @@ import { logger, schedules, task } from "@trigger.dev/sdk/v3";
 
 export const firstScheduledTask = schedules.task({
   id: "first-scheduled-task",
-  cron: "* * * * *",
+  //every other minute
+  cron: "*/4 * * * *",
   run: async (payload) => {
     const distanceInMs =
       payload.timestamp.getTime() - (payload.lastTimestamp ?? new Date()).getTime();

--- a/references/v3-catalog/src/trigger/scheduled.ts
+++ b/references/v3-catalog/src/trigger/scheduled.ts
@@ -3,8 +3,8 @@ import { logger, schedules, task } from "@trigger.dev/sdk/v3";
 export const firstScheduledTask = schedules.task({
   id: "first-scheduled-task",
   //every other minute
-  cron: "*/6 * * * *",
-  run: async (payload) => {
+  cron: "0 */2 * * *",
+  run: async (payload, { ctx }) => {
     const distanceInMs =
       payload.timestamp.getTime() - (payload.lastTimestamp ?? new Date()).getTime();
 


### PR DESCRIPTION
This is for this roadmap feature: https://feedback.trigger.dev/p/static-cron-attached-to-tasks

We've called them "declarative" schedules as they're declared in your code on a task like this:

```ts
export const firstScheduledTask = schedules.task({
  id: "first-scheduled-task",
  //every two hours (UTC timezone)
  cron: "0 */2 * * *",
  run: async (payload, { ctx }) => {
    //do something
  },
});
```

Or you can specify a timezone if you don't want UTC:

```ts
export const secondScheduledTask = schedules.task({
  id: "second-scheduled-task",
  cron: {
    //5am every day Tokyo time
    pattern: "0 5 * * *",
    timezone: "Asia/Tokyo",
  },
  run: async (payload) => {},
});
```

These schedules are synced when you run the `dev` or `deploy` CLI commands. If you create, edit or delete the cron property it will be reflected when this sync happens.

You can't delete, disable or enable them using the other SDK functions that work with imperative schedules.