### PR TITLE
Improved run page and replaying

### DIFF
--- a/.changeset/fast-melons-listen.md
+++ b/.changeset/fast-melons-listen.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Added version to ctx.run

--- a/apps/webapp/app/components/admin/debugTooltip.tsx
+++ b/apps/webapp/app/components/admin/debugTooltip.tsx
@@ -1,3 +1,4 @@
+import * as Property from "~/components/primitives/PropertyTable";
 import { ShieldCheckIcon } from "@heroicons/react/20/solid";
 import {
   Tooltip,
@@ -5,8 +6,13 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "~/components/primitives/Tooltip";
-import { useIsImpersonating } from "~/hooks/useOrganizations";
-import { useHasAdminAccess } from "~/hooks/useUser";
+import {
+  useIsImpersonating,
+  useOptionalOrganization,
+  useOrganization,
+} from "~/hooks/useOrganizations";
+import { useOptionalProject, useProject } from "~/hooks/useProject";
+import { useHasAdminAccess, useUser } from "~/hooks/useUser";
 
 export function AdminDebugTooltip({ children }: { children: React.ReactNode }) {
   const hasAdminAccess = useHasAdminAccess();
@@ -22,10 +28,46 @@ export function AdminDebugTooltip({ children }: { children: React.ReactNode }) {
         <TooltipTrigger>
           <ShieldCheckIcon className="size-5" />
         </TooltipTrigger>
-        <TooltipContent className="flex max-h-[90vh] items-center gap-1 overflow-y-auto">
-          {children}
+        <TooltipContent className="max-h-[90vh] overflow-y-auto">
+          <Content>{children}</Content>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>
+  );
+}
+
+function Content({ children }: { children: React.ReactNode }) {
+  const organization = useOptionalOrganization();
+  const project = useOptionalProject();
+  const user = useUser();
+
+  return (
+    <div className="flex flex-col gap-2 divide-y divide-slate-700">
+      <Property.Table>
+        <Property.Item>
+          <Property.Label>User ID</Property.Label>
+          <Property.Value>{user.id}</Property.Value>
+        </Property.Item>
+        {organization && (
+          <Property.Item>
+            <Property.Label>Org ID</Property.Label>
+            <Property.Value>{organization.id}</Property.Value>
+          </Property.Item>
+        )}
+        {project && (
+          <>
+            <Property.Item>
+              <Property.Label>Project ID</Property.Label>
+              <Property.Value>{project.id}</Property.Value>
+            </Property.Item>
+            <Property.Item>
+              <Property.Label>Project ref</Property.Label>
+              <Property.Value>{project.ref}</Property.Value>
+            </Property.Item>
+          </>
+        )}
+      </Property.Table>
+      <div className="pt-2">{children}</div>
+    </div>
   );
 }

--- a/apps/webapp/app/components/code/CodeBlock.tsx
+++ b/apps/webapp/app/components/code/CodeBlock.tsx
@@ -241,16 +241,12 @@ export const CodeBlock = forwardRef<HTMLDivElement, CodeBlockProps>(
                 onMouseEnter={() => setMouseOver(true)}
                 onMouseLeave={() => setMouseOver(false)}
                 className={cn(
-                  "absolute  right-3 z-50 transition-colors duration-100 hover:cursor-pointer",
-                  showChrome ? "top-10" : "top-3",
+                  "absolute right-3 z-50 transition-colors duration-100 hover:cursor-pointer",
+                  showChrome ? "top-10" : "top-2.5",
                   copied ? "text-emerald-500" : "text-charcoal-500 hover:text-charcoal-300"
                 )}
               >
-                {copied ? (
-                  <ClipboardCheck className="h-5 w-5" />
-                ) : (
-                  <Clipboard className="h-5 w-5" />
-                )}
+                {copied ? <ClipboardCheck className="size-4" /> : <Clipboard className="size-4" />}
               </TooltipTrigger>
               <TooltipContent side="left" className="text-xs">
                 {copied ? "Copied" : "Copy"}
@@ -391,8 +387,8 @@ function Chrome({ title }: { title?: string }) {
 
 export function TitleRow({ title }: { title: string }) {
   return (
-    <div className="flex items-center justify-between px-4">
-      <Paragraph variant="base/bright" className="w-full border-b border-grid-dimmed py-2.5">
+    <div className="flex items-center justify-between px-3">
+      <Paragraph variant="small/bright" className="w-full border-b border-grid-dimmed py-2">
         {title}
       </Paragraph>
     </div>

--- a/apps/webapp/app/components/code/CodeGroup.tsx
+++ b/apps/webapp/app/components/code/CodeGroup.tsx
@@ -1,0 +1,5 @@
+import { type ReactNode } from "react";
+
+export function CodeGroup({ children }: { children: ReactNode }) {
+  return <div className="rounded-sm border border-grid-bright bg-charcoal-850">{children}</div>;
+}

--- a/apps/webapp/app/components/code/CodeGroup.tsx
+++ b/apps/webapp/app/components/code/CodeGroup.tsx
@@ -1,5 +1,0 @@
-import { type ReactNode } from "react";
-
-export function CodeGroup({ children }: { children: ReactNode }) {
-  return <div className="rounded-sm border border-grid-bright bg-charcoal-850">{children}</div>;
-}

--- a/apps/webapp/app/components/code/JSONEditor.tsx
+++ b/apps/webapp/app/components/code/JSONEditor.tsx
@@ -107,39 +107,51 @@ export function JSONEditor(opts: JSONEditorProps) {
     }, 1500);
   }, [view]);
 
+  const showButtons = showClearButton || showCopyButton;
+
   return (
-    <div className={cn(opts.className, "grid grid-rows-[2.5rem_1fr]")}>
-      <div className="mx-3 flex items-center justify-end gap-2 border-b border-grid-dimmed">
-        {showClearButton && (
-          <Button
-            type="button"
-            variant="minimal/small"
-            TrailingIcon={TrashIcon}
-            onClick={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              clear();
-            }}
-          >
-            Clear
-          </Button>
-        )}
-        {showCopyButton && (
-          <Button
-            type="button"
-            variant="minimal/small"
-            TrailingIcon={copied ? CheckIcon : ClipboardIcon}
-            trailingIconClassName={copied ? "text-green-500 group-hover:text-green-500" : undefined}
-            onClick={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              copy();
-            }}
-          >
-            Copy
-          </Button>
-        )}
-      </div>
+    <div
+      className={cn(
+        opts.className,
+        "grid",
+        showButtons ? "grid-rows-[2.5rem_1fr]" : "grid-rows-[1fr]"
+      )}
+    >
+      {showButtons && (
+        <div className="mx-3 flex items-center justify-end gap-2 border-b border-grid-dimmed">
+          {showClearButton && (
+            <Button
+              type="button"
+              variant="minimal/small"
+              TrailingIcon={TrashIcon}
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                clear();
+              }}
+            >
+              Clear
+            </Button>
+          )}
+          {showCopyButton && (
+            <Button
+              type="button"
+              variant="minimal/small"
+              TrailingIcon={copied ? CheckIcon : ClipboardIcon}
+              trailingIconClassName={
+                copied ? "text-green-500 group-hover:text-green-500" : undefined
+              }
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                copy();
+              }}
+            >
+              Copy
+            </Button>
+          )}
+        </div>
+      )}
       <div
         className="w-full overflow-auto"
         ref={editor}

--- a/apps/webapp/app/components/primitives/PageHeader.tsx
+++ b/apps/webapp/app/components/primitives/PageHeader.tsx
@@ -10,6 +10,7 @@ import { LoadingBarDivider } from "./LoadingBarDivider";
 import { NamedIcon } from "./NamedIcon";
 import { Paragraph } from "./Paragraph";
 import { Tabs, TabsProps } from "./Tabs";
+import { ReactNode } from "react";
 
 type WithChildren = {
   children: React.ReactNode;
@@ -34,7 +35,7 @@ export function NavBar({ children }: WithChildren) {
 }
 
 type PageTitleProps = {
-  title: string;
+  title: ReactNode;
   backButton?: {
     to: string;
     text: string;

--- a/apps/webapp/app/components/primitives/PropertyTable.tsx
+++ b/apps/webapp/app/components/primitives/PropertyTable.tsx
@@ -8,11 +8,11 @@ type ChildrenClassName = {
 };
 
 function PropertyTable({ children, className }: { children: ReactNode; className?: string }) {
-  return <div className={cn("flex flex-col gap-y-2", className)}>{children}</div>;
+  return <div className={cn("flex flex-col gap-y-3", className)}>{children}</div>;
 }
 
-function Property({ children, className }: ChildrenClassName) {
-  return <div className={cn("flex flex-col gap-0.5 text-sm", className)}>{children}</div>;
+function PropertyItem({ children, className }: ChildrenClassName) {
+  return <div className={cn("flex flex-col gap-0 text-sm", className)}>{children}</div>;
 }
 
 function PropertyLabel({ children, className }: ChildrenClassName) {
@@ -23,4 +23,9 @@ function PropertyValue({ children, className }: ChildrenClassName) {
   return <div className={cn("text-text-dimmed", className)}>{children}</div>;
 }
 
-export { PropertyTable as Table, Property as Item, PropertyLabel as Label, PropertyValue as Value };
+export {
+  PropertyTable as Table,
+  PropertyItem as Item,
+  PropertyLabel as Label,
+  PropertyValue as Value,
+};

--- a/apps/webapp/app/components/primitives/PropertyTable.tsx
+++ b/apps/webapp/app/components/primitives/PropertyTable.tsx
@@ -1,40 +1,26 @@
-import { ReactNode } from "react";
+import { type ReactNode } from "react";
 import { Paragraph } from "./Paragraph";
 import { cn } from "~/utils/cn";
 
-export function PropertyTable({
-  children,
-  className,
-}: {
+type ChildrenClassName = {
   children: ReactNode;
   className?: string;
-}) {
-  return (
-    <div className={cn("grid grid-cols-[auto,1fr] items-center gap-x-4 gap-y-2", className)}>
-      {children}
-    </div>
-  );
-}
-
-export type PropertyProps = {
-  label: ReactNode;
-  labelClassName?: string;
-  children: ReactNode;
 };
 
-export function Property({ label, labelClassName, children }: PropertyProps) {
-  return (
-    <>
-      <div className={labelClassName}>
-        {typeof label === "string" ? <Paragraph variant="small">{label}</Paragraph> : label}
-      </div>
-      <div>
-        {typeof children === "string" ? (
-          <Paragraph variant="small/bright">{children}</Paragraph>
-        ) : (
-          children
-        )}
-      </div>
-    </>
-  );
+function PropertyTable({ children, className }: { children: ReactNode; className?: string }) {
+  return <div className={cn("flex flex-col gap-y-2", className)}>{children}</div>;
 }
+
+function Property({ children, className }: ChildrenClassName) {
+  return <div className={cn("flex flex-col gap-0.5 text-sm", className)}>{children}</div>;
+}
+
+function PropertyLabel({ children, className }: ChildrenClassName) {
+  return <div className={cn("font-medium text-text-bright", className)}>{children}</div>;
+}
+
+function PropertyValue({ children, className }: ChildrenClassName) {
+  return <div className={cn("text-text-dimmed", className)}>{children}</div>;
+}
+
+export { PropertyTable as Table, Property as Item, PropertyLabel as Label, PropertyValue as Value };

--- a/apps/webapp/app/components/primitives/Tabs.tsx
+++ b/apps/webapp/app/components/primitives/Tabs.tsx
@@ -1,5 +1,7 @@
 import { NavLink, useLocation } from "@remix-run/react";
 import { motion } from "framer-motion";
+import { ReactNode } from "react";
+import { useOptimisticLocation } from "~/hooks/useOptimisticLocation";
 import { cn } from "~/utils/cn";
 
 export type TabsProps = {
@@ -13,28 +15,59 @@ export type TabsProps = {
 
 export function Tabs({ tabs, className, layoutId }: TabsProps) {
   return (
-    <div className={cn(`flex flex-row gap-x-6 border-b border-grid-bright`, className)}>
+    <TabContainer className={className}>
       {tabs.map((tab, index) => (
-        <NavLink key={index} to={tab.to} className="group flex flex-col items-center pt-1" end>
-          {({ isActive, isPending }) => (
-            <>
-              <span
-                className={cn(
-                  "text-sm transition duration-200",
-                  isActive || isPending ? "text-indigo-500" : "text-charcoal-200"
-                )}
-              >
-                {tab.label}
-              </span>
-              {isActive || isPending ? (
-                <motion.div layoutId={layoutId} className="mt-1 h-0.5 w-full bg-indigo-500" />
-              ) : (
-                <div className="mt-1 h-0.5 w-full bg-charcoal-500 opacity-0 transition duration-200 group-hover:opacity-100" />
-              )}
-            </>
-          )}
-        </NavLink>
+        <TabLink key={index} to={tab.to} layoutId={layoutId}>
+          {tab.label}
+        </TabLink>
       ))}
+    </TabContainer>
+  );
+}
+
+export function TabContainer({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <div className={cn(`flex flex-row gap-x-6 border-b border-grid-bright`, className)}>
+      {children}
     </div>
+  );
+}
+
+export function TabLink({
+  to,
+  children,
+  layoutId,
+}: {
+  to: string;
+  children: ReactNode;
+  layoutId: string;
+}) {
+  const location = useOptimisticLocation();
+  const toSearch = to.split("?").at(0);
+
+  return (
+    <NavLink to={to} className="group flex flex-col items-center pt-1" end>
+      {({ isActive, isPending }) => {
+        const isActiveWithQuery = isActive && location.search;
+
+        return (
+          <>
+            <span
+              className={cn(
+                "text-sm transition duration-200",
+                isActive || isPending ? "text-indigo-500" : "text-charcoal-200"
+              )}
+            >
+              {children}
+            </span>
+            {isActive || isPending ? (
+              <motion.div layoutId={layoutId} className="mt-1 h-0.5 w-full bg-indigo-500" />
+            ) : (
+              <div className="mt-1 h-0.5 w-full bg-charcoal-500 opacity-0 transition duration-200 group-hover:opacity-100" />
+            )}
+          </>
+        );
+      }}
+    </NavLink>
   );
 }

--- a/apps/webapp/app/components/runs/v3/LiveTimer.tsx
+++ b/apps/webapp/app/components/runs/v3/LiveTimer.tsx
@@ -23,11 +23,11 @@ export function LiveTimer({
     }, updateInterval);
 
     return () => clearInterval(interval);
-  }, [startTime]);
+  }, [startTime, endTime]);
 
   return (
     <>
-      {formatDuration(startTime, now, {
+      {formatDuration(startTime, endTime ?? now, {
         style: "short",
         maxDecimalPoints: 0,
         units: ["d", "h", "m", "s"],

--- a/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
+++ b/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
@@ -1,12 +1,16 @@
-import { ArrowPathIcon } from "@heroicons/react/20/solid";
-import { Form, useFetcher, useNavigation } from "@remix-run/react";
+import { Form, useFetcher, useNavigation, useSubmit } from "@remix-run/react";
+import { useCallback, useEffect, useRef } from "react";
+import { UseDataFunctionReturn, useTypedFetcher } from "remix-typedjson";
+import { JSONEditor } from "~/components/code/JSONEditor";
+import { EnvironmentLabel } from "~/components/environments/EnvironmentLabel";
 import { Button } from "~/components/primitives/Buttons";
-import {
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-} from "~/components/primitives/Dialog";
+import { DialogContent, DialogDescription, DialogHeader } from "~/components/primitives/Dialog";
+import { Header3 } from "~/components/primitives/Headers";
+import { InputGroup } from "~/components/primitives/InputGroup";
+import { Label } from "~/components/primitives/Label";
+import { Select, SelectItem } from "~/components/primitives/Select";
+import { ButtonSpinner, Spinner } from "~/components/primitives/Spinner";
+import { type loader } from "~/routes/resources.taskruns.$runParam.replay";
 
 type ReplayRunDialogProps = {
   runFriendlyId: string;
@@ -14,10 +18,12 @@ type ReplayRunDialogProps = {
 };
 
 export function ReplayRunDialog({ runFriendlyId, failedRedirect }: ReplayRunDialogProps) {
-  const navigation = useNavigation();
+  const fetcher = useTypedFetcher<typeof loader>();
+  const isLoading = fetcher.state !== "idle";
 
-  const formAction = `/resources/taskruns/${runFriendlyId}/replay`;
-  const isLoading = navigation.formAction === formAction;
+  useEffect(() => {
+    fetcher.load(`/resources/taskruns/${runFriendlyId}/replay`);
+  }, [runFriendlyId]);
 
   return (
     <DialogContent key="replay">
@@ -25,20 +31,106 @@ export function ReplayRunDialog({ runFriendlyId, failedRedirect }: ReplayRunDial
       <DialogDescription>
         Replaying a run will create a new run with the same payload and environment as the original.
       </DialogDescription>
-      <DialogFooter>
-        <Form action={formAction} method="post">
-          <input type="hidden" name="failedRedirect" value={failedRedirect} />
-          <Button
-            type="submit"
-            variant="primary/small"
-            LeadingIcon={isLoading ? "spinner-white" : ArrowPathIcon}
-            disabled={isLoading}
-            shortcut={{ modifiers: ["meta"], key: "enter" }}
-          >
-            {isLoading ? "Replaying..." : "Replay run"}
-          </Button>
-        </Form>
-      </DialogFooter>
+
+      {isLoading ? (
+        <div>
+          <Spinner />
+        </div>
+      ) : fetcher.data ? (
+        <ReplayForm
+          {...fetcher.data}
+          failedRedirect={failedRedirect}
+          runFriendlyId={runFriendlyId}
+        />
+      ) : (
+        <>Failed to get run data</>
+      )}
     </DialogContent>
+  );
+}
+
+function ReplayForm({
+  payload,
+  environment,
+  environments,
+  failedRedirect,
+  runFriendlyId,
+}: UseDataFunctionReturn<typeof loader> & { failedRedirect: string; runFriendlyId: string }) {
+  const navigation = useNavigation();
+  const submit = useSubmit();
+  const currentJson = useRef<string>(payload);
+  const formAction = `/resources/taskruns/${runFriendlyId}/replay`;
+  const isSubmitting = navigation.formAction === formAction;
+
+  const submitForm = useCallback(
+    (e: React.FormEvent<HTMLFormElement>) => {
+      const formData = new FormData(e.currentTarget);
+      const data = {
+        environment: formData.get("environment") as string,
+        failedRedirect: formData.get("failedRedirect") as string,
+        payload: currentJson.current,
+      };
+      submit(data, {
+        action: formAction,
+        method: "post",
+      });
+      e.preventDefault();
+    },
+    [currentJson]
+  );
+
+  return (
+    <Form action={formAction} method="post" onSubmit={(e) => submitForm(e)}>
+      <Header3 spacing>Payload</Header3>
+      <div className="mb-3 rounded-sm border border-grid-dimmed bg-charcoal-900">
+        <JSONEditor
+          defaultValue={currentJson.current}
+          readOnly={false}
+          basicSetup
+          onChange={(v) => {
+            console.log(v);
+            currentJson.current = v;
+          }}
+          height="100%"
+          min-height="100%"
+          max-height="100%"
+        />
+      </div>
+      <InputGroup>
+        <Label>Environment</Label>
+        <Select
+          id="environment"
+          name="environment"
+          placeholder="Select an environment"
+          defaultValue={environment.id}
+          items={environments}
+          dropdownIcon
+          variant="tertiary/medium"
+          text={(value) => {
+            const env = environments.find((env) => env.id === value)!;
+            return <EnvironmentLabel environment={env} userName={env.userName} />;
+          }}
+        >
+          {(matches) =>
+            matches.map((env) => (
+              <SelectItem key={env.id} value={env.id}>
+                <EnvironmentLabel environment={env} userName={env.userName} />
+              </SelectItem>
+            ))
+          }
+        </Select>
+      </InputGroup>
+      <input type="hidden" name="failedRedirect" value={failedRedirect} />
+      <Button
+        type="submit"
+        variant="primary/small"
+        LeadingIcon={isSubmitting ? ButtonSpinner : undefined}
+        disabled={isSubmitting}
+        shortcut={{ modifiers: ["meta"], key: "enter" }}
+        className="mt-3"
+      >
+        {isSubmitting ? "Replaying..." : "Replay run"}
+      </Button>
+    </Form>
   );
 }

--- a/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
+++ b/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
@@ -18,6 +18,14 @@ type ReplayRunDialogProps = {
 };
 
 export function ReplayRunDialog({ runFriendlyId, failedRedirect }: ReplayRunDialogProps) {
+  return (
+    <DialogContent key={`replay`} className="md:max-w-3xl">
+      <ReplayContent runFriendlyId={runFriendlyId} failedRedirect={failedRedirect} />
+    </DialogContent>
+  );
+}
+
+function ReplayContent({ runFriendlyId, failedRedirect }: ReplayRunDialogProps) {
   const fetcher = useTypedFetcher<typeof loader>();
   const isLoading = fetcher.state !== "idle";
 
@@ -26,10 +34,10 @@ export function ReplayRunDialog({ runFriendlyId, failedRedirect }: ReplayRunDial
   }, [runFriendlyId]);
 
   return (
-    <DialogContent key={`replay`}>
-      <DialogHeader>Replay this run?</DialogHeader>
+    <>
+      <DialogHeader>Replay this run</DialogHeader>
       {isLoading ? (
-        <div>
+        <div className="grid place-items-center p-6">
           <Spinner />
         </div>
       ) : fetcher.data ? (
@@ -41,7 +49,7 @@ export function ReplayRunDialog({ runFriendlyId, failedRedirect }: ReplayRunDial
       ) : (
         <>Failed to get run data</>
       )}
-    </DialogContent>
+    </>
   );
 }
 
@@ -83,7 +91,7 @@ function ReplayForm({
   );
 
   return (
-    <Form action={formAction} method="post" onSubmit={(e) => submitForm(e)}>
+    <Form action={formAction} method="post" onSubmit={(e) => submitForm(e)} className="pt-2">
       {editablePayload ? (
         <>
           <Header3 spacing>Payload</Header3>
@@ -114,9 +122,14 @@ function ReplayForm({
           items={environments}
           dropdownIcon
           variant="tertiary/medium"
+          className="w-fit pl-2"
           text={(value) => {
             const env = environments.find((env) => env.id === value)!;
-            return <EnvironmentLabel environment={env} userName={env.userName} />;
+            return (
+              <div className="flex items-center pr-2">
+                <EnvironmentLabel environment={env} userName={env.userName} />
+              </div>
+            );
           }}
         >
           {(matches) =>
@@ -131,11 +144,11 @@ function ReplayForm({
       <input type="hidden" name="failedRedirect" value={failedRedirect} />
       <Button
         type="submit"
-        variant="primary/small"
+        variant="primary/medium"
         LeadingIcon={isSubmitting ? ButtonSpinner : undefined}
         disabled={isSubmitting}
         shortcut={{ modifiers: ["meta"], key: "enter", enabledOnInputElements: true }}
-        className="mt-3"
+        className="mt-5"
       >
         {isSubmitting ? "Replaying..." : "Replay run"}
       </Button>

--- a/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
+++ b/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
@@ -28,10 +28,6 @@ export function ReplayRunDialog({ runFriendlyId, failedRedirect }: ReplayRunDial
   return (
     <DialogContent key="replay">
       <DialogHeader>Replay this run?</DialogHeader>
-      <DialogDescription>
-        Replaying a run will create a new run with the same payload and environment as the original.
-      </DialogDescription>
-
       {isLoading ? (
         <div>
           <Spinner />
@@ -91,13 +87,12 @@ function ReplayForm({
       {editablePayload ? (
         <>
           <Header3 spacing>Payload</Header3>
-          <div className="mb-3 max-h-[70vh] rounded-sm border border-grid-dimmed bg-charcoal-900">
+          <div className="mb-3 max-h-[70vh] overflow-y-auto rounded-sm border border-grid-dimmed bg-charcoal-900 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600">
             <JSONEditor
               defaultValue={currentJson.current}
               readOnly={false}
               basicSetup
               onChange={(v) => {
-                console.log(v);
                 currentJson.current = v;
               }}
               showClearButton={false}

--- a/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
+++ b/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
@@ -67,7 +67,8 @@ function ReplayForm({
   const formAction = `/resources/taskruns/${runFriendlyId}/replay`;
   const isSubmitting = navigation.formAction === formAction;
 
-  const editablePayload = payloadType === "application/json";
+  const editablePayload =
+    payloadType === "application/json" || payloadType === "application/super+json";
 
   const submitForm = useCallback(
     (e: React.FormEvent<HTMLFormElement>) => {

--- a/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
+++ b/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
@@ -26,7 +26,7 @@ export function ReplayRunDialog({ runFriendlyId, failedRedirect }: ReplayRunDial
   }, [runFriendlyId]);
 
   return (
-    <DialogContent key="replay">
+    <DialogContent key={`replay`}>
       <DialogHeader>Replay this run?</DialogHeader>
       {isLoading ? (
         <div>

--- a/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
+++ b/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
@@ -91,7 +91,7 @@ function ReplayForm({
       {editablePayload ? (
         <>
           <Header3 spacing>Payload</Header3>
-          <div className="mb-3 rounded-sm border border-grid-dimmed bg-charcoal-900">
+          <div className="mb-3 max-h-[70vh] rounded-sm border border-grid-dimmed bg-charcoal-900">
             <JSONEditor
               defaultValue={currentJson.current}
               readOnly={false}
@@ -100,6 +100,8 @@ function ReplayForm({
                 console.log(v);
                 currentJson.current = v;
               }}
+              showClearButton={false}
+              showCopyButton={false}
               height="100%"
               min-height="100%"
               max-height="100%"

--- a/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
+++ b/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
@@ -51,6 +51,7 @@ export function ReplayRunDialog({ runFriendlyId, failedRedirect }: ReplayRunDial
 
 function ReplayForm({
   payload,
+  payloadType,
   environment,
   environments,
   failedRedirect,
@@ -62,14 +63,20 @@ function ReplayForm({
   const formAction = `/resources/taskruns/${runFriendlyId}/replay`;
   const isSubmitting = navigation.formAction === formAction;
 
+  const editablePayload = payloadType === "application/json";
+
   const submitForm = useCallback(
     (e: React.FormEvent<HTMLFormElement>) => {
       const formData = new FormData(e.currentTarget);
-      const data = {
+      const data: Record<string, string> = {
         environment: formData.get("environment") as string,
         failedRedirect: formData.get("failedRedirect") as string,
-        payload: currentJson.current,
       };
+
+      if (editablePayload) {
+        data.payload = currentJson.current;
+      }
+
       submit(data, {
         action: formAction,
         method: "post",
@@ -81,21 +88,25 @@ function ReplayForm({
 
   return (
     <Form action={formAction} method="post" onSubmit={(e) => submitForm(e)}>
-      <Header3 spacing>Payload</Header3>
-      <div className="mb-3 rounded-sm border border-grid-dimmed bg-charcoal-900">
-        <JSONEditor
-          defaultValue={currentJson.current}
-          readOnly={false}
-          basicSetup
-          onChange={(v) => {
-            console.log(v);
-            currentJson.current = v;
-          }}
-          height="100%"
-          min-height="100%"
-          max-height="100%"
-        />
-      </div>
+      {editablePayload ? (
+        <>
+          <Header3 spacing>Payload</Header3>
+          <div className="mb-3 rounded-sm border border-grid-dimmed bg-charcoal-900">
+            <JSONEditor
+              defaultValue={currentJson.current}
+              readOnly={false}
+              basicSetup
+              onChange={(v) => {
+                console.log(v);
+                currentJson.current = v;
+              }}
+              height="100%"
+              min-height="100%"
+              max-height="100%"
+            />
+          </div>
+        </>
+      ) : null}
       <InputGroup>
         <Label>Environment</Label>
         <Select

--- a/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
+++ b/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
@@ -134,7 +134,7 @@ function ReplayForm({
         variant="primary/small"
         LeadingIcon={isSubmitting ? ButtonSpinner : undefined}
         disabled={isSubmitting}
-        shortcut={{ modifiers: ["meta"], key: "enter" }}
+        shortcut={{ modifiers: ["meta"], key: "enter", enabledOnInputElements: true }}
         className="mt-3"
       >
         {isSubmitting ? "Replaying..." : "Replay run"}

--- a/apps/webapp/app/components/runs/v3/SpanEvents.tsx
+++ b/apps/webapp/app/components/runs/v3/SpanEvents.tsx
@@ -6,7 +6,7 @@ import {
 import { CodeBlock } from "~/components/code/CodeBlock";
 import { Callout } from "~/components/primitives/Callout";
 import { DateTimeAccurate } from "~/components/primitives/DateTime";
-import { Header2 } from "~/components/primitives/Headers";
+import { Header2, Header3 } from "~/components/primitives/Headers";
 import { Paragraph } from "~/components/primitives/Paragraph";
 
 type SpanEventsProps = {
@@ -34,8 +34,8 @@ function SpanEventHeader({
 }) {
   return (
     <div className="flex items-center justify-between">
-      <Header2 className={titleClassName}>{title}</Header2>
-      <Paragraph variant="small">
+      <Header3 className={titleClassName}>{title}</Header3>
+      <Paragraph variant="extra-small">
         <DateTimeAccurate date={time} />
       </Paragraph>
     </div>
@@ -57,7 +57,7 @@ function SpanEvent({ spanEvent }: { spanEvent: OtelSpanEvent }) {
   );
 }
 
-function SpanEventError({
+export function SpanEventError({
   spanEvent,
   exception,
 }: {
@@ -65,7 +65,7 @@ function SpanEventError({
   exception: ExceptionEventProperties;
 }) {
   return (
-    <div className="flex flex-col gap-2 rounded-sm border border-rose-500/50 p-3">
+    <div className="flex flex-col gap-2 rounded-sm border border-rose-500/50 px-3 pb-3 pt-2">
       <SpanEventHeader
         title={exception.type ?? "Error"}
         time={spanEvent.time}

--- a/apps/webapp/app/models/taskRunTag.server.ts
+++ b/apps/webapp/app/models/taskRunTag.server.ts
@@ -1,6 +1,8 @@
 import { prisma } from "~/db.server";
 import { generateFriendlyId } from "~/v3/friendlyIdentifiers";
 
+export const MAX_TAGS_PER_RUN = 5;
+
 export async function createTag({ tag, projectId }: { tag: string; projectId: string }) {
   if (tag.trim().length === 0) return;
   return prisma.taskRunTag.upsert({

--- a/apps/webapp/app/presenters/v3/RunPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/RunPresenter.server.ts
@@ -1,5 +1,6 @@
 import { millisecondsToNanoseconds } from "@trigger.dev/core/v3";
 import { createTreeFromFlatItems, flattenTree } from "~/components/primitives/TreeView/TreeView";
+import { FINISHED_STATUSES } from "~/components/runs/v3/TaskRunStatus";
 import { PrismaClient, prisma } from "~/db.server";
 import { getUsername } from "~/utils/username";
 import { eventRepository } from "~/v3/eventRepository.server";
@@ -33,6 +34,7 @@ export class RunPresenter {
         traceId: true,
         spanId: true,
         friendlyId: true,
+        status: true,
         runtimeEnvironment: {
           select: {
             id: true,
@@ -71,6 +73,9 @@ export class RunPresenter {
           number: run.number,
           friendlyId: run.friendlyId,
           traceId: run.traceId,
+          spanId: run.spanId,
+          status: run.status,
+          isFinished: FINISHED_STATUSES.includes(run.status),
           environment: {
             id: run.runtimeEnvironment.id,
             organizationId: run.runtimeEnvironment.organizationId,
@@ -127,6 +132,9 @@ export class RunPresenter {
         number: run.number,
         friendlyId: run.friendlyId,
         traceId: run.traceId,
+        spanId: run.spanId,
+        status: run.status,
+        isFinished: FINISHED_STATUSES.includes(run.status),
         environment: {
           id: run.runtimeEnvironment.id,
           organizationId: run.runtimeEnvironment.organizationId,

--- a/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
@@ -75,7 +75,6 @@ export class SpanPresenter extends BasePresenter {
             sdkVersion: true,
           },
         },
-
         //status + duration
         status: true,
         startedAt: true,
@@ -207,6 +206,7 @@ export class SpanPresenter extends BasePresenter {
     };
 
     return {
+      friendlyId: run.friendlyId,
       status: run.status,
       createdAt: run.createdAt,
       startedAt: run.startedAt,

--- a/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
@@ -2,6 +2,7 @@ import { prettyPrintPacket } from "@trigger.dev/core/v3";
 import { PrismaClient, prisma } from "~/db.server";
 import { eventRepository } from "~/v3/eventRepository.server";
 import { BasePresenter } from "./basePresenter.server";
+import { FINISHED_STATUSES, RUNNING_STATUSES } from "~/components/runs/v3/TaskRunStatus";
 
 type Result = Awaited<ReturnType<SpanPresenter["call"]>>;
 export type Span = NonNullable<Result>["event"];
@@ -117,6 +118,8 @@ export class SpanPresenter extends BasePresenter {
       run: spanRun
         ? {
             ...spanRun,
+            isFinished: FINISHED_STATUSES.includes(spanRun.status),
+            isRunning: RUNNING_STATUSES.includes(spanRun.status),
           }
         : undefined,
       event: {

--- a/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
@@ -155,6 +155,7 @@ export class SpanPresenter extends BasePresenter {
             usageDurationMs: spanRun.usageDurationMs,
             isFinished: FINISHED_STATUSES.includes(spanRun.status),
             isRunning: RUNNING_STATUSES.includes(spanRun.status),
+            context: span.context ? JSON.stringify(span.context, null, 2) : undefined,
           }
         : undefined,
       event: {
@@ -165,6 +166,7 @@ export class SpanPresenter extends BasePresenter {
         payload,
         payloadType: span.payloadType ?? "application/json",
         properties: span.properties ? JSON.stringify(span.properties, null, 2) : undefined,
+        context: span.context ? JSON.stringify(span.context, null, 2) : undefined,
         showActionBar: span.show?.actions === true,
       },
     };

--- a/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
@@ -75,6 +75,7 @@ export class SpanPresenter extends BasePresenter {
             sdkVersion: true,
           },
         },
+
         //status + duration
         status: true,
         startedAt: true,
@@ -149,7 +150,7 @@ export class SpanPresenter extends BasePresenter {
         ? undefined
         : finishedAttempt.outputType === "application/store"
         ? `/resources/packets/${run.runtimeEnvironment.id}/${finishedAttempt.output}`
-        : typeof finishedAttempt.output !== "undefined"
+        : typeof finishedAttempt.output !== "undefined" && finishedAttempt.output !== null
         ? await prettyPrintPacket(finishedAttempt.output, finishedAttempt.outputType ?? undefined)
         : undefined;
 
@@ -165,6 +166,8 @@ export class SpanPresenter extends BasePresenter {
     const context = {
       task: {
         id: run.taskIdentifier,
+        filePath: run.lockedBy?.filePath,
+        exportName: run.lockedBy?.exportName,
       },
       run: {
         id: run.friendlyId,
@@ -177,6 +180,7 @@ export class SpanPresenter extends BasePresenter {
         costInCents: run.costInCents,
         baseCostInCents: run.baseCostInCents,
         maxAttempts: run.maxAttempts ?? undefined,
+        version: run.lockedToVersion?.version,
       },
       queue: {
         name: run.queue,

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam._index/route.tsx
@@ -20,7 +20,7 @@ import { Header1, Header2, Header3 } from "~/components/primitives/Headers";
 import { Input } from "~/components/primitives/Input";
 import { NavBar, PageAccessories, PageTitle } from "~/components/primitives/PageHeader";
 import { Paragraph } from "~/components/primitives/Paragraph";
-import { Property, PropertyTable } from "~/components/primitives/PropertyTable";
+import * as Property from "~/components/primitives/PropertyTable";
 import { Spinner } from "~/components/primitives/Spinner";
 import { StepNumber } from "~/components/primitives/StepNumber";
 import {
@@ -129,21 +129,20 @@ export default function Page() {
         <PageTitle title="Tasks" />
         <PageAccessories>
           <AdminDebugTooltip>
-            <PropertyTable>
+            <Property.Table>
               {tasks.map((task) => (
-                <Property label={task.exportName} key={task.slug}>
-                  <div className="flex items-center gap-2">
-                    <Paragraph variant="extra-small/bright/mono">
-                      {task.environments
-                        .map((e) =>
-                          e.userName ? `${e.userName}/${e.id}` : `${e.type.slice(0, 3)}/${e.id}`
-                        )
-                        .join(", ")}
-                    </Paragraph>
-                  </div>
-                </Property>
+                <Property.Item key={task.slug}>
+                  <Property.Label>{task.exportName}</Property.Label>
+                  <Property.Value>
+                    {task.environments
+                      .map((e) =>
+                        e.userName ? `${e.userName}/${e.id}` : `${e.type.slice(0, 3)}/${e.id}`
+                      )
+                      .join(", ")}
+                  </Property.Value>
+                </Property.Item>
               ))}
-            </PropertyTable>
+            </Property.Table>
           </AdminDebugTooltip>
         </PageAccessories>
       </NavBar>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.apikeys/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.apikeys/route.tsx
@@ -11,7 +11,7 @@ import { DateTime } from "~/components/primitives/DateTime";
 import { InfoPanel } from "~/components/primitives/InfoPanel";
 import { NavBar, PageAccessories, PageTitle } from "~/components/primitives/PageHeader";
 import { Paragraph } from "~/components/primitives/Paragraph";
-import { Property, PropertyTable } from "~/components/primitives/PropertyTable";
+import * as Property from "~/components/primitives/PropertyTable";
 import {
   Table,
   TableBody,
@@ -61,15 +61,14 @@ export default function Page() {
         <PageTitle title="API keys" />
         <PageAccessories>
           <AdminDebugTooltip>
-            <PropertyTable>
+            <Property.Table>
               {environments.map((environment) => (
-                <Property label={environment.slug} key={environment.id}>
-                  <div className="flex items-center gap-2">
-                    <Paragraph variant="extra-small/bright/mono">{environment.id}</Paragraph>
-                  </div>
-                </Property>
+                <Property.Item key={environment.id}>
+                  <Property.Label>{environment.slug}</Property.Label>
+                  <Property.Value>{environment.id}</Property.Value>
+                </Property.Item>
               ))}
-            </PropertyTable>
+            </Property.Table>
           </AdminDebugTooltip>
 
           <LinkButton

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.deployments.$deploymentParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.deployments.$deploymentParam/route.tsx
@@ -11,7 +11,7 @@ import { LinkButton } from "~/components/primitives/Buttons";
 import { DateTimeAccurate } from "~/components/primitives/DateTime";
 import { Header2 } from "~/components/primitives/Headers";
 import { Paragraph } from "~/components/primitives/Paragraph";
-import { Property, PropertyTable } from "~/components/primitives/PropertyTable";
+import * as Property from "~/components/primitives/PropertyTable";
 import {
   Table,
   TableBody,
@@ -71,44 +71,39 @@ export default function Page() {
         <Header2 className={cn("whitespace-nowrap")}>Deploy: {deployment.shortCode}</Header2>
 
         <AdminDebugTooltip>
-          <PropertyTable>
-            <Property label="ID">
-              <div className="flex items-center gap-2">
-                <Paragraph variant="extra-small/bright/mono">{deployment.id}</Paragraph>
-              </div>
-            </Property>
-            <Property label="Project ID">
-              <div className="flex items-center gap-2">
-                <Paragraph variant="extra-small/bright/mono">{deployment.projectId}</Paragraph>
-              </div>
-            </Property>
-            <Property label="Org ID">
-              <div className="flex items-center gap-2">
-                <Paragraph variant="extra-small/bright/mono">{deployment.organizationId}</Paragraph>
-              </div>
-            </Property>
+          <Property.Table>
+            <Property.Item>
+              <Property.Label>ID</Property.Label>
+              <Property.Value>{deployment.id}</Property.Value>
+            </Property.Item>
+            <Property.Item>
+              <Property.Label>Project ID</Property.Label>
+              <Property.Value>{deployment.projectId}</Property.Value>
+            </Property.Item>
+            <Property.Item>
+              <Property.Label>Org ID</Property.Label>
+              <Property.Value>{deployment.organizationId}</Property.Value>
+            </Property.Item>
             {deployment.imageReference && (
-              <Property label="Image">
-                <div className="flex items-center gap-2">
-                  <Paragraph variant="extra-small/bright/mono">
-                    {deployment.imageReference}
-                  </Paragraph>
-                </div>
-              </Property>
+              <Property.Item>
+                <Property.Label>Image</Property.Label>
+                <Property.Value>{deployment.imageReference}</Property.Value>
+              </Property.Item>
             )}
             {deployment.externalBuildData && (
-              <Property label="Build Server">
-                <div className="flex items-center gap-2">
+              <Property.Item>
+                <Property.Label>Build Server</Property.Label>
+                <Property.Value>
                   <Link
                     to={`/resources/${deployment.projectId}/deployments/${deployment.id}/logs`}
                     className="extra-small/bright/mono underline"
                   >
                     {deployment.externalBuildData.buildId}
                   </Link>
-                </div>
-              </Property>
+                </Property.Value>
+              </Property.Item>
             )}
-          </PropertyTable>
+          </Property.Table>
         </AdminDebugTooltip>
 
         <LinkButton
@@ -120,35 +115,51 @@ export default function Page() {
       </div>
       <div className="overflow-y-auto px-3 pt-4 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600">
         <div className="flex flex-col gap-4">
-          <PropertyTable>
-            <Property label="Deploy">
-              <div className="flex items-center gap-2">
-                <Paragraph variant="small/bright">{deployment.shortCode}</Paragraph>
+          <Property.Table>
+            <Property.Item>
+              <Property.Label>Deploy</Property.Label>
+              <Property.Value className="flex items-center gap-2">
+                <span>{deployment.shortCode}</span>
                 {deployment.label && <Badge variant="outline-rounded">{deployment.label}</Badge>}
-              </div>
-            </Property>
-            <Property label="Environment">
-              <EnvironmentLabel environment={deployment.environment} userName={usernameForEnv} />
-            </Property>
-            <Property label="Version">{deployment.version}</Property>
-            <Property label="Status">
-              <DeploymentStatus
-                status={deployment.status}
-                isBuilt={deployment.isBuilt}
-                className="text-sm"
-              />
-            </Property>
-            <Property label="Tasks">{deployment.tasks ? deployment.tasks.length : "–"}</Property>
-            <Property label="SDK Version">
-              {deployment.sdkVersion ? deployment.sdkVersion : "–"}
-            </Property>
-            <Property label="Started at">
-              <Paragraph variant="small/bright">
+              </Property.Value>
+            </Property.Item>
+            <Property.Item>
+              <Property.Label>Environment</Property.Label>
+              <Property.Value>
+                <EnvironmentLabel environment={deployment.environment} userName={usernameForEnv} />
+              </Property.Value>
+            </Property.Item>
+            <Property.Item>
+              <Property.Label>Version</Property.Label>
+              <Property.Value>{deployment.version}</Property.Value>
+            </Property.Item>
+            <Property.Item>
+              <Property.Label>Status</Property.Label>
+              <Property.Value>
+                <DeploymentStatus
+                  status={deployment.status}
+                  isBuilt={deployment.isBuilt}
+                  className="text-sm"
+                />
+              </Property.Value>
+            </Property.Item>
+            <Property.Item>
+              <Property.Label>Tasks</Property.Label>
+              <Property.Value>{deployment.tasks ? deployment.tasks.length : "–"}</Property.Value>
+            </Property.Item>
+            <Property.Item>
+              <Property.Label>SDK Version</Property.Label>
+              <Property.Value>{deployment.sdkVersion ? deployment.sdkVersion : "–"}</Property.Value>
+            </Property.Item>
+            <Property.Item>
+              <Property.Label>Started at</Property.Label>
+              <Property.Value>
                 <DateTimeAccurate date={deployment.createdAt} /> UTC
-              </Paragraph>
-            </Property>
-            <Property label="Built at">
-              <Paragraph variant="small/bright">
+              </Property.Value>
+            </Property.Item>
+            <Property.Item>
+              <Property.Label>Built at</Property.Label>
+              <Property.Value>
                 {deployment.builtAt ? (
                   <>
                     <DateTimeAccurate date={deployment.builtAt} /> UTC
@@ -156,10 +167,11 @@ export default function Page() {
                 ) : (
                   "–"
                 )}
-              </Paragraph>
-            </Property>
-            <Property label="Deployed at">
-              <Paragraph variant="small/bright">
+              </Property.Value>
+            </Property.Item>
+            <Property.Item>
+              <Property.Label>Deployed at</Property.Label>
+              <Property.Value>
                 {deployment.deployedAt ? (
                   <>
                     <DateTimeAccurate date={deployment.deployedAt} /> UTC
@@ -167,25 +179,28 @@ export default function Page() {
                 ) : (
                   "–"
                 )}
-              </Paragraph>
-            </Property>
-            <Property label="Deployed by">
-              {deployment.deployedBy ? (
-                <div className="flex items-center gap-1">
-                  <UserAvatar
-                    avatarUrl={deployment.deployedBy.avatarUrl}
-                    name={deployment.deployedBy.name ?? deployment.deployedBy.displayName}
-                    className="h-4 w-4"
-                  />
-                  <Paragraph variant="small">
-                    {deployment.deployedBy.name ?? deployment.deployedBy.displayName}
-                  </Paragraph>
-                </div>
-              ) : (
-                "–"
-              )}
-            </Property>
-          </PropertyTable>
+              </Property.Value>
+            </Property.Item>
+            <Property.Item>
+              <Property.Label>Deployed by</Property.Label>
+              <Property.Value>
+                {deployment.deployedBy ? (
+                  <div className="flex items-center gap-1">
+                    <UserAvatar
+                      avatarUrl={deployment.deployedBy.avatarUrl}
+                      name={deployment.deployedBy.name ?? deployment.deployedBy.displayName}
+                      className="h-4 w-4"
+                    />
+                    <Paragraph variant="small">
+                      {deployment.deployedBy.name ?? deployment.deployedBy.displayName}
+                    </Paragraph>
+                  </div>
+                ) : (
+                  "–"
+                )}
+              </Property.Value>
+            </Property.Item>
+          </Property.Table>
 
           {deployment.tasks ? (
             <div className="divide-y divide-charcoal-800 overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600">

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.environment-variables/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.environment-variables/route.tsx
@@ -248,6 +248,7 @@ export default function Page() {
                       <EditEnvironmentVariablePanel
                         environments={environments}
                         variable={variable}
+                        revealAll={revealAll}
                       />
                       <DeleteEnvironmentVariableButton variable={variable} />
                     </TableCellMenu>
@@ -293,15 +294,21 @@ export default function Page() {
 function EditEnvironmentVariablePanel({
   variable,
   environments,
+  revealAll,
 }: {
   variable: EnvironmentVariableWithSetValues;
   environments: Pick<RuntimeEnvironment, "id" | "type">[];
+  revealAll: boolean;
 }) {
+  const [reveal, setReveal] = useState(revealAll);
+
   const [isOpen, setIsOpen] = useState(false);
   const lastSubmission = useActionData();
   const navigation = useNavigation();
 
-  const hiddenValues = Object.values(variable.values).filter((value) => !environments.map(e => e.id).includes(value.environment.id));
+  const hiddenValues = Object.values(variable.values).filter(
+    (value) => !environments.map((e) => e.id).includes(value.environment.id)
+  );
 
   const isLoading =
     navigation.state !== "idle" &&
@@ -340,7 +347,11 @@ function EditEnvironmentVariablePanel({
           <input type="hidden" name="key" value={variable.key} />
           {hiddenValues.map((value, index) => (
             <Fragment key={index}>
-              <input type="hidden" name={`values[${index}].environmentId`} value={value.environment.id} />
+              <input
+                type="hidden"
+                name={`values[${index}].environmentId`}
+                value={value.environment.id}
+              />
               <input type="hidden" name={`values[${index}].value`} value={value.value} />
             </Fragment>
           ))}
@@ -355,7 +366,15 @@ function EditEnvironmentVariablePanel({
           </Fieldset>
           <Fieldset>
             <InputGroup fullWidth>
-              <Label>Values</Label>
+              <div className="flex justify-between gap-1">
+                <Label>Values</Label>
+                <Switch
+                  variant="small"
+                  label="Reveal"
+                  checked={reveal}
+                  onCheckedChange={(e) => setReveal(e.valueOf())}
+                />
+              </div>
               <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-2">
                 {environments.map((environment, index) => {
                   const value = variable.values[environment.id]?.value;
@@ -377,7 +396,7 @@ function EditEnvironmentVariablePanel({
                         name={`values[${index}].value`}
                         placeholder="Not set"
                         defaultValue={value}
-                        type="password"
+                        type={reveal ? "text" : "password"}
                       />
                     </Fragment>
                   );

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
@@ -1,9 +1,12 @@
 import {
+  ArrowPathIcon,
+  ArrowUturnLeftIcon,
   BoltSlashIcon,
   ChevronDownIcon,
   ChevronRightIcon,
   MagnifyingGlassMinusIcon,
   MagnifyingGlassPlusIcon,
+  StopCircleIcon,
 } from "@heroicons/react/20/solid";
 import type { Location } from "@remix-run/react";
 import { useLoaderData, useParams, useRevalidator } from "@remix-run/react";
@@ -26,7 +29,7 @@ import { InlineCode } from "~/components/code/InlineCode";
 import { EnvironmentLabel } from "~/components/environments/EnvironmentLabel";
 import { MainCenteredContainer, PageBody } from "~/components/layout/AppLayout";
 import { Badge } from "~/components/primitives/Badge";
-import { LinkButton } from "~/components/primitives/Buttons";
+import { Button, LinkButton } from "~/components/primitives/Buttons";
 import { Callout } from "~/components/primitives/Callout";
 import { Header3 } from "~/components/primitives/Headers";
 import { Input } from "~/components/primitives/Input";
@@ -71,6 +74,9 @@ import {
 import { SpanView } from "../resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route";
 import { SimpleTooltip } from "~/components/primitives/Tooltip";
 import { env } from "~/env.server";
+import { Dialog, DialogTrigger } from "~/components/primitives/Dialog";
+import { CancelRunDialog } from "~/components/runs/v3/CancelRunDialog";
+import { ReplayRunDialog } from "~/components/runs/v3/ReplayRunDialog";
 
 type TraceEvent = NonNullable<SerializeFrom<typeof loader>["trace"]>["events"][0];
 
@@ -123,14 +129,14 @@ export default function Page() {
               text: "Runs",
             }}
             title={
-              <>
-                <span>Cock #${run.number}</span>
+              <div className="flex items-center gap-3">
+                <span>Run #{run.number}</span>
                 <EnvironmentLabel
                   size="large"
                   environment={run.environment}
                   userName={usernameForEnv}
                 />
-              </>
+              </div>
             }
           />
           <PageAccessories>
@@ -229,6 +235,44 @@ export default function Page() {
               </Property.Item>
             </Property.Table>
           </AdminDebugTooltip>
+          <Dialog key="replay">
+            <DialogTrigger asChild>
+              <Button
+                variant="tertiary/small"
+                LeadingIcon={ArrowUturnLeftIcon}
+                shortcut={{ key: "R" }}
+              >
+                Replay run
+              </Button>
+            </DialogTrigger>
+            <ReplayRunDialog
+              runFriendlyId={run.friendlyId}
+              failedRedirect={v3RunSpanPath(
+                organization,
+                project,
+                { friendlyId: run.friendlyId },
+                { spanId: run.spanId }
+              )}
+            />
+          </Dialog>
+          {run.isFinished ? null : (
+            <Dialog key="cancel">
+              <DialogTrigger asChild>
+                <Button variant="danger/small" LeadingIcon={StopCircleIcon}>
+                  Cancel run
+                </Button>
+              </DialogTrigger>
+              <CancelRunDialog
+                runFriendlyId={run.friendlyId}
+                redirectPath={v3RunSpanPath(
+                  organization,
+                  project,
+                  { friendlyId: run.friendlyId },
+                  { spanId: run.spanId }
+                )}
+              />
+            </Dialog>
+          )}
         </PageAccessories>
       </NavBar>
       <PageBody scrollable={false}>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
@@ -235,7 +235,7 @@ export default function Page() {
               </Property.Item>
             </Property.Table>
           </AdminDebugTooltip>
-          <Dialog key="replay">
+          <Dialog key={`replay-${run.friendlyId}`}>
             <DialogTrigger asChild>
               <Button
                 variant="tertiary/small"
@@ -256,7 +256,7 @@ export default function Page() {
             />
           </Dialog>
           {run.isFinished ? null : (
-            <Dialog key="cancel">
+            <Dialog key={`cancel-${run.friendlyId}`}>
               <DialogTrigger asChild>
                 <Button variant="danger/small" LeadingIcon={StopCircleIcon}>
                   Cancel run

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
@@ -232,7 +232,7 @@ export default function Page() {
               setResizableRunSettings(document, layout);
             }}
           >
-            <ResizablePanel order={1} minSize={30} defaultSize={resizeSettings.layout?.[0]}>
+            <ResizablePanel order={1} minSize={30} defaultSize={resizeSettings.layout?.[0] ?? 65}>
               <TasksTreeView
                 selectedId={selectedSpanId}
                 key={events[0]?.id ?? "-"}
@@ -257,7 +257,7 @@ export default function Page() {
             </ResizablePanel>
             <ResizableHandle withHandle />
             {selectedSpanId && (
-              <ResizablePanel order={2} minSize={30} defaultSize={resizeSettings.layout?.[1]}>
+              <ResizablePanel order={2} minSize={25} defaultSize={resizeSettings.layout?.[1] ?? 35}>
                 <SpanView
                   runParam={run.friendlyId}
                   spanId={selectedSpanId}
@@ -299,7 +299,7 @@ function TasksTreeView({
 }: TasksTreeViewProps) {
   const [filterText, setFilterText] = useState("");
   const [errorsOnly, setErrorsOnly] = useState(false);
-  const [showDurations, setShowDurations] = useState(false);
+  const [showDurations, setShowDurations] = useState(true);
   const [scale, setScale] = useState(0);
   const parentRef = useRef<HTMLDivElement>(null);
   const treeScrollRef = useRef<HTMLDivElement>(null);
@@ -1021,11 +1021,6 @@ function KeyboardShortcuts({
         title="Collapse all"
       />
       <NumberShortcuts toggleLevel={(number) => toggleExpandLevel(number)} />
-      <ShortcutWithAction
-        shortcut={{ key: "d" }}
-        action={() => setShowDurations((d) => !d)}
-        title="Toggle durations"
-      />
     </>
   );
 }

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
@@ -122,7 +122,16 @@ export default function Page() {
               to: v3RunsPath(organization, project),
               text: "Runs",
             }}
-            title={`Run #${run.number}`}
+            title={
+              <>
+                <span>Cock #${run.number}</span>
+                <EnvironmentLabel
+                  size="large"
+                  environment={run.environment}
+                  userName={usernameForEnv}
+                />
+              </>
+            }
           />
           <PageAccessories>
             <AdminDebugTooltip>
@@ -145,12 +154,6 @@ export default function Page() {
                 </Property.Item>
               </Property.Table>
             </AdminDebugTooltip>
-
-            <EnvironmentLabel
-              size="large"
-              environment={run.environment}
-              userName={usernameForEnv}
-            />
           </PageAccessories>
         </NavBar>
         <PageBody>
@@ -194,7 +197,16 @@ export default function Page() {
             to: v3RunsPath(organization, project),
             text: "Runs",
           }}
-          title={`Run #${run.number}`}
+          title={
+            <div className="flex items-center gap-3">
+              <span>Run #{run.number}</span>
+              <EnvironmentLabel
+                size="large"
+                environment={run.environment}
+                userName={usernameForEnv}
+              />
+            </div>
+          }
         />
         <PageAccessories>
           <AdminDebugTooltip>
@@ -217,8 +229,6 @@ export default function Page() {
               </Property.Item>
             </Property.Table>
           </AdminDebugTooltip>
-
-          <EnvironmentLabel size="large" environment={run.environment} userName={usernameForEnv} />
         </PageAccessories>
       </NavBar>
       <PageBody scrollable={false}>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
@@ -1070,7 +1070,7 @@ function KeyboardShortcuts({
         title="Expand all"
       />
       <ShortcutWithAction
-        shortcut={{ key: "c" }}
+        shortcut={{ key: "w" }}
         action={() => collapseAllBelowDepth(1)}
         title="Collapse all"
       />

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
@@ -286,7 +286,7 @@ export default function Page() {
               setResizableRunSettings(document, layout);
             }}
           >
-            <ResizablePanel order={1} minSize={30} defaultSize={resizeSettings.layout?.[0] ?? 65}>
+            <ResizablePanel order={1} minSize={30} defaultSize={resizeSettings.layout?.[0] ?? 70}>
               <TasksTreeView
                 selectedId={selectedSpanId}
                 key={events[0]?.id ?? "-"}
@@ -311,7 +311,7 @@ export default function Page() {
             </ResizablePanel>
             <ResizableHandle withHandle />
             {selectedSpanId && (
-              <ResizablePanel order={2} minSize={25} defaultSize={resizeSettings.layout?.[1] ?? 35}>
+              <ResizablePanel order={2} minSize={25} defaultSize={resizeSettings.layout?.[1] ?? 30}>
                 <SpanView
                   runParam={run.friendlyId}
                   spanId={selectedSpanId}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
@@ -33,7 +33,7 @@ import { Input } from "~/components/primitives/Input";
 import { NavBar, PageAccessories, PageTitle } from "~/components/primitives/PageHeader";
 import { Paragraph } from "~/components/primitives/Paragraph";
 import { Popover, PopoverArrowTrigger, PopoverContent } from "~/components/primitives/Popover";
-import { Property, PropertyTable } from "~/components/primitives/PropertyTable";
+import * as Property from "~/components/primitives/PropertyTable";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -126,30 +126,24 @@ export default function Page() {
           />
           <PageAccessories>
             <AdminDebugTooltip>
-              <PropertyTable>
-                <Property label="ID">
-                  <div className="flex items-center gap-2">
-                    <Paragraph variant="extra-small/bright/mono">{run.id}</Paragraph>
-                  </div>
-                </Property>
-                <Property label="Trace ID">
-                  <div className="flex items-center gap-2">
-                    <Paragraph variant="extra-small/bright/mono">{run.traceId}</Paragraph>
-                  </div>
-                </Property>
-                <Property label="Env ID">
-                  <div className="flex items-center gap-2">
-                    <Paragraph variant="extra-small/bright/mono">{run.environment.id}</Paragraph>
-                  </div>
-                </Property>
-                <Property label="Org ID">
-                  <div className="flex items-center gap-2">
-                    <Paragraph variant="extra-small/bright/mono">
-                      {run.environment.organizationId}
-                    </Paragraph>
-                  </div>
-                </Property>
-              </PropertyTable>
+              <Property.Table>
+                <Property.Item>
+                  <Property.Label>ID</Property.Label>
+                  <Property.Value>{run.id}</Property.Value>
+                </Property.Item>
+                <Property.Item>
+                  <Property.Label>Trace ID</Property.Label>
+                  <Property.Value>{run.traceId}</Property.Value>
+                </Property.Item>
+                <Property.Item>
+                  <Property.Label>Env ID</Property.Label>
+                  <Property.Value>{run.environment.id}</Property.Value>
+                </Property.Item>
+                <Property.Item>
+                  <Property.Label>Org ID</Property.Label>
+                  <Property.Value>{run.environment.organizationId}</Property.Value>
+                </Property.Item>
+              </Property.Table>
             </AdminDebugTooltip>
 
             <EnvironmentLabel
@@ -204,30 +198,24 @@ export default function Page() {
         />
         <PageAccessories>
           <AdminDebugTooltip>
-            <PropertyTable>
-              <Property label="ID">
-                <div className="flex items-center gap-2">
-                  <Paragraph variant="extra-small/bright/mono">{run.id}</Paragraph>
-                </div>
-              </Property>
-              <Property label="Trace ID">
-                <div className="flex items-center gap-2">
-                  <Paragraph variant="extra-small/bright/mono">{run.traceId}</Paragraph>
-                </div>
-              </Property>
-              <Property label="Env ID">
-                <div className="flex items-center gap-2">
-                  <Paragraph variant="extra-small/bright/mono">{run.environment.id}</Paragraph>
-                </div>
-              </Property>
-              <Property label="Org ID">
-                <div className="flex items-center gap-2">
-                  <Paragraph variant="extra-small/bright/mono">
-                    {run.environment.organizationId}
-                  </Paragraph>
-                </div>
-              </Property>
-            </PropertyTable>
+            <Property.Table>
+              <Property.Item>
+                <Property.Label>ID</Property.Label>
+                <Property.Value>{run.id}</Property.Value>
+              </Property.Item>
+              <Property.Item>
+                <Property.Label>Trace ID</Property.Label>
+                <Property.Value>{run.traceId}</Property.Value>
+              </Property.Item>
+              <Property.Item>
+                <Property.Label>Env ID</Property.Label>
+                <Property.Value>{run.environment.id}</Property.Value>
+              </Property.Item>
+              <Property.Item>
+                <Property.Label>Org ID</Property.Label>
+                <Property.Value>{run.environment.organizationId}</Property.Value>
+              </Property.Item>
+            </Property.Table>
           </AdminDebugTooltip>
 
           <EnvironmentLabel size="large" environment={run.environment} userName={usernameForEnv} />

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules.$scheduleParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules.$scheduleParam/route.tsx
@@ -15,7 +15,6 @@ import { ExitIcon } from "~/assets/icons/ExitIcon";
 import { InlineCode } from "~/components/code/InlineCode";
 import { EnvironmentLabels } from "~/components/environments/EnvironmentLabel";
 import { Button, LinkButton } from "~/components/primitives/Buttons";
-import { Callout, variantClasses } from "~/components/primitives/Callout";
 import { DateTime } from "~/components/primitives/DateTime";
 import {
   Dialog,
@@ -324,12 +323,12 @@ export default function Page() {
                         </TableRow>
                       ))
                     ) : (
-                      <TableBlankRow colSpan={1}>
+                      <TableBlankRow colSpan={isUtc ? 1 : 2}>
                         <PlaceholderText title="You found a bug" />
                       </TableBlankRow>
                     )
                   ) : (
-                    <TableBlankRow colSpan={1}>
+                    <TableBlankRow colSpan={isUtc ? 1 : 2}>
                       <PlaceholderText title="Schedule disabled" />
                     </TableBlankRow>
                   )}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules.$scheduleParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules.$scheduleParam/route.tsx
@@ -27,7 +27,7 @@ import {
 import { Header2, Header3 } from "~/components/primitives/Headers";
 import { InfoPanel } from "~/components/primitives/InfoPanel";
 import { Paragraph } from "~/components/primitives/Paragraph";
-import { Property, PropertyTable } from "~/components/primitives/PropertyTable";
+import * as Property from "~/components/primitives/PropertyTable";
 import {
   Table,
   TableBlankRow,
@@ -225,36 +225,63 @@ export default function Page() {
       <div className="overflow-y-scroll scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600">
         <div className="p-3">
           <div className="space-y-3">
-            <PropertyTable>
-              <Property label="Schedule ID">{schedule.friendlyId}</Property>
-              <Property label="Task ID">{schedule.taskIdentifier}</Property>
-              <Property label="Type">
-                <ScheduleTypeCombo type={schedule.type} className="text-sm" />
-              </Property>
-              <Property label="CRON (UTC)" labelClassName="self-start">
-                <div className="space-y-2">
-                  <InlineCode variant="extra-small">{schedule.cron}</InlineCode>
-                  <Paragraph variant="small">{schedule.cronDescription}</Paragraph>
-                </div>
-              </Property>
-              <Property label="Timezone">{schedule.timezone}</Property>
-              <Property label="Environments">
-                <EnvironmentLabels size="small" environments={schedule.environments} />
-              </Property>
+            <Property.Table>
+              <Property.Item>
+                <Property.Label>Schedule ID</Property.Label>
+                <Property.Value>{schedule.friendlyId}</Property.Value>
+              </Property.Item>
+              <Property.Item>
+                <Property.Label>Task ID</Property.Label>
+                <Property.Value>{schedule.taskIdentifier}</Property.Value>
+              </Property.Item>
+              <Property.Item>
+                <Property.Label>Type</Property.Label>
+                <Property.Value>
+                  <ScheduleTypeCombo type={schedule.type} className="text-sm" />
+                </Property.Value>
+              </Property.Item>
+              <Property.Item>
+                <Property.Label>CRON</Property.Label>
+                <Property.Value>
+                  <div className="space-y-2">
+                    <InlineCode variant="extra-small">{schedule.cron}</InlineCode>
+                    <Paragraph variant="small">{schedule.cronDescription}</Paragraph>
+                  </div>
+                </Property.Value>
+              </Property.Item>
+              <Property.Item>
+                <Property.Label>Timezone</Property.Label>
+                <Property.Value>{schedule.timezone}</Property.Value>
+              </Property.Item>
+              <Property.Item>
+                <Property.Label>Environments</Property.Label>
+                <Property.Value>
+                  <EnvironmentLabels size="small" environments={schedule.environments} />
+                </Property.Value>
+              </Property.Item>
               {isImperative && (
                 <>
-                  <Property label="External ID">
-                    {schedule.externalId ? schedule.externalId : "–"}
-                  </Property>
-                  <Property label="Deduplication key">
-                    {schedule.userProvidedDeduplicationKey ? schedule.deduplicationKey : "–"}
-                  </Property>
-                  <Property label="Status">
-                    <EnabledStatus enabled={schedule.active} />
-                  </Property>
+                  <Property.Item>
+                    <Property.Label>External ID</Property.Label>
+                    <Property.Value>
+                      {schedule.externalId ? schedule.externalId : "–"}
+                    </Property.Value>
+                  </Property.Item>
+                  <Property.Item>
+                    <Property.Label>Deduplication key</Property.Label>
+                    <Property.Value>
+                      {schedule.userProvidedDeduplicationKey ? schedule.deduplicationKey : "–"}
+                    </Property.Value>
+                  </Property.Item>
+                  <Property.Item>
+                    <Property.Label>Status</Property.Label>
+                    <Property.Value>
+                      <EnabledStatus enabled={schedule.active} />
+                    </Property.Value>
+                  </Property.Item>
                 </>
               )}
-            </PropertyTable>
+            </Property.Table>
             <div className="flex flex-col gap-1">
               <Header3>Last 5 runs</Header3>
               <TaskRunsTable

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.schedules/route.tsx
@@ -28,7 +28,7 @@ import { InfoPanel } from "~/components/primitives/InfoPanel";
 import { NavBar, PageAccessories, PageTitle } from "~/components/primitives/PageHeader";
 import { PaginationControls } from "~/components/primitives/Pagination";
 import { Paragraph } from "~/components/primitives/Paragraph";
-import { Property, PropertyTable } from "~/components/primitives/PropertyTable";
+import * as Property from "~/components/primitives/PropertyTable";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -122,15 +122,14 @@ export default function Page() {
         <PageTitle title="Schedules" />
         <PageAccessories>
           <AdminDebugTooltip>
-            <PropertyTable>
+            <Property.Table>
               {schedules.map((schedule) => (
-                <Property label={schedule.friendlyId} key={schedule.id}>
-                  <div className="flex items-center gap-2">
-                    <Paragraph variant="extra-small/bright/mono">{schedule.id}</Paragraph>
-                  </div>
-                </Property>
+                <Property.Item key={schedule.id}>
+                  <Property.Label>{schedule.friendlyId}</Property.Label>
+                  <Property.Value>{schedule.id}</Property.Value>
+                </Property.Item>
               ))}
-            </PropertyTable>
+            </Property.Table>
           </AdminDebugTooltip>
 
           {limits.used >= limits.limit ? (

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.settings/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.settings/route.tsx
@@ -17,7 +17,7 @@ import { InputGroup } from "~/components/primitives/InputGroup";
 import { Label } from "~/components/primitives/Label";
 import { NavBar, PageAccessories, PageTitle } from "~/components/primitives/PageHeader";
 import { Paragraph } from "~/components/primitives/Paragraph";
-import { Property, PropertyTable } from "~/components/primitives/PropertyTable";
+import * as Property from "~/components/primitives/PropertyTable";
 import { prisma } from "~/db.server";
 import { useProject } from "~/hooks/useProject";
 import { redirectWithSuccessMessage } from "~/models/message.server";
@@ -116,18 +116,19 @@ export default function Page() {
 
         <PageAccessories>
           <AdminDebugTooltip>
-            <PropertyTable>
-              <Property label="ID">
+            <Property.Table>
+              <Property.Item>
+                <Property.Label>ID</Property.Label>
+                <Property.Value>{project.id}</Property.Value>
                 <div className="flex items-center gap-2">
                   <Paragraph variant="extra-small/bright/mono">{project.id}</Paragraph>
                 </div>
-              </Property>
-              <Property label="Org ID">
-                <div className="flex items-center gap-2">
-                  <Paragraph variant="extra-small/bright/mono">{project.organizationId}</Paragraph>
-                </div>
-              </Property>
-            </PropertyTable>
+              </Property.Item>
+              <Property.Item>
+                <Property.Label>Org ID</Property.Label>
+                <Property.Value>{project.organizationId}</Property.Value>
+              </Property.Item>
+            </Property.Table>
           </AdminDebugTooltip>
         </PageAccessories>
       </NavBar>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.team/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.team/route.tsx
@@ -27,7 +27,7 @@ import { InfoPanel } from "~/components/primitives/InfoPanel";
 import { NamedIcon } from "~/components/primitives/NamedIcon";
 import { NavBar, PageAccessories, PageTitle } from "~/components/primitives/PageHeader";
 import { Paragraph } from "~/components/primitives/Paragraph";
-import { Property, PropertyTable } from "~/components/primitives/PropertyTable";
+import * as Property from "~/components/primitives/PropertyTable";
 import { SimpleTooltip } from "~/components/primitives/Tooltip";
 import { $replica } from "~/db.server";
 import { useOrganization } from "~/hooks/useOrganizations";
@@ -128,23 +128,25 @@ export default function Page() {
 
         <PageAccessories>
           <AdminDebugTooltip>
-            <PropertyTable>
-              <Property label="Org ID">
-                <div className="flex items-center gap-2">
-                  <Paragraph variant="extra-small/bright/mono">{organization.id}</Paragraph>
-                </div>
-              </Property>
+            <Property.Table>
+              <Property.Item>
+                <Property.Label>Org ID</Property.Label>
+                <Property.Value>{organization.id}</Property.Value>
+              </Property.Item>
 
               {members.map((member) => (
-                <Property label={member.user.name} key={member.id}>
-                  <div className="flex items-center gap-2">
-                    <Paragraph variant="extra-small/bright/mono">
-                      {member.user.email} - {member.user.id}
-                    </Paragraph>
-                  </div>
-                </Property>
+                <Property.Item key={member.id}>
+                  <Property.Label>{member.user.name}</Property.Label>
+                  <Property.Value>
+                    <div className="flex items-center gap-2">
+                      <Paragraph variant="extra-small/bright/mono">
+                        {member.user.email} - {member.user.id}
+                      </Paragraph>
+                    </div>
+                  </Property.Value>
+                </Property.Item>
               ))}
-            </PropertyTable>
+            </Property.Table>
           </AdminDebugTooltip>
         </PageAccessories>
       </NavBar>

--- a/apps/webapp/app/routes/api.v1.runs.$runId.tags.ts
+++ b/apps/webapp/app/routes/api.v1.runs.$runId.tags.ts
@@ -2,7 +2,7 @@ import { type ActionFunctionArgs, json } from "@remix-run/server-runtime";
 import { AddTagsRequestBody } from "@trigger.dev/core/v3";
 import { z } from "zod";
 import { prisma } from "~/db.server";
-import { createTag, getTagsForRunId } from "~/models/taskRunTag.server";
+import { createTag, getTagsForRunId, MAX_TAGS_PER_RUN } from "~/models/taskRunTag.server";
 import { authenticateApiRequest } from "~/services/apiAuth.server";
 import { generateFriendlyId } from "~/v3/friendlyIdentifiers";
 
@@ -51,12 +51,12 @@ export async function action({ request, params }: ActionFunctionArgs) {
       return !existingTags.map((t) => t.name).includes(tag);
     });
 
-    if (existingTags.length + newTags.length > 3) {
+    if (existingTags.length + newTags.length > MAX_TAGS_PER_RUN) {
       return json(
         {
-          error: `Runs can only have 3 tags, you're trying to set ${
+          error: `Runs can only have ${MAX_TAGS_PER_RUN} tags, you're trying to set ${
             existingTags.length + newTags.length
-          }.`,
+          }. These tags have not been set: ${newTags.map((t) => `'${t}'`).join(", ")}.`,
         },
         { status: 422 }
       );

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -249,16 +249,7 @@ function SpanBody({
                   <Property.Label>Version</Property.Label>
                   <Property.Value>
                     {span.workerVersion ? (
-                      <SimpleTooltip
-                        button={
-                          <TextLink
-                            to={v3RunsPath(organization, project, { tasks: [span.workerVersion] })}
-                          >
-                            {span.workerVersion}
-                          </TextLink>
-                        }
-                        content={`Filter runs by ${span.workerVersion}`}
-                      />
+                      span.workerVersion
                     ) : (
                       <span className="flex items-center gap-1">
                         <span>Never started</span>
@@ -456,16 +447,7 @@ function RunBody({
                   <Property.Label>Version</Property.Label>
                   <Property.Value>
                     {run.version ? (
-                      <SimpleTooltip
-                        button={
-                          <TextLink
-                            to={v3RunsPath(organization, project, { tasks: [run.version] })}
-                          >
-                            {run.version}
-                          </TextLink>
-                        }
-                        content={`Filter runs by ${run.version}`}
-                      />
+                      run.version
                     ) : (
                       <span className="flex items-center gap-1">
                         <span>Never started</span>

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -592,6 +592,14 @@ function RunBody({
                   </Property.Value>
                 </Property.Item>
               </Property.Table>
+              {run.context && (
+                <CodeBlock
+                  rowTitle="Context"
+                  code={run.context}
+                  maxLines={20}
+                  showLineNumbers={false}
+                />
+              )}
             </div>
           ) : (
             <div className="flex flex-col gap-4 pt-3">
@@ -602,19 +610,11 @@ function RunBody({
               {run.payload !== undefined && (
                 <PacketDisplay data={run.payload} dataType={run.payloadType} title="Payload" />
               )}
-              {run.events !== undefined ? (
+              {run.events !== undefined && run.events.length > 0 ? (
                 <SpanEvents spanEvents={run.events} />
               ) : run.output !== undefined ? (
                 <PacketDisplay data={run.output} dataType={run.outputType} title="Output" />
               ) : null}
-              {run.context && (
-                <CodeBlock
-                  rowTitle="Context"
-                  code={run.context}
-                  maxLines={20}
-                  showLineNumbers={false}
-                />
-              )}
             </div>
           )}
         </div>

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -159,7 +159,7 @@ function SpanBody({
   }
 
   return (
-    <div className="grid h-full max-h-full grid-rows-[2.5rem_1fr] overflow-hidden bg-background-bright">
+    <div className="grid h-full max-h-full grid-rows-[2.5rem_2rem_1fr] overflow-hidden bg-background-bright">
       <div className="mx-3 flex items-center justify-between gap-2 overflow-x-hidden">
         <div className="flex items-center gap-1 overflow-x-hidden">
           <RunIcon
@@ -180,30 +180,32 @@ function SpanBody({
           />
         )}
       </div>
+      <div className="px-3">
+        <TabContainer>
+          <TabButton
+            isActive={!tab || tab === "overview"}
+            layoutId="span-span"
+            onClick={() => {
+              replace({ tab: "overview" });
+            }}
+            shortcut={{ key: "o" }}
+          >
+            Overview
+          </TabButton>
+          <TabButton
+            isActive={tab === "detail"}
+            layoutId="span-span"
+            onClick={() => {
+              replace({ tab: "detail" });
+            }}
+            shortcut={{ key: "d" }}
+          >
+            Detail
+          </TabButton>
+        </TabContainer>
+      </div>
       <div className="overflow-y-auto px-3 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600">
         <div>
-          <TabContainer>
-            <TabButton
-              isActive={!tab || tab === "overview"}
-              layoutId="span-span"
-              onClick={() => {
-                replace({ tab: "overview" });
-              }}
-              shortcut={{ key: "o" }}
-            >
-              Overview
-            </TabButton>
-            <TabButton
-              isActive={tab === "detail"}
-              layoutId="span-span"
-              onClick={() => {
-                replace({ tab: "detail" });
-              }}
-              shortcut={{ key: "d" }}
-            >
-              Detail
-            </TabButton>
-          </TabContainer>
           {tab === "detail" ? (
             <div className="flex flex-col gap-4 pt-3">
               <Property.Table>
@@ -364,7 +366,7 @@ function RunBody({
   const environment = project.environments.find((e) => e.id === run.environmentId);
 
   return (
-    <div className="grid h-full max-h-full grid-rows-[2.5rem_1fr_3.25rem] overflow-hidden bg-background-bright">
+    <div className="grid h-full max-h-full grid-rows-[2.5rem_2rem_1fr_3.25rem] overflow-hidden bg-background-bright">
       <div className="mx-3 flex items-center justify-between gap-2 overflow-x-hidden">
         <div className="flex items-center gap-1 overflow-x-hidden">
           <RunIcon
@@ -385,40 +387,42 @@ function RunBody({
           />
         )}
       </div>
+      <div className="px-3">
+        <TabContainer>
+          <TabButton
+            isActive={!tab || tab === "overview"}
+            layoutId="span-run"
+            onClick={() => {
+              replace({ tab: "overview" });
+            }}
+            shortcut={{ key: "o" }}
+          >
+            Overview
+          </TabButton>
+          <TabButton
+            isActive={tab === "detail"}
+            layoutId="span-run"
+            onClick={() => {
+              replace({ tab: "detail" });
+            }}
+            shortcut={{ key: "d" }}
+          >
+            Detail
+          </TabButton>
+          <TabButton
+            isActive={tab === "context"}
+            layoutId="span-run"
+            onClick={() => {
+              replace({ tab: "context" });
+            }}
+            shortcut={{ key: "c" }}
+          >
+            Context
+          </TabButton>
+        </TabContainer>
+      </div>
       <div className="overflow-y-auto px-3 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600">
         <div>
-          <TabContainer>
-            <TabButton
-              isActive={!tab || tab === "overview"}
-              layoutId="span-run"
-              onClick={() => {
-                replace({ tab: "overview" });
-              }}
-              shortcut={{ key: "o" }}
-            >
-              Overview
-            </TabButton>
-            <TabButton
-              isActive={tab === "detail"}
-              layoutId="span-run"
-              onClick={() => {
-                replace({ tab: "detail" });
-              }}
-              shortcut={{ key: "d" }}
-            >
-              Detail
-            </TabButton>
-            <TabButton
-              isActive={tab === "context"}
-              layoutId="span-run"
-              onClick={() => {
-                replace({ tab: "context" });
-              }}
-              shortcut={{ key: "c" }}
-            >
-              Context
-            </TabButton>
-          </TabContainer>
           {tab === "detail" ? (
             <div className="flex flex-col gap-4 py-3">
               <Property.Table>

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -940,30 +940,16 @@ function SpanLinkElement({ link }: { link: SpanLink }) {
   switch (link.type) {
     case "run": {
       return (
-        <LinkButton
-          to={v3RunPath(organization, project, { friendlyId: link.runId })}
-          variant="minimal/medium"
-          LeadingIcon={link.icon}
-          leadingIconClassName="text-text-dimmed"
-          fullWidth
-          textAlignLeft
-        >
+        <TextLink to={v3RunPath(organization, project, { friendlyId: link.runId })}>
           {link.title}
-        </LinkButton>
+        </TextLink>
       );
     }
     case "span": {
       return (
-        <LinkButton
-          to={v3TraceSpanPath(organization, project, link.traceId, link.spanId)}
-          variant="minimal/medium"
-          LeadingIcon={link.icon}
-          leadingIconClassName="text-text-dimmed"
-          fullWidth
-          textAlignLeft
-        >
+        <TextLink to={v3TraceSpanPath(organization, project, link.traceId, link.spanId)}>
           {link.title}
-        </LinkButton>
+        </TextLink>
       );
     }
   }

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -1,18 +1,9 @@
-import {
-  ArrowPathIcon,
-  ArrowUturnLeftIcon,
-  CheckIcon,
-  ClockIcon,
-  CloudArrowDownIcon,
-  QueueListIcon,
-  StopCircleIcon,
-} from "@heroicons/react/20/solid";
+import { CheckIcon, ClockIcon, CloudArrowDownIcon, QueueListIcon } from "@heroicons/react/20/solid";
 import { Link, useParams } from "@remix-run/react";
 import { LoaderFunctionArgs } from "@remix-run/server-runtime";
 import {
   formatDuration,
   formatDurationMilliseconds,
-  formatDurationNanoseconds,
   nanosecondsToMilliseconds,
 } from "@trigger.dev/core/v3";
 import { ReactNode, useEffect } from "react";
@@ -21,25 +12,15 @@ import { ExitIcon } from "~/assets/icons/ExitIcon";
 import { CodeBlock } from "~/components/code/CodeBlock";
 import { EnvironmentLabel } from "~/components/environments/EnvironmentLabel";
 import { Button, LinkButton } from "~/components/primitives/Buttons";
-import {
-  ClientTabs,
-  ClientTabsContent,
-  ClientTabsList,
-  ClientTabsTrigger,
-} from "~/components/primitives/ClientTabs";
-import { ClipboardField } from "~/components/primitives/ClipboardField";
 import { DateTime, DateTimeAccurate } from "~/components/primitives/DateTime";
-import { Dialog, DialogTrigger } from "~/components/primitives/Dialog";
 import { Header2 } from "~/components/primitives/Headers";
 import { Paragraph } from "~/components/primitives/Paragraph";
 import * as Property from "~/components/primitives/PropertyTable";
 import { Spinner } from "~/components/primitives/Spinner";
-import { TabContainer, TabButton, Tabs } from "~/components/primitives/Tabs";
+import { TabButton, TabContainer } from "~/components/primitives/Tabs";
 import { TextLink } from "~/components/primitives/TextLink";
 import { InfoIconTooltip, SimpleTooltip } from "~/components/primitives/Tooltip";
-import { CancelRunDialog } from "~/components/runs/v3/CancelRunDialog";
 import { LiveTimer } from "~/components/runs/v3/LiveTimer";
-import { ReplayRunDialog } from "~/components/runs/v3/ReplayRunDialog";
 import { RunIcon } from "~/components/runs/v3/RunIcon";
 import { RunTag } from "~/components/runs/v3/RunTag";
 import { SpanEvents } from "~/components/runs/v3/SpanEvents";
@@ -47,11 +28,9 @@ import { SpanTitle } from "~/components/runs/v3/SpanTitle";
 import { TaskPath } from "~/components/runs/v3/TaskPath";
 import { TaskRunAttemptStatusCombo } from "~/components/runs/v3/TaskRunAttemptStatus";
 import { TaskRunStatusCombo } from "~/components/runs/v3/TaskRunStatus";
-import { useOptimisticLocation } from "~/hooks/useOptimisticLocation";
 import { useOrganization } from "~/hooks/useOrganizations";
 import { useProject } from "~/hooks/useProject";
 import { useSearchParams } from "~/hooks/useSearchParam";
-import { runBasicStatus } from "~/models/jobRun.server";
 import { redirectWithErrorMessage } from "~/models/message.server";
 import { Span, SpanPresenter, SpanRun } from "~/presenters/v3/SpanPresenter.server";
 import { requireUserId } from "~/services/session.server";
@@ -725,68 +704,19 @@ function RunTimelineLine({ title, state }: RunTimelineLineProps) {
 }
 
 function RunActionButtons({ span }: { span: Span }) {
-  const organization = useOrganization();
-  const project = useProject();
   const { runParam } = useParams();
-
   if (!runParam) return null;
 
-  if (span.isPartial) {
-    return (
-      <Dialog key="in-progress">
-        <LinkButton
-          to={v3RunDownloadLogsPath({ friendlyId: runParam })}
-          LeadingIcon={CloudArrowDownIcon}
-          variant="tertiary/medium"
-          target="_blank"
-          download
-        >
-          Download logs
-        </LinkButton>
-        <DialogTrigger asChild>
-          <Button variant="danger/medium" LeadingIcon={StopCircleIcon}>
-            Cancel run
-          </Button>
-        </DialogTrigger>
-        <CancelRunDialog
-          runFriendlyId={span.runId}
-          redirectPath={v3RunSpanPath(
-            organization,
-            project,
-            { friendlyId: runParam },
-            { spanId: span.spanId }
-          )}
-        />
-      </Dialog>
-    );
-  }
-
   return (
-    <Dialog key="complete">
-      <LinkButton
-        to={v3RunDownloadLogsPath({ friendlyId: runParam })}
-        LeadingIcon={CloudArrowDownIcon}
-        variant="tertiary/medium"
-        target="_blank"
-        download
-      >
-        Download logs
-      </LinkButton>
-      <DialogTrigger asChild>
-        <Button variant="tertiary/medium" LeadingIcon={ArrowUturnLeftIcon}>
-          Replay run
-        </Button>
-      </DialogTrigger>
-      <ReplayRunDialog
-        runFriendlyId={span.runId}
-        failedRedirect={v3RunSpanPath(
-          organization,
-          project,
-          { friendlyId: runParam },
-          { spanId: span.spanId }
-        )}
-      />
-    </Dialog>
+    <LinkButton
+      to={v3RunDownloadLogsPath({ friendlyId: runParam })}
+      LeadingIcon={CloudArrowDownIcon}
+      variant="tertiary/medium"
+      target="_blank"
+      download
+    >
+      Download logs
+    </LinkButton>
   );
 }
 

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -621,14 +621,16 @@ function RunBody({
       </div>
       <div className="flex items-center justify-between gap-2 border-t border-grid-dimmed px-2">
         <div className="flex items-center gap-4">
-          <LinkButton
-            to={v3RunSpanPath(organization, project, { friendlyId: runParam }, { spanId })}
-            variant="minimal/medium"
-            LeadingIcon={QueueListIcon}
-            shortcut={{ key: "f" }}
-          >
-            Focus on span
-          </LinkButton>
+          {run.friendlyId !== runParam && (
+            <LinkButton
+              to={v3RunSpanPath(organization, project, { friendlyId: run.friendlyId }, { spanId })}
+              variant="minimal/medium"
+              LeadingIcon={QueueListIcon}
+              shortcut={{ key: "f" }}
+            >
+              Focus on run
+            </LinkButton>
+          )}
         </div>
         <div className="flex items-center gap-4">
           <LinkButton

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -1,5 +1,6 @@
 import {
   ArrowPathIcon,
+  ArrowUturnLeftIcon,
   CheckIcon,
   ClockIcon,
   CloudArrowDownIcon,
@@ -772,7 +773,7 @@ function RunActionButtons({ span }: { span: Span }) {
         Download logs
       </LinkButton>
       <DialogTrigger asChild>
-        <Button variant="tertiary/medium" LeadingIcon={ArrowPathIcon}>
+        <Button variant="tertiary/medium" LeadingIcon={ArrowUturnLeftIcon}>
           Replay run
         </Button>
       </DialogTrigger>

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -415,7 +415,7 @@ function RunBody({
             </TabButton>
           </TabContainer>
           {tab === "detail" ? (
-            <div className="flex flex-col gap-4 pt-3">
+            <div className="flex flex-col gap-4 py-3">
               <Property.Table>
                 <Property.Item>
                   <Property.Label>Status</Property.Label>

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -152,7 +152,11 @@ function SpanBody({
   const organization = useOrganization();
   const project = useProject();
   const { value, replace } = useSearchParams();
-  const tab = value("tab");
+  let tab = value("tab");
+
+  if (tab === "context") {
+    tab = "overview";
+  }
 
   return (
     <div className="grid h-full max-h-full grid-rows-[2.5rem_1fr] overflow-hidden bg-background-bright">
@@ -181,7 +185,7 @@ function SpanBody({
           <TabContainer>
             <TabButton
               isActive={!tab || tab === "overview"}
-              layoutId="span-run"
+              layoutId="span-span"
               onClick={() => {
                 replace({ tab: "overview" });
               }}
@@ -191,7 +195,7 @@ function SpanBody({
             </TabButton>
             <TabButton
               isActive={tab === "detail"}
-              layoutId="span-run"
+              layoutId="span-span"
               onClick={() => {
                 replace({ tab: "detail" });
               }}
@@ -413,6 +417,16 @@ function RunBody({
             >
               Detail
             </TabButton>
+            <TabButton
+              isActive={tab === "context"}
+              layoutId="span-run"
+              onClick={() => {
+                replace({ tab: "context" });
+              }}
+              shortcut={{ key: "c" }}
+            >
+              Context
+            </TabButton>
           </TabContainer>
           {tab === "detail" ? (
             <div className="flex flex-col gap-4 py-3">
@@ -592,14 +606,10 @@ function RunBody({
                   </Property.Value>
                 </Property.Item>
               </Property.Table>
-              {run.context && (
-                <CodeBlock
-                  rowTitle="Context"
-                  code={run.context}
-                  maxLines={20}
-                  showLineNumbers={false}
-                />
-              )}
+            </div>
+          ) : tab === "context" ? (
+            <div className="flex flex-col gap-4 py-3">
+              <CodeBlock code={run.context} showLineNumbers={false} />
             </div>
           ) : (
             <div className="flex flex-col gap-4 pt-3">

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -701,12 +701,21 @@ function RunTimelineLine({ title, state }: RunTimelineLineProps) {
         <div
           className={cn(
             "w-px",
-            state === "complete"
-              ? "bg-success"
-              : state === "delayed"
-              ? "bg-text-dimmed"
-              : "bg-gradient-to-b from-[#3B82F6] from-50% to-transparent"
+            state === "complete" ? "bg-success" : state === "delayed" ? "bg-text-dimmed" : ""
           )}
+          style={
+            state === "inprogress"
+              ? {
+                  width: "1px",
+                  height: "100%",
+                  background:
+                    "repeating-linear-gradient(to bottom, #3B82F6 0%, #3B82F6 50%, transparent 50%, transparent 100%)",
+                  backgroundSize: "1px 6px",
+                  maskImage: "linear-gradient(to bottom, black 50%, transparent 100%)",
+                  WebkitMaskImage: "linear-gradient(to bottom, black 50%, transparent 100%)",
+                }
+              : undefined
+          }
         ></div>
       </div>
       <div className="flex items-center justify-between gap-3">

--- a/apps/webapp/app/routes/resources.taskruns.$runParam.replay.ts
+++ b/apps/webapp/app/routes/resources.taskruns.$runParam.replay.ts
@@ -71,6 +71,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   return typedjson({
     payload: await prettyPrintPacket(run.payload, run.payloadType),
+    payloadType: run.payloadType,
     environment: displayableEnvironment(environment, userId),
     environments: sortEnvironments(
       run.project.environments.map((environment) => displayableEnvironment(environment, userId))
@@ -79,8 +80,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 }
 
 const FormSchema = z.object({
-  environment: z.string(),
-  payload: z.string(),
+  environment: z.string().optional(),
+  payload: z.string().optional(),
   failedRedirect: z.string(),
 });
 

--- a/apps/webapp/app/v3/eventRepository.server.ts
+++ b/apps/webapp/app/v3/eventRepository.server.ts
@@ -11,6 +11,7 @@ import {
   SpanEvents,
   SpanMessagingEvent,
   TaskEventStyle,
+  TaskRunContext,
   TaskRunError,
   correctErrorStackTrace,
   createPacketAttributesAsJson,
@@ -552,6 +553,11 @@ export class EventRepository {
       const show = rehydrateShow(spanEvent.properties);
 
       const properties = sanitizedAttributes(spanEvent.properties);
+      const metadata = sanitizedAttributes(spanEvent.metadata);
+      const context =
+        metadata && typeof metadata === "object"
+          ? (metadata.ctx as Record<string, unknown>)
+          : undefined;
 
       const messagingEvent = SpanMessagingEvent.optional().safeParse(
         (properties as any)?.messaging
@@ -602,6 +608,8 @@ export class EventRepository {
         payload,
         output,
         properties,
+        metadata,
+        context,
         events: spanEvents,
         show,
         links,

--- a/apps/webapp/app/v3/eventRepository.server.ts
+++ b/apps/webapp/app/v3/eventRepository.server.ts
@@ -553,11 +553,6 @@ export class EventRepository {
       const show = rehydrateShow(spanEvent.properties);
 
       const properties = sanitizedAttributes(spanEvent.properties);
-      const metadata = sanitizedAttributes(spanEvent.metadata);
-      const context =
-        metadata && typeof metadata === "object"
-          ? (metadata.ctx as Record<string, unknown>)
-          : undefined;
 
       const messagingEvent = SpanMessagingEvent.optional().safeParse(
         (properties as any)?.messaging
@@ -608,8 +603,6 @@ export class EventRepository {
         payload,
         output,
         properties,
-        metadata,
-        context,
         events: spanEvents,
         show,
         links,

--- a/apps/webapp/app/v3/eventRepository.server.ts
+++ b/apps/webapp/app/v3/eventRepository.server.ts
@@ -11,7 +11,6 @@ import {
   SpanEvents,
   SpanMessagingEvent,
   TaskEventStyle,
-  TaskRunContext,
   TaskRunError,
   correctErrorStackTrace,
   createPacketAttributesAsJson,

--- a/apps/webapp/app/v3/machinePresets.server.ts
+++ b/apps/webapp/app/v3/machinePresets.server.ts
@@ -24,7 +24,7 @@ export function machinePresetFromConfig(config: unknown): MachinePreset {
   return machinePresetFromName("small-1x");
 }
 
-function machinePresetFromName(name: MachinePresetName): MachinePreset {
+export function machinePresetFromName(name: MachinePresetName): MachinePreset {
   return {
     name,
     ...machines[name],

--- a/apps/webapp/app/v3/services/createTaskRunAttempt.server.ts
+++ b/apps/webapp/app/v3/services/createTaskRunAttempt.server.ts
@@ -190,6 +190,7 @@ export class CreateTaskRunAttemptService extends BaseService {
           costInCents: taskRun.costInCents,
           baseCostInCents: taskRun.baseCostInCents,
           maxAttempts: taskRun.maxAttempts ?? undefined,
+          version: taskRun.lockedBy.worker.version,
         },
         queue: {
           id: queue.friendlyId,

--- a/apps/webapp/app/v3/services/expireEnqueuedRun.server.ts
+++ b/apps/webapp/app/v3/services/expireEnqueuedRun.server.ts
@@ -1,6 +1,7 @@
 import { logger } from "~/services/logger.server";
 import { marqs } from "~/v3/marqs/index.server";
 import { BaseService } from "./baseService.server";
+import { eventRepository } from "../eventRepository.server";
 
 export class ExpireEnqueuedRunService extends BaseService {
   public async call(runId: string) {
@@ -46,6 +47,24 @@ export class ExpireEnqueuedRunService extends BaseService {
         status: "EXPIRED",
         expiredAt: new Date(),
       },
+    });
+
+    await eventRepository.completeEvent(run.spanId, {
+      endTime: new Date(),
+      attributes: {
+        isError: true,
+      },
+      events: [
+        {
+          name: "exception",
+          time: new Date(),
+          properties: {
+            exception: {
+              message: "Run expired",
+            },
+          },
+        },
+      ],
     });
 
     await marqs?.acknowledgeMessage(run.id);

--- a/apps/webapp/app/v3/services/expireEnqueuedRun.server.ts
+++ b/apps/webapp/app/v3/services/expireEnqueuedRun.server.ts
@@ -60,7 +60,7 @@ export class ExpireEnqueuedRunService extends BaseService {
           time: new Date(),
           properties: {
             exception: {
-              message: "Run expired",
+              message: `Run expired because the TTL (${run.ttl}) was reached`,
             },
           },
         },

--- a/apps/webapp/app/v3/services/replayTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/replayTaskRun.server.ts
@@ -7,8 +7,8 @@ import { OutOfEntitlementError, TriggerTaskService } from "./triggerTask.server"
 import { getTagsForRunId } from "~/models/taskRunTag.server";
 
 type OverrideOptions = {
-  environmentId: string;
-  payload: string;
+  environmentId?: string;
+  payload?: string;
 };
 
 export class ReplayTaskRunService extends BaseService {
@@ -27,7 +27,7 @@ export class ReplayTaskRunService extends BaseService {
 
     let payloadPacket: IOPacket;
 
-    if (overrideOptions) {
+    if (overrideOptions?.payload) {
       payloadPacket = await conditionallyImportPacket({
         data: overrideOptions.payload,
         dataType: "application/json",

--- a/apps/webapp/app/v3/services/replayTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/replayTaskRun.server.ts
@@ -52,7 +52,7 @@ export class ReplayTaskRunService extends BaseService {
 
     try {
       const tags = await getTagsForRunId({
-        friendlyId: existingTaskRun.id,
+        friendlyId: existingTaskRun.friendlyId,
         environmentId: authenticatedEnvironment.id,
       });
 

--- a/packages/core/src/v3/schemas/api.ts
+++ b/packages/core/src/v3/schemas/api.ts
@@ -57,10 +57,7 @@ export type CreateBackgroundWorkerResponse = z.infer<typeof CreateBackgroundWork
 
 //an array of 1, 2, or 3 strings
 const RunTag = z.string().max(64, "Tags must be less than 64 characters");
-export const RunTags = z.union([
-  RunTag,
-  RunTag.array().max(3, "You can only set a maximum of 3 tags on a run."),
-]);
+export const RunTags = z.union([RunTag, RunTag.array()]);
 
 export type RunTags = z.infer<typeof RunTags>;
 

--- a/packages/core/src/v3/schemas/common.ts
+++ b/packages/core/src/v3/schemas/common.ts
@@ -137,6 +137,7 @@ export const TaskRun = z.object({
   durationMs: z.number().default(0),
   costInCents: z.number().default(0),
   baseCostInCents: z.number().default(0),
+  version: z.string().optional(),
 });
 
 export type TaskRun = z.infer<typeof TaskRun>;

--- a/packages/core/src/v3/utils/ioSerialization.ts
+++ b/packages/core/src/v3/utils/ioSerialization.ts
@@ -351,3 +351,16 @@ function safeJsonParse(value: string): any {
     return;
   }
 }
+
+export async function replaceSuperJsonPayload(original: string, newPayload: string) {
+  const superjson = await loadSuperJSON();
+  const originalObject = superjson.parse(original);
+  const { meta } = superjson.serialize(originalObject);
+
+  const newSuperJson = {
+    json: JSON.parse(newPayload) as any,
+    meta,
+  };
+
+  return superjson.deserialize(newSuperJson);
+}

--- a/packages/database/prisma/migrations/20240729101628_task_run_span_id_index/migration.sql
+++ b/packages/database/prisma/migrations/20240729101628_task_run_span_id_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "TaskRun_spanId_idx" ON "TaskRun"("spanId");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1691,6 +1691,8 @@ model TaskRun {
   @@index([projectId, taskIdentifier, status])
   //Schedules
   @@index([scheduleId])
+  // Run page inspector
+  @@index([spanId])
 }
 
 enum TaskRunStatus {

--- a/references/v3-catalog/src/trigger/subtasks.ts
+++ b/references/v3-catalog/src/trigger/subtasks.ts
@@ -31,6 +31,10 @@ export const simpleChildTask = task({
     await tags.add("product:1");
 
     await wait.for({ seconds: 10 });
+
+    return {
+      foo: "bar",
+    };
   },
 });
 

--- a/references/v3-catalog/src/trigger/tags.ts
+++ b/references/v3-catalog/src/trigger/tags.ts
@@ -9,6 +9,8 @@ type Payload = {
 export const triggerRunsWithTags = task({
   id: "trigger-runs-with-tags",
   run: async (payload: Payload, { ctx }) => {
+    logger.info(`${ctx.run.version}`);
+
     const { id } = await simpleChildTask.trigger(
       { message: "trigger from triggerRunsWithTags" },
       { tags: payload.tags }


### PR DESCRIPTION
The run page inspector panel (on the right) has been redesigned

![Trigger_dev _development_ · 6 11pm · 07-30](https://github.com/user-attachments/assets/279df48e-3e90-4d12-94a2-6359e72bb18b)

We show more relevant information than before and have added tabs so you can get more detail if you want. Runs now show the payload, output, context and full details. The run status is shown, which matches the data from the Runs page table. There's a new timeline which gives you a detailed account of what has happened with a run.

We've also added the ability to edit the payload and environment when doing a replay of a run.