### PR TITLE
fix: support for IPv6 redis connections

### DIFF
--- a/apps/webapp/app/services/autoIncrementCounter.server.ts
+++ b/apps/webapp/app/services/autoIncrementCounter.server.ts
@@ -89,6 +89,10 @@ function getAutoIncrementCounter() {
       username: env.REDIS_USERNAME,
       password: env.REDIS_PASSWORD,
       enableAutoPipelining: true,
+      // Force support for both IPv6 and IPv4, by default ioredis sets this to 4,
+      // only allowing IPv4 connections:
+      // https://github.com/redis/ioredis/issues/1576
+      family: 0,
       ...(env.REDIS_TLS_DISABLED === "true" ? {} : { tls: {} }),
     },
   });

--- a/apps/webapp/app/services/rateLimiter.server.ts
+++ b/apps/webapp/app/services/rateLimiter.server.ts
@@ -29,6 +29,10 @@ export class RateLimiter {
           username: env.REDIS_USERNAME,
           password: env.REDIS_PASSWORD,
           enableAutoPipelining: true,
+          // Force support for both IPv6 and IPv4, by default ioredis sets this to 4,
+          // only allowing IPv4 connections:
+          // https://github.com/redis/ioredis/issues/1576
+          family: 0,
           ...(env.REDIS_TLS_DISABLED === "true" ? {} : { tls: {} }),
         }
       ),

--- a/apps/webapp/app/services/runExecutionRateLimiter.server.ts
+++ b/apps/webapp/app/services/runExecutionRateLimiter.server.ts
@@ -402,6 +402,10 @@ function getRateLimiter() {
           username: env.REDIS_USERNAME,
           password: env.REDIS_PASSWORD,
           enableAutoPipelining: true,
+          // Force support for both IPv6 and IPv4, by default ioredis sets this to 4,
+          // only allowing IPv4 connections:
+          // https://github.com/redis/ioredis/issues/1576
+          family: 0,
           ...(env.REDIS_TLS_DISABLED === "true" ? {} : { tls: {} }),
         },
         defaultConcurrency: env.DEFAULT_ORG_EXECUTION_CONCURRENCY_LIMIT,

--- a/apps/webapp/app/v3/eventRepository.server.ts
+++ b/apps/webapp/app/v3/eventRepository.server.ts
@@ -1134,6 +1134,10 @@ function initializeEventRepo() {
       username: env.REDIS_USERNAME,
       password: env.REDIS_PASSWORD,
       enableAutoPipelining: true,
+      // Force support for both IPv6 and IPv4, by default ioredis sets this to 4,
+      // only allowing IPv4 connections:
+      // https://github.com/redis/ioredis/issues/1576
+      family: 0,
       ...(env.REDIS_TLS_DISABLED === "true" ? {} : { tls: {} }),
     },
   });

--- a/apps/webapp/app/v3/handleSocketIo.server.ts
+++ b/apps/webapp/app/v3/handleSocketIo.server.ts
@@ -54,6 +54,10 @@ function initializeSocketIOServerInstance() {
       username: env.REDIS_USERNAME,
       password: env.REDIS_PASSWORD,
       enableAutoPipelining: true,
+      // Force support for both IPv6 and IPv4, by default ioredis sets this to 4,
+      // only allowing IPv4 connections:
+      // https://github.com/redis/ioredis/issues/1576
+      family: 0,
       ...(env.REDIS_TLS_DISABLED === "true" ? {} : { tls: {} }),
     });
     const subClient = pubClient.duplicate();

--- a/apps/webapp/app/v3/marqs/devPubSub.server.ts
+++ b/apps/webapp/app/v3/marqs/devPubSub.server.ts
@@ -26,6 +26,10 @@ function initializeDevPubSub() {
       username: env.REDIS_USERNAME,
       password: env.REDIS_PASSWORD,
       enableAutoPipelining: true,
+      // Force support for both IPv6 and IPv4, by default ioredis sets this to 4,
+      // only allowing IPv4 connections:
+      // https://github.com/redis/ioredis/issues/1576
+      family: 0,
       ...(env.REDIS_TLS_DISABLED === "true" ? {} : { tls: {} }),
     },
     schema: messageCatalog,

--- a/apps/webapp/app/v3/marqs/index.server.ts
+++ b/apps/webapp/app/v3/marqs/index.server.ts
@@ -1720,6 +1720,10 @@ function getMarQSClient() {
         username: env.REDIS_USERNAME,
         password: env.REDIS_PASSWORD,
         enableAutoPipelining: true,
+        // Force support for both IPv6 and IPv4, by default ioredis sets this to 4,
+        // only allowing IPv4 connections:
+        // https://github.com/redis/ioredis/issues/1576
+        family: 0,
         ...(env.REDIS_TLS_DISABLED === "true" ? {} : { tls: {} }),
       };
 

--- a/apps/webapp/app/v3/marqs/v2.server.ts
+++ b/apps/webapp/app/v3/marqs/v2.server.ts
@@ -64,6 +64,10 @@ function getMarQSClient() {
     username: env.REDIS_USERNAME,
     password: env.REDIS_PASSWORD,
     enableAutoPipelining: true,
+    // Force support for both IPv6 and IPv4, by default ioredis sets this to 4,
+    // only allowing IPv4 connections:
+    // https://github.com/redis/ioredis/issues/1576
+    family: 0,
     ...(env.REDIS_TLS_DISABLED === "true" ? {} : { tls: {} }),
   };
 

--- a/apps/webapp/app/v3/services/projectPubSub.server.ts
+++ b/apps/webapp/app/v3/services/projectPubSub.server.ts
@@ -27,6 +27,10 @@ function initializeProjectPubSub() {
       username: env.REDIS_USERNAME,
       password: env.REDIS_PASSWORD,
       enableAutoPipelining: true,
+      // Force support for both IPv6 and IPv4, by default ioredis sets this to 4,
+      // only allowing IPv4 connections:
+      // https://github.com/redis/ioredis/issues/1576
+      family: 0,
       ...(env.REDIS_TLS_DISABLED === "true" ? {} : { tls: {} }),
     },
     schema: messageCatalog,

--- a/apps/webapp/app/v3/services/taskRunConcurrencyTracker.server.ts
+++ b/apps/webapp/app/v3/services/taskRunConcurrencyTracker.server.ts
@@ -301,6 +301,10 @@ function getTracker() {
       username: env.REDIS_USERNAME,
       password: env.REDIS_PASSWORD,
       enableAutoPipelining: true,
+      // Force support for both IPv6 and IPv4, by default ioredis sets this to 4,
+      // only allowing IPv4 connections:
+      // https://github.com/redis/ioredis/issues/1576
+      family: 0,
       ...(env.REDIS_TLS_DISABLED === "true" ? {} : { tls: {} }),
     },
   });


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [ ] The PR title follows the convention.
- [ ] I ran and tested the code works

---

## Testing

While trying to self-host it, I was trying to add a Redis instance as result, I was getting this error in the logs.

```
[ioredis] Unhandled error event: Error: connect ETIMEDOUT
    at TLSSocket.<anonymous> (/triggerdotdev/node_modules/.pnpm/ioredis@5.3.2/node_modules/ioredis/built/Redis.js:170:41)
    at Object.onceWrapper (node:events:631:28)
    at TLSSocket.emit (node:events:517:28)
    at Socket._onTimeout (node:net:598:8)
    at listOnTimeout (node:internal/timers:569:17)
    at process.processTimers (node:internal/timers:512:7)
```

---

## Changelog

By default `ioredis` set the connection host to `IPv4`.

The documentation for the `family` parameter are: https://nodejs.org/docs/latest-v20.x/api/net.html#socketconnectoptions-connectlistener
