### PR TITLE
Fix Handling of Keys with Periods in flattenAttributes and unflattenAttributes

### DIFF
--- a/packages/core/src/v3/utils/flattenAttributes.ts
+++ b/packages/core/src/v3/utils/flattenAttributes.ts
@@ -132,7 +132,7 @@ export function unflattenAttributes(
     }, [] as (string | number)[])
     .map(unescapeKey); // Unescape keys
    }
-   );
+   
 
     let current: any = result;
     for (let i = 0; i < parts.length - 1; i++) {

--- a/packages/core/src/v3/utils/flattenAttributes.ts
+++ b/packages/core/src/v3/utils/flattenAttributes.ts
@@ -118,26 +118,21 @@ export function unflattenAttributes(
   const result: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(obj)) {
-    const parts = key
-    .split(/(?<!\\)\./) // Split by unescaped dots
-    .map(unescapeKey)   // Unescape keys
-    .reduce((acc, part) => {
-        if (part.startsWith("[") && part.endsWith("]")) {
-          // Handle array indices more precisely
-          const match = part.match(/^\[(\d+)\]$/);
-          if (match && match[1]) {
-            acc.push(parseInt(match[1]));
-          } else {
-            // Remove brackets for non-numeric array keys
-            acc.push(part.slice(1, -1));
-          }
-        } else {
-          acc.push(part);
-        }
-        return acc;
-      },
-      [] as (string | number)[]
-    );
+  const parts = key
+    .split('.') // Split by all dots
+    .reduce((acc, part, i, arr) => {
+      // If the previous part ends with an odd number of backslashes,
+      // the dot is escaped and should be part of the last segment.
+      if (i > 0 && arr[i - 1].match(/\\+$/)?.[0]?.length % 2 === 1) {
+        acc[acc.length - 1] += '.' + part;
+      } else {
+        acc.push(part);
+      }
+      return acc;
+    }, [] as (string | number)[])
+    .map(unescapeKey); // Unescape keys
+   }
+   );
 
     let current: any = result;
     for (let i = 0; i < parts.length - 1; i++) {


### PR DESCRIPTION

This pull request addresses an issue where keys containing periods (.) were misinterpreted as nested object keys during the flattening and unflattening process.
Changes Implemented:
 Key Escaping Logic:
Implemented functions to escape periods (.) in keys during flattening (escapeDots) and to unescape them during unflattening 
(unescapeDots). Ensures that keys with periods are treated as literal keys rather than paths to nested properties.

Issue Resolved: #1510 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced functions for improved handling of keys containing dots during attribute processing.
- **Bug Fixes**
	- Enhanced key processing in flattening and unflattening attributes to prevent key collisions and misinterpretations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->