### PR TITLE
Free up concurrency when using triggerAndWait. Improved errors on runs

### DIFF
--- a/.changeset/fast-ladybugs-eat.md
+++ b/.changeset/fast-ladybugs-eat.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Removed the folder/filepath from Attempt spans

--- a/packages/core/src/v3/workers/taskExecutor.ts
+++ b/packages/core/src/v3/workers/taskExecutor.ts
@@ -202,17 +202,6 @@ export class TaskExecutor {
         kind: SpanKind.CONSUMER,
         attributes: {
           [SemanticInternalAttributes.STYLE_ICON]: "attempt",
-          ...accessoryAttributes({
-            items: [
-              {
-                text: ctx.task.filePath,
-              },
-              {
-                text: `${ctx.task.exportName}.run()`,
-              },
-            ],
-            style: "codepath",
-          }),
         },
       },
       this._tracer.extractContext(traceContext)

--- a/references/v3-catalog/src/trigger/checkpoints.ts
+++ b/references/v3-catalog/src/trigger/checkpoints.ts
@@ -18,13 +18,16 @@ export const checkpointBatchResumer = task({
 /** Test that checkpoints and resuming works if the checkpoint isn't created before the resume */
 export const checkpointResumer = task({
   id: "checkpoint-resume",
+  queue: {
+    concurrencyLimit: 1,
+  },
   run: async ({ count = 1 }: Payload) => {
-    await noop.triggerAndWait();
-    logger.info(`Successfully 1/3 resumed`);
-    await noop.triggerAndWait();
-    logger.info(`Successfully 2/3 resumed`);
-    await noop.triggerAndWait();
-    logger.info(`Successfully 3/3 resumed`);
+    logger.info(`Starting ${count} runs`);
+
+    for (let i = 0; i < count; i++) {
+      await noop.triggerAndWait();
+      logger.info(`Successfully ${i + 1}/${count} resumed`);
+    }
   },
 });
 


### PR DESCRIPTION
## Freeing up concurrency
When using `triggerAndWait()` or `batchTriggerAndWait()` free up concurrency for the environment and org straight away. If it's a recursive task (i.e. the task calls itself again) then also free up the concurrency for the task queue.

This fixes some issues where at maximum concurrency it's possible for a run to get stuck. In production runs were clearing their concurrency after the heartbeats failed, but this slowed down execution by up to 2 mins.

## Adding errors when failing runs
When a run fails, we now ensure there is an error on the final attempt (if there isn't already one). There were some runs with "SYSTEM_FAILURE" but no information on why, except in the logs which is hard to dig out.

## Run inspector error
We were showing run errors even if attempts were still happening. This was confusing. Now we only show an error on the run if the run is in a final state. You can still see attempt errors on the individual attempts.