### PR TITLE
`chore: remove unnecessary browser export condition`

### DIFF
--- a/.changeset/weak-comics-burn.md
+++ b/.changeset/weak-comics-burn.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+Remove browser export condition - not necessary with the react-hooks package that uses core

--- a/packages/trigger-sdk/package.json
+++ b/packages/trigger-sdk/package.json
@@ -27,9 +27,6 @@
     },
     "sourceDialects": [
       "@triggerdotdev/source"
-    ],
-    "esmDialects": [
-      "browser"
     ]
   },
   "typesVersions": {
@@ -83,10 +80,6 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "browser": {
-        "types": "./dist/browser/index.d.ts",
-        "default": "./dist/browser/index.js"
-      },
       "import": {
         "@triggerdotdev/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
@@ -98,10 +91,6 @@
       }
     },
     "./v3": {
-      "browser": {
-        "types": "./dist/browser/v3/index.d.ts",
-        "default": "./dist/browser/v3/index.js"
-      },
       "import": {
         "@triggerdotdev/source": "./src/v3/index.ts",
         "types": "./dist/esm/v3/index.d.ts",


### PR DESCRIPTION
Closes #1454

Removes the “browser” export condition from `@trigger.dev/sdk/v3` which didn’t export a bunch of stuff that’s needed on edge runtimes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified export logic for the `@trigger.dev/sdk` package, enhancing its usability across different environments.
  
- **Bug Fixes**
	- Removed unnecessary browser export conditions, improving integration with react-hooks.

- **Chores**
	- Updated `package.json` to streamline export configurations, focusing on core functionalities without browser-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->