### PR TITLE
Associate child runs with the parent span ID

### DIFF
--- a/.changeset/short-tomatoes-beam.md
+++ b/.changeset/short-tomatoes-beam.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Add otel propagation headers "below" the API fetch span, to attribute the child runs with the proper parent span ID

--- a/apps/webapp/app/v3/eventRepository.server.ts
+++ b/apps/webapp/app/v3/eventRepository.server.ts
@@ -835,7 +835,8 @@ export class EventRepository {
     options: TraceEventOptions & { incomplete?: boolean },
     callback: (
       e: EventBuilder,
-      traceContext: Record<string, string | undefined>
+      traceContext: Record<string, string | undefined>,
+      traceparent?: { traceId: string; spanId: string }
     ) => Promise<TResult>
   ): Promise<TResult> {
     const propagatedContext = extractContextFromCarrier(options.context ?? {});
@@ -892,7 +893,7 @@ export class EventRepository {
       },
     };
 
-    const result = await callback(eventBuilder, traceContext);
+    const result = await callback(eventBuilder, traceContext, propagatedContext?.traceparent);
 
     const duration = process.hrtime.bigint() - start;
 

--- a/apps/webapp/app/v3/services/triggerTask.server.ts
+++ b/apps/webapp/app/v3/services/triggerTask.server.ts
@@ -240,7 +240,7 @@ export class TriggerTaskService extends BaseService {
           incomplete: true,
           immediate: true,
         },
-        async (event, traceContext) => {
+        async (event, traceContext, traceparent) => {
           const run = await autoIncrementCounter.incrementInTransaction(
             `v3-run:${environment.id}:${taskId}`,
             async (num, tx) => {
@@ -307,6 +307,8 @@ export class TriggerTaskService extends BaseService {
                   traceContext: traceContext,
                   traceId: event.traceId,
                   spanId: event.spanId,
+                  parentSpanId:
+                    options.parentAsLinkType === "replay" ? undefined : traceparent?.spanId,
                   lockedToVersionId: lockedToBackgroundWorker?.id,
                   concurrencyKey: body.options?.concurrencyKey,
                   queue: queueName,

--- a/packages/cli-v3/src/config.ts
+++ b/packages/cli-v3/src/config.ts
@@ -228,7 +228,7 @@ function validateConfig(config: TriggerConfig, warn = true) {
   if (config.additionalFiles && config.additionalFiles.length > 0) {
     warn &&
       prettyWarning(
-        `The "additionalFiles" option is deprecated and will be removed. Use the "additionalFiles" build extension instead. See https://trigger.dev/docs/guides/new-build-system-preview#additionalfiles for more information.`
+        `The "additionalFiles" option is deprecated and will be removed. Use the "additionalFiles" build extension instead. See https://trigger.dev/docs/config/config-file#additionalfiles for more information.`
       );
 
     config.build ??= {};
@@ -239,7 +239,7 @@ function validateConfig(config: TriggerConfig, warn = true) {
   if (config.additionalPackages && config.additionalPackages.length > 0) {
     warn &&
       prettyWarning(
-        `The "additionalPackages" option is deprecated and will be removed. Use the "additionalPackages" build extension instead. See https://trigger.dev/docs/guides/new-build-system-preview#additionalpackages for more information.`
+        `The "additionalPackages" option is deprecated and will be removed. Use the "additionalPackages" build extension instead. See https://trigger.dev/docs/config/config-file#additionalpackages for more information.`
       );
 
     config.build ??= {};
@@ -275,7 +275,7 @@ function validateConfig(config: TriggerConfig, warn = true) {
   if ("resolveEnvVars" in config && typeof config.resolveEnvVars === "function") {
     warn &&
       prettyWarning(
-        `The "resolveEnvVars" option is deprecated and will be removed. Use the "syncEnvVars" build extension instead. See https://trigger.dev/docs/guides/new-build-system-preview#resolveenvvars for more information.`
+        `The "resolveEnvVars" option is deprecated and will be removed. Use the "syncEnvVars" build extension instead. See https://trigger.dev/docs/config/config-file#syncenvvars for more information.`
       );
 
     const resolveEnvVarsFn = config.resolveEnvVars as ResolveEnvironmentVariablesFunction;

--- a/packages/core/src/v3/apiClient/index.ts
+++ b/packages/core/src/v3/apiClient/index.ts
@@ -1,4 +1,3 @@
-import { context, propagation } from "@opentelemetry/api";
 import { z } from "zod";
 import {
   AddTagsRequestBody,
@@ -509,7 +508,6 @@ export class ApiClient {
     // Only inject the context if we are inside a task
     if (taskContext.isInsideTask) {
       headers["x-trigger-worker"] = "true";
-      propagation.inject(context.active(), headers);
 
       if (spanParentAsLink) {
         headers["x-trigger-span-parent-as-link"] = "1";

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -1,0 +1,38 @@
+## @trigger.dev/database
+
+This is the internal database package for the Trigger.dev project. It exports a generated prisma client that can be instantiated with a connection string.
+
+### How to add a new index on a large table
+
+1. Modify the Prisma.schema with a single index change (no other changes, just one index at a time)
+2. Create a Prisma migration using `cd packages/database && pnpm run db:migrate:dev --create-only`
+3. Modify the SQL file: add IF NOT EXISTS to it and CONCURRENTLY:
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "JobRun_eventId_idx" ON "JobRun" ("eventId");
+```
+
+4. Don’t apply the Prisma migration locally yet. This is a good opportunity to test the flow.
+5. Manually apply the index to your database, by running the index command.
+6. Then locally run `pnpm run db:migrate:deploy`
+
+#### Before deploying
+
+Run the index creation before deploying
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "JobRun_eventId_idx" ON "JobRun" ("eventId");
+```
+
+These commands are useful:
+
+```sql
+-- creates an index safely, this can take a long time (2 mins maybe)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "JobRun_eventId_idx" ON "JobRun" ("eventId");
+-- checks the status of an index
+SELECT * FROM pg_stat_progress_create_index WHERE relid = '"JobRun"'::regclass;
+-- checks if the index is there
+SELECT * FROM pg_indexes WHERE tablename = 'JobRun' AND indexname = 'JobRun_eventId_idx';
+```
+
+Now, when you deploy and prisma runs the migration, it will skip the index creation because it already exists. If you don't do this, there will be pain.

--- a/packages/database/prisma/migrations/20240924125845_add_root_task_run_id_index/migration.sql
+++ b/packages/database/prisma/migrations/20240924125845_add_root_task_run_id_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "TaskRun_rootTaskRunId_idx" ON "TaskRun"("rootTaskRunId");

--- a/packages/database/prisma/migrations/20240924130558_add_parent_span_id_to_task_run/migration.sql
+++ b/packages/database/prisma/migrations/20240924130558_add_parent_span_id_to_task_run/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "TaskRun" ADD COLUMN     "parentSpanId" TEXT;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1748,6 +1748,9 @@ model TaskRun {
   /// The depth of this task run in the task run hierarchy
   depth Int @default(0)
 
+  /// The span ID of the "trigger" span in the parent task run
+  parentSpanId String?
+
   @@unique([runtimeEnvironmentId, taskIdentifier, idempotencyKey])
   // Finding child runs
   @@index([parentTaskRunId])

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1751,6 +1751,8 @@ model TaskRun {
   @@unique([runtimeEnvironmentId, taskIdentifier, idempotencyKey])
   // Finding child runs
   @@index([parentTaskRunId])
+  // Finding ancestor runs
+  @@index([rootTaskRunId])
   // Task activity graph
   @@index([projectId, createdAt, taskIdentifier])
   //Runs list


### PR DESCRIPTION
This is needed so we can show which runs were triggered when selecting the "triggering" span in the parent run.

![CleanShot 2024-09-24 at 14 41 47](https://github.com/user-attachments/assets/caaecf9b-642d-4db6-bcd4-3bb65b2de017)

This PR also adds an index to the `rootTaskRunId`, and the following `CREATE INDEX` sql should be run before deploying:

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS "TaskRun_rootTaskRunId_idx" ON "TaskRun"("rootTaskRunId");
```

> [!NOTE]
> Before this can be used, an INDEX will need to be added to the `parentSpanId` column on TaskRun, but that must be done in a separate PR/deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced tracing capabilities with the addition of OpenTelemetry propagation headers.
	- New `traceparent` parameter in event handling to improve context for tracing.
	- New documentation for the internal database package, detailing index creation.
	- New index on the "TaskRun" table to optimize query performance.
	- Added `parentSpanId` field in the TaskRun model for better task tracking.

- **Bug Fixes**
	- Updated deprecation warnings for configuration options to direct users to new documentation.

- **Documentation**
	- Comprehensive README for the `@trigger.dev/database` package outlining usage and migration steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->