### PR TITLE
FinalizeRunService

### DIFF
--- a/apps/webapp/app/v3/failedTaskRun.server.ts
+++ b/apps/webapp/app/v3/failedTaskRun.server.ts
@@ -40,6 +40,19 @@ export class FailedTaskRunService extends BaseService {
     // No more retries, we need to fail the task run
     logger.debug("[FailedTaskRunService] Failing task run", { taskRun, completion });
 
+    /*
+    "SYSTEM_FAILURE"
+
+    Steps:
+    1. marqs ack
+    2. Completes the run span OTEL event
+    3. Updates the run to system failure
+
+    Inputs:
+    - taskRun: id, spanId
+    - completion: error
+    */
+
     await marqs?.acknowledgeMessage(taskRun.id);
 
     // Now we need to "complete" the task run event/span

--- a/apps/webapp/app/v3/failedTaskRun.server.ts
+++ b/apps/webapp/app/v3/failedTaskRun.server.ts
@@ -1,8 +1,6 @@
 import { TaskRunFailedExecutionResult } from "@trigger.dev/core/v3";
-import { logger } from "~/services/logger.server";
-import { marqs } from "~/v3/marqs/index.server";
-
 import { TaskRunStatus } from "@trigger.dev/database";
+import { logger } from "~/services/logger.server";
 import { createExceptionPropertiesFromError, eventRepository } from "./eventRepository.server";
 import { BaseService } from "./services/baseService.server";
 import { FinalizeTaskRunService } from "./services/finalizeTaskRun.server";

--- a/apps/webapp/app/v3/services/cancelAttempt.server.ts
+++ b/apps/webapp/app/v3/services/cancelAttempt.server.ts
@@ -51,6 +51,23 @@ export class CancelAttemptService extends BaseService {
         return;
       }
 
+      /*
+      "INTERRUPTED" (or leave it as is)
+      
+      Steps:
+      1. marqs ack
+      2. Updates the run *attempt* to canceled AND potentially the run to INTERRUPTED
+      3. Cancels all incomplete OTEL events
+      4. Enqueues resuming task run dependencies
+
+      Inputs: 
+      - taskRun: id, status, friendlyId
+      - taskRunAttempt: friendlyId
+      - cancelledAt
+      - reason
+      - Prisma client/transaction
+      */
+
       await marqs?.acknowledgeMessage(taskRunId);
 
       await this._prisma.taskRunAttempt.update({

--- a/apps/webapp/app/v3/services/cancelTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/cancelTaskRun.server.ts
@@ -47,6 +47,22 @@ export class CancelTaskRunService extends BaseService {
       return;
     }
 
+    /*
+    "CANCELED"
+    
+    Steps:
+    1. marqs ack
+    2. Updates the run to canceled and gets attempts, dependencies, etc
+    3. Cancels all incomplete OTEL events
+    4. Cancels all in progress attempts
+    5. Cancels all in progress workers
+
+    Inputs:
+    - taskRun: id, friendlyId
+    - cancelledAt
+    - reason
+    */
+
     // Remove the task run from the queue if it's there for some reason
     await marqs?.acknowledgeMessage(taskRun.id);
 

--- a/apps/webapp/app/v3/services/crashTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/crashTaskRun.server.ts
@@ -43,6 +43,22 @@ export class CrashTaskRunService extends BaseService {
       return;
     }
 
+    /*
+    "CRASHED"
+    
+    Steps:
+    1. marqs ack
+    2. Updates the run to crashed, gets attempts, dependencies, etc
+    3. Crashes all the relevant OTEL events
+    4. Cancels any in progress attempts
+
+    Inputs:
+    - taskRun: id, friendlyId
+    - crashedAt
+    - reason
+    - logs/stacktrace
+    */
+
     // Remove the task run from the queue if it's there for some reason
     await marqs?.acknowledgeMessage(taskRun.id);
 

--- a/apps/webapp/app/v3/services/crashTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/crashTaskRun.server.ts
@@ -44,22 +44,6 @@ export class CrashTaskRunService extends BaseService {
       return;
     }
 
-    /*
-    "CRASHED"
-    
-    Steps:
-    1. marqs ack
-    2. Updates the run to crashed, gets attempts, dependencies, etc
-    3. Crashes all the relevant OTEL events
-    4. Cancels any in progress attempts
-
-    Inputs:
-    - taskRun: id, friendlyId
-    - crashedAt
-    - reason
-    - logs/stacktrace
-    */
-
     const finalizeService = new FinalizeTaskRunService();
     const crashedTaskRun = await finalizeService.call({
       tx: this._prisma,

--- a/apps/webapp/app/v3/services/crashTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/crashTaskRun.server.ts
@@ -7,6 +7,7 @@ import { AuthenticatedEnvironment } from "~/services/apiAuth.server";
 import { ResumeTaskRunDependenciesService } from "./resumeTaskRunDependencies.server";
 import { CRASHABLE_ATTEMPT_STATUSES, isCrashableRunStatus } from "../taskStatus";
 import { sanitizeError } from "@trigger.dev/core/v3";
+import { FinalizeTaskRunService } from "./finalizeTaskRun.server";
 
 export type CrashTaskRunServiceOptions = {
   reason?: string;
@@ -59,18 +60,12 @@ export class CrashTaskRunService extends BaseService {
     - logs/stacktrace
     */
 
-    // Remove the task run from the queue if it's there for some reason
-    await marqs?.acknowledgeMessage(taskRun.id);
-
-    // Set the task run status to crashed
-    const crashedTaskRun = await this._prisma.taskRun.update({
-      where: {
-        id: taskRun.id,
-      },
-      data: {
-        status: "CRASHED",
-        completedAt: new Date(),
-      },
+    const finalizeService = new FinalizeTaskRunService();
+    const crashedTaskRun = await finalizeService.call({
+      tx: this._prisma,
+      id: taskRun.id,
+      status: "CRASHED",
+      completedAt: new Date(),
       include: {
         attempts: {
           where: {

--- a/apps/webapp/app/v3/services/expireEnqueuedRun.server.ts
+++ b/apps/webapp/app/v3/services/expireEnqueuedRun.server.ts
@@ -39,6 +39,21 @@ export class ExpireEnqueuedRunService extends BaseService {
       run,
     });
 
+    /*
+    "EXPIRED"
+
+    Steps:
+    1. Updates the run to expired, with dates
+    2. Completes the run span OTEL event
+    3. marqs ack
+
+    Inputs:
+    - taskRun: id, spanId, ttl
+
+    Questions:
+    - Why do we ack after the db update?
+    */
+
     await this._prisma.taskRun.update({
       where: {
         id: run.id,

--- a/apps/webapp/app/v3/services/finalizeTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/finalizeTaskRun.server.ts
@@ -2,6 +2,7 @@ import { type Prisma, type TaskRun, type TaskRunStatus } from "@trigger.dev/data
 import { type PrismaClientOrTransaction } from "~/db.server";
 import { marqs } from "~/v3/marqs/index.server";
 import { BaseService } from "./baseService.server";
+import { logger } from "~/services/logger.server";
 
 type BaseInput = {
   tx: PrismaClientOrTransaction;
@@ -34,7 +35,20 @@ export class FinalizeTaskRunService extends BaseService {
   }: T extends Prisma.TaskRunInclude ? InputWithInclude<T> : InputWithoutInclude): Promise<
     Output<T>
   > {
+    logger.debug("Finalizing run marqs ack", {
+      id,
+      status,
+      expiredAt,
+      completedAt,
+    });
     await marqs?.acknowledgeMessage(id);
+
+    logger.debug("Finalizing run updating run status", {
+      id,
+      status,
+      expiredAt,
+      completedAt,
+    });
 
     const run = await tx.taskRun.update({
       where: { id },

--- a/apps/webapp/app/v3/services/finalizeTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/finalizeTaskRun.server.ts
@@ -1,4 +1,4 @@
-import { TaskRun, type Prisma, type TaskRunStatus } from "@trigger.dev/database";
+import { type Prisma, type TaskRun, type TaskRunStatus } from "@trigger.dev/database";
 import { type PrismaClientOrTransaction } from "~/db.server";
 import { marqs } from "~/v3/marqs/index.server";
 import { BaseService } from "./baseService.server";

--- a/apps/webapp/app/v3/services/finalizeTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/finalizeTaskRun.server.ts
@@ -6,7 +6,7 @@ import { BaseService } from "./baseService.server";
 type BaseInput = {
   tx: PrismaClientOrTransaction;
   id: string;
-  status: TaskRunStatus;
+  status?: TaskRunStatus;
   expiredAt?: Date;
   completedAt?: Date;
 };

--- a/apps/webapp/app/v3/services/finalizeTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/finalizeTaskRun.server.ts
@@ -1,0 +1,37 @@
+import { marqs } from "~/v3/marqs/index.server";
+import { BaseService } from "./baseService.server";
+import { type TaskRunStatus } from "@trigger.dev/database";
+import { type PrismaClientOrTransaction } from "~/db.server";
+
+type Input = {
+  tx: PrismaClientOrTransaction;
+  id: string;
+  status: TaskRunStatus;
+  expiredAt?: Date;
+  completedAt?: Date;
+};
+
+//todo
+//1. ack
+//2. Using the passed in transaction client, update the run status and any optional dates passed in
+//3. Remove the run from it's concurrency sets in Redis
+//4? Do alerts if the run has failed
+
+export class FinalizeTaskRunService extends BaseService {
+  public async call({ tx, id, status, expiredAt, completedAt }: Input) {
+    await marqs?.acknowledgeMessage(id);
+
+    const run = await tx.taskRun.update({
+      where: {
+        id,
+      },
+      data: {
+        status,
+        expiredAt,
+        completedAt,
+      },
+    });
+
+    return run;
+  }
+}


### PR DESCRIPTION
Centralize where we update the TaskRun to a final state and do marqs.ack.

In the future we will:
- enqueue run failure alerts from here
- update Redis concurrency for Task/global