### PR TITLE
Fix issue with lost built trigger.dev files after prisma generate

### DIFF
--- a/.changeset/cuddly-pugs-begin.md
+++ b/.changeset/cuddly-pugs-begin.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Fix issue with prisma extension breaking deploy builds

--- a/packages/cli-v3/src/deploy/buildImage.ts
+++ b/packages/cli-v3/src/deploy/buildImage.ts
@@ -602,6 +602,9 @@ COPY --chown=node:node . .
 
 ${postInstallCommands}
 
+# IMPORTANT: Doing this again to fix an issue with prisma generate removing the files in node_modules/trigger.dev for some reason...
+COPY --chown=node:node . .
+
 FROM build AS indexer
 
 USER node


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue causing deploy builds to break due to the Prisma extension.
	- Enhanced error handling for missing external build data during the image build process.

- **New Features**
	- Improved Docker image building process with better file retention and network configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->