### PR TITLE
Auto-resolve payload/output presigned urls when retrieving a run

### DIFF
--- a/.changeset/polite-tables-exercise.md
+++ b/.changeset/polite-tables-exercise.md
@@ -1,0 +1,6 @@
+---
+"@trigger.dev/sdk": patch
+"@trigger.dev/core": patch
+---
+
+Auto-resolve payload/output presigned urls when retrieving a run with runs.retrieve

--- a/packages/core/src/v3/utils/ioSerialization.ts
+++ b/packages/core/src/v3/utils/ioSerialization.ts
@@ -160,6 +160,31 @@ export async function conditionallyImportPacket(
   }
 }
 
+export async function resolvePresignedPacketUrl(
+  url: string,
+  tracer?: TriggerTracer
+): Promise<any | undefined> {
+  try {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      return;
+    }
+
+    const data = await response.text();
+    const dataType = response.headers.get("content-type") ?? "application/json";
+
+    const packet = {
+      data,
+      dataType,
+    };
+
+    return await parsePacket(packet);
+  } catch (error) {
+    return;
+  }
+}
+
 async function importPacket(packet: IOPacket, span?: Span): Promise<IOPacket> {
   if (!packet.data) {
     return packet;


### PR DESCRIPTION
When a task run has a large payload or output, we store it in an object store like s3 or r2, to prevent very large JSON objects getting in our database (and causing event loop lags on serialize/deserialize). 

Currently, when you retrieve a run using `runs.retrieve()`, if that run has stored the payload/output in the object store, we return a `payloadPresignedUrl` and/or a `outputPresignedUrl`, which can then be fetched separately. This has a couple problems:

- Makes client code pretty complicated having to deal with this (@jacobparis)
- This is really an implementation detail that's being exposed to users
- The content type of the JSON object in the store might be stored as superjson, so the downloaded data from the presigned URL still needs to be put through superjson to get back the original value.

This PR makes it so `runs.retrieve()` will automatically "resolve" the payload and output presigned urls, and pass them through superjson if needed. This also makes it so the type-safety of `runs.retrieve()` when passing a run handle or providing the typeof the task as a generic param works correctly.

Note that `payloadPresignedUrl` and `outputPresignedUrl` are still left on the result, for backwards compat reasons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Automatic resolution of payload and output presigned URLs when retrieving a run, enhancing user experience.
	- Introduction of a new task to generate and manage large JSON payloads, improving SDK capabilities.
  
- **Improvements**
	- Streamlined retrieval of run data, simplifying the process for users.
	- Enhanced handling of presigned URLs for better efficiency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->