### PR TITLE
Puppeteer extension: set the PUPPETEER_EXECUTABLE_PATH env var

### DIFF
--- a/packages/build/src/extensions/puppeteer.ts
+++ b/packages/build/src/extensions/puppeteer.ts
@@ -29,6 +29,12 @@ class PuppeteerExtension implements BuildExtension {
       image: {
         instructions,
       },
+      deploy: {
+        env: {
+          PUPPETEER_EXECUTABLE_PATH: "/usr/bin/google-chrome-stable",
+        },
+        override: true,
+      },
     });
   }
 }


### PR DESCRIPTION
With this change when launching puppeteer you don't need to set the executable path.