### PR TITLE
Concurrency page and more accurate tracking

### DIFF
--- a/apps/webapp/app/components/admin/debugTooltip.tsx
+++ b/apps/webapp/app/components/admin/debugTooltip.tsx
@@ -1,20 +1,16 @@
-import * as Property from "~/components/primitives/PropertyTable";
 import { ShieldCheckIcon } from "@heroicons/react/20/solid";
+import * as Property from "~/components/primitives/PropertyTable";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "~/components/primitives/Tooltip";
-import {
-  useIsImpersonating,
-  useOptionalOrganization,
-  useOrganization,
-} from "~/hooks/useOrganizations";
-import { useOptionalProject, useProject } from "~/hooks/useProject";
+import { useIsImpersonating, useOptionalOrganization } from "~/hooks/useOrganizations";
+import { useOptionalProject } from "~/hooks/useProject";
 import { useHasAdminAccess, useUser } from "~/hooks/useUser";
 
-export function AdminDebugTooltip({ children }: { children: React.ReactNode }) {
+export function AdminDebugTooltip({ children }: { children?: React.ReactNode }) {
   const hasAdminAccess = useHasAdminAccess();
   const isImpersonating = useIsImpersonating();
 

--- a/apps/webapp/app/components/navigation/SideMenu.tsx
+++ b/apps/webapp/app/components/navigation/SideMenu.tsx
@@ -9,6 +9,7 @@ import {
   CursorArrowRaysIcon,
   IdentificationIcon,
   KeyIcon,
+  RectangleStackIcon,
   ServerStackIcon,
   ShieldCheckIcon,
   SignalIcon,
@@ -46,6 +47,7 @@ import {
   projectTriggersPath,
   v3ApiKeysPath,
   v3BillingPath,
+  v3ConcurrencyPath,
   v3DeploymentsPath,
   v3EnvironmentVariablesPath,
   v3ProjectAlertsPath,
@@ -77,9 +79,9 @@ import {
   PopoverSectionHeader,
 } from "../primitives/Popover";
 import { StepNumber } from "../primitives/StepNumber";
+import { TextLink } from "../primitives/TextLink";
 import { SideMenuHeader } from "./SideMenuHeader";
 import { SideMenuItem } from "./SideMenuItem";
-import { TextLink } from "../primitives/TextLink";
 
 type SideMenuUser = Pick<User, "email" | "admin"> & { isImpersonating: boolean };
 type SideMenuProject = Pick<
@@ -601,6 +603,13 @@ function V3ProjectSideMenu({
         iconColor="text-pink-500"
         to={v3EnvironmentVariablesPath(organization, project)}
         data-action="environment variables"
+      />
+      <SideMenuItem
+        name="Concurrency"
+        icon={RectangleStackIcon}
+        iconColor="text-indigo-500"
+        to={v3ConcurrencyPath(organization, project)}
+        data-action="concurrency"
       />
       <SideMenuItem
         name="Deployments"

--- a/apps/webapp/app/components/navigation/SideMenu.tsx
+++ b/apps/webapp/app/components/navigation/SideMenu.tsx
@@ -604,13 +604,7 @@ function V3ProjectSideMenu({
         to={v3EnvironmentVariablesPath(organization, project)}
         data-action="environment variables"
       />
-      <SideMenuItem
-        name="Concurrency"
-        icon={RectangleStackIcon}
-        iconColor="text-indigo-500"
-        to={v3ConcurrencyPath(organization, project)}
-        data-action="concurrency"
-      />
+
       <SideMenuItem
         name="Deployments"
         icon={ServerStackIcon}
@@ -627,6 +621,13 @@ function V3ProjectSideMenu({
           data-action="alerts"
         />
       )}
+      <SideMenuItem
+        name="Concurrency limits"
+        icon={RectangleStackIcon}
+        iconColor="text-indigo-500"
+        to={v3ConcurrencyPath(organization, project)}
+        data-action="concurrency"
+      />
       <SideMenuItem
         name="Project settings"
         icon="settings"

--- a/apps/webapp/app/models/runtimeEnvironment.server.ts
+++ b/apps/webapp/app/models/runtimeEnvironment.server.ts
@@ -116,7 +116,7 @@ export async function disconnectSession(environmentId: string) {
   return session;
 }
 
-type DisplayableInputEnvironment = Prisma.RuntimeEnvironmentGetPayload<{
+export type DisplayableInputEnvironment = Prisma.RuntimeEnvironmentGetPayload<{
   select: {
     id: true;
     type: true;

--- a/apps/webapp/app/models/task.server.ts
+++ b/apps/webapp/app/models/task.server.ts
@@ -118,6 +118,12 @@ function calculateCachedTaskSize(task: CachedTask): number {
   return JSON.stringify(task).length;
 }
 
+/**
+ *
+ * @param prisma An efficient query to get all task identifiers for a project.
+ * It has indexes for fast performance.
+ * It does NOT care about versions, so includes all tasks ever created.
+ */
 export function getAllTaskIdentifiers(prisma: PrismaClientOrTransaction, projectId: string) {
   return prisma.$queryRaw<
     {

--- a/apps/webapp/app/models/task.server.ts
+++ b/apps/webapp/app/models/task.server.ts
@@ -1,5 +1,6 @@
-import type { JobRun, Task, TaskAttempt } from "@trigger.dev/database";
+import type { JobRun, Task, TaskAttempt, TaskTriggerSource } from "@trigger.dev/database";
 import { CachedTask, ServerTask } from "@trigger.dev/core";
+import { PrismaClientOrTransaction, sqlDatabaseSchema } from "~/db.server";
 
 export type TaskWithAttempts = Task & {
   attempts: TaskAttempt[];
@@ -115,4 +116,17 @@ function prepareTaskForCaching(task: TaskForCaching): CachedTask {
 
 function calculateCachedTaskSize(task: CachedTask): number {
   return JSON.stringify(task).length;
+}
+
+export function getAllTaskIdentifiers(prisma: PrismaClientOrTransaction, projectId: string) {
+  return prisma.$queryRaw<
+    {
+      slug: string;
+      triggerSource: TaskTriggerSource;
+    }[]
+  >`
+    SELECT DISTINCT(slug), "triggerSource"
+    FROM ${sqlDatabaseSchema}."BackgroundWorkerTask"
+    WHERE "projectId" = ${projectId}
+    ORDER BY slug ASC;`;
 }

--- a/apps/webapp/app/presenters/v3/ConcurrencyPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ConcurrencyPresenter.server.ts
@@ -5,14 +5,12 @@ import {
   displayableEnvironment,
   type DisplayableInputEnvironment,
 } from "~/models/runtimeEnvironment.server";
-import { getAllTaskIdentifiers } from "~/models/task.server";
 import { type User } from "~/models/user.server";
 import { getLimit } from "~/services/platform.v3.server";
 import { sortEnvironments } from "~/utils/environmentSort";
 import { concurrencyTracker } from "~/v3/services/taskRunConcurrencyTracker.server";
 import { BasePresenter } from "./basePresenter.server";
 
-export type Task = Awaited<ReturnType<ConcurrencyPresenter["taskConcurrency"]>>[number];
 export type Environment = Awaited<
   ReturnType<ConcurrencyPresenter["environmentConcurrency"]>
 >[number];
@@ -56,50 +54,9 @@ export class ConcurrencyPresenter extends BasePresenter {
       throw new Error(`Project not found: ${projectSlug}`);
     }
 
-    const limit = await getLimit(project.organizationId, "concurrentRuns", 10);
-
     return {
       environments: this.environmentConcurrency(project.id, userId, project.environments),
-      tasks: this.taskConcurrency(project.id),
-      limit,
     };
-  }
-
-  async taskConcurrency(projectId: string) {
-    //get all possible tasks
-    const possibleTasks = await getAllTaskIdentifiers(this._replica, projectId);
-    const concurrencies = await concurrencyTracker.taskConcurrentRunCounts(
-      projectId,
-      possibleTasks.map((task) => task.slug)
-    );
-    const queued = await this._replica.$queryRaw<
-      {
-        taskIdentifier: string;
-        count: BigInt;
-      }[]
-    >`
-SELECT 
-  tr."taskIdentifier",
-  COUNT(*) 
-FROM 
-  ${sqlDatabaseSchema}."TaskRun" as tr
-WHERE 
-  tr."taskIdentifier" IN (${Prisma.join(possibleTasks.map((task) => task.slug))})
-  AND tr."projectId" = ${projectId}
-  AND tr."status" = ANY(ARRAY[${Prisma.join(QUEUED_STATUSES)}]::\"TaskRunStatus\"[])
-GROUP BY 
-  tr."taskIdentifier"
-ORDER BY 
-  tr."taskIdentifier" ASC`;
-
-    return possibleTasks
-      .map((task) => ({
-        identifier: task.slug,
-        triggerSource: task.triggerSource,
-        concurrency: concurrencies[task.slug] ?? 0,
-        queued: Number(queued.find((q) => q.taskIdentifier === task.slug)?.count ?? 0),
-      }))
-      .sort((a, b) => a.identifier.localeCompare(b.identifier));
   }
 
   async environmentConcurrency(

--- a/apps/webapp/app/presenters/v3/ConcurrencyPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ConcurrencyPresenter.server.ts
@@ -1,0 +1,76 @@
+import { type Project } from "~/models/project.server";
+import { displayableEnvironment } from "~/models/runtimeEnvironment.server";
+import { getAllTaskIdentifiers } from "~/models/task.server";
+import { type User } from "~/models/user.server";
+import { sortEnvironments } from "~/utils/environmentSort";
+import { concurrencyTracker } from "~/v3/services/taskRunConcurrencyTracker.server";
+import { BasePresenter } from "./basePresenter.server";
+
+export class ConcurrencyPresenter extends BasePresenter {
+  public async call({ userId, projectSlug }: { userId: User["id"]; projectSlug: Project["slug"] }) {
+    const project = await this._replica.project.findFirst({
+      select: {
+        id: true,
+        environments: {
+          select: {
+            id: true,
+            apiKey: true,
+            pkApiKey: true,
+            type: true,
+            slug: true,
+            updatedAt: true,
+            orgMember: {
+              select: {
+                user: { select: { id: true, name: true, displayName: true } },
+              },
+            },
+            maximumConcurrencyLimit: true,
+          },
+        },
+      },
+      where: {
+        slug: projectSlug,
+        organization: {
+          members: {
+            some: {
+              userId,
+            },
+          },
+        },
+      },
+    });
+
+    if (!project) {
+      throw new Error(`Project not found: ${projectSlug}`);
+    }
+
+    //get all possible tasks
+    const possibleTasks = await getAllTaskIdentifiers(this._replica, project.id);
+    const concurrencies = await concurrencyTracker.taskConcurrentRunCounts(
+      project.id,
+      possibleTasks.map((task) => task.slug)
+    );
+
+    const environmentConcurrency = await concurrencyTracker.environmentConcurrentRunCounts(
+      project.id,
+      project.environments.map((env) => env.id)
+    );
+
+    const sortedEnvironments = sortEnvironments(project.environments).map((environment) => ({
+      ...displayableEnvironment(environment, userId),
+      concurrencyLimit: environment.maximumConcurrencyLimit,
+      concurrency: environmentConcurrency[environment.id] ?? 0,
+    }));
+
+    return {
+      environments: sortedEnvironments,
+      tasks: possibleTasks
+        .map((task) => ({
+          identifier: task.slug,
+          triggerSource: task.triggerSource,
+          concurrency: concurrencies[task.slug] ?? 0,
+        }))
+        .sort((a, b) => a.identifier.localeCompare(b.identifier)),
+    };
+  }
+}

--- a/apps/webapp/app/presenters/v3/ConcurrencyPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ConcurrencyPresenter.server.ts
@@ -12,7 +12,6 @@ import { sortEnvironments } from "~/utils/environmentSort";
 import { concurrencyTracker } from "~/v3/services/taskRunConcurrencyTracker.server";
 import { BasePresenter } from "./basePresenter.server";
 
-//from the ConcurrencyPresenter taskConcurrency method
 export type Task = Awaited<ReturnType<ConcurrencyPresenter["taskConcurrency"]>>[number];
 export type Environment = Awaited<
   ReturnType<ConcurrencyPresenter["environmentConcurrency"]>

--- a/apps/webapp/app/presenters/v3/RunListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/RunListPresenter.server.ts
@@ -6,6 +6,7 @@ import { sqlDatabaseSchema } from "~/db.server";
 import { displayableEnvironment } from "~/models/runtimeEnvironment.server";
 import { isCancellableRunStatus } from "~/v3/taskStatus";
 import { BasePresenter } from "./basePresenter.server";
+import { getAllTaskIdentifiers } from "~/models/task.server";
 
 export type RunListOptions = {
   userId?: string;
@@ -97,16 +98,7 @@ export class RunListPresenter extends BasePresenter {
     });
 
     //get all possible tasks
-    const possibleTasksAsync = this._replica.$queryRaw<
-      {
-        slug: string;
-        triggerSource: TaskTriggerSource;
-      }[]
-    >`
-    SELECT DISTINCT(slug), "triggerSource"
-    FROM ${sqlDatabaseSchema}."BackgroundWorkerTask"
-    WHERE "projectId" = ${project.id}
-    ORDER BY slug ASC;`;
+    const possibleTasksAsync = getAllTaskIdentifiers(this._replica, project.id);
 
     //get possible bulk actions
     const bulkActionsAsync = this._replica.bulkActionGroup.findMany({

--- a/apps/webapp/app/presenters/v3/TaskListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/TaskListPresenter.server.ts
@@ -1,9 +1,9 @@
+import { Prisma } from "@trigger.dev/database";
 import type {
   RuntimeEnvironmentType,
   TaskTriggerSource,
   TaskRunStatus as TaskRunStatusType,
 } from "@trigger.dev/database";
-import { Prisma } from "@trigger.dev/database";
 import { QUEUED_STATUSES, RUNNING_STATUSES } from "~/components/runs/v3/TaskRunStatus";
 import { sqlDatabaseSchema } from "~/db.server";
 import type { Organization } from "~/models/organization.server";

--- a/apps/webapp/app/presenters/v3/TaskListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/TaskListPresenter.server.ts
@@ -20,6 +20,7 @@ import { logger } from "~/services/logger.server";
 import { BasePresenter } from "./basePresenter.server";
 import { TaskRunStatus } from "~/database-types";
 import { CURRENT_DEPLOYMENT_LABEL } from "~/consts";
+import { concurrencyTracker } from "~/v3/services/taskRunConcurrencyTracker.server";
 
 export type Task = {
   slug: string;
@@ -114,7 +115,7 @@ export class TaskListPresenter extends BasePresenter {
     JOIN ${sqlDatabaseSchema}."BackgroundWorkerTask" tasks ON tasks."workerId" = workers.id
     ORDER BY slug ASC;`;
 
-    //group by the task identifier (task.slug). Add the latestRun and add all the environments.
+    //group by the task identifier (task.slug).
     const outputTasks = tasks.reduce((acc, task) => {
       const environment = project.environments.find((env) => env.id === task.runtimeEnvironmentId);
       if (!environment) {
@@ -251,51 +252,40 @@ export class TaskListPresenter extends BasePresenter {
       return {};
     }
 
-    const statuses = await this._replica.$queryRaw<
+    const concurrencies = await concurrencyTracker.taskConcurrentRunCounts(projectId, tasks);
+
+    const queued = await this._replica.$queryRaw<
       {
         taskIdentifier: string;
-        status: TaskRunStatusType;
         count: BigInt;
       }[]
     >`
     SELECT 
-    tr."taskIdentifier", 
-    tr."status",
+    tr."taskIdentifier",
     COUNT(*) 
   FROM 
     ${sqlDatabaseSchema}."TaskRun" as tr
   WHERE 
     tr."taskIdentifier" IN (${Prisma.join(tasks)})
     AND tr."projectId" = ${projectId}
-    AND tr."status" IN ('PENDING', 'WAITING_FOR_DEPLOY', 'EXECUTING', 'RETRYING_AFTER_FAILURE', 'WAITING_TO_RESUME')
+    AND tr."status" = ANY(ARRAY[${Prisma.join(QUEUED_STATUSES)}]::\"TaskRunStatus\"[])
   GROUP BY 
-    tr."taskIdentifier", 
-    tr."status"
+    tr."taskIdentifier"
   ORDER BY 
-    tr."taskIdentifier" ASC,
-    tr."status" ASC;`;
+    tr."taskIdentifier" ASC`;
 
-    return statuses.reduce((acc, a) => {
-      let existingTask = acc[a.taskIdentifier];
+    //create an object combining the queued and concurrency counts
+    const result: Record<string, { queued: number; running: number }> = {};
+    for (const task of tasks) {
+      const concurrency = concurrencies[task] ?? 0;
+      const queuedCount = queued.find((q) => q.taskIdentifier === task)?.count ?? 0;
 
-      if (!existingTask) {
-        existingTask = {
-          queued: 0,
-          running: 0,
-        };
-
-        acc[a.taskIdentifier] = existingTask;
-      }
-
-      if (QUEUED_STATUSES.includes(a.status)) {
-        existingTask.queued += Number(a.count);
-      }
-      if (RUNNING_STATUSES.includes(a.status)) {
-        existingTask.running += Number(a.count);
-      }
-
-      return acc;
-    }, {} as Record<string, { queued: number; running: number }>);
+      result[task] = {
+        queued: Number(queuedCount),
+        running: concurrency,
+      };
+    }
+    return result;
   }
 
   async #getAverageDurations(tasks: string[], projectId: string) {

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.concurrency/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.concurrency/route.tsx
@@ -147,7 +147,7 @@ function EnvironmentsTable({ environments }: { environments: Environment[] }) {
           <TableCell>
             <EnvironmentLabel environment={environment} userName={environment.userName} />
           </TableCell>
-          <TableCell alignment="right">–</TableCell>
+          <TableCell alignment="right">{environment.queued}</TableCell>
           <TableCell alignment="right">{environment.concurrency}</TableCell>
           <TableCell alignment="right">{environment.concurrencyLimit}</TableCell>
         </TableRow>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.concurrency/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.concurrency/route.tsx
@@ -1,0 +1,167 @@
+import { BookOpenIcon } from "@heroicons/react/20/solid";
+import { LoaderFunctionArgs } from "@remix-run/server-runtime";
+import { typedjson, UseDataFunctionReturn, useTypedLoaderData } from "remix-typedjson";
+import { AdminDebugTooltip } from "~/components/admin/debugTooltip";
+import { EnvironmentLabel } from "~/components/environments/EnvironmentLabel";
+import { PageBody, PageContainer } from "~/components/layout/AppLayout";
+import { LinkButton } from "~/components/primitives/Buttons";
+import { Header2 } from "~/components/primitives/Headers";
+import { Input } from "~/components/primitives/Input";
+import { NavBar, PageAccessories, PageTitle } from "~/components/primitives/PageHeader";
+import { Paragraph } from "~/components/primitives/Paragraph";
+import * as Property from "~/components/primitives/PropertyTable";
+import {
+  Table,
+  TableBlankRow,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+} from "~/components/primitives/Table";
+import { useOrganization } from "~/hooks/useOrganizations";
+import { useTextFilter } from "~/hooks/useTextFilter";
+import { ConcurrencyPresenter } from "~/presenters/v3/ConcurrencyPresenter.server";
+import { requireUserId } from "~/services/session.server";
+import { ProjectParamSchema, docsPath } from "~/utils/pathBuilder";
+
+export const loader = async ({ request, params }: LoaderFunctionArgs) => {
+  const userId = await requireUserId(request);
+  const { projectParam } = ProjectParamSchema.parse(params);
+
+  try {
+    const presenter = new ConcurrencyPresenter();
+    const { environments, tasks } = await presenter.call({
+      userId,
+      projectSlug: projectParam,
+    });
+
+    return typedjson({
+      environments,
+      tasks,
+    });
+  } catch (error) {
+    console.error(error);
+    throw new Response(undefined, {
+      status: 400,
+      statusText: "Something went wrong, if this problem persists please contact support.",
+    });
+  }
+};
+
+type Task = UseDataFunctionReturn<typeof loader>["tasks"][0];
+
+export default function Page() {
+  const { environments, tasks } = useTypedLoaderData<typeof loader>();
+  const { filterText, setFilterText, filteredItems } = useTextFilter<Task>({
+    items: tasks,
+    filter: (task, text) => {
+      if (task.identifier.toLowerCase().includes(text.toLowerCase())) {
+        return true;
+      }
+
+      if (task.triggerSource === "SCHEDULED" && "scheduled".includes(text.toLowerCase())) {
+        return true;
+      }
+
+      return false;
+    },
+  });
+
+  return (
+    <PageContainer>
+      <NavBar>
+        <PageTitle title="Concurrency" />
+        <PageAccessories>
+          <AdminDebugTooltip>
+            <Property.Table>
+              {environments.map((environment) => (
+                <Property.Item key={environment.id}>
+                  <Property.Label>{environment.slug}</Property.Label>
+                  <Property.Value>{environment.id}</Property.Value>
+                </Property.Item>
+              ))}
+            </Property.Table>
+          </AdminDebugTooltip>
+
+          <LinkButton
+            variant={"minimal/small"}
+            LeadingIcon={BookOpenIcon}
+            to={docsPath("/queue-concurrency")}
+          >
+            Concurrency docs
+          </LinkButton>
+        </PageAccessories>
+      </NavBar>
+      <PageBody>
+        <div className="mt-1 flex flex-col gap-4">
+          <div>
+            <Header2 spacing>Environments</Header2>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHeaderCell>Environment</TableHeaderCell>
+                  <TableHeaderCell alignment="right">Queued</TableHeaderCell>
+                  <TableHeaderCell alignment="right">Running</TableHeaderCell>
+                  <TableHeaderCell alignment="right">Concurrency limit</TableHeaderCell>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {environments.map((environment) => (
+                  <TableRow key={environment.id}>
+                    <TableCell>
+                      <EnvironmentLabel environment={environment} userName={environment.userName} />
+                    </TableCell>
+                    <TableCell alignment="right">–</TableCell>
+                    <TableCell alignment="right">{environment.concurrency}</TableCell>
+                    <TableCell alignment="right">{environment.concurrencyLimit}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+          <div>
+            <Header2 spacing>Tasks</Header2>
+            <div className="h-8">
+              <Input
+                placeholder="Search tasks"
+                variant="tertiary"
+                icon="search"
+                fullWidth={true}
+                value={filterText}
+                onChange={(e) => setFilterText(e.target.value)}
+                autoFocus
+              />
+            </div>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHeaderCell>Task ID</TableHeaderCell>
+                  <TableHeaderCell alignment="right">Queued</TableHeaderCell>
+                  <TableHeaderCell alignment="right">Running</TableHeaderCell>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredItems.length > 0 ? (
+                  filteredItems.map((task) => (
+                    <TableRow key={task.identifier}>
+                      <TableCell>{task.identifier}</TableCell>
+                      <TableCell alignment="right">–</TableCell>
+                      <TableCell alignment="right">{task.concurrency}</TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableBlankRow colSpan={3}>
+                    <Paragraph variant="small" className="flex items-center justify-center">
+                      {tasks.length > 0 ? "No tasks match your filters" : "No tasks"}
+                    </Paragraph>
+                  </TableBlankRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+      </PageBody>
+    </PageContainer>
+  );
+}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.concurrency/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.concurrency/route.tsx
@@ -183,7 +183,7 @@ export default function Page() {
                           <span>{task.identifier}</span>
                         </div>
                       </TableCell>
-                      <TableCell alignment="right">–</TableCell>
+                      <TableCell alignment="right">{task.queued}</TableCell>
                       <TableCell alignment="right">{task.concurrency}</TableCell>
                     </TableRow>
                   ))

--- a/apps/webapp/app/routes/admin.concurrency.tsx
+++ b/apps/webapp/app/routes/admin.concurrency.tsx
@@ -1,0 +1,38 @@
+import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
+import { redirect, typedjson, useTypedLoaderData } from "remix-typedjson";
+import { Header1 } from "~/components/primitives/Headers";
+import { Paragraph } from "~/components/primitives/Paragraph";
+import { requireUser } from "~/services/session.server";
+import { concurrencyTracker } from "~/v3/services/taskRunConcurrencyTracker.server";
+
+export const loader = async ({ request, params }: LoaderFunctionArgs) => {
+  const user = await requireUser(request);
+  if (!user.admin) {
+    return redirect("/");
+  }
+
+  const deployedConcurrency = await concurrencyTracker.globalConcurrentRunCount(true);
+  const devConcurrency = await concurrencyTracker.globalConcurrentRunCount(false);
+
+  return typedjson({ deployedConcurrency, devConcurrency });
+};
+
+export default function AdminDashboardRoute() {
+  const { deployedConcurrency, devConcurrency } = useTypedLoaderData<typeof loader>();
+
+  return (
+    <main
+      aria-labelledby="primary-heading"
+      className="flex h-full min-w-0 flex-1 flex-col gap-6 overflow-y-auto px-4 pb-4 lg:order-last"
+    >
+      <div>
+        <Header1 spacing>Dev</Header1>
+        <Paragraph spacing>{devConcurrency}</Paragraph>
+      </div>
+      <div>
+        <Header1 spacing>Deployed</Header1>
+        <Paragraph spacing>{deployedConcurrency}</Paragraph>
+      </div>
+    </main>
+  );
+}

--- a/apps/webapp/app/routes/admin.orgs.tsx
+++ b/apps/webapp/app/routes/admin.orgs.tsx
@@ -1,7 +1,7 @@
 import { MagnifyingGlassIcon } from "@heroicons/react/20/solid";
 import { Form } from "@remix-run/react";
 import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
-import { typedjson, useTypedLoaderData } from "remix-typedjson";
+import { redirect, typedjson, useTypedLoaderData } from "remix-typedjson";
 import { z } from "zod";
 import { Button, LinkButton } from "~/components/primitives/Buttons";
 import { Input } from "~/components/primitives/Input";
@@ -17,7 +17,7 @@ import {
   TableRow,
 } from "~/components/primitives/Table";
 import { adminGetOrganizations } from "~/models/admin.server";
-import { requireUserId } from "~/services/session.server";
+import { requireUser, requireUserId } from "~/services/session.server";
 import { createSearchParams } from "~/utils/searchParams";
 
 export const SearchParams = z.object({
@@ -28,13 +28,16 @@ export const SearchParams = z.object({
 export type SearchParams = z.infer<typeof SearchParams>;
 
 export const loader = async ({ request, params }: LoaderFunctionArgs) => {
-  const userId = await requireUserId(request);
+  const user = await requireUser(request);
+  if (!user.admin) {
+    return redirect("/");
+  }
 
   const searchParams = createSearchParams(request.url, SearchParams);
   if (!searchParams.success) {
     throw new Error(searchParams.error);
   }
-  const result = await adminGetOrganizations(userId, searchParams.params.getAll());
+  const result = await adminGetOrganizations(user.id, searchParams.params.getAll());
 
   return typedjson(result);
 };

--- a/apps/webapp/app/routes/admin.tsx
+++ b/apps/webapp/app/routes/admin.tsx
@@ -3,15 +3,10 @@ import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { redirect, typedjson } from "remix-typedjson";
 import { LinkButton } from "~/components/primitives/Buttons";
 import { Tabs } from "~/components/primitives/Tabs";
-import { getUser, requireUserId } from "~/services/session.server";
+import { requireUser } from "~/services/session.server";
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  await requireUserId(request);
-  const user = await getUser(request);
-  if (user == null) {
-    return redirect("/");
-  }
-
+  const user = await requireUser(request);
   if (!user.admin) {
     return redirect("/");
   }
@@ -32,6 +27,10 @@ export default function Page() {
             {
               label: "Organizations",
               to: "/admin/orgs",
+            },
+            {
+              label: "Concurrency",
+              to: "/admin/concurrency",
             },
           ]}
           layoutId={"admin"}

--- a/apps/webapp/app/utils/pathBuilder.ts
+++ b/apps/webapp/app/utils/pathBuilder.ts
@@ -323,6 +323,10 @@ export function v3EnvironmentVariablesPath(organization: OrgForPath, project: Pr
   return `${v3ProjectPath(organization, project)}/environment-variables`;
 }
 
+export function v3ConcurrencyPath(organization: OrgForPath, project: ProjectForPath) {
+  return `${v3ProjectPath(organization, project)}/concurrency`;
+}
+
 export function v3NewEnvironmentVariablesPath(organization: OrgForPath, project: ProjectForPath) {
   return `${v3EnvironmentVariablesPath(organization, project)}/new`;
 }

--- a/apps/webapp/app/v3/marqs/index.server.ts
+++ b/apps/webapp/app/v3/marqs/index.server.ts
@@ -26,11 +26,13 @@ import {
   MarQSKeyProducer,
   MarQSQueuePriorityStrategy,
   MessagePayload,
+  MessageQueueSubscriber,
   QueueCapacities,
   QueueRange,
   VisibilityTimeoutStrategy,
 } from "./types";
 import { V3VisibilityTimeout } from "./v3VisibilityTimeout.server";
+import { concurrencyTracker } from "../services/taskRunConcurrencyTracker.server";
 
 const KEY_PREFIX = "marqs:";
 
@@ -60,6 +62,7 @@ export type MarQSOptions = {
   visibilityTimeoutStrategy: VisibilityTimeoutStrategy;
   enableRebalancing?: boolean;
   verbose?: boolean;
+  subscriber?: MessageQueueSubscriber;
 };
 
 /**
@@ -207,6 +210,8 @@ export class MarQS {
         });
 
         await this.#callEnqueueMessage(messagePayload);
+
+        await this.options.subscriber?.messageEnqueued(messagePayload);
       },
       {
         kind: SpanKind.PRODUCER,
@@ -264,6 +269,8 @@ export class MarQS {
             [SemanticAttributes.CONCURRENCY_KEY]: message.concurrencyKey,
             [SemanticAttributes.PARENT_QUEUE]: message.parentQueue,
           });
+
+          await this.options.subscriber?.messageDequeued(message);
         } else {
           logger.error(`Failed to read message, undoing the dequeueing of the message`, {
             messageData,
@@ -427,6 +434,8 @@ export class MarQS {
           orgConcurrencyKey: this.keys.orgCurrentConcurrencyKeyFromQueue(message.queue),
           messageId,
         });
+
+        await this.options.subscriber?.messageAcked(message);
       },
       {
         kind: SpanKind.CONSUMER,
@@ -580,6 +589,8 @@ export class MarQS {
           messageId,
           messageScore: retryAt,
         });
+
+        await this.options.subscriber?.messageNacked(message);
       },
       {
         kind: SpanKind.CONSUMER,
@@ -1721,6 +1732,7 @@ function getMarQSClient() {
         defaultOrgConcurrency: env.DEFAULT_ORG_EXECUTION_CONCURRENCY_LIMIT,
         visibilityTimeoutInMs: 120 * 1000, // 2 minutes,
         enableRebalancing: !env.MARQS_DISABLE_REBALANCING,
+        subscriber: concurrencyTracker,
       });
     } else {
       console.warn(

--- a/apps/webapp/app/v3/marqs/types.ts
+++ b/apps/webapp/app/v3/marqs/types.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { AuthenticatedEnvironment } from "~/services/apiAuth.server";
+import { type AuthenticatedEnvironment } from "~/services/apiAuth.server";
 
 export type QueueCapacity = {
   current: number;
@@ -91,6 +91,13 @@ export const MessagePayload = z.object({
 });
 
 export type MessagePayload = z.infer<typeof MessagePayload>;
+
+export interface MessageQueueSubscriber {
+  messageEnqueued(message: MessagePayload): Promise<void>;
+  messageDequeued(message: MessagePayload): Promise<void>;
+  messageAcked(message: MessagePayload): Promise<void>;
+  messageNacked(message: MessagePayload): Promise<void>;
+}
 
 export interface VisibilityTimeoutStrategy {
   heartbeat(messageId: string, timeoutInMs: number): Promise<void>;

--- a/apps/webapp/app/v3/services/enqueueDelayedRun.server.ts
+++ b/apps/webapp/app/v3/services/enqueueDelayedRun.server.ts
@@ -65,7 +65,13 @@ export class EnqueueDelayedRunService extends BaseService {
       run.runtimeEnvironment,
       run.queue,
       run.id,
-      { type: "EXECUTE", taskIdentifier: run.taskIdentifier },
+      {
+        type: "EXECUTE",
+        taskIdentifier: run.taskIdentifier,
+        projectId: run.runtimeEnvironment.projectId,
+        environmentId: run.runtimeEnvironment.id,
+        environmentType: run.runtimeEnvironment.type,
+      },
       run.concurrencyKey ?? undefined
     );
   }

--- a/apps/webapp/app/v3/services/executeTasksWaitingForDeploy.ts
+++ b/apps/webapp/app/v3/services/executeTasksWaitingForDeploy.ts
@@ -79,6 +79,9 @@ export class ExecuteTasksWaitingForDeployService extends BaseService {
           {
             type: "EXECUTE",
             taskIdentifier: run.taskIdentifier,
+            projectId: backgroundWorker.runtimeEnvironment.projectId,
+            environmentId: backgroundWorker.runtimeEnvironment.id,
+            environmentType: backgroundWorker.runtimeEnvironment.type,
           },
           run.concurrencyKey ?? undefined,
           Date.now() + i * 5 // slight delay to help preserve order

--- a/apps/webapp/app/v3/services/resumeBatchRun.server.ts
+++ b/apps/webapp/app/v3/services/resumeBatchRun.server.ts
@@ -80,6 +80,9 @@ export class ResumeBatchRunService extends BaseService {
           completedAttemptIds: [sourceTaskAttemptId],
           resumableAttemptId: batchRun.dependentTaskAttempt.id,
           checkpointEventId: batchRun.checkpointEventId,
+          projectId: batchRun.dependentTaskAttempt.runtimeEnvironment.projectId,
+          environmentId: batchRun.dependentTaskAttempt.runtimeEnvironment.id,
+          environmentType: batchRun.dependentTaskAttempt.runtimeEnvironment.type,
         },
         dependentRun.concurrencyKey ?? undefined
       );

--- a/apps/webapp/app/v3/services/resumeTaskDependency.server.ts
+++ b/apps/webapp/app/v3/services/resumeTaskDependency.server.ts
@@ -57,6 +57,9 @@ export class ResumeTaskDependencyService extends BaseService {
           completedAttemptIds: [sourceTaskAttemptId],
           resumableAttemptId: dependency.dependentAttempt.id,
           checkpointEventId: dependency.checkpointEventId,
+          projectId: dependency.taskRun.runtimeEnvironment.projectId,
+          environmentId: dependency.taskRun.runtimeEnvironment.id,
+          environmentType: dependency.taskRun.runtimeEnvironment.type,
         },
         dependentRun.concurrencyKey ?? undefined
       );

--- a/apps/webapp/app/v3/services/taskRunConcurrencyTracker.server.ts
+++ b/apps/webapp/app/v3/services/taskRunConcurrencyTracker.server.ts
@@ -227,7 +227,7 @@ export const concurrencyTracker = singleton("concurrency-tracker", getTracker);
 function getTracker() {
   if (!env.REDIS_HOST || !env.REDIS_PORT) {
     throw new Error(
-      "Could not initialize auto-increment counter because process.env.REDIS_HOST and process.env.REDIS_PORT are required to be set. "
+      "Could not initialize TaskRunConcurrencyTracker because process.env.REDIS_HOST and process.env.REDIS_PORT are required to be set. "
     );
   }
 

--- a/apps/webapp/app/v3/services/taskRunConcurrencyTracker.server.ts
+++ b/apps/webapp/app/v3/services/taskRunConcurrencyTracker.server.ts
@@ -105,9 +105,8 @@ class TaskRunConcurrencyTracker implements MessageQueueSubscriber {
   }): Promise<void> {
     const pipeline = this.redis.pipeline();
 
-    if (deployed) {
-      pipeline.sadd(this.getTaskKey(projectId, taskId), runId);
-    }
+    pipeline.sadd(this.getTaskKey(projectId, taskId), runId);
+    pipeline.sadd(this.getTaskEnvironmentKey(projectId, taskId, environmentId), runId);
     pipeline.sadd(this.getEnvironmentKey(projectId, environmentId), runId);
     pipeline.sadd(this.getGlobalKey(deployed), runId);
 
@@ -129,10 +128,8 @@ class TaskRunConcurrencyTracker implements MessageQueueSubscriber {
   }): Promise<void> {
     const pipeline = this.redis.pipeline();
 
-    if (deployed) {
-      pipeline.srem(this.getTaskKey(projectId, taskId), runId);
-    }
-
+    pipeline.srem(this.getTaskKey(projectId, taskId), runId);
+    pipeline.srem(this.getTaskEnvironmentKey(projectId, taskId, environmentId), runId);
     pipeline.srem(this.getEnvironmentKey(projectId, environmentId), runId);
     pipeline.srem(this.getGlobalKey(deployed), runId);
 
@@ -184,6 +181,10 @@ class TaskRunConcurrencyTracker implements MessageQueueSubscriber {
 
   private getTaskKey(projectId: string, taskId: string): string {
     return `project:${projectId}:task:${taskId}`;
+  }
+
+  private getTaskEnvironmentKey(projectId: string, taskId: string, environmentId: string): string {
+    return `project:${projectId}:task:${taskId}:env:${environmentId}`;
   }
 
   private getGlobalKey(deployed: boolean): string {

--- a/apps/webapp/app/v3/services/taskRunConcurrencyTracker.server.ts
+++ b/apps/webapp/app/v3/services/taskRunConcurrencyTracker.server.ts
@@ -1,0 +1,117 @@
+import { env } from "~/env.server";
+import Redis, { type RedisOptions } from "ioredis";
+import { singleton } from "~/utils/singleton";
+
+type Options = {
+  redis: RedisOptions;
+};
+
+class TaskRunConcurrencyTracker {
+  private redis: Redis;
+
+  constructor(config: Options) {
+    this.redis = new Redis(config.redis);
+  }
+
+  private getTaskKey(projectId: string, taskId: string): string {
+    return `project:${projectId}:task:${taskId}`;
+  }
+  private getGlobalKey(deployed: boolean): string {
+    return `global:${deployed ? "deployed" : "dev"}`;
+  }
+
+  async runStarted({
+    projectId,
+    taskId,
+    runId,
+    deployed,
+  }: {
+    projectId: string;
+    taskId: string;
+    runId: string;
+    deployed: boolean;
+  }): Promise<void> {
+    await this.redis.sadd(this.getTaskKey(projectId, taskId), runId);
+    await this.redis.sadd(this.getGlobalKey(deployed), runId);
+  }
+
+  async runFinished({
+    projectId,
+    taskId,
+    runId,
+    deployed,
+  }: {
+    projectId: string;
+    taskId: string;
+    runId: string;
+    deployed: boolean;
+  }): Promise<void> {
+    await this.redis.srem(this.getTaskKey(projectId, taskId), runId);
+    await this.redis.srem(this.getGlobalKey(deployed), runId);
+  }
+
+  async taskConcurrentRunCount(projectId: string, taskId: string): Promise<number> {
+    return await this.redis.scard(this.getTaskKey(projectId, taskId));
+  }
+
+  async globalConcurrentRunCount(deployed: boolean): Promise<number> {
+    return await this.redis.scard(this.getGlobalKey(deployed));
+  }
+
+  async currentlyExecutingRuns(projectId: string, taskId: string): Promise<string[]> {
+    return await this.redis.smembers(this.getTaskKey(projectId, taskId));
+  }
+
+  private async getTaskCounts(projectId: string, taskIds: string[]): Promise<number[]> {
+    const pipeline = this.redis.pipeline();
+    taskIds.forEach((taskId) => {
+      pipeline.scard(this.getTaskKey(projectId, taskId));
+    });
+    const results = await pipeline.exec();
+    return results!.map(([err, count]) => {
+      if (err) {
+        console.error("Error in getTaskCounts:", err);
+        return 0;
+      }
+      return count as number;
+    });
+  }
+
+  async projectConcurrentRunCount(projectId: string, taskIds: string[]): Promise<number> {
+    const counts = await this.getTaskCounts(projectId, taskIds);
+    return counts.reduce((total, count) => total + count, 0);
+  }
+
+  async taskConcurrentRunCounts(
+    projectId: string,
+    taskIds: string[]
+  ): Promise<Record<string, number>> {
+    const counts = await this.getTaskCounts(projectId, taskIds);
+    return taskIds.reduce((acc, taskId, index) => {
+      acc[taskId] = counts[index];
+      return acc;
+    }, {} as Record<string, number>);
+  }
+}
+
+export const concurrencyTracker = singleton("concurrency-tracker", getTracker);
+
+function getTracker() {
+  if (!env.REDIS_HOST || !env.REDIS_PORT) {
+    throw new Error(
+      "Could not initialize auto-increment counter because process.env.REDIS_HOST and process.env.REDIS_PORT are required to be set. "
+    );
+  }
+
+  return new TaskRunConcurrencyTracker({
+    redis: {
+      keyPrefix: "concurrencytracker:",
+      port: env.REDIS_PORT,
+      host: env.REDIS_HOST,
+      username: env.REDIS_USERNAME,
+      password: env.REDIS_PASSWORD,
+      enableAutoPipelining: true,
+      ...(env.REDIS_TLS_DISABLED === "true" ? {} : { tls: {} }),
+    },
+  });
+}

--- a/apps/webapp/app/v3/services/triggerTask.server.ts
+++ b/apps/webapp/app/v3/services/triggerTask.server.ts
@@ -392,7 +392,13 @@ export class TriggerTaskService extends BaseService {
               environment,
               run.queue,
               run.id,
-              { type: "EXECUTE", taskIdentifier: taskId },
+              {
+                type: "EXECUTE",
+                taskIdentifier: taskId,
+                projectId: environment.projectId,
+                environmentId: environment.id,
+                environmentType: environment.type,
+              },
               body.options?.concurrencyKey
             );
           }

--- a/packages/database/prisma/migrations/20240809153150_background_worker_task_add_index_for_quick_lookup_of_task_identifiers/migration.sql
+++ b/packages/database/prisma/migrations/20240809153150_background_worker_task_add_index_for_quick_lookup_of_task_identifiers/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "BackgroundWorkerTask_projectId_slug_idx" ON "BackgroundWorkerTask"("projectId", "slug");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1602,6 +1602,8 @@ model BackgroundWorkerTask {
   triggerSource TaskTriggerSource @default(STANDARD)
 
   @@unique([workerId, slug])
+  // Quick lookup of task identifiers
+  @@index([projectId, slug])
 }
 
 enum TaskTriggerSource {

--- a/references/v3-catalog/src/trigger/performance.ts
+++ b/references/v3-catalog/src/trigger/performance.ts
@@ -1,0 +1,23 @@
+import { logger, task } from "@trigger.dev/sdk/v3";
+
+export const performance = task({
+  id: "performance",
+  run: async ({ count, subtaskDuration = 30_000 }: { count: number; subtaskDuration?: number }) => {
+    const payloads = Array.from({ length: count }, (_, i) => ({
+      payload: {
+        durationMs: subtaskDuration,
+      },
+    }));
+
+    await longTask.batchTrigger(payloads);
+  },
+});
+
+export const longTask = task({
+  id: "long-task",
+  run: async ({ durationMs }: { durationMs: number }) => {
+    //sleep for durationMs
+    await new Promise((resolve) => setTimeout(resolve, durationMs));
+    logger.info("long task done");
+  },
+});


### PR DESCRIPTION
In the current UI the Tasks page has a "Running" column. You would think this is the same as the amount of concurrency you have but it's not. It's the number of tasks that have actually started executing code which is different from the number that have been dequeued (and are just about to start executing). This difference can be extreme in the case of runs that do a very small amount of compute time.

This PR adds accurate tracking of actual concurrency. Any run that has been dequeued and not acked or nacked counts towards your concurrency. We track this using Redis by:
- Task
- Environment
- Globally for dev
- Globally for deployed

Additionally a new Concurrency page has been added that surfaces this data:

![CleanShot 2024-08-12 at 12 44 21@2x](https://github.com/user-attachments/assets/71e5a0e8-d705-43b0-a941-be66e684841f)

