### PR TITLE
Update dotEnv.ts to ignore OTEL_EXPORTER_OTLP_ENDPOINT as well

### DIFF
--- a/.changeset/four-buttons-run.md
+++ b/.changeset/four-buttons-run.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Ignore OTEL_EXPORTER_OTLP_ENDPOINT environment variable from `.env` files, to prevent the internal OTEL_EXPORTER_OTLP_ENDPOINT being overwritten with a user-supplied value.

--- a/packages/cli-v3/src/utilities/dotEnv.ts
+++ b/packages/cli-v3/src/utilities/dotEnv.ts
@@ -21,6 +21,7 @@ export function resolveDotEnvVars(cwd?: string, envFile?: string) {
   // remove TRIGGER_API_URL and TRIGGER_SECRET_KEY, since those should be coming from the worker
   delete result.TRIGGER_API_URL;
   delete result.TRIGGER_SECRET_KEY;
+  delete result.OTEL_EXPORTER_OTLP_ENDPOINT;
 
   return result;
 }


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [ ] The PR title follows the convention.
- [ ] I ran and tested the code works

--- 

Problem:

In my NextJS application I have a OTEL_EXPORTER_OTLP_ENDPOINT env variable and it is synced to the task runner as well. Which means, it overrides the trigger webapp otel endpoint. Maybe it should ignore this specific env variable since it kinda fucks up all telemetry, or optionally add another env var like you did for the DEV_OTEL_EXPORTER_OTLP_ENDPOINT like TRIGGER_OTEL_EXPORTER_OTLP_ENDPOINT/PROD_OTEL_EXPORTER_OTLP_ENDPOINT?  Any suggestions on how I could handle this the best, or parhaps make a PR to get hands on this issue. 

💯


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the `OTEL_EXPORTER_OTLP_ENDPOINT` variable from resolved environment variables to enhance security and consistency in managing sensitive configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->