### PR TITLE
Fix: was showing deleted team member dev environments

### DIFF
--- a/apps/webapp/app/presenters/v3/ConcurrencyPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ConcurrencyPresenter.server.ts
@@ -7,7 +7,7 @@ import {
 } from "~/models/runtimeEnvironment.server";
 import { type User } from "~/models/user.server";
 import { getLimit } from "~/services/platform.v3.server";
-import { sortEnvironments } from "~/utils/environmentSort";
+import { filterOrphanedEnvironments, sortEnvironments } from "~/utils/environmentSort";
 import { concurrencyTracker } from "~/v3/services/taskRunConcurrencyTracker.server";
 import { BasePresenter } from "./basePresenter.server";
 
@@ -55,7 +55,11 @@ export class ConcurrencyPresenter extends BasePresenter {
     }
 
     return {
-      environments: this.environmentConcurrency(project.id, userId, project.environments),
+      environments: this.environmentConcurrency(
+        project.id,
+        userId,
+        filterOrphanedEnvironments(project.environments)
+      ),
     };
   }
 

--- a/apps/webapp/app/presenters/v3/EnvironmentVariablesPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/EnvironmentVariablesPresenter.server.ts
@@ -1,7 +1,7 @@
 import { PrismaClient, prisma } from "~/db.server";
 import { Project } from "~/models/project.server";
 import { User } from "~/models/user.server";
-import { sortEnvironments } from "~/utils/environmentSort";
+import { filterOrphanedEnvironments, sortEnvironments } from "~/utils/environmentSort";
 import { EnvironmentVariablesRepository } from "~/v3/environmentVariables/environmentVariablesRepository.server";
 
 type Result = Awaited<ReturnType<EnvironmentVariablesPresenter["call"]>>;
@@ -78,11 +78,11 @@ export class EnvironmentVariablesPresenter {
       where: {
         project: {
           slug: projectSlug,
-        }
+        },
       },
     });
 
-    const sortedEnvironments = sortEnvironments(environments);
+    const sortedEnvironments = sortEnvironments(filterOrphanedEnvironments(environments));
 
     const repository = new EnvironmentVariablesRepository(this.#prismaClient);
     const variables = await repository.getProject(project.id);
@@ -104,12 +104,12 @@ export class EnvironmentVariablesPresenter {
           }, {} as Record<string, { value: string | undefined; environment: { type: string; id: string } }>),
         };
       }),
-      environments: sortedEnvironments.filter(
-        (e) => e.orgMember?.userId === userId || e.orgMember === null
-      ).map((environment) => ({
-        id: environment.id,
-        type: environment.type,
-      })),
+      environments: sortedEnvironments
+        .filter((e) => e.orgMember?.userId === userId || e.orgMember === null)
+        .map((environment) => ({
+          id: environment.id,
+          type: environment.type,
+        })),
       hasStaging: environments.some((environment) => environment.type === "STAGING"),
     };
   }


### PR DESCRIPTION
We were showing "Dev" environments for removed team members on:
- Environment variables page
- Environment variables create/edit page
- Concurrency limits
- Create/edit schedule