### PR TITLE
feat: exit if docker buildx can't be found for self-hosted builds

### DIFF
--- a/.changeset/spicy-turkeys-hug.md
+++ b/.changeset/spicy-turkeys-hug.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": minor
+---
+
+feat: exit if docker buildx can't be found for self-hosted builds

--- a/packages/cli-v3/package.json
+++ b/packages/cli-v3/package.json
@@ -118,7 +118,7 @@
     "std-env": "^3.7.0",
     "terminal-link": "^3.0.0",
     "tiny-invariant": "^1.2.0",
-    "tinyexec": "^0.2.0",
+    "tinyexec": "^0.3.1",
     "ws": "^8.18.0",
     "xdg-app-paths": "^8.3.0",
     "zod": "3.22.3",

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -270,7 +270,7 @@ async function _deployCommand(dir: string, options: DeployCommandOptions) {
     const result = await x("docker", ["buildx", "version"]);
 
     if (result.exitCode !== 0) {
-      logger.debug("`docker buildx version` exited with a non-zero code:", result.exitCode);
+      logger.debug(`"docker buildx version" failed (${result.exitCode}):`, result);
       throw new Error("Failed to find docker buildx, please install it.");
     }
   }

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -37,6 +37,7 @@ import { spinner } from "../utilities/windows.js";
 import { login } from "./login.js";
 import { updateTriggerPackages } from "./update.js";
 import { resolveAlwaysExternal } from "../build/externals.js";
+import { x } from "tinyexec";
 
 const DeployCommandOptions = CommonCommandOptions.extend({
   dryRun: z.boolean().default(false),
@@ -263,6 +264,15 @@ async function _deployCommand(dir: string, options: DeployCommandOptions) {
     throw new Error(
       `Failed to start deployment, as your instance of trigger.dev does not support hosting. To deploy this project, you must use the --self-hosted flag to build and push the image yourself.`
     );
+  }
+
+  if (options.selfHosted) {
+    const result = await x("docker", ["buildx", "version"]);
+
+    if (result.exitCode !== 0) {
+      logger.debug("`docker buildx version` exited with a non-zero code:", result.exitCode);
+      throw new Error("Failed to find docker buildx, please install it.");
+    }
   }
 
   if (

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -271,7 +271,9 @@ async function _deployCommand(dir: string, options: DeployCommandOptions) {
 
     if (result.exitCode !== 0) {
       logger.debug(`"docker buildx version" failed (${result.exitCode}):`, result);
-      throw new Error("Failed to find docker buildx, please install it.");
+      throw new Error(
+        "Failed to find docker buildx. Please install it: https://github.com/docker/buildx#installing."
+      );
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1184,8 +1184,8 @@ importers:
         specifier: ^1.2.0
         version: 1.3.1
       tinyexec:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.3.1
+        version: 0.3.1
       ws:
         specifier: ^8.18.0
         version: 8.18.0
@@ -28547,12 +28547,12 @@ packages:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
     dev: false
 
-  /tinyexec@0.2.0:
-    resolution: {integrity: sha512-au8dwv4xKSDR+Fw52csDo3wcDztPdne2oM1o/7LFro4h6bdFmvyUAeAfX40pwDtzHgRFqz1XWaUqgKS2G83/ig==}
-    dev: false
-
   /tinyexec@0.3.0:
     resolution: {integrity: sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==}
+
+  /tinyexec@0.3.1:
+    resolution: {integrity: sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==}
+    dev: false
 
   /tinyglobby@0.2.2:
     resolution: {integrity: sha512-mZ2sDMaySvi1PkTp4lTo1In2zjU+cY8OvZsfwrDrx3YGRbXPX1/cbPwCR9zkm3O/Fz9Jo0F1HNgIQ1b8BepqyQ==}


### PR DESCRIPTION
I ran into an issue when using trigger that I docker would fail to build as it couldn't find the `--progress` flag. This flag is only available when docker buildx is installed. This change adds in a check to see if docker buildx is installed, and if it's not it'll fail with a helpful message.

When buildx is installed the `docker buildx version` command will return a version, if it's not then the command will fail.

![image](https://github.com/user-attachments/assets/c9902f5a-8feb-4c71-a48a-744111fccc56)

(`install-docker-buildx` isn't a real command, I just wrapped the arch linux `yay -S docker-buildx` for the demo)

We can then test the warning I added based on this

![image](https://github.com/user-attachments/assets/bf1e30b1-0bc3-425a-93e9-06169144f282)

Additionally, I added a debug log for this. You can test that by running `trigger deploy --self-hosted --log-level debug`, and you'll get something like this at the end of the log:

![image](https://github.com/user-attachments/assets/082f589c-f428-43d5-9bf8-ce3c84edd206)

**Edit**: added a better build message based on rabbit's suggestion

![image](https://github.com/user-attachments/assets/af06f272-c41e-4b56-999d-09804c9470a1)

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced deployment command functionality with checks for Docker Buildx during self-hosted builds.
	- Added visual feedback with a spinner during the build process.

- **Bug Fixes**
	- Improved error handling for deployment failures and environment variable synchronization.

- **Chores**
	- Updated `tinyexec` dependency to version `^0.3.1`.
	- Updated `package.json` to version `3.2.0` and refined module export structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->