### PR TITLE
batchTriggerAndWait checkpoint race condition when at max concurrency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ apps/**/public/build
 .tshy*
 .yarn
 *.tsbuildinfo
+/packages/cli-v3/src/package.json

--- a/apps/webapp/app/presenters/TeamPresenter.server.ts
+++ b/apps/webapp/app/presenters/TeamPresenter.server.ts
@@ -1,6 +1,7 @@
 import { getTeamMembersAndInvites } from "~/models/member.server";
 import { BasePresenter } from "./v3/basePresenter.server";
 import { getLimit } from "~/services/platform.v3.server";
+import { number } from "zod";
 
 export class TeamPresenter extends BasePresenter {
   public async call({ userId, organizationId }: { userId: string; organizationId: string }) {
@@ -13,7 +14,7 @@ export class TeamPresenter extends BasePresenter {
       return;
     }
 
-    const limit = await getLimit(organizationId, "teamMembers", 25);
+    const limit = await getLimit(organizationId, "teamMembers", 100_000_000);
 
     return {
       ...result,

--- a/apps/webapp/app/presenters/TeamPresenter.server.ts
+++ b/apps/webapp/app/presenters/TeamPresenter.server.ts
@@ -1,7 +1,6 @@
 import { getTeamMembersAndInvites } from "~/models/member.server";
-import { BasePresenter } from "./v3/basePresenter.server";
 import { getLimit } from "~/services/platform.v3.server";
-import { number } from "zod";
+import { BasePresenter } from "./v3/basePresenter.server";
 
 export class TeamPresenter extends BasePresenter {
   public async call({ userId, organizationId }: { userId: string; organizationId: string }) {

--- a/apps/webapp/app/presenters/v3/AlertChannelListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/AlertChannelListPresenter.server.ts
@@ -43,7 +43,7 @@ export class AlertChannelListPresenter extends BasePresenter {
       throw new Error(`Project not found: ${projectId}`);
     }
 
-    const limit = await getLimit(organization.organizationId, "alerts", 25);
+    const limit = await getLimit(organization.organizationId, "alerts", 100_000_000);
 
     return {
       alertChannels: await Promise.all(

--- a/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
@@ -256,7 +256,7 @@ export class ScheduleListPresenter extends BasePresenter {
       };
     });
 
-    const limit = await getLimit(project.organizationId, "schedules", 500);
+    const limit = await getLimit(project.organizationId, "schedules", 100_000_000);
 
     return {
       currentPage: page,

--- a/apps/webapp/app/v3/services/checkSchedule.server.ts
+++ b/apps/webapp/app/v3/services/checkSchedule.server.ts
@@ -76,7 +76,7 @@ export class CheckScheduleService extends BaseService {
         throw new ServiceValidationError("Project not found");
       }
 
-      const limit = await getLimit(project.organizationId, "schedules", 500);
+      const limit = await getLimit(project.organizationId, "schedules", 100_000_000);
       const schedulesCount = await this._prisma.taskSchedule.count({
         where: {
           projectId,

--- a/apps/webapp/app/v3/services/createCheckpoint.server.ts
+++ b/apps/webapp/app/v3/services/createCheckpoint.server.ts
@@ -258,6 +258,16 @@ export class CreateCheckpointService extends BaseService {
             };
           }
 
+          //if there's a message in the queue, we make sure the checkpoint event is on it
+          await marqs?.replaceMessage(
+            attempt.taskRun.id,
+            {
+              checkpointEventId: checkpointEvent.id,
+            },
+            undefined,
+            true
+          );
+
           await ResumeBatchRunService.enqueue(batchRun.id, this._prisma);
 
           return {

--- a/apps/webapp/app/v3/services/initializeDeployment.server.ts
+++ b/apps/webapp/app/v3/services/initializeDeployment.server.ts
@@ -29,9 +29,9 @@ export class InitializeDeploymentService extends BaseService {
       const nextVersion = calculateNextBuildVersion(latestDeployment?.version);
 
       // Try and create a depot build and get back the external build data
-      const externalBuildData = !!payload.selfHosted
-        ? await createRemoteImageBuild(environment.project)
-        : undefined;
+      const externalBuildData = payload.selfHosted
+        ? undefined
+        : await createRemoteImageBuild(environment.project);
 
       const triggeredBy = payload.userId
         ? await this._prisma.user.findUnique({

--- a/apps/webapp/app/v3/services/resumeTaskDependency.server.ts
+++ b/apps/webapp/app/v3/services/resumeTaskDependency.server.ts
@@ -39,6 +39,16 @@ export class ResumeTaskDependencyService extends BaseService {
     const dependentRun = dependency.dependentAttempt.taskRun;
 
     if (dependency.dependentAttempt.status === "PAUSED" && dependency.checkpointEventId) {
+      logger.debug(
+        "Task dependency resume: Attempt is paused and there's a checkpoint. Enqueuing resume with checkpoint.",
+        {
+          attemptId: dependency.id,
+          dependentAttempt: dependency.dependentAttempt,
+          checkpointEventId: dependency.checkpointEventId,
+          hasCheckpointEvent: !!dependency.checkpointEventId,
+          runId: dependentRun.id,
+        }
+      );
       await marqs?.enqueueMessage(
         dependency.taskRun.runtimeEnvironment,
         dependentRun.queue,
@@ -61,6 +71,7 @@ export class ResumeTaskDependencyService extends BaseService {
         dependentAttempt: dependency.dependentAttempt,
         checkpointEventId: dependency.checkpointEventId,
         hasCheckpointEvent: !!dependency.checkpointEventId,
+        runId: dependentRun.id,
       });
 
       if (dependency.dependentAttempt.status === "PAUSED" && !dependency.checkpointEventId) {


### PR DESCRIPTION
It's possible that runs can get permanently frozen when at max concurrency (for your parent task or on your entire environment/org) when using batchTriggerAndWait.

This happens when the child run finishes before the checkpoint has completed.

Additionally a couple of unrelated fixes in this PR:
- Fix for doing remote image build when not self-hosting
- Set team members, alerts and schedule limits to 100m for self-hosting