### PR TITLE
Increase maximum retry count for deploy run controller

### DIFF
--- a/.changeset/poor-parrots-attend.md
+++ b/.changeset/poor-parrots-attend.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Increase max retry count for deploy run controller operations

--- a/packages/cli-v3/src/entryPoints/deploy-run-controller.ts
+++ b/packages/cli-v3/src/entryPoints/deploy-run-controller.ts
@@ -43,7 +43,7 @@ const SHORT_HASH = env.TRIGGER_CONTENT_HASH!.slice(0, 9);
 const logger = new SimpleLogger(`[${MACHINE_NAME}][${SHORT_HASH}]`);
 
 const defaultBackoff = new ExponentialBackoff("FullJitter", {
-  maxRetries: 5,
+  maxRetries: 7,
 });
 
 cliLogger.loggerLevel = "debug";
@@ -418,7 +418,7 @@ class ProdWorker {
 
     // Retry if we don't receive EXECUTE_TASK_RUN_LAZY_ATTEMPT in a reasonable time
     // ..but we also have to be fast to avoid failing the task due to missing heartbeat
-    for await (const { delay, retry } of defaultBackoff.min(10).maxRetries(3)) {
+    for await (const { delay, retry } of defaultBackoff.min(10).maxRetries(7)) {
       if (retry > 0) {
         logger.log("retrying ready for lazy attempt", { retry });
       }


### PR DESCRIPTION
With jitter and operation timeouts we should now retry for up to 2-6m. This will improve resilience to any intermittent issues up and down the chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased maximum retry count for deployment operations to enhance resilience during failures.
  
- **Bug Fixes**
  - Improved error handling with more detailed logging for task execution failures.
  - Enhanced task management by ensuring proper detachment from event listeners during termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->