### PR TITLE
Prevent stuck runs after duplicate dependency resume messages

### DIFF
--- a/.changeset/lovely-swans-pump.md
+++ b/.changeset/lovely-swans-pump.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Ignore duplicate dependency resume messages in deployed tasks


### PR DESCRIPTION
In rare cases the platform could retry sending dependency resume messages even if the task run correctly received it. To deal with this, newly deployed tasks will now discard non-current dependency resumes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of duplicate dependency resume messages during task deployment, reducing log clutter.
	- Enhanced logging and error handling for task execution, particularly when resuming from a paused state.

- **Bug Fixes**
	- Fixed issues related to task completion verification, ensuring accurate execution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->