### PR TITLE
v3: fix triggering tasks with custom queues

### DIFF
--- a/.changeset/few-poems-vanish.md
+++ b/.changeset/few-poems-vanish.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+Fix trigger functions for custom queues

--- a/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
+++ b/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
@@ -274,14 +274,6 @@ export class SharedQueueConsumer {
           where: {
             id: message.messageId,
           },
-          include: {
-            lockedToVersion: {
-              include: {
-                deployment: true,
-                tasks: true,
-              },
-            },
-          },
         });
 
         if (!existingTaskRun) {

--- a/apps/webapp/app/v3/models/workerDeployment.server.ts
+++ b/apps/webapp/app/v3/models/workerDeployment.server.ts
@@ -1,6 +1,8 @@
 import type { Prettify } from "@trigger.dev/core";
+import { BackgroundWorker } from "@trigger.dev/database";
 import { CURRENT_DEPLOYMENT_LABEL } from "~/consts";
 import { Prisma, prisma } from "~/db.server";
+import { AuthenticatedEnvironment } from "~/services/apiAuth.server";
 
 export type CurrentWorkerDeployment = Prettify<
   NonNullable<Awaited<ReturnType<typeof findCurrentWorkerDeployment>>>
@@ -40,6 +42,25 @@ export async function findCurrentWorkerDeployment(
   });
 
   return promotion?.deployment;
+}
+
+export async function findCurrentWorkerFromEnvironment(
+  environment: Pick<AuthenticatedEnvironment, "id" | "type">
+): Promise<BackgroundWorker | null> {
+  if (environment.type === "DEVELOPMENT") {
+    const latestDevWorker = await prisma.backgroundWorker.findFirst({
+      where: {
+        runtimeEnvironmentId: environment.id,
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+    return latestDevWorker;
+  } else {
+    const deployment = await findCurrentWorkerDeployment(environment.id);
+    return deployment?.worker ?? null;
+  }
 }
 
 export async function getWorkerDeploymentFromWorker(

--- a/apps/webapp/app/v3/services/triggerTask.server.ts
+++ b/apps/webapp/app/v3/services/triggerTask.server.ts
@@ -1,5 +1,6 @@
 import {
   IOPacket,
+  QueueOptions,
   SemanticInternalAttributes,
   TriggerTaskRequestBody,
   packetRequiresOffloading,
@@ -18,6 +19,7 @@ import { BaseService, ServiceValidationError } from "./baseService.server";
 import { logger } from "~/services/logger.server";
 import { isFinalAttemptStatus, isFinalRunStatus } from "../taskStatus";
 import { createTag } from "~/models/taskRunTag.server";
+import { findCurrentWorkerFromEnvironment } from "../models/workerDeployment.server";
 
 export type TriggerTaskServiceOptions = {
   idempotencyKey?: string;
@@ -201,7 +203,9 @@ export class TriggerTaskService extends BaseService {
                   })
                 : undefined;
 
-              let queueName = sanitizeQueueName(body.options?.queue?.name ?? `task/${taskId}`);
+              let queueName = sanitizeQueueName(
+                await this.#getQueueName(taskId, environment, body.options?.queue?.name)
+              );
 
               // Check that the queuename is not an empty string
               if (!queueName) {
@@ -387,6 +391,57 @@ export class TriggerTaskService extends BaseService {
         }
       );
     });
+  }
+
+  async #getQueueName(taskId: string, environment: AuthenticatedEnvironment, queueName?: string) {
+    if (queueName) {
+      return queueName;
+    }
+
+    const defaultQueueName = `task/${taskId}`;
+
+    const worker = await findCurrentWorkerFromEnvironment(environment);
+
+    if (!worker) {
+      logger.debug("Failed to get queue name: No worker found", {
+        taskId,
+        environmentId: environment.id,
+      });
+
+      return defaultQueueName;
+    }
+
+    const task = await this._prisma.backgroundWorkerTask.findUnique({
+      where: {
+        workerId_slug: {
+          workerId: worker.id,
+          slug: taskId,
+        },
+      },
+    });
+
+    if (!task) {
+      console.log("Failed to get queue name: No task found", {
+        taskId,
+        environmentId: environment.id,
+      });
+
+      return defaultQueueName;
+    }
+
+    const queueConfig = QueueOptions.optional().safeParse(task.queueConfig);
+
+    if (!queueConfig.success) {
+      console.log("Failed to get queue name: Invalid queue config", {
+        taskId,
+        environmentId: environment.id,
+        queueConfig: task.queueConfig,
+      });
+
+      return defaultQueueName;
+    }
+
+    return queueConfig.data?.name ?? defaultQueueName;
   }
 
   async #handlePayloadPacket(

--- a/references/v3-catalog/package.json
+++ b/references/v3-catalog/package.json
@@ -7,8 +7,8 @@
   },
   "scripts": {
     "dev:trigger": "triggerdev dev",
-    "management": "ts-node -r tsconfig-paths/register ./src/management.ts",
-    "queues": "ts-node -r tsconfig-paths/register ./src/queues.ts",
+    "management": "ts-node -r dotenv/config -r tsconfig-paths/register ./src/management.ts",
+    "queues": "ts-node -r dotenv/config -r tsconfig-paths/register ./src/queues.ts",
     "build:client": "tsup-node ./src/clientUsage.ts --format esm,cjs",
     "client": "ts-node -r dotenv/config -r tsconfig-paths/register ./src/clientUsage.ts",
     "triggerWithLargePayload": "ts-node -r dotenv/config -r tsconfig-paths/register ./src/triggerWithLargePayload.ts",


### PR DESCRIPTION
Custom queues defined at task creation will now be respected when triggering those tasks in different scenarios. This covers all envs, including the test page. Changes can be tested by running `pnpm queues` in the v3 catalog.