### PR TITLE
Fix dotenv overrides for dev runs

### DIFF
--- a/.changeset/gentle-mails-smoke.md
+++ b/.changeset/gentle-mails-smoke.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Local env files like `.env` will now correctly override dev env vars configured in the dashboard

--- a/packages/cli-v3/src/dev/backgroundWorker.ts
+++ b/packages/cli-v3/src/dev/backgroundWorker.ts
@@ -319,9 +319,9 @@ export class BackgroundWorker {
     const processOptions: TaskRunProcessOptions = {
       payload,
       env: {
-        ...sanitizeEnvVars(this.params.env),
         // TODO: this needs the stripEmptyValues stuff too
         ...sanitizeEnvVars(payload.environment ?? {}),
+        ...sanitizeEnvVars(this.params.env),
         TRIGGER_WORKER_MANIFEST_PATH: this.workerManifestPath,
       },
       serverWorker: this.serverWorker,

--- a/references/v3-catalog/src/trigger/other.ts
+++ b/references/v3-catalog/src/trigger/other.ts
@@ -156,3 +156,11 @@ export const returnZeroCharacters = task({
     };
   },
 });
+
+export const testEnvVars = task({
+  id: "test-env-vars",
+  run: async (payload: any) => {
+    console.log(`env.FOO: ${process.env.FOO}`);
+    console.log(`env.BAR: ${process.env.BAR}`);
+  },
+});


### PR DESCRIPTION
Local env files like `.env` will now correctly override dev env vars configured in the dashboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved management of local environment files to prioritize local settings over dashboard configurations.
	- Introduced a new task to log environment variable values for easier debugging.

- **Bug Fixes**
	- Corrected sanitization of environment variables during task runs to maintain integrity.
	- Enhanced error handling for task execution, providing clearer error responses.

- **Refactor**
	- Streamlined error reporting within the task execution process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->