### PR TITLE
Remove unused path arg from the CLI dev command

### DIFF
--- a/.changeset/healthy-hornets-wave.md
+++ b/.changeset/healthy-hornets-wave.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Remove (unused) path arg from the CLI dev command

--- a/packages/cli-v3/src/commands/dev.ts
+++ b/packages/cli-v3/src/commands/dev.ts
@@ -27,7 +27,6 @@ export function configureDevCommand(program: Command) {
     program
       .command("dev")
       .description("Run your Trigger.dev tasks locally")
-      .argument("[path]", "The path to the project", ".")
       .option("-c, --config <config file>", "The name of the config file, found at [path].")
       .option(
         "-p, --project-ref <project ref>",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified CLI development command by removing the unused project path argument, defaulting to the current directory.
	- Introduced new configuration options for enhanced flexibility in command execution.

- **Bug Fixes**
	- Improved command interface by eliminating unnecessary complexity.

- **Documentation**
	- Updated type definitions and method signatures for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->