### PR TITLE
Add and use new internal error for very outdated SDK versions

### DIFF
--- a/.changeset/giant-mugs-clean.md
+++ b/.changeset/giant-mugs-clean.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Add outdated SDK error

--- a/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
+++ b/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
@@ -4,6 +4,7 @@ import {
   ProdTaskRunExecution,
   ProdTaskRunExecutionPayload,
   TaskRunError,
+  TaskRunErrorCodes,
   TaskRunExecution,
   TaskRunExecutionLazyAttemptPayload,
   TaskRunExecutionResult,
@@ -517,6 +518,11 @@ export class SharedQueueConsumer {
               logger.error("Failed to create task run attempt for outdate worker", {
                 error,
                 taskRun: lockedTaskRun.id,
+              });
+
+              const service = new CrashTaskRunService();
+              await service.call(lockedTaskRun.id, {
+                errorCode: TaskRunErrorCodes.OUTDATED_SDK_VERSION,
               });
 
               await this.#ackAndDoMoreWork(message.messageId);

--- a/packages/core/src/v3/errors.ts
+++ b/packages/core/src/v3/errors.ts
@@ -167,6 +167,7 @@ export function shouldRetryError(error: TaskRunError): boolean {
         case "MAX_DURATION_EXCEEDED":
         case "DISK_SPACE_EXCEEDED":
         case "TASK_RUN_HEARTBEAT_TIMEOUT":
+        case "OUTDATED_SDK_VERSION":
           return false;
 
         case "GRACEFUL_EXIT_TIMEOUT":
@@ -426,6 +427,14 @@ const prettyInternalErrors: Partial<
       name: "Contact us",
       href: links.site.contact,
       magic: "CONTACT_FORM",
+    },
+  },
+  OUTDATED_SDK_VERSION: {
+    message:
+      "Your task is using an outdated version of the SDK. Please upgrade to the latest version.",
+    link: {
+      name: "Beta upgrade guide",
+      href: links.docs.upgrade.beta,
     },
   },
 };

--- a/packages/core/src/v3/links.ts
+++ b/packages/core/src/v3/links.ts
@@ -9,6 +9,9 @@ export const links = {
     machines: {
       home: "https://trigger.dev/docs/v3/machines",
     },
+    upgrade: {
+      beta: "https://trigger.dev/docs/upgrading-beta",
+    },
   },
   site: {
     home: "https://trigger.dev",

--- a/packages/core/src/v3/schemas/common.ts
+++ b/packages/core/src/v3/schemas/common.ts
@@ -104,6 +104,7 @@ export const TaskRunInternalError = z.object({
     "DISK_SPACE_EXCEEDED",
     "POD_EVICTED",
     "POD_UNKNOWN_ERROR",
+    "OUTDATED_SDK_VERSION",
   ]),
   message: z.string().optional(),
   stackTrace: z.string().optional(),


### PR DESCRIPTION
Runs locked to very old SDK versions `< beta.25` would previously get stuck in a queued state. This will crash those runs instead and advise uprading to latest.