### PR TITLE
Fix for short runs inside (batch)triggerAndWait

### DIFF
--- a/.changeset/early-impalas-itch.md
+++ b/.changeset/early-impalas-itch.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+Fixes for continuing after waits

--- a/.changeset/long-feet-invent.md
+++ b/.changeset/long-feet-invent.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+Rollback to try and fix some dependent attempt issues

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -97,6 +97,7 @@
     "light-bulldogs-press",
     "light-dragons-complain",
     "little-crabs-cross",
+    "long-feet-invent",
     "long-fireants-search",
     "long-hounds-wave",
     "loud-actors-remember",

--- a/apps/webapp/app/services/worker.server.ts
+++ b/apps/webapp/app/services/worker.server.ts
@@ -131,7 +131,6 @@ const workerCatalog = {
   }),
   "v3.resumeBatchRun": z.object({
     batchRunId: z.string(),
-    sourceTaskAttemptId: z.string().optional(),
   }),
   "v3.resumeTaskDependency": z.object({
     dependencyId: z.string(),
@@ -550,7 +549,7 @@ function getWorkerQueue() {
         handler: async (payload, job) => {
           const service = new ResumeBatchRunService();
 
-          return await service.call(payload.batchRunId, payload.sourceTaskAttemptId);
+          return await service.call(payload.batchRunId);
         },
       },
       "v3.resumeTaskDependency": {

--- a/apps/webapp/app/services/worker.server.ts
+++ b/apps/webapp/app/services/worker.server.ts
@@ -131,7 +131,7 @@ const workerCatalog = {
   }),
   "v3.resumeBatchRun": z.object({
     batchRunId: z.string(),
-    sourceTaskAttemptId: z.string(),
+    sourceTaskAttemptId: z.string().optional(),
   }),
   "v3.resumeTaskDependency": z.object({
     dependencyId: z.string(),

--- a/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
+++ b/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
@@ -617,16 +617,6 @@ export class SharedQueueConsumer {
           return;
         }
 
-        // if (messageBody.data.completedAttemptIds.length < 1) {
-        //   logger.error("No attempt IDs provided", {
-        //     queueMessage: message.data,
-        //     messageId: message.messageId,
-        //   });
-
-        //   await this.#ackAndDoMoreWork(message.messageId);
-        //   return;
-        // }
-
         const resumableRun = await prisma.taskRun.findUnique({
           where: {
             id: message.messageId,

--- a/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
+++ b/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
@@ -617,16 +617,6 @@ export class SharedQueueConsumer {
           return;
         }
 
-        // if (messageBody.data.completedAttemptIds.length < 1) {
-        //   logger.error("No attempt IDs provided", {
-        //     queueMessage: message.data,
-        //     messageId: message.messageId,
-        //   });
-
-        //   await this.#ackAndDoMoreWork(message.messageId);
-        //   return;
-        // }
-
         const resumableRun = await prisma.taskRun.findUnique({
           where: {
             id: message.messageId,
@@ -691,55 +681,6 @@ export class SharedQueueConsumer {
           return;
         }
 
-        const completions: TaskRunExecutionResult[] = [];
-        const executions: TaskRunExecution[] = [];
-
-        for (const completedAttemptId of messageBody.data.completedAttemptIds) {
-          const completedAttempt = await prisma.taskRunAttempt.findUnique({
-            where: {
-              id: completedAttemptId,
-              taskRun: {
-                lockedAt: {
-                  not: null,
-                },
-                lockedById: {
-                  not: null,
-                },
-              },
-            },
-          });
-
-          if (!completedAttempt) {
-            logger.error("Completed attempt not found", {
-              queueMessage: message.data,
-              messageId: message.messageId,
-            });
-
-            await this.#ackAndDoMoreWork(message.messageId);
-            return;
-          }
-
-          const completion = await this._tasks.getCompletionPayloadFromAttempt(completedAttempt.id);
-
-          if (!completion) {
-            await this.#ackAndDoMoreWork(message.messageId);
-            return;
-          }
-
-          completions.push(completion);
-
-          const executionPayload = await this._tasks.getExecutionPayloadFromAttempt(
-            completedAttempt.id
-          );
-
-          if (!executionPayload) {
-            await this.#ackAndDoMoreWork(message.messageId);
-            return;
-          }
-
-          executions.push(executionPayload.execution);
-        }
-
         try {
           logger.debug("Broadcasting RESUME_AFTER_DEPENDENCY", {
             runId: resumableAttempt.taskRunId,
@@ -752,8 +693,8 @@ export class SharedQueueConsumer {
             runId: resumableAttempt.taskRunId,
             attemptId: resumableAttempt.id,
             attemptFriendlyId: resumableAttempt.friendlyId,
-            completions,
-            executions,
+            completions: [],
+            executions: [],
           });
         } catch (e) {
           if (e instanceof Error) {

--- a/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
+++ b/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
@@ -617,15 +617,15 @@ export class SharedQueueConsumer {
           return;
         }
 
-        if (messageBody.data.completedAttemptIds.length < 1) {
-          logger.error("No attempt IDs provided", {
-            queueMessage: message.data,
-            messageId: message.messageId,
-          });
+        // if (messageBody.data.completedAttemptIds.length < 1) {
+        //   logger.error("No attempt IDs provided", {
+        //     queueMessage: message.data,
+        //     messageId: message.messageId,
+        //   });
 
-          await this.#ackAndDoMoreWork(message.messageId);
-          return;
-        }
+        //   await this.#ackAndDoMoreWork(message.messageId);
+        //   return;
+        // }
 
         const resumableRun = await prisma.taskRun.findUnique({
           where: {

--- a/apps/webapp/app/v3/services/createCheckpoint.server.ts
+++ b/apps/webapp/app/v3/services/createCheckpoint.server.ts
@@ -178,7 +178,7 @@ export class CreateCheckpointService extends BaseService {
             };
           }
 
-          await ResumeBatchRunService.enqueue(batchRun.id, undefined, this._prisma);
+          await ResumeBatchRunService.enqueue(batchRun.id, this._prisma);
 
           return {
             success: true,

--- a/apps/webapp/app/v3/services/createCheckpoint.server.ts
+++ b/apps/webapp/app/v3/services/createCheckpoint.server.ts
@@ -222,7 +222,7 @@ export class CreateCheckpointService extends BaseService {
               success: true,
               checkpoint,
               event: checkpointEvent,
-              keepRunAlive: true,
+              keepRunAlive: false,
             };
           }
 

--- a/apps/webapp/app/v3/services/createCheckpoint.server.ts
+++ b/apps/webapp/app/v3/services/createCheckpoint.server.ts
@@ -2,18 +2,17 @@ import { CoordinatorToPlatformMessages } from "@trigger.dev/core/v3";
 import type { InferSocketMessageSchema } from "@trigger.dev/core/v3/zodSocket";
 import type { Checkpoint, CheckpointRestoreEvent } from "@trigger.dev/database";
 import { logger } from "~/services/logger.server";
-import { generateFriendlyId } from "../friendlyIdentifiers";
 import { marqs } from "~/v3/marqs/index.server";
-import { CreateCheckpointRestoreEventService } from "./createCheckpointRestoreEvent.server";
-import { BaseService } from "./baseService.server";
+import { generateFriendlyId } from "../friendlyIdentifiers";
 import {
   FINAL_ATTEMPT_STATUSES,
   isFinalRunStatus,
   isFreezableAttemptStatus,
   isFreezableRunStatus,
 } from "../taskStatus";
+import { BaseService } from "./baseService.server";
+import { CreateCheckpointRestoreEventService } from "./createCheckpointRestoreEvent.server";
 import { ResumeBatchRunService } from "./resumeBatchRun.server";
-import { ResumeTaskRunDependenciesService } from "./resumeTaskRunDependencies.server";
 import { ResumeTaskDependencyService } from "./resumeTaskDependency.server";
 
 export class CreateCheckpointService extends BaseService {
@@ -238,11 +237,15 @@ export class CreateCheckpointService extends BaseService {
           });
 
           if (!batchRun) {
-            logger.error("Batch not found", { friendlyId: reason.batchFriendlyId });
-            await marqs?.acknowledgeMessage(attempt.taskRunId);
+            logger.error("CreateCheckpointService: Batch not found", {
+              friendlyId: reason.batchFriendlyId,
+            });
 
             return {
-              success: false,
+              success: true,
+              checkpoint,
+              event: checkpointEvent,
+              keepRunAlive: false,
             };
           }
 

--- a/apps/webapp/app/v3/services/resumeBatchRun.server.ts
+++ b/apps/webapp/app/v3/services/resumeBatchRun.server.ts
@@ -5,7 +5,7 @@ import { BaseService } from "./baseService.server";
 import { logger } from "~/services/logger.server";
 
 export class ResumeBatchRunService extends BaseService {
-  public async call(batchRunId: string, sourceTaskAttemptId?: string) {
+  public async call(batchRunId: string) {
     const batchRun = await this._prisma.batchTaskRun.findFirst({
       where: {
         id: batchRunId,
@@ -77,7 +77,7 @@ export class ResumeBatchRunService extends BaseService {
         dependentRun.id,
         {
           type: "RESUME",
-          completedAttemptIds: sourceTaskAttemptId ? [sourceTaskAttemptId] : [],
+          completedAttemptIds: [],
           resumableAttemptId: batchRun.dependentTaskAttempt.id,
           checkpointEventId: batchRun.checkpointEventId,
           projectId: batchRun.dependentTaskAttempt.runtimeEnvironment.projectId,
@@ -98,17 +98,11 @@ export class ResumeBatchRunService extends BaseService {
     }
   }
 
-  static async enqueue(
-    batchRunId: string,
-    sourceTaskAttemptId: string | undefined,
-    tx: PrismaClientOrTransaction,
-    runAt?: Date
-  ) {
+  static async enqueue(batchRunId: string, tx: PrismaClientOrTransaction, runAt?: Date) {
     return await workerQueue.enqueue(
       "v3.resumeBatchRun",
       {
         batchRunId,
-        sourceTaskAttemptId,
       },
       {
         tx,

--- a/apps/webapp/app/v3/services/resumeTaskDependency.server.ts
+++ b/apps/webapp/app/v3/services/resumeTaskDependency.server.ts
@@ -55,14 +55,28 @@ export class ResumeTaskDependencyService extends BaseService {
         dependentRun.concurrencyKey ?? undefined
       );
     } else {
+      logger.debug("Task dependency resume: Attempt is not paused or there's no checkpoint event", {
+        attemptId: dependency.id,
+        dependentAttempt: dependency.dependentAttempt,
+        checkpointEventId: dependency.checkpointEventId,
+        hasCheckpointEvent: !!dependency.checkpointEventId,
+      });
+
       if (dependency.dependentAttempt.status === "PAUSED" && !dependency.checkpointEventId) {
-        // In case of race conditions and other bugs, the status can be PAUSED without a checkpoint event
-        // The worker may still be up, so we will try to resume the dependent attempt by sending a message to the worker (on dequeue)
-        logger.warn("Task dependency resume: Attempt is paused but there's no checkpoint event", {
+        // In case of race conditions the status can be PAUSED without a checkpoint event
+        // When the checkpoint is created, it will continue the run
+        logger.error("Task dependency resume: Attempt is paused but there's no checkpoint event", {
           attemptId: dependency.id,
           dependentAttemptId: dependency.dependentAttempt.id,
         });
+        return;
       }
+
+      await marqs?.replaceMessage(dependentRun.id, {
+        type: "RESUME",
+        completedAttemptIds: [sourceTaskAttemptId],
+        resumableAttemptId: dependency.dependentAttempt.id,
+      });
     }
   }
 

--- a/apps/webapp/app/v3/services/resumeTaskDependency.server.ts
+++ b/apps/webapp/app/v3/services/resumeTaskDependency.server.ts
@@ -63,12 +63,6 @@ export class ResumeTaskDependencyService extends BaseService {
           dependentAttemptId: dependency.dependentAttempt.id,
         });
       }
-
-      await marqs?.replaceMessage(dependentRun.id, {
-        type: "RESUME",
-        completedAttemptIds: [sourceTaskAttemptId],
-        resumableAttemptId: dependency.dependentAttempt.id,
-      });
     }
   }
 

--- a/apps/webapp/app/v3/services/resumeTaskRunDependencies.server.ts
+++ b/apps/webapp/app/v3/services/resumeTaskRunDependencies.server.ts
@@ -65,7 +65,7 @@ export class ResumeTaskRunDependenciesService extends BaseService {
         },
       });
 
-      await ResumeBatchRunService.enqueue(batchItem.batchTaskRunId, taskAttempt.id, tx);
+      await ResumeBatchRunService.enqueue(batchItem.batchTaskRunId, tx);
     });
   }
 

--- a/integrations/airtable/CHANGELOG.md
+++ b/integrations/airtable/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @trigger.dev/airtable
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+  - @trigger.dev/integration-kit@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/integrations/airtable/package.json
+++ b/integrations/airtable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/airtable",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "Trigger.dev integration for airtable",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.53",
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53",
+    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.54",
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54",
     "airtable": "^0.12.1",
     "zod": "3.22.3"
   },

--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @trigger.dev/github
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+  - @trigger.dev/integration-kit@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/integrations/github/package.json
+++ b/integrations/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/github",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "The official GitHub integration for Trigger.dev",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,8 +30,8 @@
     "@octokit/request-error": "^5.0.1",
     "@octokit/webhooks": "^12.0.10",
     "octokit": "^3.1.2",
-    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.53",
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53",
+    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.54",
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54",
     "zod": "3.22.3"
   },
   "engines": {

--- a/integrations/linear/CHANGELOG.md
+++ b/integrations/linear/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @trigger.dev/linear
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+  - @trigger.dev/integration-kit@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/integrations/linear/package.json
+++ b/integrations/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/linear",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "Trigger.dev integration for @linear/sdk",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@linear/sdk": "^8.0.0",
-    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.53",
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53",
+    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.54",
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54",
     "zod": "3.22.3"
   },
   "engines": {

--- a/integrations/openai/CHANGELOG.md
+++ b/integrations/openai/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @trigger.dev/slack
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+  - @trigger.dev/integration-kit@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/integrations/openai/package.json
+++ b/integrations/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/openai",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "The official OpenAI integration for Trigger.dev",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -42,8 +42,8 @@
   },
   "dependencies": {
     "openai": "^4.16.1",
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53",
-    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.53"
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54",
+    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.54"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/integrations/plain/CHANGELOG.md
+++ b/integrations/plain/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @trigger.dev/plain
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+  - @trigger.dev/integration-kit@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/integrations/plain/package.json
+++ b/integrations/plain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/plain",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "The official Plain.com integration for Trigger.dev",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -24,8 +24,8 @@
     "build:tsup": "tsup"
   },
   "dependencies": {
-    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.53",
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53",
+    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.54",
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54",
     "@team-plain/typescript-sdk": "^2.7.0"
   },
   "engines": {

--- a/integrations/replicate/CHANGELOG.md
+++ b/integrations/replicate/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @trigger.dev/replicate
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+  - @trigger.dev/integration-kit@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/integrations/replicate/package.json
+++ b/integrations/replicate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/replicate",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "Trigger.dev integration for replicate",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.53",
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53",
+    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.54",
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54",
     "replicate": "^0.18.1",
     "zod": "3.22.3"
   },

--- a/integrations/resend/CHANGELOG.md
+++ b/integrations/resend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @trigger.dev/resend
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+  - @trigger.dev/integration-kit@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/integrations/resend/package.json
+++ b/integrations/resend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/resend",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "The official Resend.com integration for Trigger.dev",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -24,8 +24,8 @@
     "build:tsup": "tsup"
   },
   "dependencies": {
-    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.53",
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53",
+    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.54",
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54",
     "resend": "^2.1.0"
   },
   "engines": {

--- a/integrations/sendgrid/CHANGELOG.md
+++ b/integrations/sendgrid/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @trigger.dev/sendgrid
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+  - @trigger.dev/integration-kit@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/integrations/sendgrid/package.json
+++ b/integrations/sendgrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/sendgrid",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "Trigger.dev integration for @sendgrid/mail",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@sendgrid/mail": "^7.7.0",
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53",
-    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.53"
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54",
+    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.54"
   },
   "engines": {
     "node": ">=16.8.0"

--- a/integrations/shopify/CHANGELOG.md
+++ b/integrations/shopify/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @trigger.dev/shopify
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+  - @trigger.dev/integration-kit@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/integrations/shopify/package.json
+++ b/integrations/shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/shopify",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "Trigger.dev integration for @shopify/shopify-api",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@shopify/shopify-api": "^8.0.2",
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53",
-    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.53",
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54",
+    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.54",
     "zod": "3.22.3"
   },
   "engines": {

--- a/integrations/slack/CHANGELOG.md
+++ b/integrations/slack/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @trigger.dev/slack
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/integrations/slack/package.json
+++ b/integrations/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/slack",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "The official Slack integration for Trigger.dev",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@slack/web-api": "^6.8.1",
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53",
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54",
     "zod": "3.22.3"
   },
   "engines": {

--- a/integrations/stripe/CHANGELOG.md
+++ b/integrations/stripe/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @trigger.dev/stripe
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+  - @trigger.dev/integration-kit@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/integrations/stripe/package.json
+++ b/integrations/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/stripe",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "Trigger.dev integration for stripe",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.53",
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53",
+    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.54",
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54",
     "stripe": "^12.14.0",
     "zod": "3.22.3"
   },

--- a/integrations/supabase/CHANGELOG.md
+++ b/integrations/supabase/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @trigger.dev/supabase
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+  - @trigger.dev/integration-kit@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/integrations/supabase/package.json
+++ b/integrations/supabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/supabase",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "Trigger.dev integration for @supabase/supabase-js",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.26.0",
-    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.53",
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53",
+    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.54",
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54",
     "supabase-management-js": "^1.0.0",
     "zod": "3.22.3"
   },

--- a/integrations/typeform/CHANGELOG.md
+++ b/integrations/typeform/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @trigger.dev/typeform
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+  - @trigger.dev/integration-kit@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/integrations/typeform/package.json
+++ b/integrations/typeform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/typeform",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "The official Typeform integration for Trigger.dev",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -24,8 +24,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.53",
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53",
+    "@trigger.dev/integration-kit": "workspace:^3.0.0-beta.54",
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54",
     "@typeform/api-client": "^1.8.0",
     "zod": "3.22.3"
   },

--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @trigger.dev/astro
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@trigger.dev/astro",
   "description": "An Astro-native integration for Trigger.dev background jobs platform",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -20,7 +20,7 @@
     "build:tsup": "tsup"
   },
   "peerDependencies": {
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53"
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54"
   },
   "devDependencies": {
     "astro": "^3.0.12",

--- a/packages/cli-v3/CHANGELOG.md
+++ b/packages/cli-v3/CHANGELOG.md
@@ -1,5 +1,11 @@
 # trigger.dev
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- @trigger.dev/core@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/packages/cli-v3/package.json
+++ b/packages/cli-v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trigger.dev",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "A Command-Line Interface for Trigger.dev (v3) projects",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -87,7 +87,7 @@
     "@opentelemetry/sdk-trace-base": "^1.22.0",
     "@opentelemetry/sdk-trace-node": "^1.22.0",
     "@opentelemetry/semantic-conventions": "^1.22.0",
-    "@trigger.dev/core": "workspace:3.0.0-beta.53",
+    "@trigger.dev/core": "workspace:3.0.0-beta.54",
     "@types/degit": "^2.8.3",
     "chalk": "^5.2.0",
     "chokidar": "^3.5.3",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # create-trigger
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- @trigger.dev/core@3.0.0-beta.54
+- @trigger.dev/yalt@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/cli",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "The Trigger.dev CLI",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/core-apps/CHANGELOG.md
+++ b/packages/core-apps/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @trigger.dev/core-apps
 
+## 3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/packages/core-apps/package.json
+++ b/packages/core-apps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@trigger.dev/core-apps",
   "description": "Backend core code used across apps",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "private": true,
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/core-backend/CHANGELOG.md
+++ b/packages/core-backend/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @trigger.dev/core-backend
 
+## 3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ## 3.0.0-beta.52

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/core-backend",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "Core code used across `@trigger.dev/sdk` and Trigger.dev server",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # internal-platform
 
+## 3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/core",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "Core code used across the Trigger.dev SDK and platform",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @trigger.dev/eslint-plugin
 
+## 3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ## 3.0.0-beta.52

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/eslint-plugin",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "ESLint plugin with trigger.dev best practices",
   "keywords": [
     "eslint",

--- a/packages/express/CHANGELOG.md
+++ b/packages/express/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @trigger.dev/express
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/express",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "Official Express adapter for Trigger.dev",
   "license": "MIT",
   "main": "./dist/index.js",
@@ -23,7 +23,7 @@
     "./package.json": "./package.json"
   },
   "devDependencies": {
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53",
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54",
     "@trigger.dev/tsconfig": "workspace:*",
     "@types/debug": "^4.1.7",
     "@types/express": "^4.17.13",
@@ -39,7 +39,7 @@
     "build:tsup": "tsup"
   },
   "peerDependencies": {
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53"
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54"
   },
   "dependencies": {
     "debug": "^4.3.4",

--- a/packages/hono/CHANGELOG.md
+++ b/packages/hono/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @trigger.dev/hono
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/hono",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "A Trigger.dev adapter for Hono.dev",
   "license": "MIT",
   "main": "./dist/index.js",
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "hono": "3.x",
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53"
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54"
   },
   "devDependencies": {
     "@trigger.dev/tsconfig": "workspace:*",

--- a/packages/integration-kit/CHANGELOG.md
+++ b/packages/integration-kit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @trigger.dev/integration-kit
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- @trigger.dev/core@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/packages/integration-kit/package.json
+++ b/packages/integration-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/integration-kit",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "Trigger.dev Integration Kit has helpers to make creating integrations easier",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/nestjs/CHANGELOG.md
+++ b/packages/nestjs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @trigger.dev/nestjs
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/nestjs",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "Official NestJS adapter for Trigger.dev",
   "license": "MIT",
   "main": "./dist/index.js",
@@ -23,7 +23,7 @@
     "./package.json": "./package.json"
   },
   "devDependencies": {
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53",
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54",
     "@trigger.dev/tsconfig": "workspace:*",
     "@types/debug": "^4.1.7",
     "@types/express": "^4.17.13",
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@nestjs/common": ">=10.0.0",
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53"
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54"
   },
   "dependencies": {
     "@nestjs/common": "^10.2.4",

--- a/packages/nextjs/CHANGELOG.md
+++ b/packages/nextjs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @trigger.dev/nextjs
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/nextjs",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "Trigger.dev Next.js integration",
   "license": "MIT",
   "main": "./dist/index.js",
@@ -41,7 +41,7 @@
     "build:tsup": "tsup"
   },
   "peerDependencies": {
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53",
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54",
     "next": ">=12.0.0"
   },
   "dependencies": {

--- a/packages/otlp-importer/CHANGELOG.md
+++ b/packages/otlp-importer/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @trigger.dev/otlp-importer
 
+## 3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ## 3.0.0-beta.52

--- a/packages/otlp-importer/package.json
+++ b/packages/otlp-importer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/otlp-importer",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "OpenTelemetry OTLP Importer for Node.js written in TypeScript",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @trigger.dev/react
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- @trigger.dev/core@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/react",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "Trigger.dev React SDK",
   "license": "MIT",
   "types": "dist/index.d.ts",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "5.0.0-beta.2",
-    "@trigger.dev/core": "workspace:^3.0.0-beta.53",
+    "@trigger.dev/core": "workspace:^3.0.0-beta.54",
     "debug": "^4.3.4",
     "zod": "3.22.3"
   },

--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @trigger.dev/remix
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/remix",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "Trigger.dev Remix integration",
   "license": "MIT",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "build:tsup": "tsup"
   },
   "peerDependencies": {
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53",
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54",
     "@remix-run/server-runtime": ">1.19.0"
   },
   "dependencies": {

--- a/packages/sveltekit/CHANGELOG.md
+++ b/packages/sveltekit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @trigger.dev/sveltekit
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/sveltekit",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "Trigger.dev svelteKit integration",
   "license": "MIT",
   "main": "./dist/index.js",
@@ -39,7 +39,7 @@
     "build:tsup": "tsup"
   },
   "peerDependencies": {
-    "@trigger.dev/sdk": "workspace:^3.0.0-beta.53"
+    "@trigger.dev/sdk": "workspace:^3.0.0-beta.54"
   },
   "dependencies": {
     "debug": "^4.3.4"

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @trigger.dev/testing
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- Updated dependencies [728eeeff6]
+  - @trigger.dev/sdk@3.0.0-beta.54
+  - @trigger.dev/core@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@trigger.dev/testing",
   "description": "A collection of useful tools to write tests for Trigger.dev.",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/trigger-sdk/CHANGELOG.md
+++ b/packages/trigger-sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @trigger.dev/sdk
 
+## 3.0.0-beta.54
+
+### Patch Changes
+
+- 728eeeff6: Rollback to try and fix some dependent attempt issues
+  - @trigger.dev/core@3.0.0-beta.54
+  - @trigger.dev/core-backend@3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ### Patch Changes

--- a/packages/trigger-sdk/package.json
+++ b/packages/trigger-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/sdk",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "trigger.dev Node.JS SDK",
   "license": "MIT",
   "main": "./dist/index.js",
@@ -48,8 +48,8 @@
     "@opentelemetry/api": "^1.8.0",
     "@opentelemetry/api-logs": "^0.48.0",
     "@opentelemetry/semantic-conventions": "^1.22.0",
-    "@trigger.dev/core": "workspace:3.0.0-beta.53",
-    "@trigger.dev/core-backend": "workspace:3.0.0-beta.53",
+    "@trigger.dev/core": "workspace:3.0.0-beta.54",
+    "@trigger.dev/core-backend": "workspace:3.0.0-beta.54",
     "chalk": "^5.2.0",
     "cronstrue": "^2.21.0",
     "debug": "^4.3.4",

--- a/packages/yalt/CHANGELOG.md
+++ b/packages/yalt/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @trigger.dev/yalt
 
+## 3.0.0-beta.54
+
 ## 3.0.0-beta.53
 
 ## 3.0.0-beta.52

--- a/packages/yalt/package.json
+++ b/packages/yalt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trigger.dev/yalt",
-  "version": "3.0.0-beta.53",
+  "version": "3.0.0-beta.54",
   "description": "yalt.dev client library",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -878,10 +878,10 @@ importers:
   integrations/airtable:
     dependencies:
       '@trigger.dev/integration-kit':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/integration-kit
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/trigger-sdk
       airtable:
         specifier: ^0.12.1
@@ -921,10 +921,10 @@ importers:
         specifier: ^12.0.10
         version: 12.0.10
       '@trigger.dev/integration-kit':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/integration-kit
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/trigger-sdk
       octokit:
         specifier: ^3.1.2
@@ -964,10 +964,10 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       '@trigger.dev/integration-kit':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/integration-kit
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/trigger-sdk
       zod:
         specifier: 3.22.3
@@ -995,10 +995,10 @@ importers:
   integrations/openai:
     dependencies:
       '@trigger.dev/integration-kit':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/integration-kit
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/trigger-sdk
       openai:
         specifier: ^4.16.1
@@ -1038,10 +1038,10 @@ importers:
         specifier: ^2.7.0
         version: 2.7.0
       '@trigger.dev/integration-kit':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/integration-kit
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/trigger-sdk
     devDependencies:
       '@trigger.dev/tsconfig':
@@ -1066,10 +1066,10 @@ importers:
   integrations/replicate:
     dependencies:
       '@trigger.dev/integration-kit':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/integration-kit
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/trigger-sdk
       replicate:
         specifier: ^0.18.1
@@ -1100,10 +1100,10 @@ importers:
   integrations/resend:
     dependencies:
       '@trigger.dev/integration-kit':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/integration-kit
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/trigger-sdk
       resend:
         specifier: ^2.1.0
@@ -1134,10 +1134,10 @@ importers:
         specifier: ^7.7.0
         version: 7.7.0
       '@trigger.dev/integration-kit':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/integration-kit
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/trigger-sdk
     devDependencies:
       '@trigger.dev/tsconfig':
@@ -1165,10 +1165,10 @@ importers:
         specifier: ^8.0.2
         version: 8.0.2
       '@trigger.dev/integration-kit':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/integration-kit
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/trigger-sdk
       zod:
         specifier: 3.22.3
@@ -1199,7 +1199,7 @@ importers:
         specifier: ^6.8.1
         version: 6.8.1
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/trigger-sdk
       zod:
         specifier: 3.22.3
@@ -1227,10 +1227,10 @@ importers:
   integrations/stripe:
     dependencies:
       '@trigger.dev/integration-kit':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/integration-kit
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/trigger-sdk
       stripe:
         specifier: ^12.14.0
@@ -1264,10 +1264,10 @@ importers:
         specifier: ^2.26.0
         version: 2.31.0
       '@trigger.dev/integration-kit':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/integration-kit
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/trigger-sdk
       supabase-management-js:
         specifier: ^1.0.0
@@ -1298,10 +1298,10 @@ importers:
   integrations/typeform:
     dependencies:
       '@trigger.dev/integration-kit':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/integration-kit
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../../packages/trigger-sdk
       '@typeform/api-client':
         specifier: ^1.8.0
@@ -1329,7 +1329,7 @@ importers:
   packages/astro:
     dependencies:
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../trigger-sdk
       debug:
         specifier: ^4.3.4
@@ -1547,7 +1547,7 @@ importers:
         specifier: ^1.22.0
         version: 1.22.0
       '@trigger.dev/core':
-        specifier: workspace:3.0.0-beta.53
+        specifier: workspace:3.0.0-beta.54
         version: link:../core
       '@types/degit':
         specifier: ^2.8.3
@@ -1972,7 +1972,7 @@ importers:
         version: 4.18.2
     devDependencies:
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../trigger-sdk
       '@trigger.dev/tsconfig':
         specifier: workspace:*
@@ -2067,7 +2067,7 @@ importers:
         version: 4.3.4(supports-color@8.1.1)
     devDependencies:
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../trigger-sdk
       '@trigger.dev/tsconfig':
         specifier: workspace:*
@@ -2100,7 +2100,7 @@ importers:
   packages/nextjs:
     dependencies:
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../trigger-sdk
       debug:
         specifier: ^4.3.4
@@ -2186,7 +2186,7 @@ importers:
         specifier: 5.0.0-beta.2
         version: 5.0.0-beta.2(react@18.2.0)
       '@trigger.dev/core':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../core
       debug:
         specifier: ^4.3.4
@@ -2229,7 +2229,7 @@ importers:
   packages/remix:
     dependencies:
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../trigger-sdk
       debug:
         specifier: ^4.3.4
@@ -2266,7 +2266,7 @@ importers:
   packages/sveltekit:
     dependencies:
       '@trigger.dev/sdk':
-        specifier: workspace:^3.0.0-beta.53
+        specifier: workspace:^3.0.0-beta.54
         version: link:../trigger-sdk
       debug:
         specifier: ^4.3.4
@@ -2340,10 +2340,10 @@ importers:
         specifier: ^1.22.0
         version: 1.22.0
       '@trigger.dev/core':
-        specifier: workspace:3.0.0-beta.53
+        specifier: workspace:3.0.0-beta.54
         version: link:../core
       '@trigger.dev/core-backend':
-        specifier: workspace:3.0.0-beta.53
+        specifier: workspace:3.0.0-beta.54
         version: link:../core-backend
       chalk:
         specifier: ^5.2.0

--- a/references/v3-catalog/src/trigger/checkpoints.ts
+++ b/references/v3-catalog/src/trigger/checkpoints.ts
@@ -1,11 +1,15 @@
-import { tasks, task, logger } from "@trigger.dev/sdk/v3";
+import { logger, task } from "@trigger.dev/sdk/v3";
+
+type Payload = {
+  count?: number;
+};
 
 /** Test that checkpoints and resuming works if the checkpoint isn't created before the resume */
 export const checkpointBatchResumer = task({
   id: "checkpoint-batch-resume",
-  run: async () => {
-    await noop.batchTriggerAndWait([{}]);
-    logger.info("Successfully resumed");
+  run: async ({ count = 1 }: Payload) => {
+    await noop.batchTriggerAndWait(Array.from({ length: count }, (_, i) => ({})));
+    logger.info(`Successfully resumed after ${count} runs`);
   },
 });
 

--- a/references/v3-catalog/src/trigger/checkpoints.ts
+++ b/references/v3-catalog/src/trigger/checkpoints.ts
@@ -1,0 +1,15 @@
+import { tasks, task, logger } from "@trigger.dev/sdk/v3";
+
+/** Test that checkpoints and resuming works if the checkpoint isn't created before the resume */
+export const checkpointBatchResumer = task({
+  id: "checkpoint-batch-resume",
+  run: async () => {
+    await noop.batchTriggerAndWait([{}]);
+    logger.info("Successfully resumed");
+  },
+});
+
+export const noop = task({
+  id: "noop",
+  run: async () => {},
+});

--- a/references/v3-catalog/src/trigger/checkpoints.ts
+++ b/references/v3-catalog/src/trigger/checkpoints.ts
@@ -9,7 +9,55 @@ export const checkpointBatchResumer = task({
   id: "checkpoint-batch-resume",
   run: async ({ count = 1 }: Payload) => {
     await noop.batchTriggerAndWait(Array.from({ length: count }, (_, i) => ({})));
-    logger.info(`Successfully resumed after ${count} runs`);
+    logger.info(`Successfully 1/1 resumed after ${count} runs`);
+    await noop.batchTriggerAndWait(Array.from({ length: count }, (_, i) => ({})));
+    logger.info(`Successfully 2/2 resumed after ${count} runs`);
+  },
+});
+
+/** Test that checkpoints and resuming works if the checkpoint isn't created before the resume */
+export const checkpointResumer = task({
+  id: "checkpoint-resume",
+  run: async ({ count = 1 }: Payload) => {
+    await noop.triggerAndWait();
+    logger.info(`Successfully 1/3 resumed`);
+    await noop.triggerAndWait();
+    logger.info(`Successfully 2/3 resumed`);
+    await noop.triggerAndWait();
+    logger.info(`Successfully 3/3 resumed`);
+  },
+});
+
+export const nestedDependencies = task({
+  id: "nested-dependencies",
+  run: async ({
+    depth = 0,
+    maxDepth = 6,
+    batchSize = 4,
+  }: {
+    depth?: number;
+    maxDepth?: number;
+    batchSize?: number;
+  }) => {
+    if (depth >= maxDepth) {
+      return;
+    }
+
+    logger.log(`${depth}/${maxDepth} depth`);
+
+    const triggerOrBatch = depth % 2 === 0;
+
+    await nestedDependencies.triggerAndWait({ depth: depth + 1, maxDepth });
+    logger.log(`Triggered complete`);
+    // if (triggerOrBatch) {
+    // } else {
+    //   await nestedDependencies.batchTriggerAndWait(
+    //     Array.from({ length: batchSize }, (_, i) => ({
+    //       payload: { depth: depth + 1, maxDepth, batchSize },
+    //     }))
+    //   );
+    //   logger.log(`Batch triggered complete`);
+    // }
   },
 });
 


### PR DESCRIPTION
If short runs were inside `triggerAndWait` or `batchTriggerAndWait` there was a race condition where a checkpoint wouldn't be created in time. In some cases the run wasn't running in the cluster anymore and they got stuck frozen forever.

Changes
- Don't attempt to continue these runs in the cluster if there's no checkpoint.
- When we create the checkpoint try and continue these runs (they won't continue if the sub-runs aren't finished).
- Remove some code that was failing attempts to prevent infinite recursion. It was causing errors in certain conditions where runs would have otherwise succeeded.