### PR TITLE
feat: always show alerts tab and lock email alerts when keys are missing

### DIFF
--- a/apps/webapp/app/components/navigation/SideMenu.tsx
+++ b/apps/webapp/app/components/navigation/SideMenu.tsx
@@ -631,8 +631,6 @@ function V3ProjectSideMenu({
   project: SideMenuProject;
   organization: MatchedOrganization;
 }) {
-  const { alertsEnabled } = useFeatures();
-
   return (
     <>
       <SideMenuHeader title={"Project"} />
@@ -685,15 +683,13 @@ function V3ProjectSideMenu({
         to={v3DeploymentsPath(organization, project)}
         data-action="deployments"
       />
-      {alertsEnabled && (
-        <SideMenuItem
-          name="Alerts"
-          icon={BellAlertIcon}
-          activeIconColor="text-red-500"
-          to={v3ProjectAlertsPath(organization, project)}
-          data-action="alerts"
-        />
-      )}
+      <SideMenuItem
+        name="Alerts"
+        icon={BellAlertIcon}
+        activeIconColor="text-red-500"
+        to={v3ProjectAlertsPath(organization, project)}
+        data-action="alerts"
+      />
       <SideMenuItem
         name="Concurrency limits"
         icon={RectangleStackIcon}

--- a/apps/webapp/app/features.server.ts
+++ b/apps/webapp/app/features.server.ts
@@ -4,7 +4,6 @@ import { requestUrl } from "./utils/requestUrl.server";
 export type TriggerFeatures = {
   isManagedCloud: boolean;
   v3Enabled: boolean;
-  alertsEnabled: boolean;
 };
 
 function isManagedCloud(host: string): boolean {
@@ -20,7 +19,6 @@ function featuresForHost(host: string): TriggerFeatures {
   return {
     isManagedCloud: isManagedCloud(host),
     v3Enabled: env.V3_ENABLED === "true",
-    alertsEnabled: env.ALERT_FROM_EMAIL !== undefined && env.ALERT_RESEND_API_KEY !== undefined,
   };
 }
 

--- a/apps/webapp/app/hooks/useFeatures.ts
+++ b/apps/webapp/app/hooks/useFeatures.ts
@@ -5,5 +5,5 @@ import type { TriggerFeatures } from "~/features.server";
 export function useFeatures(): TriggerFeatures {
   const routeMatch = useTypedRouteLoaderData<typeof loader>("root");
 
-  return routeMatch?.features ?? { isManagedCloud: false, v3Enabled: false, alertsEnabled: false };
+  return routeMatch?.features ?? { isManagedCloud: false, v3Enabled: false };
 }


### PR DESCRIPTION
When I was testing my self hosted installation, I noticed that the alerts tab was missing. It was still accessible if I manually changed the url, and the webhook alerts were fully functional. This PR removes the _feature flag_ `alertsEnabled` and makes the alerts page always visible. Similarly to the Slack alert, it'll now show a notice to the user if they don't have their resend configured for alerts.

![image](https://github.com/user-attachments/assets/5ba539aa-e58c-4af8-9caf-eefb91dce434)

It has the same behaviour as before for checking whether email alerts are enabled. It uses the two environment variables. I've never used Remix before so let me know if it's not safe to check those there. I think it is as I did see there is other server code in that file, and the remix docs say that loaders run on the server.

If there is interest, I could also update the self hosting docs with how to configure email alerts in a follow up pr?

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The "Alerts" menu item is now always visible in the side menu, enhancing accessibility.
	- The alert creation page now provides immediate feedback on email alert availability with a new input field or warning message.

- **Bug Fixes**
	- Simplified the control flow related to alert settings by removing unnecessary conditions.

- **Documentation**
	- Updated return values and properties in relevant functions to reflect the removal of the `alertsEnabled` feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->