### PR TITLE
Fix default machine preset in config not being used

### DIFF
--- a/.changeset/new-yaks-fail.md
+++ b/.changeset/new-yaks-fail.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Apply default machine preset in config

--- a/.changeset/quick-bulldogs-float.md
+++ b/.changeset/quick-bulldogs-float.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Add additional error message and stack trace when a task file cannot be imported for run

--- a/packages/cli-v3/src/entryPoints/deploy-index-worker.ts
+++ b/packages/cli-v3/src/entryPoints/deploy-index-worker.ts
@@ -95,9 +95,25 @@ async function bootstrap() {
   };
 }
 
-const { buildManifest, importErrors } = await bootstrap();
+const { buildManifest, importErrors, config } = await bootstrap();
 
-const tasks = taskCatalog.listTaskManifests();
+let tasks = taskCatalog.listTaskManifests();
+
+// If the config has a machine preset, we need to apply it to all tasks that don't have a machine preset
+if (typeof config.machine === "string") {
+  tasks = tasks.map((task) => {
+    if (typeof task.machine?.preset !== "string") {
+      return {
+        ...task,
+        machine: {
+          preset: config.machine,
+        },
+      };
+    }
+
+    return task;
+  });
+}
 
 await sendMessageInCatalog(
   indexerToWorkerMessages,

--- a/packages/cli-v3/src/entryPoints/deploy-run-worker.ts
+++ b/packages/cli-v3/src/entryPoints/deploy-run-worker.ts
@@ -219,6 +219,7 @@ const zodIpc = new ZodIpcConnection({
               error: {
                 type: "INTERNAL_ERROR",
                 code: TaskRunErrorCodes.COULD_NOT_FIND_TASK,
+                message: `Could not find task ${execution.task.id}. Make sure the task is exported and the ID is correct.`,
               },
               usage: {
                 durationMs: 0,
@@ -248,6 +249,8 @@ const zodIpc = new ZodIpcConnection({
               error: {
                 type: "INTERNAL_ERROR",
                 code: TaskRunErrorCodes.COULD_NOT_IMPORT_TASK,
+                message: err instanceof Error ? err.message : String(err),
+                stackTrace: err instanceof Error ? err.stack : undefined,
               },
               usage: {
                 durationMs: 0,

--- a/packages/cli-v3/src/entryPoints/dev-run-worker.ts
+++ b/packages/cli-v3/src/entryPoints/dev-run-worker.ts
@@ -219,6 +219,8 @@ const zodIpc = new ZodIpcConnection({
             error: {
               type: "INTERNAL_ERROR",
               code: TaskRunErrorCodes.COULD_NOT_IMPORT_TASK,
+              message: err instanceof Error ? err.message : String(err),
+              stackTrace: err instanceof Error ? err.stack : undefined,
             },
             usage: {
               durationMs: 0,

--- a/packages/cli-v3/src/indexing/indexWorkerManifest.ts
+++ b/packages/cli-v3/src/indexing/indexWorkerManifest.ts
@@ -49,6 +49,7 @@ export async function indexWorkerManifest({
         OTEL_IMPORT_HOOK_EXCLUDES: otelHookExclude?.join(","),
         TRIGGER_BUILD_MANIFEST_PATH: buildManifestPath,
         NODE_OPTIONS: nodeOptions,
+        TRIGGER_INDEXING: "1",
       },
       execPath: execPathForRuntime(runtime),
     });

--- a/references/v3-catalog/src/trigger/simple.ts
+++ b/references/v3-catalog/src/trigger/simple.ts
@@ -11,6 +11,7 @@ let headerGenerator = new HeaderGenerator({
 
 export const fetchPostTask = task({
   id: "fetch-post-task",
+  machine: { preset: "small-1x" },
   run: async (payload: { url: string }) => {
     const headers = headerGenerator.getHeaders({
       operatingSystems: ["linux"],

--- a/references/v3-catalog/trigger.config.ts
+++ b/references/v3-catalog/trigger.config.ts
@@ -13,7 +13,7 @@ export { handleError } from "./src/handleError.js";
 export default defineConfig({
   runtime: "node",
   project: "yubjwjsfkxnylobaqvqz",
-  machine: "small-2x",
+  machine: "medium-1x",
   instrumentations: [new OpenAIInstrumentation()],
   additionalFiles: ["wrangler/wrangler.toml"],
   retries: {


### PR DESCRIPTION
The default machine preset set in the `trigger.config.ts` file was not being applied to tasks that didn't already have a machine preset set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a default machine preset configuration for easier setup in "trigger.dev" settings.
	- Added a new environment variable `TRIGGER_INDEXING` to influence indexing behavior.
	- Enhanced task configuration with a specific machine preset in task execution.

- **Bug Fixes**
	- Improved error handling with detailed messages and stack traces for task file imports and internal errors.

- **Chores**
	- Updated machine type in project configuration from `"small-2x"` to `"medium-1x"` for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->