### PR TITLE
Stop using Response errors when validating API Keys

### DIFF
--- a/apps/webapp/app/services/apiAuth.server.ts
+++ b/apps/webapp/app/services/apiAuth.server.ts
@@ -71,11 +71,14 @@ export async function authenticateApiRequest(
 export async function authenticateApiRequestWithFailure(
   request: Request,
   options: { allowPublicKey?: boolean; allowJWT?: boolean } = {}
-): Promise<ApiAuthenticationResult | undefined> {
+): Promise<ApiAuthenticationResult> {
   const apiKey = getApiKeyFromRequest(request);
 
   if (!apiKey) {
-    return;
+    return {
+      ok: false,
+      error: "Invalid API Key",
+    };
   }
 
   const authentication = await authenticateApiKeyWithFailure(apiKey, options);

--- a/apps/webapp/app/services/apiRateLimit.server.ts
+++ b/apps/webapp/app/services/apiRateLimit.server.ts
@@ -29,7 +29,7 @@ export const apiRateLimiter = authorizationRateLimitMiddleware({
       allowJWT: true,
     });
 
-    if (!authenticatedEnv) {
+    if (!authenticatedEnv || !authenticatedEnv.ok) {
       return;
     }
 

--- a/apps/webapp/app/v3/handleWebsockets.server.ts
+++ b/apps/webapp/app/v3/handleWebsockets.server.ts
@@ -51,7 +51,7 @@ async function handleWebSocketConnection(ws: WebSocket, req: IncomingMessage) {
 
   const authenticationResult = await authenticateApiKey(apiKey);
 
-  if (!authenticationResult) {
+  if (!authenticationResult || !authenticationResult.ok) {
     ws.close(1008, "Invalid API key");
     return;
   }


### PR DESCRIPTION
Stop using Response errors when validating API Keys, instead introduce a new "Result" type that has success and failure conditions. Adding in a way to progressively adopt because this touches everything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced API authentication logic, providing clearer success and failure states.
	- Improved error handling for API key and JWT validations, returning structured results instead of throwing errors.

- **Bug Fixes**
	- Strengthened authentication checks in the WebSocket server to prevent invalid connections.

- **Documentation**
	- Updated method signatures and types to reflect changes in authentication handling and error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->