### PR TITLE
Deploy refactor resolve step

### DIFF
--- a/.changeset/purple-bikes-own.md
+++ b/.changeset/purple-bikes-own.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Stop using esbuild output metadata to build the bundle's package.json file.

--- a/.changeset/purple-bikes-own.md
+++ b/.changeset/purple-bikes-own.md
@@ -2,4 +2,4 @@
 "trigger.dev": patch
 ---
 
-Stop using esbuild output metadata to build the bundle's package.json file.
+Use only one call to dependencies listing commands in order to build the bundle's package.json file.

--- a/packages/cli-v3/e2e/compile.ts
+++ b/packages/cli-v3/e2e/compile.ts
@@ -214,6 +214,7 @@ export async function compile(options: CompileOptions) {
   await writeFile(join(tempDir, "index.js"), entryPointOutputFile.text);
 
   return {
+    directDependenciesMeta,
     workerMetaOutput: metaOutput,
     workerOutputFile,
     entryPointMetaOutput,

--- a/packages/cli-v3/e2e/handleDependencies.ts
+++ b/packages/cli-v3/e2e/handleDependencies.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import { log } from "@clack/prompts";
-import { Metafile } from "esbuild";
 import { join } from "node:path";
 
 import { SkipLoggingError } from "../src/cli/common.js";
@@ -20,8 +19,6 @@ import { DependencyMeta } from "../src/utilities/javascriptProject.js";
 
 type HandleDependenciesOptions = {
   directDependenciesMeta: Record<string, DependencyMeta>;
-  entryPointMetaOutput: Metafile["outputs"]["out/stdin.js"];
-  metaOutput: Metafile["outputs"]["out/stdin.js"];
   packageManager: PackageManager;
   resolvedConfig: ReadConfigResult;
   tempDir: string;
@@ -33,17 +30,10 @@ export async function handleDependencies(options: HandleDependenciesOptions) {
   }
   const {
     directDependenciesMeta,
-    entryPointMetaOutput,
-    metaOutput,
     packageManager,
     resolvedConfig: { config },
     tempDir,
   } = options;
-
-  logger.debug("Imports for the worker and entryPoint builds", {
-    workerImports: metaOutput.imports,
-    entryPointImports: entryPointMetaOutput.imports,
-  });
 
   const javascriptProject = new E2EJavascriptProject(config.projectDir, packageManager);
 

--- a/packages/cli-v3/e2e/handleDependencies.ts
+++ b/packages/cli-v3/e2e/handleDependencies.ts
@@ -16,8 +16,10 @@ import { PackageManager } from "../src/utilities/getUserPackageManager.js";
 import { logger } from "../src/utilities/logger.js";
 import { cliLink } from "../src/utilities/cliOutput.js";
 import { E2EJavascriptProject } from "./javascriptProject.js";
+import { DependencyMeta } from "../src/utilities/javascriptProject.js";
 
 type HandleDependenciesOptions = {
+  directDependenciesMeta: Record<string, DependencyMeta>;
   entryPointMetaOutput: Metafile["outputs"]["out/stdin.js"];
   metaOutput: Metafile["outputs"]["out/stdin.js"];
   packageManager: PackageManager;
@@ -30,6 +32,7 @@ export async function handleDependencies(options: HandleDependenciesOptions) {
     throw new Error("cannot resolve config");
   }
   const {
+    directDependenciesMeta,
     entryPointMetaOutput,
     metaOutput,
     packageManager,
@@ -37,17 +40,14 @@ export async function handleDependencies(options: HandleDependenciesOptions) {
     tempDir,
   } = options;
 
-  logger.debug("Getting the imports for the worker and entryPoint builds", {
+  logger.debug("Imports for the worker and entryPoint builds", {
     workerImports: metaOutput.imports,
     entryPointImports: entryPointMetaOutput.imports,
   });
 
-  // Get all the required dependencies from the metaOutputs and save them to /tmp/dir/package.json
-  const allImports = [...metaOutput.imports, ...entryPointMetaOutput.imports];
-
   const javascriptProject = new E2EJavascriptProject(config.projectDir, packageManager);
 
-  const dependencies = await resolveRequiredDependencies(allImports, config, javascriptProject);
+  const dependencies = await resolveRequiredDependencies(directDependenciesMeta, config);
 
   logger.debug("gatherRequiredDependencies()", { dependencies });
 

--- a/packages/cli-v3/e2e/index.test.ts
+++ b/packages/cli-v3/e2e/index.test.ts
@@ -18,7 +18,7 @@ import { createDeployHash } from "./createDeployHash";
 import { handleDependencies } from "./handleDependencies";
 import { E2EOptions, E2EOptionsSchema } from "./schemas";
 import { fixturesConfig, TestCase } from "./fixtures.config";
-import { OutputFile } from "esbuild";
+import { Metafile, OutputFile } from "esbuild";
 import { findUpMultiple } from "find-up";
 import { DependencyMeta } from "../src/utilities/javascriptProject";
 
@@ -164,8 +164,10 @@ if (testCases.length > 0) {
             ).resolves.not.toThrowError();
           }
 
+          let entryPointMetaOutput: Metafile["outputs"]["out/stdin.js"];
           let directDependenciesMeta: Record<string, DependencyMeta>;
           let entryPointOutputFile: OutputFile;
+          let workerMetaOutput: Metafile["outputs"]["out/stdin.js"];
           let workerOutputFile: OutputFile;
 
           const compileExpect = expect(
@@ -175,8 +177,10 @@ if (testCases.length > 0) {
                 resolvedConfig: resolvedConfig!,
                 tempDir,
               });
+              entryPointMetaOutput = compilationResult.entryPointMetaOutput;
               directDependenciesMeta = compilationResult.directDependenciesMeta;
               entryPointOutputFile = compilationResult.entryPointOutputFile;
+              workerMetaOutput = compilationResult.workerMetaOutput;
               workerOutputFile = compilationResult.workerOutputFile;
             })(),
             wantCompilationError ? "does not compile" : "compiles"
@@ -200,6 +204,8 @@ if (testCases.length > 0) {
           const depsExpectation = expect(
             (async () => {
               dependencies = await handleDependencies({
+                entryPointMetaOutput: entryPointMetaOutput!,
+                metaOutput: workerMetaOutput!,
                 directDependenciesMeta: directDependenciesMeta!,
                 resolvedConfig: resolvedConfig!,
                 tempDir,

--- a/packages/cli-v3/e2e/index.test.ts
+++ b/packages/cli-v3/e2e/index.test.ts
@@ -18,7 +18,7 @@ import { createDeployHash } from "./createDeployHash";
 import { handleDependencies } from "./handleDependencies";
 import { E2EOptions, E2EOptionsSchema } from "./schemas";
 import { fixturesConfig, TestCase } from "./fixtures.config";
-import { Metafile, OutputFile } from "esbuild";
+import { OutputFile } from "esbuild";
 import { findUpMultiple } from "find-up";
 import { DependencyMeta } from "../src/utilities/javascriptProject";
 
@@ -165,9 +165,7 @@ if (testCases.length > 0) {
           }
 
           let directDependenciesMeta: Record<string, DependencyMeta>;
-          let entryPointMetaOutput: Metafile["outputs"]["out/stdin.js"];
           let entryPointOutputFile: OutputFile;
-          let workerMetaOutput: Metafile["outputs"]["out/stdin.js"];
           let workerOutputFile: OutputFile;
 
           const compileExpect = expect(
@@ -178,9 +176,7 @@ if (testCases.length > 0) {
                 tempDir,
               });
               directDependenciesMeta = compilationResult.directDependenciesMeta;
-              entryPointMetaOutput = compilationResult.entryPointMetaOutput;
               entryPointOutputFile = compilationResult.entryPointOutputFile;
-              workerMetaOutput = compilationResult.workerMetaOutput;
               workerOutputFile = compilationResult.workerOutputFile;
             })(),
             wantCompilationError ? "does not compile" : "compiles"
@@ -205,8 +201,6 @@ if (testCases.length > 0) {
             (async () => {
               dependencies = await handleDependencies({
                 directDependenciesMeta: directDependenciesMeta!,
-                entryPointMetaOutput: entryPointMetaOutput!,
-                metaOutput: workerMetaOutput!,
                 resolvedConfig: resolvedConfig!,
                 tempDir,
                 packageManager,

--- a/packages/cli-v3/e2e/index.test.ts
+++ b/packages/cli-v3/e2e/index.test.ts
@@ -20,6 +20,7 @@ import { E2EOptions, E2EOptionsSchema } from "./schemas";
 import { fixturesConfig, TestCase } from "./fixtures.config";
 import { Metafile, OutputFile } from "esbuild";
 import { findUpMultiple } from "find-up";
+import { DependencyMeta } from "../src/utilities/javascriptProject";
 
 interface E2EFixtureTest extends TestCase {
   fixtureDir: string;
@@ -163,6 +164,7 @@ if (testCases.length > 0) {
             ).resolves.not.toThrowError();
           }
 
+          let directDependenciesMeta: Record<string, DependencyMeta>;
           let entryPointMetaOutput: Metafile["outputs"]["out/stdin.js"];
           let entryPointOutputFile: OutputFile;
           let workerMetaOutput: Metafile["outputs"]["out/stdin.js"];
@@ -175,6 +177,7 @@ if (testCases.length > 0) {
                 resolvedConfig: resolvedConfig!,
                 tempDir,
               });
+              directDependenciesMeta = compilationResult.directDependenciesMeta;
               entryPointMetaOutput = compilationResult.entryPointMetaOutput;
               entryPointOutputFile = compilationResult.entryPointOutputFile;
               workerMetaOutput = compilationResult.workerMetaOutput;
@@ -201,6 +204,7 @@ if (testCases.length > 0) {
           const depsExpectation = expect(
             (async () => {
               dependencies = await handleDependencies({
+                directDependenciesMeta: directDependenciesMeta!,
                 entryPointMetaOutput: entryPointMetaOutput!,
                 metaOutput: workerMetaOutput!,
                 resolvedConfig: resolvedConfig!,

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -56,7 +56,7 @@ import {
   parseBuildErrorStack,
   parseNpmInstallError,
 } from "../utilities/deployErrors";
-import { JavascriptProject } from "../utilities/javascriptProject";
+import { DependencyMeta, JavascriptProject } from "../utilities/javascriptProject";
 import { docs, getInTouch } from "../utilities/links";
 import { cliRootPath } from "../utilities/resolveInternalFilePath";
 import { safeJsonParse } from "../utilities/safeJsonParse";
@@ -1170,6 +1170,9 @@ async function compileProject(
         );
       }
 
+      const javascriptProject = new JavascriptProject(config.projectDir);
+      const directDependenciesMeta = await javascriptProject.extractDirectDependenciesMeta();
+
       const result = await build({
         stdin: {
           contents: workerContents,
@@ -1327,17 +1330,16 @@ async function compileProject(
       // Save the entryPoint outputFile to /tmp/dir/index.js
       await writeFile(join(tempDir, "index.js"), entryPointOutputFile.text);
 
-      logger.debug("Getting the imports for the worker and entryPoint builds", {
+      logger.debug("Imports for the worker and entryPoint builds", {
         workerImports: metaOutput.imports,
         entryPointImports: entryPointMetaOutput.imports,
       });
 
-      // Get all the required dependencies from the metaOutputs and save them to /tmp/dir/package.json
-      const allImports = [...metaOutput.imports, ...entryPointMetaOutput.imports];
-
-      const javascriptProject = new JavascriptProject(config.projectDir);
-
-      const dependencies = await resolveRequiredDependencies(allImports, config, javascriptProject);
+      const dependencies = await resolveRequiredDependencies(
+        directDependenciesMeta,
+        config,
+        javascriptProject
+      );
 
       logger.debug("gatherRequiredDependencies()", { dependencies });
 
@@ -1707,36 +1709,19 @@ export async function typecheckProject(config: ResolvedConfig) {
 // Returns the dependencies that are required by the output that are found in output and the CLI package dependencies
 // Returns the dependency names and the version to use (taken from the CLI deps package.json)
 export async function resolveRequiredDependencies(
-  imports: Metafile["outputs"][string]["imports"],
+  directDependenciesMeta: Record<string, DependencyMeta>,
   config: ResolvedConfig,
   project: JavascriptProject
 ) {
   return await tracer.startActiveSpan("resolveRequiredDependencies", async (span) => {
-    const resolvablePackageNames = new Set<string>();
+    span.setAttribute("resolvablePackageNames", Object.keys(directDependenciesMeta));
 
-    for (const file of imports) {
-      if ((file.kind !== "require-call" && file.kind !== "dynamic-import") || !file.external) {
-        continue;
-      }
-
-      const packageName = detectPackageNameFromImportPath(file.path);
-
-      if (!packageName) {
-        continue;
-      }
-
-      resolvablePackageNames.add(packageName);
-    }
-
-    span.setAttribute("resolvablePackageNames", Array.from(resolvablePackageNames));
-
-    const resolvedPackageVersions = await project.resolveAll(Array.from(resolvablePackageNames));
-    const missingPackages = Array.from(resolvablePackageNames).filter(
-      (packageName) => !resolvedPackageVersions[packageName]
-    );
+    const missingPackages = Object.entries(directDependenciesMeta)
+      .filter(([, pkgMeta]) => !pkgMeta.version)
+      .map(([name]) => name);
 
     span.setAttributes({
-      ...flattenAttributes(resolvedPackageVersions, "resolvedPackageVersions"),
+      ...flattenAttributes(directDependenciesMeta, "resolvedPackageVersions"),
     });
     span.setAttribute("missingPackages", missingPackages);
 
@@ -1752,8 +1737,8 @@ export async function resolveRequiredDependencies(
       }
     }
 
-    for (const [packageName, version] of Object.entries(resolvedPackageVersions)) {
-      dependencies[packageName] = version;
+    for (const [pkgName, { version }] of Object.entries(directDependenciesMeta)) {
+      dependencies[pkgName] = version;
     }
 
     if (config.additionalPackages) {

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -9,12 +9,12 @@ import {
 } from "@trigger.dev/core/v3";
 import { recordSpanException } from "@trigger.dev/core/v3/workers";
 import { Command, Option as CommandOption } from "commander";
-import { Metafile, build } from "esbuild";
+import { build } from "esbuild";
 import { execa } from "execa";
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join, posix, relative, resolve } from "node:path";
+import { dirname, join, posix, relative } from "node:path";
 import { setTimeout } from "node:timers/promises";
 import invariant from "tiny-invariant";
 import { z } from "zod";
@@ -32,11 +32,7 @@ import {
 import { ReadConfigResult, readConfig } from "../utilities/configFiles.js";
 import { createTempDir, writeJSONFile } from "../utilities/fileSystem";
 import { printStandloneInitialBanner } from "../utilities/initialBanner.js";
-import {
-  detectPackageNameFromImportPath,
-  parsePackageName,
-  stripWorkspaceFromVersion,
-} from "../utilities/installPackages";
+import { parsePackageName, stripWorkspaceFromVersion } from "../utilities/installPackages";
 import { logger } from "../utilities/logger.js";
 import { createTaskFileImports, gatherTaskFiles } from "../utilities/taskFiles";
 import { login } from "./login";
@@ -1335,11 +1331,7 @@ async function compileProject(
         entryPointImports: entryPointMetaOutput.imports,
       });
 
-      const dependencies = await resolveRequiredDependencies(
-        directDependenciesMeta,
-        config,
-        javascriptProject
-      );
+      const dependencies = await resolveRequiredDependencies(directDependenciesMeta, config);
 
       logger.debug("gatherRequiredDependencies()", { dependencies });
 
@@ -1710,8 +1702,7 @@ export async function typecheckProject(config: ResolvedConfig) {
 // Returns the dependency names and the version to use (taken from the CLI deps package.json)
 export async function resolveRequiredDependencies(
   directDependenciesMeta: Record<string, DependencyMeta>,
-  config: ResolvedConfig,
-  project: JavascriptProject
+  config: ResolvedConfig
 ) {
   return await tracer.startActiveSpan("resolveRequiredDependencies", async (span) => {
     span.setAttribute("resolvablePackageNames", Object.keys(directDependenciesMeta));
@@ -1737,8 +1728,8 @@ export async function resolveRequiredDependencies(
       }
     }
 
-    for (const [pkgName, { version }] of Object.entries(directDependenciesMeta)) {
-      dependencies[pkgName] = version;
+    for (const [packageName, { version }] of Object.entries(directDependenciesMeta)) {
+      dependencies[packageName] = version;
     }
 
     if (config.additionalPackages) {
@@ -1755,9 +1746,7 @@ export async function resolveRequiredDependencies(
           dependencies[packageParts.name] = packageParts.version;
           continue;
         } else {
-          const externalDependencyVersion = await project.resolve(packageParts.name, {
-            allowDev: true,
-          });
+          const externalDependencyVersion = directDependenciesMeta[packageParts.name]?.version;
 
           if (externalDependencyVersion) {
             dependencies[packageParts.name] = externalDependencyVersion;

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -1169,6 +1169,8 @@ async function compileProject(
       const javascriptProject = new JavascriptProject(config.projectDir);
       const directDependenciesMeta = await javascriptProject.extractDirectDependenciesMeta();
 
+      logger.debug("Direct dependencies metadata", directDependenciesMeta);
+
       const result = await build({
         stdin: {
           contents: workerContents,
@@ -1284,17 +1286,6 @@ async function compileProject(
 
       logger.debug(`Writing compiled files to ${tempDir}`);
 
-      // Get the metaOutput for the result build
-      const metaOutput = result.metafile!.outputs[posix.join("out", "stdin.js")];
-
-      invariant(metaOutput, "Meta output for the result build is missing");
-
-      // Get the metaOutput for the entryPoint build
-      const entryPointMetaOutput =
-        entryPointResult.metafile!.outputs[posix.join("out", "stdin.js")];
-
-      invariant(entryPointMetaOutput, "Meta output for the entryPoint build is missing");
-
       // Get the outputFile and the sourceMapFile for the result build
       const workerOutputFile = result.outputFiles.find(
         (file) => file.path === join(config.projectDir, "out", "stdin.js")
@@ -1325,11 +1316,6 @@ async function compileProject(
       await writeFile(join(tempDir, "worker.js.map"), workerSourcemapFile.text);
       // Save the entryPoint outputFile to /tmp/dir/index.js
       await writeFile(join(tempDir, "index.js"), entryPointOutputFile.text);
-
-      logger.debug("Imports for the worker and entryPoint builds", {
-        workerImports: metaOutput.imports,
-        entryPointImports: entryPointMetaOutput.imports,
-      });
 
       const dependencies = await resolveRequiredDependencies(directDependenciesMeta, config);
 

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -1705,14 +1705,19 @@ export async function resolveRequiredDependencies(
   config: ResolvedConfig
 ) {
   return await tracer.startActiveSpan("resolveRequiredDependencies", async (span) => {
-    span.setAttribute("resolvablePackageNames", Object.keys(directDependenciesMeta));
+    const externalDirectDependenciesVersion = Object.fromEntries(
+      Object.entries(directDependenciesMeta)
+        .filter(([, { external }]) => external)
+        .map(([packageName, { version }]) => [packageName, version])
+    );
+    span.setAttribute("resolvablePackageNames", Object.keys(externalDirectDependenciesVersion));
 
-    const missingPackages = Object.entries(directDependenciesMeta)
-      .filter(([, pkgMeta]) => !pkgMeta.version)
+    const missingPackages = Object.entries(externalDirectDependenciesVersion)
+      .filter(([, version]) => !version)
       .map(([name]) => name);
 
     span.setAttributes({
-      ...flattenAttributes(directDependenciesMeta, "resolvedPackageVersions"),
+      ...flattenAttributes(externalDirectDependenciesVersion, "resolvedPackageVersions"),
     });
     span.setAttribute("missingPackages", missingPackages);
 
@@ -1728,7 +1733,7 @@ export async function resolveRequiredDependencies(
       }
     }
 
-    for (const [packageName, { version }] of Object.entries(directDependenciesMeta)) {
+    for (const [packageName, version] of Object.entries(externalDirectDependenciesVersion)) {
       dependencies[packageName] = version;
     }
 
@@ -1746,7 +1751,7 @@ export async function resolveRequiredDependencies(
           dependencies[packageParts.name] = packageParts.version;
           continue;
         } else {
-          const externalDependencyVersion = directDependenciesMeta[packageParts.name]?.version;
+          const externalDependencyVersion = externalDirectDependenciesVersion[packageParts.name];
 
           if (externalDependencyVersion) {
             dependencies[packageParts.name] = externalDependencyVersion;

--- a/packages/cli-v3/src/utilities/javascriptProject.ts
+++ b/packages/cli-v3/src/utilities/javascriptProject.ts
@@ -106,10 +106,39 @@ export class JavascriptProject {
         });
 
         try {
-          span.end();
-          return await command.extractDirectDependenciesMeta({
+          const packagesMeta = await command.extractDirectDependenciesMeta({
             cwd: this.projectPath,
           });
+
+          // Merge the resolved versions with the package.json dependencies
+          const missingPackagesMeta = Object.entries(packagesMeta).filter(
+            ([, { version }]) => !version
+          );
+          const missingPackageVersions: Record<string, string> = {};
+
+          for (const [packageName, { external }] of missingPackagesMeta) {
+            const packageJsonVersion = this.packageJson.dependencies?.[packageName];
+
+            if (typeof packageJsonVersion === "string") {
+              logger.debug(`Resolved ${packageName} version using package.json`, {
+                packageJsonVersion,
+              });
+
+              packagesMeta[packageName] = { version: packageJsonVersion, external };
+              missingPackageVersions[packageName] = packageJsonVersion;
+            }
+          }
+
+          span.setAttributes({
+            ...flattenAttributes(missingPackageVersions, "missingPackageVersions"),
+            missingPackages: missingPackagesMeta.map(
+              ([pkgName]: [string, DependencyMeta]) => pkgName
+            ),
+          });
+
+          span.end();
+
+          return packagesMeta;
         } catch (error) {
           recordSpanException(span, error);
           span.end();
@@ -122,70 +151,6 @@ export class JavascriptProject {
         }
       }
     );
-  }
-
-  async resolveAll(packageNames: string[]): Promise<Record<string, string>> {
-    return tracer.startActiveSpan("JavascriptProject.resolveAll", async (span) => {
-      const externalPackages = packageNames.filter((packageName) => !isBuiltInModule(packageName));
-
-      const command = await this.#getCommand();
-
-      span.setAttributes({
-        externalPackages,
-        packageManager: command.name,
-      });
-
-      try {
-        const versions = await command.resolveDependencyVersions(externalPackages, {
-          cwd: this.projectPath,
-        });
-
-        if (versions) {
-          logger.debug(`Resolved [${externalPackages.join(", ")}] version using ${command.name}`, {
-            versions,
-          });
-
-          span.setAttributes({
-            ...flattenAttributes(versions, "versions"),
-          });
-        }
-
-        // Merge the resolved versions with the package.json dependencies
-        const missingPackages = externalPackages.filter((packageName) => !versions[packageName]);
-        const missingPackageVersions: Record<string, string> = {};
-
-        for (const packageName of missingPackages) {
-          const packageJsonVersion = this.packageJson.dependencies?.[packageName];
-
-          if (typeof packageJsonVersion === "string") {
-            logger.debug(`Resolved ${packageName} version using package.json`, {
-              packageJsonVersion,
-            });
-
-            missingPackageVersions[packageName] = packageJsonVersion;
-          }
-        }
-
-        span.setAttributes({
-          ...flattenAttributes(missingPackageVersions, "missingPackageVersions"),
-          missingPackages,
-        });
-
-        span.end();
-
-        return { ...versions, ...missingPackageVersions };
-      } catch (error) {
-        recordSpanException(span, error);
-        span.end();
-
-        logger.debug(`Failed to resolve dependency versions using ${command.name}`, {
-          packageNames,
-          error,
-        });
-
-        return {};
-      }
-    });
   }
 
   async resolve(packageName: string, options?: ResolveOptions): Promise<string | undefined> {
@@ -292,11 +257,6 @@ interface PackageManagerCommands {
     packageName: string,
     options: PackageManagerOptions
   ): Promise<string | undefined>;
-
-  resolveDependencyVersions(
-    packageNames: string[],
-    options: PackageManagerOptions
-  ): Promise<Record<string, string>>;
 }
 
 class PNPMCommands implements PackageManagerCommands {
@@ -330,30 +290,6 @@ class PNPMCommands implements PackageManagerCommands {
     }
   }
 
-  async resolveDependencyVersions(
-    packageNames: string[],
-    options: PackageManagerOptions
-  ): Promise<Record<string, string>> {
-    const result = await this.#listDependencies(packageNames, options);
-
-    logger.debug(`Resolving ${packageNames.join(" ")} version using ${this.name}`);
-
-    const results: Record<string, string> = {};
-
-    // Return the first dependency version that matches the package name
-    for (const dep of result) {
-      for (const packageName of packageNames) {
-        const dependency = dep.dependencies?.[packageName];
-
-        if (dependency) {
-          results[packageName] = dependency.version;
-        }
-      }
-    }
-
-    return results;
-  }
-
   async extractDirectDependenciesMeta(options: PackageManagerOptions) {
     const result = await this.#listDirectDependencies(options);
 
@@ -384,21 +320,6 @@ class PNPMCommands implements PackageManagerCommands {
       cwd: options.cwd,
       reject: false,
     })`${this.cmd} list --recursive --json`;
-
-    if (childProcess.failed) {
-      logger.debug("Failed to list dependencies, using stdout anyway...", {
-        error: childProcess,
-      });
-    }
-
-    return JSON.parse(childProcess.stdout) as PnpmList;
-  }
-
-  async #listDependencies(packageNames: string[], options: PackageManagerOptions) {
-    const childProcess = await $({
-      cwd: options.cwd,
-      reject: false,
-    })`${this.cmd} list ${packageNames} -r --json`;
 
     if (childProcess.failed) {
       logger.debug("Failed to list dependencies, using stdout anyway...", {
@@ -446,27 +367,6 @@ class NPMCommands implements PackageManagerCommands {
     return this.#recursivelySearchDependencies(output.dependencies, packageName);
   }
 
-  async resolveDependencyVersions(
-    packageNames: string[],
-    options: PackageManagerOptions
-  ): Promise<Record<string, string>> {
-    const output = await this.#listDependencies(packageNames, options);
-
-    logger.debug(`Resolving ${packageNames.join(" ")} version using ${this.name}`, { output });
-
-    const results: Record<string, string> = {};
-
-    for (const packageName of packageNames) {
-      const version = this.#recursivelySearchDependencies(output.dependencies, packageName);
-
-      if (version) {
-        results[packageName] = version;
-      }
-    }
-
-    return results;
-  }
-
   async extractDirectDependenciesMeta(
     options: PackageManagerOptions
   ): Promise<Record<string, DependencyMeta>> {
@@ -482,21 +382,6 @@ class NPMCommands implements PackageManagerCommands {
       cwd: options.cwd,
       reject: false,
     })`${this.cmd} list --json`;
-
-    if (childProcess.failed) {
-      logger.debug("Failed to list dependencies, using stdout anyway...", {
-        error: childProcess,
-      });
-    }
-
-    return JSON.parse(childProcess.stdout) as NpmListOutput;
-  }
-
-  async #listDependencies(packageNames: string[], options: PackageManagerOptions) {
-    const childProcess = await $({
-      cwd: options.cwd,
-      reject: false,
-    })`${this.cmd} list ${packageNames} --json`;
 
     if (childProcess.failed) {
       logger.debug("Failed to list dependencies, using stdout anyway...", {
@@ -575,31 +460,6 @@ class YarnCommands implements PackageManagerCommands {
     }
   }
 
-  async resolveDependencyVersions(
-    packageNames: string[],
-    options: PackageManagerOptions
-  ): Promise<Record<string, string>> {
-    const stdout = await this.#listDependencies(packageNames, options);
-
-    const lines = stdout.split("\n");
-
-    logger.debug(`Resolving ${packageNames.join(" ")} version using ${this.name}`);
-
-    const results: Record<string, string> = {};
-
-    for (const line of lines) {
-      const json = JSON.parse(line);
-
-      const packageName = this.#parseYarnValueIntoPackageName(json.value);
-
-      if (packageNames.includes(packageName)) {
-        results[packageName] = json.children.Version;
-      }
-    }
-
-    return results;
-  }
-
   async extractDirectDependenciesMeta(options: PackageManagerOptions) {
     const result = await this.#listDirectDependencies(options);
 
@@ -633,37 +493,10 @@ class YarnCommands implements PackageManagerCommands {
     return childProcess.stdout;
   }
 
-  async #listDependencies(packageNames: string[], options: PackageManagerOptions) {
-    const childProcess = await $({
-      cwd: options.cwd,
-      reject: false,
-    })`${this.cmd} info ${packageNames} --json`;
-
-    if (childProcess.failed) {
-      logger.debug("Failed to list dependencies, using stdout anyway...", {
-        error: childProcess,
-      });
-    }
-
-    return childProcess.stdout;
-  }
-
   // The "value" when doing yarn info is formatted like this:
   // "package-name@npm:version" or "package-name@workspace:version"
   // This function will parse the value into just the package name.
   // This correctly handles scoped packages as well e.g. @scope/package-name@npm:version
-  #parseYarnValueIntoPackageName(value: string): string {
-    const parts = value.split("@");
-
-    // If the value does not contain an "@" symbol, then it's just the package name
-    if (parts.length === 3) {
-      return parts[1] as string;
-    }
-
-    // If the value contains an "@" symbol, then the package name is the first part
-    return parts[0] as string;
-  }
-
   #parseYarnValueIntoDependencyMeta(value: string): [string, DependencyMeta] {
     const parts = value.split("@");
     let name: string, protocol: string, version: string;

--- a/packages/cli-v3/src/utilities/javascriptProject.ts
+++ b/packages/cli-v3/src/utilities/javascriptProject.ts
@@ -1,16 +1,14 @@
-import { $, ExecaError } from "execa";
+import { $ } from "execa";
 import { join } from "node:path";
 import { readJSONFileSync } from "./fileSystem";
 import { logger } from "./logger";
 import { PackageManager, getUserPackageManager } from "./getUserPackageManager";
 import { PackageJson } from "type-fest";
 import { assertExhaustive } from "./assertExhaustive";
-import { builtinModules } from "node:module";
 import { tracer } from "../cli/common";
 import { recordSpanException } from "@trigger.dev/core/v3/otel";
 import { flattenAttributes } from "@trigger.dev/core/v3";
 
-export type ResolveOptions = { allowDev: boolean };
 export type DependencyMeta = { version: string; external: boolean };
 
 export class JavascriptProject {
@@ -126,13 +124,25 @@ export class JavascriptProject {
 
               packagesMeta[packageName] = { version: packageJsonVersion, external };
               missingPackageVersions[packageName] = packageJsonVersion;
+            } else {
+              // Last resort: check devDependencies
+              const devPackageJsonVersion = this.packageJson.devDependencies?.[packageName];
+
+              if (typeof devPackageJsonVersion === "string") {
+                logger.debug(`Resolved ${packageName} version using devDependencies`, {
+                  devPackageJsonVersion,
+                });
+
+                packagesMeta[packageName] = { version: devPackageJsonVersion, external };
+                missingPackageVersions[packageName] = devPackageJsonVersion;
+              }
             }
           }
 
           span.setAttributes({
             ...flattenAttributes(missingPackageVersions, "missingPackageVersions"),
             missingPackages: missingPackagesMeta.map(
-              ([pkgName]: [string, DependencyMeta]) => pkgName
+              ([packageName]: [string, DependencyMeta]) => packageName
             ),
           });
 
@@ -151,53 +161,6 @@ export class JavascriptProject {
         }
       }
     );
-  }
-
-  async resolve(packageName: string, options?: ResolveOptions): Promise<string | undefined> {
-    if (isBuiltInModule(packageName)) {
-      return undefined;
-    }
-
-    const opts = { allowDev: false, ...options };
-
-    const command = await this.#getCommand();
-
-    try {
-      const version = await command.resolveDependencyVersion(packageName, {
-        cwd: this.projectPath,
-      });
-
-      if (version) {
-        logger.debug(`Resolved ${packageName} version using ${command.name}`, { version });
-
-        return version;
-      }
-
-      const packageJsonVersion = this.packageJson.dependencies?.[packageName];
-
-      if (typeof packageJsonVersion === "string") {
-        logger.debug(`Resolved ${packageName} version using package.json`, { packageJsonVersion });
-
-        return packageJsonVersion;
-      }
-
-      if (opts.allowDev) {
-        const devPackageJsonVersion = this.packageJson.devDependencies?.[packageName];
-
-        if (typeof devPackageJsonVersion === "string") {
-          logger.debug(`Resolved ${packageName} version using devDependencies`, {
-            devPackageJsonVersion,
-          });
-
-          return devPackageJsonVersion;
-        }
-      }
-    } catch (error) {
-      logger.debug(`Failed to resolve dependency version using ${command.name}`, {
-        packageName,
-        error,
-      });
-    }
   }
 
   async #getCommand(): Promise<PackageManagerCommands> {
@@ -252,11 +215,6 @@ interface PackageManagerCommands {
   extractDirectDependenciesMeta(
     options: PackageManagerOptions
   ): Promise<Record<string, DependencyMeta>>;
-
-  resolveDependencyVersion(
-    packageName: string,
-    options: PackageManagerOptions
-  ): Promise<string | undefined>;
 }
 
 class PNPMCommands implements PackageManagerCommands {
@@ -272,22 +230,6 @@ class PNPMCommands implements PackageManagerCommands {
     const { stdout, stderr } = await $({ cwd: options.cwd })`${this.cmd} install`;
 
     logger.debug(`Installing dependencies using ${this.name}`, { stdout, stderr });
-  }
-
-  async resolveDependencyVersion(packageName: string, options: PackageManagerOptions) {
-    const { stdout } = await $({ cwd: options.cwd })`${this.cmd} list ${packageName} -r --json`;
-    const result = JSON.parse(stdout) as PnpmList;
-
-    logger.debug(`Resolving ${packageName} version using ${this.name}`);
-
-    // Return the first dependency version that matches the package name
-    for (const dep of result) {
-      const dependency = dep.dependencies?.[packageName];
-
-      if (dependency) {
-        return dependency.version;
-      }
-    }
   }
 
   async extractDirectDependenciesMeta(options: PackageManagerOptions) {
@@ -358,15 +300,6 @@ class NPMCommands implements PackageManagerCommands {
     logger.debug(`Installing dependencies using ${this.name}`, { stdout, stderr });
   }
 
-  async resolveDependencyVersion(packageName: string, options: PackageManagerOptions) {
-    const { stdout } = await $({ cwd: options.cwd })`${this.cmd} list ${packageName} --json`;
-    const output = JSON.parse(stdout) as NpmListOutput;
-
-    logger.debug(`Resolving ${packageName} version using ${this.name}`, { output });
-
-    return this.#recursivelySearchDependencies(output.dependencies, packageName);
-  }
-
   async extractDirectDependenciesMeta(
     options: PackageManagerOptions
   ): Promise<Record<string, DependencyMeta>> {
@@ -390,25 +323,6 @@ class NPMCommands implements PackageManagerCommands {
     }
 
     return JSON.parse(childProcess.stdout) as NpmListOutput;
-  }
-
-  #recursivelySearchDependencies(
-    dependencies: Record<string, NpmDependency>,
-    packageName: string
-  ): string | undefined {
-    for (const [name, dependency] of Object.entries(dependencies)) {
-      if (name === packageName) {
-        return dependency.version;
-      }
-
-      if (dependency.dependencies) {
-        const result = this.#recursivelySearchDependencies(dependency.dependencies, packageName);
-
-        if (result) {
-          return result;
-        }
-      }
-    }
   }
 
   #flattenDependenciesMeta(
@@ -442,22 +356,6 @@ class YarnCommands implements PackageManagerCommands {
     const { stdout, stderr } = await $({ cwd: options.cwd })`${this.cmd} install`;
 
     logger.debug(`Installing dependencies using ${this.name}`, { stdout, stderr });
-  }
-
-  async resolveDependencyVersion(packageName: string, options: PackageManagerOptions) {
-    const { stdout } = await $({ cwd: options.cwd })`${this.cmd} info ${packageName} --json`;
-
-    const lines = stdout.split("\n");
-
-    logger.debug(`Resolving ${packageName} version using ${this.name}`);
-
-    for (const line of lines) {
-      const json = JSON.parse(line);
-
-      if (json.value === packageName) {
-        return json.children.Version;
-      }
-    }
   }
 
   async extractDirectDependenciesMeta(options: PackageManagerOptions) {
@@ -521,13 +419,4 @@ class YarnCommands implements PackageManagerCommands {
       },
     ];
   }
-}
-
-function isBuiltInModule(module: string): boolean {
-  // if the module has node: prefix, it's a built-in module
-  if (module.startsWith("node:")) {
-    return true;
-  }
-
-  return builtinModules.includes(module);
 }


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Ran e2e test suite and checked v3 catalog in dev mode.
Ran deploy test with local setup.

---

## Changelog

Stop using **esbuild** metaOutput imports to build bundle `package.json`. This can be done because : 
- Direct dependencies metadata (version, external) is now collected before bundling since #1208 
- The previous way was to look for all bundle seen imports inside those direct dependencies
- The fallback to a package.json `dependencies` then `devDependencies` then CLI dependencies check has been kept

---

## Screenshots

_[Screenshots]_

💯
