### PR TITLE
When enqueuing clear concurrency for that run

### DIFF
--- a/apps/webapp/app/routes/api.v1.projects.$projectRef.background-workers.ts
+++ b/apps/webapp/app/routes/api.v1.projects.$projectRef.background-workers.ts
@@ -58,7 +58,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
       { status: 200 }
     );
   } catch (e) {
-    logger.error("Failed to create background worker", { error: e });
+    logger.error("Failed to create background worker", { error: JSON.stringify(e) });
 
     if (e instanceof ServiceValidationError) {
       return json({ error: e.message }, { status: 400 });


### PR DESCRIPTION
It was possible in some edge cases for the concurrency to be taken by a run and the message to get enqueued again without the original concurrency being cleared. This causes problems if you're maxed out with your concurrency (at the org, environment, or task/queue level).

The change here remove the concurrency keys when enqueuing, since obviously it's not running if we're enqueuing.