### PR TITLE
Add acking to RESUME_AFTER_DEPENDENCY message to the coordinator

### DIFF
--- a/apps/coordinator/src/index.ts
+++ b/apps/coordinator/src/index.ts
@@ -835,10 +835,16 @@ class TaskCoordinator {
             return;
           }
 
+          logger.log("WAIT_FOR_TASK checkpoint created", {
+            checkpoint,
+            socketData: socket.data,
+          });
+
           //setting this means we can only resume from a checkpoint
           socket.data.requiresCheckpointResumeWithMessage = `location:${checkpoint.location}-docker:${checkpoint.docker}`;
           logger.log("WAIT_FOR_TASK set requiresCheckpointResumeWithMessage", {
-            requiresCheckpointResumeWithMessage: socket.data.requiresCheckpointResumeWithMessage,
+            checkpoint,
+            socketData: socket.data,
           });
 
           const ack = await this.#platformSocket?.sendWithAck("CHECKPOINT_CREATED", {
@@ -912,10 +918,16 @@ class TaskCoordinator {
             return;
           }
 
+          logger.log("WAIT_FOR_BATCH checkpoint created", {
+            checkpoint,
+            socketData: socket.data,
+          });
+
           //setting this means we can only resume from a checkpoint
           socket.data.requiresCheckpointResumeWithMessage = `location:${checkpoint.location}-docker:${checkpoint.docker}`;
-          logger.log("WAIT_FOR_BATCH set requiresCheckpointResumeWithMessage", {
-            requiresCheckpointResumeWithMessage: socket.data.requiresCheckpointResumeWithMessage,
+          logger.log("WAIT_FOR_BATCH set checkpoint", {
+            checkpoint,
+            socketData: socket.data,
           });
 
           const ack = await this.#platformSocket?.sendWithAck("CHECKPOINT_CREATED", {

--- a/apps/coordinator/src/index.ts
+++ b/apps/coordinator/src/index.ts
@@ -853,6 +853,7 @@ class TaskCoordinator {
           });
 
           if (ack?.keepRunAlive) {
+            socket.data.requiresCheckpointResumeWithMessage = undefined;
             logger.log("keeping run alive after task checkpoint", { runId: socket.data.runId });
             return;
           }
@@ -930,6 +931,7 @@ class TaskCoordinator {
           });
 
           if (ack?.keepRunAlive) {
+            socket.data.requiresCheckpointResumeWithMessage = undefined;
             logger.log("keeping run alive after batch checkpoint", { runId: socket.data.runId });
             return;
           }

--- a/apps/webapp/app/hooks/useSearchParam.ts
+++ b/apps/webapp/app/hooks/useSearchParam.ts
@@ -18,13 +18,13 @@ export function useSearchParams() {
         }
 
         if (typeof value === "string") {
-          search.set(param, encodeURIComponent(value));
+          search.set(param, value);
           continue;
         }
 
         search.delete(param);
         for (const v of value) {
-          search.append(param, encodeURIComponent(v));
+          search.append(param, v);
         }
       }
     },

--- a/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
+++ b/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
@@ -725,20 +725,47 @@ export class SharedQueueConsumer {
         }
 
         try {
-          logger.debug("Broadcasting RESUME_AFTER_DEPENDENCY", {
-            runId: resumableAttempt.taskRunId,
-            attemptId: resumableAttempt.id,
-          });
-
-          // The attempt should still be running so we can broadcast to all coordinators to resume immediately
-          socketIo.coordinatorNamespace.emit("RESUME_AFTER_DEPENDENCY", {
-            version: "v1",
+          const resumeMessage = {
+            version: "v1" as const,
             runId: resumableAttempt.taskRunId,
             attemptId: resumableAttempt.id,
             attemptFriendlyId: resumableAttempt.friendlyId,
             completions,
             executions,
+          };
+
+          logger.debug("Broadcasting RESUME_AFTER_DEPENDENCY_WITH_ACK", { resumeMessage, message });
+
+          // The attempt should still be running so we can broadcast to all coordinators to resume immediately
+          const responses = await socketIo.coordinatorNamespace
+            .timeout(10_000)
+            .emitWithAck("RESUME_AFTER_DEPENDENCY_WITH_ACK", resumeMessage);
+
+          logger.debug("RESUME_AFTER_DEPENDENCY_WITH_ACK received", {
+            resumeMessage,
+            responses,
+            message,
           });
+
+          if (responses.length === 0) {
+            logger.error("RESUME_AFTER_DEPENDENCY_WITH_ACK no response", {
+              resumeMessage,
+              message,
+            });
+            await this.#nackAndDoMoreWork(message.messageId, this._options.nextTickInterval, 1_000);
+            return;
+          }
+
+          const failed = responses.filter((response) => !response.success);
+          if (failed.length > 0) {
+            logger.error("RESUME_AFTER_DEPENDENCY_WITH_ACK failed", {
+              resumeMessage,
+              failed,
+              message,
+            });
+            await this.#nackAndDoMoreWork(message.messageId, this._options.nextTickInterval, 1_000);
+            return;
+          }
         } catch (e) {
           if (e instanceof Error) {
             this._currentSpan?.recordException(e);

--- a/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
+++ b/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
@@ -752,7 +752,7 @@ export class SharedQueueConsumer {
               resumeMessage,
               message,
             });
-            await this.#nackAndDoMoreWork(message.messageId, this._options.nextTickInterval, 1_000);
+            await this.#nackAndDoMoreWork(message.messageId, this._options.nextTickInterval, 5_000);
             return;
           }
 
@@ -763,7 +763,7 @@ export class SharedQueueConsumer {
               failed,
               message,
             });
-            await this.#nackAndDoMoreWork(message.messageId, this._options.nextTickInterval, 1_000);
+            await this.#nackAndDoMoreWork(message.messageId, this._options.nextTickInterval, 5_000);
             return;
           }
         } catch (e) {

--- a/apps/webapp/app/v3/services/resumeBatchRun.server.ts
+++ b/apps/webapp/app/v3/services/resumeBatchRun.server.ts
@@ -132,7 +132,9 @@ export class ResumeBatchRunService extends BaseService {
       if (wasUpdated) {
         logger.debug("ResumeBatchRunService: Resuming dependent run without checkpoint", {
           batchRunId: batchRun.id,
-          dependentTaskAttemptId: batchRun.dependentTaskAttempt.id,
+          dependentTaskAttempt: batchRun.dependentTaskAttempt,
+          checkpointEventId: batchRun.checkpointEventId,
+          hasCheckpointEvent: !!batchRun.checkpointEventId,
         });
         await marqs?.replaceMessage(dependentRun.id, {
           type: "RESUME",

--- a/packages/core/src/v3/schemas/messages.ts
+++ b/packages/core/src/v3/schemas/messages.ts
@@ -861,6 +861,7 @@ export const ProdWorkerSocketData = z.object({
   podName: z.string(),
   deploymentId: z.string(),
   deploymentVersion: z.string(),
+  requiresCheckpointResumeWithMessage: z.string().optional(),
 });
 
 export const CoordinatorSocketData = z.object({


### PR DESCRIPTION
We were just broadcasting `RESUME_AFTER_DEPENDENCY` to the coordinator before. If the coordinator crashed at the wrong time.

I've added a new message called `RESUME_AFTER_DEPENDENCY_WITH_ACK` which requires an ack to be sent back. If it's not sent back then we nack the message in the queue with a 5 second delay.

I've verified locally that this continues runs in normal situations, and if the coordinator is down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new event handler for resuming tasks after dependencies are resolved, enhancing task coordination.
	- Added acknowledgment mechanism for message handling, improving error handling.
	- Added a new message type for resuming tasks with acknowledgment in the coordinator messages.

- **Improvements**
	- Enhanced control flow for task resumption, ensuring stricter management of dependencies and checkpoints.
	- Centralized callback structure for improved code reusability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->