### PR TITLE
Added the new Help & Feedback popover to the account side menu

### DIFF
--- a/apps/webapp/app/components/navigation/AccountSideMenu.tsx
+++ b/apps/webapp/app/components/navigation/AccountSideMenu.tsx
@@ -1,14 +1,13 @@
 import { ShieldCheckIcon } from "@heroicons/react/20/solid";
 import { ArrowLeftIcon } from "@heroicons/react/24/solid";
-import { DiscordIcon } from "@trigger.dev/companyicons";
 import { User } from "@trigger.dev/database";
 import { useFeatures } from "~/hooks/useFeatures";
 import { cn } from "~/utils/cn";
 import { accountPath, personalAccessTokensPath, rootPath } from "~/utils/pathBuilder";
-import { Feedback } from "../Feedback";
-import { Button, LinkButton } from "../primitives/Buttons";
+import { LinkButton } from "../primitives/Buttons";
 import { SideMenuHeader } from "./SideMenuHeader";
 import { SideMenuItem } from "./SideMenuItem";
+import { HelpAndFeedback } from "./HelpAndFeedbackPopover";
 
 export function AccountSideMenu({ user }: { user: User }) {
   const { v3Enabled } = useFeatures();
@@ -20,7 +19,7 @@ export function AccountSideMenu({ user }: { user: User }) {
       )}
     >
       <div className="flex h-full flex-col">
-        <div className={cn("flex items-center justify-between border-b p-px transition")}>
+        <div className={cn("flex h-10 items-center justify-between border-b p-1 transition")}>
           <LinkButton
             variant="minimal/medium"
             LeadingIcon={ArrowLeftIcon}
@@ -57,42 +56,7 @@ export function AccountSideMenu({ user }: { user: User }) {
           )}
         </div>
         <div className="flex flex-col gap-1 border-t border-grid-bright p-1">
-          <SideMenuItem
-            name="Join our Discord"
-            icon={DiscordIcon}
-            to="https://trigger.dev/discord"
-            data-action="join our discord"
-            target="_blank"
-          />
-
-          <SideMenuItem
-            name="Documentation"
-            icon="docs"
-            to="https://trigger.dev/docs"
-            data-action="documentation"
-            target="_blank"
-          />
-          <SideMenuItem
-            name="Changelog"
-            icon="star"
-            to="https://trigger.dev/changelog"
-            data-action="changelog"
-            target="_blank"
-          />
-
-          <Feedback
-            button={
-              <Button
-                variant="small-menu-item"
-                LeadingIcon="log"
-                data-action="help & feedback"
-                fullWidth
-                textAlignLeft
-              >
-                Help & Feedback
-              </Button>
-            }
-          />
+          <HelpAndFeedback />
         </div>
       </div>
     </div>

--- a/apps/webapp/app/components/navigation/HelpAndFeedbackPopover.tsx
+++ b/apps/webapp/app/components/navigation/HelpAndFeedbackPopover.tsx
@@ -1,0 +1,182 @@
+import {
+  ArrowUpRightIcon,
+  CalendarDaysIcon,
+  ChatBubbleLeftEllipsisIcon,
+  EnvelopeIcon,
+  LightBulbIcon,
+  SignalIcon,
+} from "@heroicons/react/20/solid";
+import { DiscordIcon, SlackIcon } from "@trigger.dev/companyicons";
+import { Fragment, useState } from "react";
+import { useCurrentPlan } from "~/routes/_app.orgs.$organizationSlug/route";
+import { Feedback } from "../Feedback";
+import { StepContentContainer } from "../StepContentContainer";
+import { Button } from "../primitives/Buttons";
+import { ClipboardField } from "../primitives/ClipboardField";
+import { Dialog, DialogContent, DialogHeader, DialogTrigger } from "../primitives/Dialog";
+import { Icon } from "../primitives/Icon";
+import { Paragraph } from "../primitives/Paragraph";
+import { Popover, PopoverContent, PopoverSideMenuTrigger } from "../primitives/Popover";
+import { StepNumber } from "../primitives/StepNumber";
+import { MenuCount, SideMenuItem } from "./SideMenuItem";
+
+export function HelpAndFeedback() {
+  const [isHelpMenuOpen, setHelpMenuOpen] = useState(false);
+  const currentPlan = useCurrentPlan();
+
+  return (
+    <Popover onOpenChange={(open) => setHelpMenuOpen(open)}>
+      <PopoverSideMenuTrigger isOpen={isHelpMenuOpen} shortcut={{ key: "h" }}>
+        <div className="flex items-center gap-1.5">
+          <ChatBubbleLeftEllipsisIcon className="size-4 text-success" />
+          Help & Feedback
+        </div>
+      </PopoverSideMenuTrigger>
+      <PopoverContent
+        className="min-w-[14rem] divide-y divide-grid-bright overflow-y-auto p-0 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600"
+        align="start"
+      >
+        <Fragment>
+          <div className="flex flex-col gap-1 p-1">
+            <SideMenuItem
+              name="Documentation"
+              icon="docs"
+              trailingIcon={ArrowUpRightIcon}
+              trailingIconClassName="text-text-dimmed"
+              inactiveIconColor="text-green-500"
+              activeIconColor="text-green-500"
+              to="https://trigger.dev/docs"
+              data-action="documentation"
+              target="_blank"
+            />
+          </div>
+          <div className="flex flex-col gap-1 p-1">
+            <SideMenuItem
+              name="Status"
+              icon={SignalIcon}
+              trailingIcon={ArrowUpRightIcon}
+              trailingIconClassName="text-text-dimmed"
+              inactiveIconColor="text-green-500"
+              activeIconColor="text-green-500"
+              to="https://status.trigger.dev/"
+              data-action="status"
+              target="_blank"
+            />
+            <SideMenuItem
+              name="Suggest a feature"
+              icon={LightBulbIcon}
+              trailingIcon={ArrowUpRightIcon}
+              trailingIconClassName="text-text-dimmed"
+              inactiveIconColor="text-sun-500"
+              activeIconColor="text-sun-500"
+              to="https://feedback.trigger.dev/"
+              data-action="suggest-a-feature"
+              target="_blank"
+            />
+            <SideMenuItem
+              name="Changelog"
+              icon="star"
+              trailingIcon={ArrowUpRightIcon}
+              trailingIconClassName="text-text-dimmed"
+              inactiveIconColor="text-sun-500"
+              activeIconColor="text-sun-500"
+              to="https://trigger.dev/changelog"
+              data-action="changelog"
+              target="_blank"
+            />
+          </div>
+          <div className="flex flex-col gap-1 p-1">
+            <Paragraph className="pb-1 pl-1.5 pt-1.5 text-xs">Need help?</Paragraph>
+            {currentPlan?.v3Subscription?.plan?.limits.support === "slack" && (
+              <div>
+                <Dialog>
+                  <DialogTrigger asChild>
+                    <Button
+                      variant="small-menu-item"
+                      LeadingIcon={SlackIcon}
+                      data-action="join-our-slack"
+                      fullWidth
+                      textAlignLeft
+                    >
+                      <div className="flex w-full items-center justify-between">
+                        <span className="text-text-bright">Join our Slack…</span>
+                        <MenuCount count="PRO" />
+                      </div>
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent>
+                    <DialogHeader>Join our Slack</DialogHeader>
+                    <div className="mt-2 flex flex-col gap-4">
+                      <div className="flex items-center gap-4">
+                        <Icon icon={SlackIcon} className="h-10 w-10 min-w-[2.5rem]" />
+                        <Paragraph variant="base/bright">
+                          As a subscriber, you have access to a dedicated Slack channel for 1-to-1
+                          support with the Trigger.dev team.
+                        </Paragraph>
+                      </div>
+                      <hr className="border-charcoal-800" />
+                      <div>
+                        <StepNumber stepNumber="1" title="Email us" />
+                        <StepContentContainer>
+                          <Paragraph>
+                            Send us an email to this address from your Trigger.dev account email
+                            address:
+                            <ClipboardField
+                              variant="secondary/medium"
+                              value="priority-support@trigger.dev"
+                              className="my-2"
+                            />
+                          </Paragraph>
+                        </StepContentContainer>
+                        <StepNumber stepNumber="2" title="Look out for an invite from Slack" />
+                        <StepContentContainer>
+                          <Paragraph>
+                            As soon as we can, we'll setup a Slack Connect channel and say hello!
+                          </Paragraph>
+                        </StepContentContainer>
+                      </div>
+                    </div>
+                  </DialogContent>
+                </Dialog>
+              </div>
+            )}
+            <SideMenuItem
+              name="Ask in our Discord"
+              icon={DiscordIcon}
+              trailingIcon={ArrowUpRightIcon}
+              trailingIconClassName="text-text-dimmed"
+              to="https://trigger.dev/discord"
+              data-action="join our discord"
+              target="_blank"
+            />
+            <SideMenuItem
+              name="Book a 15 min call"
+              icon={CalendarDaysIcon}
+              trailingIcon={ArrowUpRightIcon}
+              trailingIconClassName="text-text-dimmed"
+              inactiveIconColor="text-rose-500"
+              activeIconColor="text-rose-500"
+              to="https://cal.com/team/triggerdotdev/founders-call"
+              data-action="book-a-call"
+              target="_blank"
+            />
+            <Feedback
+              button={
+                <Button
+                  variant="small-menu-item"
+                  LeadingIcon={EnvelopeIcon}
+                  leadingIconClassName="text-blue-500"
+                  data-action="contact-us"
+                  fullWidth
+                  textAlignLeft
+                >
+                  Contact us…
+                </Button>
+              }
+            />
+          </div>
+        </Fragment>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/webapp/app/components/navigation/SideMenu.tsx
+++ b/apps/webapp/app/components/navigation/SideMenu.tsx
@@ -1,27 +1,20 @@
 import {
   AcademicCapIcon,
   ArrowRightOnRectangleIcon,
-  ArrowUpRightIcon,
   BeakerIcon,
   BellAlertIcon,
-  CalendarDaysIcon,
   ChartBarIcon,
-  ChatBubbleLeftEllipsisIcon,
   ClockIcon,
   CreditCardIcon,
   CursorArrowRaysIcon,
-  EnvelopeIcon,
   IdentificationIcon,
   KeyIcon,
-  LightBulbIcon,
   RectangleStackIcon,
   ServerStackIcon,
   ShieldCheckIcon,
-  SignalIcon,
 } from "@heroicons/react/20/solid";
 import { UserGroupIcon, UserPlusIcon } from "@heroicons/react/24/solid";
 import { useNavigation } from "@remix-run/react";
-import { DiscordIcon, SlackIcon } from "@trigger.dev/companyicons";
 import { Fragment, ReactNode, useEffect, useRef, useState } from "react";
 import { TaskIcon } from "~/assets/icons/TaskIcon";
 import { useFeatures } from "~/hooks/useFeatures";
@@ -64,17 +57,12 @@ import {
   v3TestPath,
   v3UsagePath,
 } from "~/utils/pathBuilder";
-import { Feedback } from "../Feedback";
 import { ImpersonationBanner } from "../ImpersonationBanner";
 import { LogoIcon } from "../LogoIcon";
-import { StepContentContainer } from "../StepContentContainer";
 import { UserProfilePhoto } from "../UserProfilePhoto";
 import { FreePlanUsage } from "../billing/v2/FreePlanUsage";
 import { Badge } from "../primitives/Badge";
-import { Button, LinkButton } from "../primitives/Buttons";
-import { ClipboardField } from "../primitives/ClipboardField";
-import { Dialog, DialogContent, DialogHeader, DialogTrigger } from "../primitives/Dialog";
-import { Icon } from "../primitives/Icon";
+import { LinkButton } from "../primitives/Buttons";
 import { Paragraph } from "../primitives/Paragraph";
 import {
   Popover,
@@ -83,12 +71,11 @@ import {
   PopoverCustomTrigger,
   PopoverMenuItem,
   PopoverSectionHeader,
-  PopoverSideMenuTrigger,
 } from "../primitives/Popover";
-import { StepNumber } from "../primitives/StepNumber";
 import { TextLink } from "../primitives/TextLink";
+import { HelpAndFeedback } from "./HelpAndFeedbackPopover";
 import { SideMenuHeader } from "./SideMenuHeader";
-import { MenuCount, SideMenuItem } from "./SideMenuItem";
+import { SideMenuItem } from "./SideMenuItem";
 
 type SideMenuUser = Pick<User, "email" | "admin"> & { isImpersonating: boolean };
 type SideMenuProject = Pick<MatchedProject, "id" | "name" | "slug" | "version">;
@@ -258,167 +245,6 @@ export function SideMenu({ user, project, organization, organizations }: SideMen
         </div>
       </div>
     </div>
-  );
-}
-
-function HelpAndFeedback() {
-  const [isHelpMenuOpen, setHelpMenuOpen] = useState(false);
-  const currentPlan = useCurrentPlan();
-
-  return (
-    <Popover onOpenChange={(open) => setHelpMenuOpen(open)}>
-      <PopoverSideMenuTrigger isOpen={isHelpMenuOpen} shortcut={{ key: "h" }}>
-        <div className="flex items-center gap-1.5">
-          <ChatBubbleLeftEllipsisIcon className="size-4 text-success" />
-          Help & Feedback
-        </div>
-      </PopoverSideMenuTrigger>
-      <PopoverContent
-        className="min-w-[14rem] divide-y divide-grid-bright overflow-y-auto p-0 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600"
-        align="start"
-      >
-        <Fragment>
-          <div className="flex flex-col gap-1 p-1">
-            <SideMenuItem
-              name="Documentation"
-              icon="docs"
-              trailingIcon={ArrowUpRightIcon}
-              trailingIconClassName="text-text-dimmed"
-              inactiveIconColor="text-green-500"
-              activeIconColor="text-green-500"
-              to="https://trigger.dev/docs"
-              data-action="documentation"
-              target="_blank"
-            />
-          </div>
-          <div className="flex flex-col gap-1 p-1">
-            <SideMenuItem
-              name="Status"
-              icon={SignalIcon}
-              trailingIcon={ArrowUpRightIcon}
-              trailingIconClassName="text-text-dimmed"
-              inactiveIconColor="text-green-500"
-              activeIconColor="text-green-500"
-              to="https://status.trigger.dev/"
-              data-action="status"
-              target="_blank"
-            />
-            <SideMenuItem
-              name="Suggest a feature"
-              icon={LightBulbIcon}
-              trailingIcon={ArrowUpRightIcon}
-              trailingIconClassName="text-text-dimmed"
-              inactiveIconColor="text-sun-500"
-              activeIconColor="text-sun-500"
-              to="https://feedback.trigger.dev/"
-              data-action="suggest-a-feature"
-              target="_blank"
-            />
-            <SideMenuItem
-              name="Changelog"
-              icon="star"
-              trailingIcon={ArrowUpRightIcon}
-              trailingIconClassName="text-text-dimmed"
-              inactiveIconColor="text-sun-500"
-              activeIconColor="text-sun-500"
-              to="https://trigger.dev/changelog"
-              data-action="changelog"
-              target="_blank"
-            />
-          </div>
-          <div className="flex flex-col gap-1 p-1">
-            <Paragraph className="pb-1 pl-1.5 pt-1.5 text-xs">Need help?</Paragraph>
-            {currentPlan?.v3Subscription?.plan?.limits.support === "slack" && (
-              <div>
-                <Dialog>
-                  <DialogTrigger asChild>
-                    <Button
-                      variant="small-menu-item"
-                      LeadingIcon={SlackIcon}
-                      data-action="join-our-slack"
-                      fullWidth
-                      textAlignLeft
-                    >
-                      <div className="flex w-full items-center justify-between">
-                        <span className="text-text-bright">Join our Slack…</span>
-                        <MenuCount count="PRO" />
-                      </div>
-                    </Button>
-                  </DialogTrigger>
-                  <DialogContent>
-                    <DialogHeader>Join our Slack</DialogHeader>
-                    <div className="mt-2 flex flex-col gap-4">
-                      <div className="flex items-center gap-4">
-                        <Icon icon={SlackIcon} className="h-10 w-10 min-w-[2.5rem]" />
-                        <Paragraph variant="base/bright">
-                          As a subscriber, you have access to a dedicated Slack channel for 1-to-1
-                          support with the Trigger.dev team.
-                        </Paragraph>
-                      </div>
-                      <hr className="border-charcoal-800" />
-                      <div>
-                        <StepNumber stepNumber="1" title="Email us" />
-                        <StepContentContainer>
-                          <Paragraph>
-                            Send us an email to this address from your Trigger.dev account email
-                            address:
-                            <ClipboardField
-                              variant="secondary/medium"
-                              value="priority-support@trigger.dev"
-                              className="my-2"
-                            />
-                          </Paragraph>
-                        </StepContentContainer>
-                        <StepNumber stepNumber="2" title="Look out for an invite from Slack" />
-                        <StepContentContainer>
-                          <Paragraph>
-                            As soon as we can, we'll setup a Slack Connect channel and say hello!
-                          </Paragraph>
-                        </StepContentContainer>
-                      </div>
-                    </div>
-                  </DialogContent>
-                </Dialog>
-              </div>
-            )}
-            <SideMenuItem
-              name="Ask in our Discord"
-              icon={DiscordIcon}
-              trailingIcon={ArrowUpRightIcon}
-              trailingIconClassName="text-text-dimmed"
-              to="https://trigger.dev/discord"
-              data-action="join our discord"
-              target="_blank"
-            />
-            <SideMenuItem
-              name="Book a 15 min call"
-              icon={CalendarDaysIcon}
-              trailingIcon={ArrowUpRightIcon}
-              trailingIconClassName="text-text-dimmed"
-              inactiveIconColor="text-rose-500"
-              activeIconColor="text-rose-500"
-              to="https://cal.com/team/triggerdotdev/founders-call"
-              data-action="book-a-call"
-              target="_blank"
-            />
-            <Feedback
-              button={
-                <Button
-                  variant="small-menu-item"
-                  LeadingIcon={EnvelopeIcon}
-                  leadingIconClassName="text-blue-500"
-                  data-action="contact-us"
-                  fullWidth
-                  textAlignLeft
-                >
-                  Contact us…
-                </Button>
-              }
-            />
-          </div>
-        </Fragment>
-      </PopoverContent>
-    </Popover>
   );
 }
 


### PR DESCRIPTION
- Added the new Help & Feedback menu to the Accounts page
- Moved the Help & Feedback component to a new file as it's accessed in 2 routes now
- Tweaked the height of the Back to Account button so it aligns with the header

![CleanShot 2024-11-19 at 09 06 53@2x](https://github.com/user-attachments/assets/f14765eb-8477-4459-987b-20f3c9e3e353)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `HelpAndFeedback` component for improved access to support options.
	- Consolidated help and feedback resources into a single popover menu.
- **Bug Fixes**
	- Removed outdated links and components for a cleaner navigation experience.
- **Refactor**
	- Streamlined the `SideMenu` layout by integrating the `HelpAndFeedback` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->