### PR TITLE
Show "root" runs by default, save the preference to a cookie

### DIFF
--- a/apps/webapp/app/components/primitives/Switch.tsx
+++ b/apps/webapp/app/components/primitives/Switch.tsx
@@ -16,7 +16,7 @@ const variations = {
       "flex items-center h-[1.5rem] gap-x-1.5 rounded hover:bg-tertiary disabled:hover:bg-transparent pr-1 py-[0.1rem] pl-1.5 transition focus-custom disabled:hover:text-charcoal-400 disabled:opacity-50 text-charcoal-400 hover:text-charcoal-200 disabled:hover:cursor-not-allowed hover:cursor-pointer",
     root: "h-3 w-6",
     thumb: "h-2.5 w-2.5 data-[state=checked]:translate-x-2.5 data-[state=unchecked]:translate-x-0",
-    text: "text-xs transition",
+    text: "text-xs",
   },
 };
 

--- a/apps/webapp/app/components/runs/v3/RunFilters.tsx
+++ b/apps/webapp/app/components/runs/v3/RunFilters.tsx
@@ -99,7 +99,7 @@ export const TaskRunListSearchFilters = z.object({
   bulkId: z.string().optional(),
   from: z.coerce.number().optional(),
   to: z.coerce.number().optional(),
-  showChildTasks: z.coerce.boolean().optional(),
+  rootOnly: z.coerce.boolean().optional(),
   batchId: z.string().optional(),
   runId: z.string().optional(),
   scheduleId: z.string().optional(),
@@ -119,6 +119,7 @@ type RunFiltersProps = {
     type: BulkActionType;
     createdAt: Date;
   }[];
+  rootOnlyDefault: boolean;
   hasFilters: boolean;
 };
 
@@ -141,16 +142,12 @@ export function RunsFilters(props: RunFiltersProps) {
   return (
     <div className="flex flex-row flex-wrap items-center gap-1">
       <FilterMenu {...props} />
-      <ShowChildTasksToggle />
+      <RootOnlyToggle defaultValue={props.rootOnlyDefault} />
       <AppliedFilters {...props} />
       {hasFilters && (
         <Form className="h-6">
-          {searchParams.has("showChildTasks") && (
-            <input
-              type="hidden"
-              name="showChildTasks"
-              value={searchParams.get("showChildTasks") as string}
-            />
+          {searchParams.has("rootOnly") && (
+            <input type="hidden" name="rootOnly" value={searchParams.get("rootOnly") as string} />
           )}
           <Button variant="minimal/small" LeadingIcon={TrashIcon}>
             Clear all
@@ -707,26 +704,27 @@ function AppliedTagsFilter() {
   );
 }
 
-function ShowChildTasksToggle() {
-  const { value, replace } = useSearchParams();
-
-  const showChildTasks = value("showChildTasks") === "true";
+function RootOnlyToggle({ defaultValue }: { defaultValue: boolean }) {
+  const { value, values, replace } = useSearchParams();
+  const searchValue = value("rootOnly");
+  const rootOnly = searchValue !== undefined ? searchValue === "true" : defaultValue;
 
   const batchId = value("batchId");
   const runId = value("runId");
   const scheduleId = value("scheduleId");
+  const tasks = values("tasks");
 
-  const disabled = !!batchId || !!runId || !!scheduleId;
+  const disabled = !!batchId || !!runId || !!scheduleId || tasks.length > 0;
 
   return (
     <Switch
       disabled={disabled}
       variant="small"
-      label="Show child runs"
-      checked={disabled ? true : showChildTasks}
+      label="Root only"
+      checked={disabled ? false : rootOnly}
       onCheckedChange={(checked) => {
         replace({
-          showChildTasks: checked ? "true" : undefined,
+          rootOnly: checked ? "true" : "false",
         });
       }}
     />

--- a/apps/webapp/app/presenters/v3/RunListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/RunListPresenter.server.ts
@@ -183,7 +183,7 @@ export class RunListPresenter extends BasePresenter {
     }
 
     //show all runs if we are filtering by batchId or runId
-    if (batchId || runId || scheduleId) {
+    if (batchId || runId || scheduleId || tasks?.length) {
       rootOnly = false;
     }
 

--- a/apps/webapp/app/services/preferences/uiPreferences.server.ts
+++ b/apps/webapp/app/services/preferences/uiPreferences.server.ts
@@ -27,3 +27,18 @@ export async function setUsefulLinksPreference(show: boolean, request: Request) 
   session.set("showUsefulLinks", show);
   return session;
 }
+
+export async function getRootOnlyFilterPreference(request: Request): Promise<boolean> {
+  const session = await getUiPreferencesSession(request);
+  const rootOnly = session.get("rootOnly");
+  if (rootOnly === undefined) {
+    return false;
+  }
+  return rootOnly;
+}
+
+export async function setRootOnlyFilterPreference(rootOnly: boolean, request: Request) {
+  const session = await getUiPreferencesSession(request);
+  session.set("rootOnly", rootOnly);
+  return session;
+}


### PR DESCRIPTION
With this PR we show "root" runs by default on the Runs page. When you toggle the switch it saves to a cookie.

This is the opposite behaviour that we introduced yesterday, but it was confusing people.

Also, if you filter by tasks it disables the switch and shows all runs that match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a "Root Only" filter for task runs, allowing users to focus on root tasks.
	- Added functionality to save and retrieve user preferences for the "Root Only" filter.

- **Improvements**
	- Updated UI components to reflect the new "Root Only" filter, enhancing the user experience.
	- Streamlined filtering logic to improve task run management.

- **Bug Fixes**
	- Adjusted filter handling to ensure accurate task display based on user preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->