### PR TITLE
docs: Update upgrading-packages.mdx

### DIFF
--- a/docs/upgrading-packages.mdx
+++ b/docs/upgrading-packages.mdx
@@ -71,8 +71,8 @@ But we recommend adding your dev and deploy commands to the `scripts` section of
 ```json
 {
   "scripts": {
-    "dev:trigger": "trigger.dev dev",
-    "deploy:trigger": "trigger.dev deploy"
+    "dev:trigger": "triggerdev dev",
+    "deploy:trigger": "triggerdev deploy"
   }
 }
 ```


### PR DESCRIPTION
I believe the name of the executable in the `bin` dir is called `triggerdev` instead of `trigger.dev`

Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

_[Describe the steps you took to test this change]_

---

## Changelog

_[Short description of what has changed]_

---

## Screenshots

_[Screenshots]_

💯
