### PR TITLE
fix: removing schedule instance no longer crashes

### DIFF
--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.schedules.new/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.schedules.new/route.tsx
@@ -44,6 +44,7 @@ import { CronPattern, UpsertSchedule } from "~/v3/schedules";
 import { UpsertTaskScheduleService } from "~/v3/services/upsertTaskSchedule.server";
 import { AIGeneratedCronField } from "../resources.orgs.$organizationSlug.projects.$projectParam.schedules.new.natural-language";
 import { TimezoneList } from "~/components/scheduled/timezones";
+import { logger } from "~/services/logger.server";
 
 const cronFormat = `*    *    *    *    *
 ┬    ┬    ┬    ┬    ┬
@@ -94,9 +95,9 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
       submission.value?.friendlyId === result.id ? "Schedule updated" : "Schedule created"
     );
   } catch (error: any) {
-    const errorMessage = `Failed: ${
-      error instanceof Error ? error.message : JSON.stringify(error)
-    }`;
+    logger.error("Failed to create schedule", error);
+
+    const errorMessage = `Something went wrong. Please try again.`;
     return redirectWithErrorMessage(
       v3SchedulesPath({ slug: organizationSlug }, { slug: projectParam }),
       request,

--- a/internal-packages/database/README.md
+++ b/internal-packages/database/README.md
@@ -5,7 +5,7 @@ This is the internal database package for the Trigger.dev project. It exports a 
 ### How to add a new index on a large table
 
 1. Modify the Prisma.schema with a single index change (no other changes, just one index at a time)
-2. Create a Prisma migration using `cd packages/database && pnpm run db:migrate:dev --create-only`
+2. Create a Prisma migration using `cd internal-packages/database && pnpm run db:migrate:dev --create-only`
 3. Modify the SQL file: add IF NOT EXISTS to it and CONCURRENTLY:
 
 ```sql

--- a/internal-packages/database/prisma/migrations/20241023154826_add_schedule_instance_id_index_to_task_run/migration.sql
+++ b/internal-packages/database/prisma/migrations/20241023154826_add_schedule_instance_id_index_to_task_run/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "TaskRun_scheduleInstanceId_idx" ON "TaskRun"("scheduleInstanceId");

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -1793,6 +1793,7 @@ model TaskRun {
   @@index([projectId, taskIdentifier, status])
   //Schedules
   @@index([scheduleId])
+  @@index([scheduleInstanceId])
   // Run page inspector
   @@index([spanId])
   @@index([parentSpanId])

--- a/references/v3-catalog/src/management.ts
+++ b/references/v3-catalog/src/management.ts
@@ -256,8 +256,8 @@ async function doTriggerUnfriendlyTaskId() {
 }
 
 // doRuns().catch(console.error);
-doListRuns().catch(console.error);
+// doListRuns().catch(console.error);
 // doScheduleLists().catch(console.error);
-// doSchedules().catch(console.error);
+doSchedules().catch(console.error);
 // doEnvVars().catch(console.error);
 // doTriggerUnfriendlyTaskId().catch(console.error);


### PR DESCRIPTION
Deleting a `TaskScheduleInstance` would cause the `UpsertTaskSchedule` service to throw a Prisma transaction timeout error, because of the cascading updates to the `TaskRun` table (setting the `scheduleInstanceId` to `null`).

I've added an index on the `TaskRun.scheduleInstanceId` column. I've also restructured the `UpsertTaskSchedule` service to do less work inside of the prisma transaction, and also increased the transaction timeout to 10s in the "update" path (where the deleting happens).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced error handling for scheduling actions with standardized user-facing messages.
  - New database models introduced for improved task management, including `BackgroundWorker`, `TaskSchedule`, and `BulkActionGroup`.

- **Bug Fixes**
  - Improved transaction management and error handling for schedule creation and updates.

- **Documentation**
  - Updated migration command instructions for clarity.

- **Database Changes**
  - Added a new SQL index to improve performance on the `TaskRun` table.

These updates aim to enhance user experience and streamline task management within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->