### PR TITLE
Improve resume reliability of restored runs

### DIFF
--- a/.changeset/sixty-donuts-fail.md
+++ b/.changeset/sixty-donuts-fail.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Improve resume reliability by replaying ready signal of restored workers

--- a/packages/cli-v3/src/entryPoints/deploy-run-controller.ts
+++ b/packages/cli-v3/src/entryPoints/deploy-run-controller.ts
@@ -371,10 +371,18 @@ class ProdWorker {
   async #prepareForRetry() {
     // Clear state for retrying
     this.paused = false;
+    this.nextResumeAfter = undefined;
     this.waitForPostStart = false;
     this.executing = false;
     this.attemptFriendlyId = undefined;
     this.attemptNumber = undefined;
+
+    // Clear replay state
+    this.waitForTaskReplay = undefined;
+    this.waitForBatchReplay = undefined;
+    this.readyForLazyAttemptReplay = undefined;
+    this.durationResumeFallback = undefined;
+    this.readyForResumeReplay = undefined;
   }
 
   // MARK: CHECKPOINT PREP


### PR DESCRIPTION
Previously, it was possible for a restored worker to come up and to signal it's ready to resume when nobody was listening. We will replay the readiness signal with exponential backoff now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced reliability of the resume functionality for workers, ensuring smooth operation after restoration.
	- Improved task replay handling and state management for better control during pauses and resumes.

- **Bug Fixes**
	- Resolved issues related to the readiness state of workers post-restoration, improving overall task management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->