### PR TITLE
Fix slack alert retries and text length limits

### DIFF
--- a/apps/webapp/app/models/orgIntegration.server.ts
+++ b/apps/webapp/app/models/orgIntegration.server.ts
@@ -69,7 +69,15 @@ export class OrgIntegrationRepository {
         return new WebClient(
           options?.forceBotToken
             ? secret.botAccessToken
-            : secret.userAccessToken ?? secret.botAccessToken
+            : secret.userAccessToken ?? secret.botAccessToken,
+          {
+            retryConfig: {
+              retries: 2,
+              randomize: true,
+              maxTimeout: 5000,
+              maxRetryTime: 10000,
+            },
+          }
         ) as AuthenticatedClientForIntegration<TService>;
       }
       default: {

--- a/apps/webapp/app/services/worker.server.ts
+++ b/apps/webapp/app/services/worker.server.ts
@@ -616,7 +616,7 @@ function getWorkerQueue() {
       },
       "v3.deliverAlert": {
         priority: 0,
-        maxAttempts: 8,
+        maxAttempts: 5,
         handler: async (payload, job) => {
           const service = new DeliverAlertService();
 

--- a/apps/webapp/app/services/worker.server.ts
+++ b/apps/webapp/app/services/worker.server.ts
@@ -615,7 +615,7 @@ function getWorkerQueue() {
         },
       },
       "v3.deliverAlert": {
-        priority: 2,
+        priority: 0,
         maxAttempts: 5,
         handler: async (payload, job) => {
           const service = new DeliverAlertService();

--- a/apps/webapp/app/services/worker.server.ts
+++ b/apps/webapp/app/services/worker.server.ts
@@ -616,7 +616,7 @@ function getWorkerQueue() {
       },
       "v3.deliverAlert": {
         priority: 0,
-        maxAttempts: 5,
+        maxAttempts: 8,
         handler: async (payload, job) => {
           const service = new DeliverAlertService();
 

--- a/apps/webapp/app/services/worker.server.ts
+++ b/apps/webapp/app/services/worker.server.ts
@@ -615,7 +615,7 @@ function getWorkerQueue() {
         },
       },
       "v3.deliverAlert": {
-        priority: 0,
+        priority: 2,
         maxAttempts: 5,
         handler: async (payload, job) => {
           const service = new DeliverAlertService();

--- a/apps/webapp/app/v3/services/alerts/deliverAlert.server.ts
+++ b/apps/webapp/app/v3/services/alerts/deliverAlert.server.ts
@@ -631,7 +631,7 @@ export class DeliverAlertService extends BaseService {
                 type: "section",
                 text: {
                   type: "mrkdwn",
-                  text: this.#truncateSlackText(`\`\`\`${error.stackTrace ?? error.message}\`\`\``),
+                  text: `\`\`\`${this.#truncateSlackText(error.stackTrace ?? error.message)}\`\`\``,
                 },
               },
               {
@@ -743,7 +743,7 @@ export class DeliverAlertService extends BaseService {
                 type: "section",
                 text: {
                   type: "mrkdwn",
-                  text: this.#truncateSlackText(`\`\`\`${error.stackTrace ?? error.message}\`\`\``),
+                  text: `\`\`\`${this.#truncateSlackText(error.stackTrace ?? error.message)}\`\`\``,
                 },
               },
               {
@@ -843,9 +843,9 @@ export class DeliverAlertService extends BaseService {
                 type: "section",
                 text: {
                   type: "mrkdwn",
-                  text: this.#truncateSlackText(
-                    `\`\`\`${preparedError.stack ?? preparedError.message}\`\`\``
-                  ),
+                  text: `\`\`\`${this.#truncateSlackText(
+                    preparedError.stack ?? preparedError.message
+                  )}\`\`\``,
                 },
               },
               {

--- a/apps/webapp/app/v3/services/alerts/deliverAlert.server.ts
+++ b/apps/webapp/app/v3/services/alerts/deliverAlert.server.ts
@@ -631,7 +631,7 @@ export class DeliverAlertService extends BaseService {
                 type: "section",
                 text: {
                   type: "mrkdwn",
-                  text: `\`\`\`${this.#truncateSlackText(error.stackTrace ?? error.message)}\`\`\``,
+                  text: this.#wrapInCodeBlock(error.stackTrace ?? error.message),
                 },
               },
               {
@@ -743,7 +743,7 @@ export class DeliverAlertService extends BaseService {
                 type: "section",
                 text: {
                   type: "mrkdwn",
-                  text: `\`\`\`${this.#truncateSlackText(error.stackTrace ?? error.message)}\`\`\``,
+                  text: this.#wrapInCodeBlock(error.stackTrace ?? error.message),
                 },
               },
               {
@@ -843,9 +843,7 @@ export class DeliverAlertService extends BaseService {
                 type: "section",
                 text: {
                   type: "mrkdwn",
-                  text: `\`\`\`${this.#truncateSlackText(
-                    preparedError.stack ?? preparedError.message
-                  )}\`\`\``,
+                  text: this.#wrapInCodeBlock(preparedError.stack ?? preparedError.message),
                 },
               },
               {
@@ -1071,9 +1069,20 @@ export class DeliverAlertService extends BaseService {
     };
   }
 
-  #truncateSlackText(text: string) {
-    if (text.length > 3000) {
-      return text.slice(0, 2900) + "\n\ntruncated - check dashboard for complete error message";
+  #wrapInCodeBlock(text: string, maxLength = 3000) {
+    return `\`\`\`${this.#truncateSlackText(text, maxLength - 10)}\`\`\``;
+  }
+
+  #truncateSlackText(text: string, length = 3000) {
+    if (text.length > length) {
+      logger.debug("[DeliverAlert] Truncating slack text", {
+        length,
+        originalLength: text.length,
+      });
+
+      const truncationSuffix = "\n\ntruncated - check dashboard for complete error message";
+
+      return text.slice(0, length - truncationSuffix.length) + truncationSuffix;
     }
 
     return text;

--- a/apps/webapp/app/v3/services/alerts/deliverAlert.server.ts
+++ b/apps/webapp/app/v3/services/alerts/deliverAlert.server.ts
@@ -617,7 +617,7 @@ export class DeliverAlertService extends BaseService {
                 type: "section",
                 text: {
                   type: "mrkdwn",
-                  text: `\`\`\`${error.stackTrace ?? error.message}\`\`\``,
+                  text: this.#truncateSlackText(`\`\`\`${error.stackTrace ?? error.message}\`\`\``),
                 },
               },
               {
@@ -729,7 +729,7 @@ export class DeliverAlertService extends BaseService {
                 type: "section",
                 text: {
                   type: "mrkdwn",
-                  text: `\`\`\`${error.stackTrace ?? error.message}\`\`\``,
+                  text: this.#truncateSlackText(`\`\`\`${error.stackTrace ?? error.message}\`\`\``),
                 },
               },
               {
@@ -829,7 +829,9 @@ export class DeliverAlertService extends BaseService {
                 type: "section",
                 text: {
                   type: "mrkdwn",
-                  text: `\`\`\`${preparedError.stack ?? preparedError.message}\`\`\``,
+                  text: this.#truncateSlackText(
+                    `\`\`\`${preparedError.stack ?? preparedError.message}\`\`\``
+                  ),
                 },
               },
               {
@@ -1045,6 +1047,14 @@ export class DeliverAlertService extends BaseService {
       type: "CUSTOM_ERROR",
       raw: "No error on attempt",
     };
+  }
+
+  #truncateSlackText(text: string) {
+    if (text.length > 3000) {
+      return text.slice(0, 2900) + "\n\ntruncated - check dashboard for complete error message";
+    }
+
+    return text;
   }
 
   static async enqueue(


### PR DESCRIPTION
A few things were causing issues with Slack alerts:

- Text fields for each block have a 3000 character limit
- The official client has a ridiculous default retry policy
- Final errors should never be retried

This has all been fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new error handling mechanism for alert delivery, allowing specific errors to skip retries.
	- Added methods for improved formatting of error messages sent to Slack, including truncation for long messages.

- **Bug Fixes**
	- Enhanced error handling for Slack-specific errors to prevent unnecessary retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->