### PR TITLE
Fix: Prevent hung worker process on flush exceptions

### DIFF
--- a/.changeset/ninety-teachers-fold.md
+++ b/.changeset/ninety-teachers-fold.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Prevent certain log statements from hanging deployed worker processes

--- a/packages/cli-v3/src/executions/taskRunProcess.ts
+++ b/packages/cli-v3/src/executions/taskRunProcess.ts
@@ -84,7 +84,7 @@ export class TaskRunProcess {
     try {
       await this.#flush();
     } catch (err) {
-      logger.error("Error flushing task run process", { err });
+      console.error("Error flushing task run process", { err });
     }
 
     await this.kill();
@@ -94,7 +94,7 @@ export class TaskRunProcess {
     try {
       await this.#flush();
     } catch (err) {
-      logger.error("Error flushing task run process", { err });
+      console.error("Error flushing task run process", { err });
     }
 
     if (kill) {

--- a/packages/cli-v3/src/utilities/logger.ts
+++ b/packages/cli-v3/src/utilities/logger.ts
@@ -58,7 +58,9 @@ export class Logger {
   };
   info = (...args: unknown[]) => this.doLog("info", args);
   log = (...args: unknown[]) => this.doLog("log", args);
+  /** @deprecated **ONLY USE THIS IN THE CLI** - It will hang the process when used in deployed code (!) */
   warn = (...args: unknown[]) => this.doLog("warn", args);
+  /** @deprecated **ONLY USE THIS IN THE CLI** - It will hang the process when used in deployed code (!) */
   error = (...args: unknown[]) => this.doLog("error", args);
   table<Keys extends string>(data: TableRow<Keys>[], level?: Exclude<LoggerLevel, "none">) {
     const keys: Keys[] = data.length === 0 ? [] : (Object.keys(data[0]!) as Keys[]);


### PR DESCRIPTION
The CLI logger uses a special esbuild formatting function that forces async code to become synchronous using worker threads. That approach is incompatible with deployed workers and could cause the worker process to hang, becoming completely unresponsive. Two affected log statements were found, both called if errors are thrown when flushing usage, tracing, and metadata.

**This only affected two methods of the internal CLI logger, which is not called by any user-facing logging functions.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where specific log statements could cause deployed worker processes to hang.

- **New Features**
  - Introduced deprecation notices for `warn` and `error` methods in the Logger class, indicating their restricted use in deployed code to prevent process hangs.

- **Style**
  - Updated method signatures in the Logger class to include deprecation comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->