### PR TITLE
Supply correct namespace to TaskMonitor

### DIFF
--- a/apps/kubernetes-provider/src/index.ts
+++ b/apps/kubernetes-provider/src/index.ts
@@ -661,6 +661,7 @@ provider.listen();
 
 const taskMonitor = new TaskMonitor({
   runtimeEnv: RUNTIME_ENV,
+  namespace: KUBERNETES_NAMESPACE,
   onIndexFailure: async (deploymentId, details) => {
     logger.log("Indexing failed", { deploymentId, details });
 


### PR DESCRIPTION
If kubernetes-provider is used with env `KUBERNETES_NAMESPACE` other than `default`, it fails due to TaskMonitor trying to monitor the wrong namespace. This PR fixes this issue.

While not being documented, since all other services use `KUBERNETES_NAMESPACE` it seems that TaskMonitor should too.

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [X] The PR title follows the convention.
- [X] I ran and tested the code works



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced components (TaskMonitor, PodCleaner, UptimeHeartbeat) to support operation within a specified Kubernetes namespace.
	- Improved configurability by allowing users to define a namespace via the `KUBERNETES_NAMESPACE` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->