### PR TITLE
Deploy page table rows stay selected when the side menu is open

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.deployments/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.deployments/route.tsx
@@ -46,6 +46,7 @@ import {
   DeploymentListPresenter,
 } from "~/presenters/v3/DeploymentListPresenter.server";
 import { requireUserId } from "~/services/session.server";
+import { cn } from "~/utils/cn";
 import {
   ProjectParamSchema,
   docsPath,
@@ -139,8 +140,12 @@ export default function Page() {
                           deployment,
                           currentPage
                         );
+                        const isSelected = deploymentParam === deployment.shortCode;
                         return (
-                          <TableRow key={deployment.id} className="group">
+                          <TableRow
+                            key={deployment.id}
+                            className={cn("group", isSelected ? "bg-grid-dimmed" : undefined)}
+                          >
                             <TableCell to={path}>
                               <div className="flex items-center gap-2">
                                 <Paragraph variant="extra-small">{deployment.shortCode}</Paragraph>


### PR DESCRIPTION
When you click on a table row on the Deployments page to open the side menu, the table row stays selected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced deployment table functionality with improved visual feedback.
	- Selected deployment rows now have distinct background coloring for better clarity.

- **Bug Fixes**
	- Maintained existing error handling and data loading logic, ensuring consistent performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->