### PR TITLE
Fix: vercelSyncEnvVars teamId

### DIFF
--- a/.changeset/rotten-dolphins-punch.md
+++ b/.changeset/rotten-dolphins-punch.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/build": minor
+---
+
+Add teamId option to vercelSyncEnvVars

--- a/docs/config/config-file.mdx
+++ b/docs/config/config-file.mdx
@@ -511,10 +511,10 @@ The `vercelSyncEnvVars` build extension syncs environment variables from your Ve
 
 <Note>
   You need to set the `VERCEL_ACCESS_TOKEN` and `VERCEL_PROJECT_ID` environment variables, or pass
-  in the token and project ID as arguments to the `vercelSyncEnvVars` build extension. You can find
-  / generate the `VERCEL_ACCESS_TOKEN` in your Vercel
-  [dashboard](https://vercel.com/account/settings/tokens). Make sure the scope of the token covers
-  the project you want to sync.
+  in the token and project ID as arguments to the `vercelSyncEnvVars` build extension. If you're
+  working with a team project, you'll also need to set `VERCEL_TEAM_ID`. You can find / generate
+  the `VERCEL_ACCESS_TOKEN` in your Vercel [dashboard](https://vercel.com/account/settings/tokens).
+  Make sure the scope of the token covers the project you want to sync.
 </Note>
 
 ```ts

--- a/docs/guides/examples/vercel-sync-env-vars.mdx
+++ b/docs/guides/examples/vercel-sync-env-vars.mdx
@@ -13,7 +13,8 @@ To sync environment variables, you just need to add our build extension to your 
 <Note>
   You need to set the `VERCEL_ACCESS_TOKEN` and `VERCEL_PROJECT_ID` environment variables in the
   Trigger.dev dashboard, or pass in the token and project ID as arguments to the `vercelSyncEnvVars`
-  build extension. You can find / generate the `VERCEL_ACCESS_TOKEN` in your Vercel
+  build extension. If you're working with a team project, you'll also need to set `VERCEL_TEAM_ID`. 
+  You can find / generate the `VERCEL_ACCESS_TOKEN` in your Vercel
   [dashboard](https://vercel.com/account/settings/tokens). Make sure the scope of the token covers
   the project with the environment variables you want to sync.
 </Note>

--- a/docs/guides/frameworks/nextjs.mdx
+++ b/docs/guides/frameworks/nextjs.mdx
@@ -251,10 +251,10 @@ If you want to automatically sync environment variables from your Vercel project
 
 <Note>
   You need to set the `VERCEL_ACCESS_TOKEN` and `VERCEL_PROJECT_ID` environment variables, or pass
-  in the token and project ID as arguments to the `vercelSyncEnvVars` build extension. You can find
-  / generate the `VERCEL_ACCESS_TOKEN` in your Vercel
-  [dashboard](https://vercel.com/account/settings/tokens). Make sure the scope of the token covers
-  the project you want to sync.
+  in the token and project ID as arguments to the `vercelSyncEnvVars` build extension. If you're
+  working with a team project, you'll also need to set `VERCEL_TEAM_ID`. You can find / generate
+  the `VERCEL_ACCESS_TOKEN` in your Vercel [dashboard](https://vercel.com/account/settings/tokens).
+  Make sure the scope of the token covers the project you want to sync.
 </Note>
 
 ```ts trigger.config.ts

--- a/packages/build/src/extensions/core/vercelSyncEnvVars.ts
+++ b/packages/build/src/extensions/core/vercelSyncEnvVars.ts
@@ -1,7 +1,7 @@
 import { BuildExtension } from "@trigger.dev/core/v3/build";
 import { syncEnvVars } from "../core.js";
 
-export function syncVercelEnvVars(
+export function vercelSyncEnvVars(
   options?: { projectId?: string; vercelAccessToken?: string; vercelTeamId?: string },
 ): BuildExtension {
   const sync = syncEnvVars(async (ctx) => {

--- a/packages/build/src/extensions/core/vercelSyncEnvVars.ts
+++ b/packages/build/src/extensions/core/vercelSyncEnvVars.ts
@@ -41,7 +41,7 @@ export function syncVercelEnvVars(
     }
     const params = new URLSearchParams();
     if (vercelTeamId) params.set("teamId", vercelTeamId);
-    const vercelApiUrl = `https://api.vercel.com/v8/projects/${projectId}/env?${params}`;
+    const vercelApiUrl = `https://api.vercel.com/v9/projects/${projectId}/env?${params}`;
 
     try {
       const response = await fetch(vercelApiUrl, {

--- a/packages/build/src/extensions/core/vercelSyncEnvVars.ts
+++ b/packages/build/src/extensions/core/vercelSyncEnvVars.ts
@@ -2,7 +2,7 @@ import { BuildExtension } from "@trigger.dev/core/v3/build";
 import { syncEnvVars } from "../core.js";
 
 export function syncVercelEnvVars(
-  options?: { projectId?: string; vercelAccessToken?: string },
+  options?: { projectId?: string; vercelAccessToken?: string; vercelTeamId?: string },
 ): BuildExtension {
   const sync = syncEnvVars(async (ctx) => {
     const projectId = options?.projectId ?? process.env.VERCEL_PROJECT_ID ??
@@ -10,6 +10,8 @@ export function syncVercelEnvVars(
     const vercelAccessToken = options?.vercelAccessToken ??
       process.env.VERCEL_ACCESS_TOKEN ??
       ctx.env.VERCEL_ACCESS_TOKEN;
+    const vercelTeamId = options?.vercelTeamId ?? process.env.VERCEL_TEAM_ID ??
+      ctx.env.VERCEL_TEAM_ID;
 
     if (!projectId) {
       throw new Error(
@@ -37,8 +39,9 @@ export function syncVercelEnvVars(
         `Invalid environment '${ctx.environment}'. Expected 'prod', 'staging', or 'dev'.`,
       );
     }
-    const vercelApiUrl =
-      `https://api.vercel.com/v8/projects/${projectId}/env?decrypt=true`;
+    const params = new URLSearchParams();
+    if (vercelTeamId) params.set("teamId", vercelTeamId);
+    const vercelApiUrl = `https://api.vercel.com/v8/projects/${projectId}/env?${params}`;
 
     try {
       const response = await fetch(vercelApiUrl, {

--- a/packages/build/src/extensions/core/vercelSyncEnvVars.ts
+++ b/packages/build/src/extensions/core/vercelSyncEnvVars.ts
@@ -39,9 +39,9 @@ export function syncVercelEnvVars(
         `Invalid environment '${ctx.environment}'. Expected 'prod', 'staging', or 'dev'.`,
       );
     }
-    const params = new URLSearchParams();
+    const params = new URLSearchParams({ decrypt: "true" });
     if (vercelTeamId) params.set("teamId", vercelTeamId);
-    const vercelApiUrl = `https://api.vercel.com/v9/projects/${projectId}/env?${params}`;
+    const vercelApiUrl = `https://api.vercel.com/v8/projects/${projectId}/env?${params}`;
 
     try {
       const response = await fetch(vercelApiUrl, {


### PR DESCRIPTION
Closes https://discord.com/channels/1066956501299777596/1303601937282895943/1304512833056411759

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

1. Configured VERCEL_TEAM_ID environment variable
2. Tested vercelSyncEnvVars with:
- Default env vars (VERCEL_TEAM_ID)
- Explicitly passed teamId option
3. Verified environment variables sync correctly with team projects

---

## Changelog

- Renamed syncVercelEnvVars to vercelSyncEnvVars to match documentation
- Added support for team projects in vercelSyncEnvVars by introducing teamId option
- Updated documentation in multiple files to include VERCEL_TEAM_ID requirement for team projects
- Added teamId parameter to URL when making Vercel API requests
- Created new changeset for minor version bump

---

## Screenshots

_[Screenshots]_

💯


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `teamId` option for `vercelSyncEnvVars`, enhancing environment variable management for team projects.
	- Added new lifecycle functions in the configuration to allow custom logic execution at various stages of task execution.
	- Expanded build configuration options for greater customization, including new extensions for managing additional files and packages.

- **Documentation**
	- Updated guides to clarify the requirement of `VERCEL_TEAM_ID` for syncing environment variables in team projects.
	- Enhanced setup instructions for integrating Trigger.dev with Next.js, including detailed revalidation handler examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->