### PR TITLE
Fix for missing logs when triggering without a `trigger-version`

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.runs.$runParam/route.tsx
@@ -420,7 +420,6 @@ function NoLogsView({ run, resizable }: LoaderData) {
           min={resizableSettings.parent.inspector.min}
           isStaticAtRest
         >
-          {" "}
           <SpanView runParam={run.friendlyId} spanId={run.spanId} />
         </ResizablePanel>
       </ResizablePanelGroup>

--- a/apps/webapp/app/routes/api.v1.tasks.$taskId.trigger.ts
+++ b/apps/webapp/app/routes/api.v1.tasks.$taskId.trigger.ts
@@ -79,13 +79,10 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const service = new TriggerTaskService();
 
   try {
-    const traceContext = traceparent
-      ? !triggerVersion // If the trigger version is NOT set, we are in an older version of the SDK
+    const traceContext =
+      traceparent ?? isFromWorker /// If the request is from a worker, we should pass the trace context
         ? { traceparent, tracestate }
-        : isFromWorker // If the trigger version is set, and the request is from a worker, we should pass the trace context
-        ? { traceparent, tracestate }
-        : undefined
-      : undefined;
+        : undefined;
 
     logger.debug("Triggering task", {
       taskId,


### PR DESCRIPTION
When trigger a run (or batch) without `trigger-version` (i.e. using HTTP POST directly) we wouldn't show any logs for a run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of trace context for requests, enhancing traceability in service calls.
	- Streamlined logic for determining trace context in task triggering.

- **Style**
	- Minor cosmetic adjustment in the `NoLogsView` component for cleaner formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->