### PR TITLE
Unflattening array fix for very large arrays

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,7 +38,9 @@ jobs:
           SESSION_SECRET: "secret"
           MAGIC_LINK_SECRET: "secret"
           ENCRYPTION_KEY: "secret"
-
+      
+      - name: 🧪 Run Package Unit Tests
+        run: pnpm run test --filter "@trigger.dev/*"
       
       - name: 🧪 Run Internal Unit Tests
         run: pnpm run test --filter "@internal/*"

--- a/packages/core/test/flattenAttributes.test.ts
+++ b/packages/core/test/flattenAttributes.test.ts
@@ -1,6 +1,20 @@
 import { flattenAttributes, unflattenAttributes } from "../src/v3/utils/flattenAttributes.js";
 
 describe("flattenAttributes", () => {
+  it("handles number keys correctl", () => {
+    expect(flattenAttributes({ bar: { "25": "foo" } })).toEqual({ "bar.25": "foo" });
+    expect(unflattenAttributes({ "bar.25": "foo" })).toEqual({ bar: { "25": "foo" } });
+    expect(flattenAttributes({ bar: ["foo", "baz"] })).toEqual({
+      "bar.[0]": "foo",
+      "bar.[1]": "baz",
+    });
+    expect(unflattenAttributes({ "bar.[0]": "foo", "bar.[1]": "baz" })).toEqual({
+      bar: ["foo", "baz"],
+    });
+    expect(flattenAttributes({ bar: { 25: "foo" } })).toEqual({ "bar.25": "foo" });
+    expect(unflattenAttributes({ "bar.25": "foo" })).toEqual({ bar: { 25: "foo" } });
+  });
+
   it("handles null correctly", () => {
     expect(flattenAttributes(null)).toEqual({ "": "$@null((" });
     expect(unflattenAttributes({ "": "$@null((" })).toEqual(null);


### PR DESCRIPTION
If JSON like this existed:

```json
{
  "akey.with.a.large.number.1234567890123": "foo"
```

When this gets unflattened it creates a massive array. An array should not be created in this situation, it should be a string key.

```json
{
  "akey.with.a.large.number.[0]": "foo"
```
This is what an array item looks like.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of nested structures and null values in attribute processing.
	- Enhanced accuracy in converting array indices for better type consistency.
	- Added a new job step for running package unit tests in the CI workflow.

- **Bug Fixes**
	- Refined logic for handling prefixes in nested objects and arrays.

- **Tests**
	- Introduced comprehensive test cases for various scenarios in attribute flattening and unflattening, enhancing overall test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->