### PR TITLE
Frozen run fixes

### DIFF
--- a/apps/webapp/app/platform/zodWorker.server.ts
+++ b/apps/webapp/app/platform/zodWorker.server.ts
@@ -318,7 +318,7 @@ export class ZodWorker<TMessageCatalog extends MessageCatalogSchema> {
     identifier: K,
     payload: z.infer<TMessageCatalog[K]>,
     options?: ZodWorkerEnqueueOptions
-  ): Promise<GraphileJob> {
+  ): Promise<GraphileJob | undefined> {
     const task = this.#tasks[identifier];
 
     const optionsWithoutTx = removeUndefinedKeys(omit(options ?? {}, ["tx"]));
@@ -439,11 +439,9 @@ export class ZodWorker<TMessageCatalog extends MessageCatalogSchema> {
         identifier,
         payload,
         spec,
+        error: JSON.stringify(rows.error),
       });
-
-      throw new Error(
-        `Failed to add job to queue, zod parsing error: ${JSON.stringify(rows.error)}`
-      );
+      return { job: undefined, durationInMs: Math.floor(durationInMs) };
     }
 
     const job = rows.data[0];

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -796,6 +796,12 @@ function RunTimelineLine({ title, state }: RunTimelineLineProps) {
 function RunError({ error }: { error: TaskRunError }) {
   switch (error.type) {
     case "STRING_ERROR":
+      return (
+        <div className="flex flex-col gap-2 rounded-sm border border-rose-500/50 px-3 pb-3 pt-2">
+          <Header3 className="text-rose-500">Error</Header3>
+          <Callout variant="error">{error.raw}</Callout>
+        </div>
+      );
     case "CUSTOM_ERROR": {
       return (
         <div className="flex flex-col gap-2 rounded-sm border border-rose-500/50 px-3 pb-3 pt-2">

--- a/apps/webapp/app/services/schedules/deliverScheduledEvent.server.ts
+++ b/apps/webapp/app/services/schedules/deliverScheduledEvent.server.ts
@@ -134,7 +134,7 @@ export class DeliverScheduledEventService {
           id,
         },
         data: {
-          workerJobId: workerJob.id,
+          workerJobId: workerJob?.id,
           nextEventTimestamp: runAt,
         },
       });

--- a/apps/webapp/app/v3/eventRepository.server.ts
+++ b/apps/webapp/app/v3/eventRepository.server.ts
@@ -226,6 +226,7 @@ export class EventRepository {
     const events = await this.queryIncompleteEvents({ spanId });
 
     if (events.length === 0) {
+      logger.warn("No incomplete events found for spanId", { spanId, options });
       return;
     }
 

--- a/apps/webapp/app/v3/services/cancelAttempt.server.ts
+++ b/apps/webapp/app/v3/services/cancelAttempt.server.ts
@@ -61,13 +61,15 @@ export class CancelAttemptService extends BaseService {
           },
         });
 
+        const isCancellable = isCancellableRunStatus(taskRunAttempt.taskRun.status);
+
         const finalizeService = new FinalizeTaskRunService(tx);
         await finalizeService.call({
           id: taskRunId,
-          status: isCancellableRunStatus(taskRunAttempt.taskRun.status) ? "INTERRUPTED" : undefined,
-          completedAt: isCancellableRunStatus(taskRunAttempt.taskRun.status)
-            ? cancelledAt
-            : undefined,
+          status: isCancellable ? "INTERRUPTED" : undefined,
+          completedAt: isCancellable ? cancelledAt : undefined,
+          attemptStatus: isCancellable ? "CANCELED" : undefined,
+          error: isCancellable ? { type: "STRING_ERROR", raw: reason } : undefined,
         });
       });
 

--- a/apps/webapp/app/v3/services/cancelTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/cancelTaskRun.server.ts
@@ -76,6 +76,11 @@ export class CancelTaskRunService extends BaseService {
         runtimeEnvironment: true,
         lockedToVersion: true,
       },
+      attemptStatus: "CANCELED",
+      error: {
+        type: "STRING_ERROR",
+        raw: opts.reason,
+      },
     });
 
     const inProgressEvents = await eventRepository.queryIncompleteEvents({

--- a/apps/webapp/app/v3/services/completeAttempt.server.ts
+++ b/apps/webapp/app/v3/services/completeAttempt.server.ts
@@ -76,6 +76,12 @@ export class CompleteAttemptService extends BaseService {
         id: run.id,
         status: "SYSTEM_FAILURE",
         completedAt: new Date(),
+        attemptStatus: "FAILED",
+        error: {
+          type: "INTERNAL_ERROR",
+          code: "TASK_EXECUTION_FAILED",
+          message: "Tried to complete attempt but it doesn't exist",
+        },
       });
 
       // No attempt, so there's no message to ACK

--- a/apps/webapp/app/v3/services/crashTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/crashTaskRun.server.ts
@@ -69,6 +69,13 @@ export class CrashTaskRunService extends BaseService {
           },
         },
       },
+      attemptStatus: "FAILED",
+      error: {
+        type: "INTERNAL_ERROR",
+        code: "TASK_RUN_CRASHED",
+        message: opts.reason,
+        stackTrace: opts.logs,
+      },
     });
 
     const inProgressEvents = await eventRepository.queryIncompleteEvents(

--- a/apps/webapp/app/v3/services/createCheckpoint.server.ts
+++ b/apps/webapp/app/v3/services/createCheckpoint.server.ts
@@ -14,6 +14,7 @@ import { BaseService } from "./baseService.server";
 import { CreateCheckpointRestoreEventService } from "./createCheckpointRestoreEvent.server";
 import { ResumeBatchRunService } from "./resumeBatchRun.server";
 import { ResumeTaskDependencyService } from "./resumeTaskDependency.server";
+import { ResumeDependentParentsService } from "./resumeDependentParents.server";
 
 export class CreateCheckpointService extends BaseService {
   public async call(
@@ -177,126 +178,14 @@ export class CreateCheckpointService extends BaseService {
           });
           await marqs?.cancelHeartbeat(attempt.taskRunId);
 
-          const dependency = await this._prisma.taskRunDependency.findFirst({
-            select: {
-              id: true,
-              taskRunId: true,
-            },
-            where: {
-              taskRun: {
-                friendlyId: reason.friendlyId,
-              },
-            },
-          });
+          const resumeService = new ResumeDependentParentsService();
+          const result = await resumeService.call({ id: attempt.taskRunId });
 
-          logger.log("CreateCheckpointService: Created checkpoint WAIT_FOR_TASK", {
-            checkpointId: checkpoint.id,
-            runFriendlyId: reason.friendlyId,
-            dependencyId: dependency?.id,
-          });
-
-          if (!dependency) {
-            logger.error("CreateCheckpointService: Dependency not found", {
-              friendlyId: reason.friendlyId,
-            });
-
-            return {
-              success: true,
-              checkpoint,
-              event: checkpointEvent,
-              keepRunAlive: false,
-            };
+          if (result.success) {
+            logger.log("CreateCheckpointService: Resumed dependent parents", result);
+          } else {
+            logger.error("CreateCheckpointService: Failed to resume dependent parents", result);
           }
-
-          const childRun = await this._prisma.taskRun.findFirst({
-            select: {
-              id: true,
-              status: true,
-            },
-            where: {
-              id: dependency.taskRunId,
-            },
-          });
-
-          if (!childRun) {
-            logger.error("CreateCheckpointService: Dependency child run not found", {
-              taskRunId: dependency.taskRunId,
-              runFriendlyId: reason.friendlyId,
-              dependencyId: dependency.id,
-            });
-
-            return {
-              success: true,
-              checkpoint,
-              event: checkpointEvent,
-              keepRunAlive: false,
-            };
-          }
-
-          const isFinished = isFinalRunStatus(childRun.status);
-          if (!isFinished) {
-            logger.debug("CreateCheckpointService: Dependency child run not finished", {
-              taskRunId: dependency.taskRunId,
-              runFriendlyId: reason.friendlyId,
-              dependencyId: dependency.id,
-              childRunStatus: childRun.status,
-              childRunId: childRun.id,
-            });
-
-            return {
-              success: true,
-              checkpoint,
-              event: checkpointEvent,
-              keepRunAlive: false,
-            };
-          }
-
-          const lastAttempt = await this._prisma.taskRunAttempt.findFirst({
-            select: {
-              id: true,
-              status: true,
-            },
-            where: {
-              taskRunId: dependency.taskRunId,
-            },
-            orderBy: {
-              createdAt: "desc",
-            },
-          });
-
-          if (!lastAttempt) {
-            logger.debug("CreateCheckpointService: Dependency child attempt not found", {
-              taskRunId: dependency.taskRunId,
-              runFriendlyId: reason.friendlyId,
-              dependencyId: dependency?.id,
-            });
-            return {
-              success: true,
-              checkpoint,
-              event: checkpointEvent,
-              keepRunAlive: false,
-            };
-          }
-
-          if (!isFinalAttemptStatus(lastAttempt.status)) {
-            logger.debug("CreateCheckpointService: Dependency child attempt not final", {
-              taskRunId: dependency.taskRunId,
-              runFriendlyId: reason.friendlyId,
-              dependencyId: dependency.id,
-              lastAttemptId: lastAttempt.id,
-              lastAttemptStatus: lastAttempt.status,
-            });
-
-            return {
-              success: true,
-              checkpoint,
-              event: checkpointEvent,
-              keepRunAlive: false,
-            };
-          }
-
-          //resume the dependent task
-          await ResumeTaskDependencyService.enqueue(dependency.id, lastAttempt.id, this._prisma);
 
           return {
             success: true,

--- a/apps/webapp/app/v3/services/expireEnqueuedRun.server.ts
+++ b/apps/webapp/app/v3/services/expireEnqueuedRun.server.ts
@@ -45,6 +45,11 @@ export class ExpireEnqueuedRunService extends BaseService {
       status: "EXPIRED",
       expiredAt: new Date(),
       completedAt: new Date(),
+      attemptStatus: "FAILED",
+      error: {
+        type: "STRING_ERROR",
+        raw: `Run expired because the TTL (${run.ttl}) was reached`,
+      },
     });
 
     await eventRepository.completeEvent(run.spanId, {

--- a/apps/webapp/app/v3/services/finalizeTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/finalizeTaskRun.server.ts
@@ -1,16 +1,23 @@
+import { sanitizeError, TaskRunError } from "@trigger.dev/core/v3";
 import { type Prisma, type TaskRun } from "@trigger.dev/database";
 import { logger } from "~/services/logger.server";
 import { marqs } from "~/v3/marqs/index.server";
-import { BaseService } from "./baseService.server";
-import { isFailedRunStatus, type FINAL_RUN_STATUSES } from "../taskStatus";
-import { PerformTaskAttemptAlertsService } from "./alerts/performTaskAttemptAlerts.server";
+import {
+  isFailedRunStatus,
+  type FINAL_ATTEMPT_STATUSES,
+  type FINAL_RUN_STATUSES,
+} from "../taskStatus";
 import { PerformTaskRunAlertsService } from "./alerts/performTaskRunAlerts.server";
+import { BaseService } from "./baseService.server";
+import { ResumeDependentParentsService } from "./resumeDependentParents.server";
 
 type BaseInput = {
   id: string;
   status?: FINAL_RUN_STATUSES;
   expiredAt?: Date;
   completedAt?: Date;
+  attemptStatus?: FINAL_ATTEMPT_STATUSES;
+  error?: TaskRunError;
 };
 
 type InputWithInclude<T extends Prisma.TaskRunInclude> = BaseInput & {
@@ -32,6 +39,8 @@ export class FinalizeTaskRunService extends BaseService {
     expiredAt,
     completedAt,
     include,
+    attemptStatus,
+    error,
   }: T extends Prisma.TaskRunInclude ? InputWithInclude<T> : InputWithoutInclude): Promise<
     Output<T>
   > {
@@ -55,6 +64,47 @@ export class FinalizeTaskRunService extends BaseService {
       data: { status, expiredAt, completedAt },
       ...(include ? { include } : {}),
     });
+
+    if (attemptStatus || error) {
+      const latestAttempt = await this._prisma.taskRunAttempt.findFirst({
+        where: { taskRunId: id },
+        orderBy: { id: "desc" },
+        take: 1,
+      });
+
+      if (latestAttempt) {
+        logger.debug("Finalizing run attempt", {
+          id: latestAttempt.id,
+          status: attemptStatus,
+          error,
+        });
+
+        await this._prisma.taskRunAttempt.update({
+          where: { id: latestAttempt.id },
+          data: { status: attemptStatus, error: error ? sanitizeError(error) : undefined },
+        });
+      } else {
+        logger.debug("Finalizing run no attempt found", {
+          id,
+          status,
+          expiredAt,
+          completedAt,
+          attemptStatus,
+        });
+
+        //todo maybe we should create a final attempt here?
+      }
+    }
+
+    //resume any dependencies
+    const resumeService = new ResumeDependentParentsService();
+    const result = await resumeService.call({ id: run.id });
+
+    if (result.success) {
+      logger.log("FinalizeTaskRunService: Resumed dependent parents", { result });
+    } else {
+      logger.error("FinalizeTaskRunService: Failed to resume dependent parents", { result });
+    }
 
     //enqueue alert
     if (isFailedRunStatus(run.status)) {

--- a/apps/webapp/app/v3/services/resumeDependentParents.server.ts
+++ b/apps/webapp/app/v3/services/resumeDependentParents.server.ts
@@ -1,0 +1,199 @@
+import { Prisma } from "@trigger.dev/database";
+import { logger } from "~/services/logger.server";
+import { isFinalAttemptStatus, isFinalRunStatus } from "../taskStatus";
+import { BaseService } from "./baseService.server";
+import { ResumeBatchRunService } from "./resumeBatchRun.server";
+import { ResumeTaskDependencyService } from "./resumeTaskDependency.server";
+
+type Input =
+  | {
+      id: string;
+    }
+  | {
+      friendlyId: string;
+    };
+
+type Output =
+  | {
+      success: true;
+      action: "resume-scheduled" | "batch-resume-scheduled" | "no-dependencies" | "not-finished";
+    }
+  | {
+      success: false;
+      error: string;
+    };
+
+type Dependency = Prisma.TaskRunDependencyGetPayload<{
+  include: {
+    taskRun: true;
+    dependentAttempt: true;
+    dependentBatchRun: true;
+  };
+}>;
+
+/** This will resume a dependent (parent) run if there is one and it makes sense. */
+export class ResumeDependentParentsService extends BaseService {
+  public async call(input: Input): Promise<Output> {
+    try {
+      const dependency = await this._prisma.taskRunDependency.findFirst({
+        include: {
+          taskRun: true,
+          dependentAttempt: true,
+          dependentBatchRun: true,
+        },
+        where: {
+          taskRun:
+            "friendlyId" in input
+              ? {
+                  friendlyId: input.friendlyId,
+                }
+              : {
+                  id: input.id,
+                },
+        },
+      });
+
+      logger.log("ResumeDependentParentsService: tried to find dependency", {
+        run: input,
+        dependency: dependency,
+      });
+
+      if (!dependency) {
+        logger.log("ResumeDependentParentsService: dependency not found", {
+          run: input,
+        });
+
+        //no dependency, that's fine most runs won't have one.
+        return {
+          success: true,
+          action: "no-dependencies",
+        };
+      }
+
+      if (dependency.dependentAttempt) {
+        return this.#singleRunDependency(dependency);
+      } else if (dependency.dependentBatchRun) {
+        return this.#batchRunDependency(dependency);
+      } else {
+        logger.error("ResumeDependentParentsService: dependency has no dependencies", {
+          run: input,
+          dependency,
+        });
+
+        return {
+          success: false,
+          error: `Dependency has no dependencies (single or batch)`,
+        };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : JSON.stringify(error),
+      };
+    }
+  }
+
+  async #singleRunDependency(dependency: Dependency): Promise<Output> {
+    logger.debug(
+      `ResumeDependentParentsService.singleRunDependency(): Resuming dependent parent for run`,
+      {
+        dependency,
+      }
+    );
+
+    const isFinished = isFinalRunStatus(dependency.taskRun.status);
+    if (!isFinished) {
+      logger.debug(
+        "ResumeDependentParentsService.singleRunDependency(): dependency child run not finished yet.",
+        {
+          dependency,
+        }
+      );
+
+      // the child run isn't finished yet, so we can't resume the parent yet.
+      return {
+        success: true,
+        action: "not-finished",
+      };
+    }
+
+    const lastAttempt = await this._prisma.taskRunAttempt.findFirst({
+      select: {
+        id: true,
+        status: true,
+      },
+      where: {
+        taskRunId: dependency.taskRunId,
+      },
+      orderBy: {
+        id: "desc",
+      },
+    });
+
+    if (!lastAttempt) {
+      logger.error(
+        "ResumeDependentParentsService.singleRunDependency(): dependency child attempt not found",
+        {
+          dependency,
+        }
+      );
+
+      return {
+        success: false,
+        error: `Dependency child attempt not found for run ${dependency.taskRunId}`,
+      };
+    }
+
+    if (!isFinalAttemptStatus(lastAttempt.status)) {
+      logger.debug(
+        "ResumeDependentParentsService.singleRunDependency(): dependency child attempt not final",
+        {
+          dependency,
+          lastAttempt,
+        }
+      );
+
+      return {
+        success: true,
+        action: "not-finished",
+      };
+    }
+
+    //resume the dependent task
+    await ResumeTaskDependencyService.enqueue(dependency.id, lastAttempt.id, this._prisma);
+    return {
+      success: true,
+      action: "resume-scheduled",
+    };
+  }
+
+  async #batchRunDependency(dependency: Dependency): Promise<Output> {
+    logger.debug(
+      `ResumeDependentParentsService.batchRunDependency(): Resuming dependent batch for run`,
+      {
+        dependency,
+      }
+    );
+
+    if (!dependency.dependentBatchRun) {
+      logger.error(
+        "ResumeDependentParentsService.batchRunDependency(): dependency has no dependent batch",
+        {
+          dependency,
+        }
+      );
+
+      return {
+        success: false,
+        error: `Dependency has no dependent batch`,
+      };
+    }
+
+    await ResumeBatchRunService.enqueue(dependency.dependentBatchRun.id, this._prisma);
+
+    return {
+      success: true,
+      action: "batch-resume-scheduled",
+    };
+  }
+}

--- a/apps/webapp/app/v3/services/resumeDependentParents.server.ts
+++ b/apps/webapp/app/v3/services/resumeDependentParents.server.ts
@@ -145,8 +145,9 @@ export class ResumeDependentParentsService extends BaseService {
     }
 
     if (!isFinalAttemptStatus(lastAttempt.status)) {
-      logger.debug(
-        "ResumeDependentParentsService.singleRunDependency(): dependency child attempt not final",
+      //We still want to continue if this happens because the run is final but log it
+      logger.error(
+        "ResumeDependentParentsService.singleRunDependency(): dependency child attempt not final, but the run is.",
         {
           dependency,
           lastAttempt,
@@ -154,8 +155,8 @@ export class ResumeDependentParentsService extends BaseService {
       );
 
       return {
-        success: true,
-        action: "not-finished",
+        success: false,
+        error: `Dependency child attempt not final, but the run is`,
       };
     }
 

--- a/apps/webapp/app/v3/taskStatus.ts
+++ b/apps/webapp/app/v3/taskStatus.ts
@@ -45,7 +45,12 @@ export const FINAL_RUN_STATUSES = [
 
 export type FINAL_RUN_STATUSES = (typeof FINAL_RUN_STATUSES)[number];
 
-export const FINAL_ATTEMPT_STATUSES: TaskRunAttemptStatus[] = ["CANCELED", "COMPLETED", "FAILED"];
+export const FINAL_ATTEMPT_STATUSES = [
+  "CANCELED",
+  "COMPLETED",
+  "FAILED",
+] satisfies TaskRunAttemptStatus[];
+export type FINAL_ATTEMPT_STATUSES = (typeof FINAL_ATTEMPT_STATUSES)[number];
 
 export const FREEZABLE_RUN_STATUSES: TaskRunStatus[] = ["EXECUTING", "RETRYING_AFTER_FAILURE"];
 export const FREEZABLE_ATTEMPT_STATUSES: TaskRunAttemptStatus[] = ["EXECUTING", "FAILED"];

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1794,9 +1794,11 @@ model TaskRunTag {
   @@index([name, id])
 }
 
+/// This is used for triggerAndWait and batchTriggerAndWait. The taskRun is the child task, it points at a parent attempt or a batch
 model TaskRunDependency {
   id String @id @default(cuid())
 
+  /// The child run
   taskRun   TaskRun @relation(fields: [taskRunId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   taskRunId String  @unique
 

--- a/references/v3-catalog/src/trigger/crash.ts
+++ b/references/v3-catalog/src/trigger/crash.ts
@@ -1,0 +1,35 @@
+import { logger, task } from "@trigger.dev/sdk/v3";
+
+type Payload = {};
+
+export const crashparent = task({
+  id: "crashparent",
+  run: async (payload: Payload, { ctx }) => {
+    logger.log("crashparent started");
+
+    const result = await crash.triggerAndWait({});
+    logger.log("crashparent done", { result });
+
+    const results = await crash.batchTriggerAndWait([
+      { payload: {} },
+      { payload: {} },
+      { payload: {} },
+      { payload: {} },
+      { payload: {} },
+    ]);
+    logger.log("crashparent batch done", { results });
+  },
+});
+
+export const crash = task({
+  id: "crash",
+  run: async (payload: Payload, { ctx }) => {
+    logger.log(`${ctx.run.version}`);
+
+    process.exit(1);
+
+    return {
+      foo: "bar",
+    };
+  },
+});

--- a/references/v3-catalog/src/trigger/scheduled.ts
+++ b/references/v3-catalog/src/trigger/scheduled.ts
@@ -3,7 +3,7 @@ import { logger, schedules, task } from "@trigger.dev/sdk/v3";
 export const firstScheduledTask = schedules.task({
   id: "first-scheduled-task",
   //every other minute
-  cron: "0 */2 * * *",
+  // cron: "0 */2 * * *",
   run: async (payload, { ctx }) => {
     const distanceInMs =
       payload.timestamp.getTime() - (payload.lastTimestamp ?? new Date()).getTime();
@@ -22,10 +22,10 @@ export const firstScheduledTask = schedules.task({
 
 export const secondScheduledTask = schedules.task({
   id: "second-scheduled-task",
-  cron: {
-    pattern: "0 5 * * *",
-    timezone: "Asia/Tokyo",
-  },
+  // cron: {
+  //   pattern: "0 5 * * *",
+  //   timezone: "Asia/Tokyo",
+  // },
   run: async (payload) => {},
 });
 


### PR DESCRIPTION
Sometimes runs weren't continuing when their children were complete. This is for `triggerAndWait` and `batchTriggerAndWait`.

Changes
- Added a new service that gets given a run and figures out if there are dependencies and then schedules a resume if it makes sense
- In the finalize run service, set a final attempt status/error if passed in. Created a final attempt if there isn't one.
- If Graphile `addJob` throws an error then we return an undefined job instead of throwing.
- Don't resume the same batch multiple times