### PR TITLE
Stop heartbeats when creating andWait checkpoints, fix for concurrency tracker

### DIFF
--- a/apps/webapp/app/v3/marqs/index.server.ts
+++ b/apps/webapp/app/v3/marqs/index.server.ts
@@ -521,6 +521,27 @@ export class MarQS {
     );
   }
 
+  public async cancelHeartbeat(messageId: string) {
+    return this.#trace(
+      "cancelHeartbeat",
+      async (span) => {
+        span.setAttributes({
+          [SemanticAttributes.MESSAGE_ID]: messageId,
+        });
+
+        await this.options.visibilityTimeoutStrategy.cancelHeartbeat(messageId);
+      },
+      {
+        kind: SpanKind.CONSUMER,
+        attributes: {
+          [SEMATTRS_MESSAGING_OPERATION]: "cancelHeartbeat",
+          [SEMATTRS_MESSAGE_ID]: messageId,
+          [SEMATTRS_MESSAGING_SYSTEM]: "marqs",
+        },
+      }
+    );
+  }
+
   async #trace<T>(
     name: string,
     fn: (span: Span) => Promise<T>,

--- a/apps/webapp/app/v3/services/createCheckpoint.server.ts
+++ b/apps/webapp/app/v3/services/createCheckpoint.server.ts
@@ -170,6 +170,11 @@ export class CreateCheckpointService extends BaseService {
 
         if (checkpointEvent) {
           //heartbeats will start again when the run resumes
+          logger.log("CreateCheckpointService: Canceling heartbeat", {
+            attemptId: attempt.id,
+            taskRunId: attempt.taskRunId,
+            type: "WAIT_FOR_TASK",
+          });
           await marqs?.cancelHeartbeat(attempt.taskRunId);
 
           const dependency = await this._prisma.taskRunDependency.findFirst({
@@ -311,6 +316,11 @@ export class CreateCheckpointService extends BaseService {
 
         if (checkpointEvent) {
           //heartbeats will start again when the run resumes
+          logger.log("CreateCheckpointService: Canceling heartbeat", {
+            attemptId: attempt.id,
+            taskRunId: attempt.taskRunId,
+            type: "WAIT_FOR_BATCH",
+          });
           await marqs?.cancelHeartbeat(attempt.taskRunId);
 
           const batchRun = await this._prisma.batchTaskRun.findFirst({

--- a/apps/webapp/app/v3/services/resumeBatchRun.server.ts
+++ b/apps/webapp/app/v3/services/resumeBatchRun.server.ts
@@ -80,6 +80,7 @@ export class ResumeBatchRunService extends BaseService {
           completedAttemptIds: [],
           resumableAttemptId: batchRun.dependentTaskAttempt.id,
           checkpointEventId: batchRun.checkpointEventId,
+          taskIdentifier: batchRun.dependentTaskAttempt.taskRun.taskIdentifier,
           projectId: batchRun.dependentTaskAttempt.runtimeEnvironment.projectId,
           environmentId: batchRun.dependentTaskAttempt.runtimeEnvironment.id,
           environmentType: batchRun.dependentTaskAttempt.runtimeEnvironment.type,
@@ -109,6 +110,10 @@ export class ResumeBatchRunService extends BaseService {
         completedAttemptIds: batchRun.items.map((item) => item.taskRunAttemptId).filter(Boolean),
         resumableAttemptId: batchRun.dependentTaskAttempt.id,
         checkpointEventId: batchRun.checkpointEventId ?? undefined,
+        taskIdentifier: batchRun.dependentTaskAttempt.taskRun.taskIdentifier,
+        projectId: batchRun.dependentTaskAttempt.runtimeEnvironment.projectId,
+        environmentId: batchRun.dependentTaskAttempt.runtimeEnvironment.id,
+        environmentType: batchRun.dependentTaskAttempt.runtimeEnvironment.type,
       });
     }
   }

--- a/apps/webapp/app/v3/services/resumeTaskDependency.server.ts
+++ b/apps/webapp/app/v3/services/resumeTaskDependency.server.ts
@@ -48,6 +48,7 @@ export class ResumeTaskDependencyService extends BaseService {
           completedAttemptIds: [sourceTaskAttemptId],
           resumableAttemptId: dependency.dependentAttempt.id,
           checkpointEventId: dependency.checkpointEventId,
+          taskIdentifier: dependency.taskRun.taskIdentifier,
           projectId: dependency.taskRun.runtimeEnvironment.projectId,
           environmentId: dependency.taskRun.runtimeEnvironment.id,
           environmentType: dependency.taskRun.runtimeEnvironment.type,
@@ -77,6 +78,10 @@ export class ResumeTaskDependencyService extends BaseService {
         completedAttemptIds: [sourceTaskAttemptId],
         resumableAttemptId: dependency.dependentAttempt.id,
         checkpointEventId: dependency.checkpointEventId ?? undefined,
+        taskIdentifier: dependency.taskRun.taskIdentifier,
+        projectId: dependency.taskRun.runtimeEnvironment.projectId,
+        environmentId: dependency.taskRun.runtimeEnvironment.id,
+        environmentType: dependency.taskRun.runtimeEnvironment.type,
       });
     }
   }

--- a/references/v3-catalog/src/trigger/checkpoints.ts
+++ b/references/v3-catalog/src/trigger/checkpoints.ts
@@ -61,16 +61,18 @@ export const nestedDependencies = task({
     const triggerOrBatch = depth % 2 === 0;
 
     if (triggerOrBatch) {
-      const result = await nestedDependencies.triggerAndWait({
-        depth: depth + 1,
-        maxDepth,
-        waitSeconds,
-        failAttemptChance,
-      });
-      logger.log(`Triggered complete`);
+      for (let i = 0; i < batchSize; i++) {
+        const result = await nestedDependencies.triggerAndWait({
+          depth: depth + 1,
+          maxDepth,
+          waitSeconds,
+          failAttemptChance,
+        });
+        logger.log(`Triggered complete ${i + 1}/${batchSize}`);
 
-      if (!result.ok && failParents) {
-        throw new Error(`Failed at ${depth}/${maxDepth} depth`);
+        if (!result.ok && failParents) {
+          throw new Error(`Failed at ${depth}/${maxDepth} depth`);
+        }
       }
     } else {
       const results = await nestedDependencies.batchTriggerAndWait(


### PR DESCRIPTION
Heartbeats weren't being stopped when a checkpoint was created for `andWait`. They were for just `wait` because `marqs.replaceMessage` stops heartbeats.

I've added a specific call to stop heartbeats in these cases.

Additionally, the concurrency tracker (not used in logic, only for display purposes in the dashboard) was getting out of sync because some marqs payloads were missing required data.