### PR TITLE
Pass init output to all error handlers

### DIFF
--- a/.changeset/cold-laws-float.md
+++ b/.changeset/cold-laws-float.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Pass init output to both local and global `handleError` functions

--- a/packages/core/src/v3/types/tasks.ts
+++ b/packages/core/src/v3/types/tasks.ts
@@ -127,6 +127,7 @@ export type HandleErrorResult =
 
 export type HandleErrorArgs = {
   ctx: Context;
+  init: unknown;
   retry?: RetryOptions;
   retryAt?: Date;
   retryDelayInMs?: number;
@@ -152,9 +153,9 @@ type CommonTaskOptions<
   /** The retry settings when an uncaught error is thrown.
        *
        * If omitted it will use the values in your `trigger.config.ts` file.
-       * 
+       *
        * @example
-       * 
+       *
        * ```
        * export const taskWithRetries = task({
           id: "task-with-retries",
@@ -174,10 +175,10 @@ type CommonTaskOptions<
   retry?: RetryOptions;
 
   /** Used to configure what should happen when more than one run is triggered at the same time.
-   * 
-   * @example 
+   *
+   * @example
    * one at a time execution
-   * 
+   *
    * ```ts
    * export const oneAtATime = task({
       id: "one-at-a-time",
@@ -192,9 +193,9 @@ type CommonTaskOptions<
    */
   queue?: QueueOptions;
   /** Configure the spec of the machine you want your task to run on.
-   * 
+   *
    * @example
-   * 
+   *
    * ```ts
    * export const heavyTask = task({
       id: "heavy-task",

--- a/packages/core/src/v3/workers/taskExecutor.ts
+++ b/packages/core/src/v3/workers/taskExecutor.ts
@@ -176,6 +176,7 @@ export class TaskExecutor {
                 runError,
                 parsedPayload,
                 ctx,
+                initOutput,
                 signal
               );
 
@@ -498,6 +499,7 @@ export class TaskExecutor {
     error: unknown,
     payload: any,
     ctx: TaskRunContext,
+    init: unknown,
     signal?: AbortSignal
   ): Promise<
     | { status: "retry"; retry: TaskRunExecutionRetry; error?: unknown }
@@ -550,6 +552,7 @@ export class TaskExecutor {
         const handleErrorResult = this.task.fns.handleError
           ? await this.task.fns.handleError(payload, error, {
               ctx,
+              init,
               retry,
               retryDelayInMs: delay,
               retryAt: delay ? new Date(Date.now() + delay) : undefined,
@@ -558,6 +561,7 @@ export class TaskExecutor {
           : this._importedConfig
           ? await this._handleErrorFn?.(payload, error, {
               ctx,
+              init,
               retry,
               retryDelayInMs: delay,
               retryAt: delay ? new Date(Date.now() + delay) : undefined,


### PR DESCRIPTION
Previously, we didn't pass init output to task-level `handleError` functions - according to the types we should have. The global default `handleError` function in `trigger.config.ts` had no init output param at all. This fixes both those issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling with the addition of a new property for more context during error management.
	- Improved retry logic, allowing for better decision-making based on error types and context.

- **Bug Fixes**
	- Refined error handling flow to make task execution more resilient and adaptable to various error scenarios.

- **Documentation**
	- Minor formatting adjustments made to improve clarity and readability of documentation comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->