### PR TITLE
Prioritize finishing waited runs

### DIFF
--- a/apps/webapp/app/components/primitives/TreeView/TreeView.tsx
+++ b/apps/webapp/app/components/primitives/TreeView/TreeView.tsx
@@ -235,9 +235,11 @@ export function useTree<TData, TFilterValue>({
     getItemKey: (index) => state.visibleNodeIds[index],
     getScrollElement: () => parentRef.current,
     estimateSize: (index: number) => {
+      const treeItem = tree[index];
+      if (!treeItem) return 0;
       return estimatedRowHeight({
-        node: tree[index],
-        state: state.nodes[tree[index].id],
+        node: treeItem,
+        state: state.nodes[treeItem.id],
         index,
       });
     },

--- a/apps/webapp/app/v3/services/resumeTaskDependency.server.ts
+++ b/apps/webapp/app/v3/services/resumeTaskDependency.server.ts
@@ -85,16 +85,20 @@ export class ResumeTaskDependencyService extends BaseService {
         return;
       }
 
-      await marqs?.replaceMessage(dependentRun.id, {
-        type: "RESUME",
-        completedAttemptIds: [sourceTaskAttemptId],
-        resumableAttemptId: dependency.dependentAttempt.id,
-        checkpointEventId: dependency.checkpointEventId ?? undefined,
-        taskIdentifier: dependency.taskRun.taskIdentifier,
-        projectId: dependency.taskRun.runtimeEnvironment.projectId,
-        environmentId: dependency.taskRun.runtimeEnvironment.id,
-        environmentType: dependency.taskRun.runtimeEnvironment.type,
-      });
+      await marqs?.replaceMessage(
+        dependentRun.id,
+        {
+          type: "RESUME",
+          completedAttemptIds: [sourceTaskAttemptId],
+          resumableAttemptId: dependency.dependentAttempt.id,
+          checkpointEventId: dependency.checkpointEventId ?? undefined,
+          taskIdentifier: dependency.taskRun.taskIdentifier,
+          projectId: dependency.taskRun.runtimeEnvironment.projectId,
+          environmentId: dependency.taskRun.runtimeEnvironment.id,
+          environmentType: dependency.taskRun.runtimeEnvironment.type,
+        },
+        dependentRun.createdAt.getTime()
+      );
     }
   }
 

--- a/apps/webapp/app/v3/services/resumeTaskDependency.server.ts
+++ b/apps/webapp/app/v3/services/resumeTaskDependency.server.ts
@@ -63,7 +63,8 @@ export class ResumeTaskDependencyService extends BaseService {
           environmentId: dependency.taskRun.runtimeEnvironment.id,
           environmentType: dependency.taskRun.runtimeEnvironment.type,
         },
-        dependentRun.concurrencyKey ?? undefined
+        dependentRun.concurrencyKey ?? undefined,
+        dependentRun.createdAt.getTime()
       );
     } else {
       logger.debug("Task dependency resume: Attempt is not paused or there's no checkpoint event", {

--- a/references/hello-world/src/trigger/prioritize-continuing.ts
+++ b/references/hello-world/src/trigger/prioritize-continuing.ts
@@ -1,0 +1,27 @@
+import { logger, task, wait } from "@trigger.dev/sdk/v3";
+
+export const prioritizeContinuing = task({
+  id: "prioritize-continuing",
+  run: async ({ count }: { count: number }) => {
+    await prioritizeContinuingChild.batchTrigger(
+      Array.from({ length: count }, (_, i) => ({ payload: {} as any }))
+    );
+  },
+});
+
+export const prioritizeContinuingChild = task({
+  id: "prioritize-continuing-child",
+  queue: {
+    concurrencyLimit: 1,
+  },
+  run: async () => {
+    await fixedLengthTask.triggerAndWait({ waitSeconds: 1 });
+  },
+});
+
+export const fixedLengthTask = task({
+  id: "fixedLengthTask",
+  run: async ({ waitSeconds }: { waitSeconds: number }) => {
+    await new Promise((resolve) => setTimeout(resolve, waitSeconds * 1000));
+  },
+});


### PR DESCRIPTION
When we try and resume after `triggerAndWait` or `batchTriggerAndWait` the run is put back into the queue, if there's a checkpoint and the run is no longer in the cluster.

We were enqueue to the back of the queue, because we weren't setting a timestamp. This meant you ended up with a lot of frozen runs and we were prioritizing starting new runs vs finishing existing ones.

Now when we enqueue we add the parent run's createdAt as the timestamp which gives it the correct position in the queue.