### PR TITLE
Added TaskRun completedAt column

### DIFF
--- a/apps/webapp/app/v3/failedTaskRun.server.ts
+++ b/apps/webapp/app/v3/failedTaskRun.server.ts
@@ -65,6 +65,7 @@ export class FailedTaskRunService extends BaseService {
       },
       data: {
         status: "SYSTEM_FAILURE",
+        completedAt: new Date(),
       },
     });
   }

--- a/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
+++ b/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
@@ -566,7 +566,6 @@ export class SharedQueueConsumer {
                 lockedById: null,
                 status: lockedTaskRun.status,
                 startedAt: existingTaskRun.startedAt,
-                //should we set the completedAt to null here?
               },
             }),
           ]);

--- a/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
+++ b/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
@@ -566,6 +566,7 @@ export class SharedQueueConsumer {
                 lockedById: null,
                 status: lockedTaskRun.status,
                 startedAt: existingTaskRun.startedAt,
+                //should we set the completedAt to null here?
               },
             }),
           ]);

--- a/apps/webapp/app/v3/services/cancelAttempt.server.ts
+++ b/apps/webapp/app/v3/services/cancelAttempt.server.ts
@@ -66,6 +66,9 @@ export class CancelAttemptService extends BaseService {
                 status: isCancellableRunStatus(taskRunAttempt.taskRun.status)
                   ? "INTERRUPTED"
                   : undefined,
+                completedAt: isCancellableRunStatus(taskRunAttempt.taskRun.status)
+                  ? cancelledAt
+                  : undefined,
               },
             },
           },

--- a/apps/webapp/app/v3/services/cancelTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/cancelTaskRun.server.ts
@@ -57,6 +57,7 @@ export class CancelTaskRunService extends BaseService {
       },
       data: {
         status: "CANCELED",
+        completedAt: opts.cancelledAt,
       },
       include: {
         attempts: {

--- a/apps/webapp/app/v3/services/completeAttempt.server.ts
+++ b/apps/webapp/app/v3/services/completeAttempt.server.ts
@@ -57,6 +57,7 @@ export class CompleteAttemptService extends BaseService {
         },
         data: {
           status: "SYSTEM_FAILURE",
+          completedAt: new Date(),
         },
       });
 
@@ -107,6 +108,7 @@ export class CompleteAttemptService extends BaseService {
           update: {
             data: {
               status: "COMPLETED_SUCCESSFULLY",
+              completedAt: new Date(),
             },
           },
         },
@@ -260,6 +262,7 @@ export class CompleteAttemptService extends BaseService {
           },
           data: {
             status: "SYSTEM_FAILURE",
+            completedAt: new Date(),
           },
         });
 
@@ -332,6 +335,7 @@ export class CompleteAttemptService extends BaseService {
           },
           data: {
             status: "SYSTEM_FAILURE",
+            completedAt: new Date(),
           },
         });
       } else {
@@ -341,6 +345,7 @@ export class CompleteAttemptService extends BaseService {
           },
           data: {
             status: "COMPLETED_WITH_ERRORS",
+            completedAt: new Date(),
           },
         });
       }

--- a/apps/webapp/app/v3/services/crashTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/crashTaskRun.server.ts
@@ -52,6 +52,7 @@ export class CrashTaskRunService extends BaseService {
       },
       data: {
         status: "CRASHED",
+        completedAt: new Date(),
       },
       include: {
         attempts: {

--- a/apps/webapp/app/v3/services/expireEnqueuedRun.server.ts
+++ b/apps/webapp/app/v3/services/expireEnqueuedRun.server.ts
@@ -46,6 +46,7 @@ export class ExpireEnqueuedRunService extends BaseService {
       data: {
         status: "EXPIRED",
         expiredAt: new Date(),
+        completedAt: new Date(),
       },
     });
 

--- a/apps/webapp/prisma/populate.ts
+++ b/apps/webapp/prisma/populate.ts
@@ -56,6 +56,7 @@ async function populate() {
 
         return {
           status: "CANCELED",
+          completedAt: new Date(),
           number: index + 1,
           friendlyId,
           runtimeEnvironmentId: project.environments[randomIndex(project.environments)].id,

--- a/packages/database/prisma/migrations/20240801175428_added_task_run_completed_at_column/migration.sql
+++ b/packages/database/prisma/migrations/20240801175428_added_task_run_completed_at_column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "TaskRun" ADD COLUMN     "completedAt" TIMESTAMP(3);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1647,6 +1647,7 @@ model TaskRun {
   checkpoints Checkpoint[]
 
   startedAt     DateTime?
+  completedAt   DateTime?
   machinePreset String?
 
   usageDurationMs Int   @default(0)


### PR DESCRIPTION
Add TaskRun `completedAt` column in preparation for some changes that are coming. It gets set when a TaskRun is in one of the finished statuses. We have not done a migration that sets this column for existing runs because that operation would be too expensive when deploying.