### PR TITLE
fix(docs): Correct typo in '/idempotency' documentation

### DIFF
--- a/docs/idempotency.mdx
+++ b/docs/idempotency.mdx
@@ -60,7 +60,7 @@ If you are triggering a task from your backend code, you can use the `idempotenc
 import { idempotencyKeys, tasks } from "@trigger.dev/sdk/v3";
 
 // You can also pass an array of strings to create a idempotency key
-const idempotencyKey = await idempotenceKeys.create([myUser.id, "my-task"]);
+const idempotencyKey = await idempotencyKeys.create([myUser.id, "my-task"]);
 await tasks.trigger("my-task", { some: "data" }, { idempotencyKey });
 ```
 
@@ -83,7 +83,7 @@ import { tasks } from "@trigger.dev/sdk/v3";
 await tasks.batchTrigger("my-task", [
   {
     payload: { some: "data" },
-    options: { idempotencyKey: await idempotenceKeys.create(myUser.id) },
+    options: { idempotencyKey: await idempotencyKeys.create(myUser.id) },
   },
 ]);
 ```


### PR DESCRIPTION
Description:
- Corrected 'idempotenceKeys' to 'idempotencyKeys' in code blocks 3 and 5.

Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

I navigated to the `/idempotency` documentation file, located code blocks 3 and 5, and replaced "idempotenceKeys" with "idempotencyKeys". I reviewed the changes to ensure accuracy and consistency.

---

## Changelog

Corrected typos in the `idempotency` documentation.

---

## Screenshots

Not applicable as this change does not affect the UI.

---

Closes #1421

💯


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the idempotency document for clarity on the usage of `idempotencyKey`.
	- Expanded explanations and corrected typographical errors in code examples.
	- Enhanced examples to demonstrate flexibility in key generation.
	- Improved overall structure for better understanding of idempotency in task execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->