### PR TITLE
fix: unintended project initialization at absolute path `/trigger` during project initialization

### DIFF
--- a/.changeset/gentle-mails-sip.md
+++ b/.changeset/gentle-mails-sip.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+fix: unintended project initialization at absolute path `/trigger` during project initialization

--- a/packages/cli-v3/DEVELOPMENT.md
+++ b/packages/cli-v3/DEVELOPMENT.md
@@ -7,11 +7,11 @@ cd packages/cli-v3
 pnpm run dev
 ```
 
-2. In the job-catalog folder you can use the CLI
+2. Test the local CLI using the job-catalogs located in the `/references` directory
 
 ```sh
 pnpm i
-pnpm exec trigger-v3-cli
+pnpm exec trigger <command>
 ```
 
 ---

--- a/packages/cli-v3/src/commands/init.ts
+++ b/packages/cli-v3/src/commands/init.ts
@@ -229,7 +229,10 @@ async function createTriggerDir(
         throw new OutroCommandError();
       }
 
-      const triggerDir = resolve(process.cwd(), location);
+      // Ensure that the path is always relative by stripping leading '/' if present
+      const relativeLocation = location.replace(/^\//, "");
+
+      const triggerDir = resolve(process.cwd(), relativeLocation);
 
       logger.debug({ triggerDir });
 


### PR DESCRIPTION
Closes #1081

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

_[Describe the steps you took to test this change]_
- Ran init command in `/references/hello-world`
- Gave `/trigger` input as project path
- Verified that `/trigger` is present at `/references/hello-world/trigger`
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
	- Updated instructions for running the CLI from source, clarifying the location of job catalogs and modifying the command structure for execution.

- **Bug Fixes**
	- Improved handling of directory paths in the initialization process, ensuring robustness by stripping leading slashes from the location variable.
	- Fixed an issue to prevent unintended project initialization at the absolute path `/trigger`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->