### PR TITLE
Multiple streams can now be consumed at the same time

### DIFF
--- a/.changeset/modern-nails-refuse.md
+++ b/.changeset/modern-nails-refuse.md
@@ -1,5 +1,5 @@
 ---
-"@trigger.dev/sdk": patch
+"@trigger.dev/core": patch
 ---
 
 Multiple streams can now be consumed simultaneously

--- a/.changeset/modern-nails-refuse.md
+++ b/.changeset/modern-nails-refuse.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+Multiple streams can now be consumed simultaneously

--- a/packages/core/src/v3/apiClient/runStream.ts
+++ b/packages/core/src/v3/apiClient/runStream.ts
@@ -8,6 +8,7 @@ import {
   IOPacket,
   parsePacket,
 } from "../utils/ioSerialization.js";
+import { ApiError } from "./errors.js";
 import { ApiClient } from "./index.js";
 import { AsyncIterableStream, createAsyncIterableStream, zodShapeStream } from "./stream.js";
 import { EventSourceParserStream } from "eventsource-parser/stream";
@@ -119,6 +120,15 @@ export class SSEStreamSubscription implements StreamSubscription {
       },
       signal: this.options.signal,
     }).then((response) => {
+      if (!response.ok) {
+        throw ApiError.generate(
+          response.status,
+          {},
+          "Could not subscribe to stream",
+          Object.fromEntries(response.headers)
+        );
+      }
+
       if (!response.body) {
         throw new Error("No response body");
       }

--- a/packages/core/test/runStream.test.ts
+++ b/packages/core/test/runStream.test.ts
@@ -9,17 +9,23 @@ import {
 import type { SubscribeRunRawShape } from "../src/v3/schemas/api.js";
 
 // Test implementations
+// Update TestStreamSubscription to return a ReadableStream
 class TestStreamSubscription implements StreamSubscription {
   constructor(private chunks: unknown[]) {}
 
-  async subscribe(onChunk: (chunk: unknown) => Promise<void>): Promise<() => void> {
-    for (const chunk of this.chunks) {
-      await onChunk(chunk);
-    }
-    return () => {};
+  async subscribe(): Promise<ReadableStream<unknown>> {
+    return new ReadableStream({
+      start: async (controller) => {
+        for (const chunk of this.chunks) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+    });
   }
 }
 
+// TestStreamSubscriptionFactory can remain the same
 class TestStreamSubscriptionFactory implements StreamSubscriptionFactory {
   private streams = new Map<string, unknown[]>();
 

--- a/scripts/publish-prerelease.sh
+++ b/scripts/publish-prerelease.sh
@@ -36,9 +36,17 @@ else
 fi
 
 # Run your commands
-
+# Run changeset version command and capture its output
 echo "Running: pnpm exec changeset version --snapshot $version"
-pnpm exec changeset version --snapshot $version
+if output=$(pnpm exec changeset version --snapshot $version 2>&1); then
+    if echo "$output" | grep -q "No unreleased changesets found"; then
+        echo "No unreleased changesets found. Exiting."
+        exit 0
+    fi
+else
+    echo "Error running changeset version command"
+    exit 1
+fi
 
 echo "Running: pnpm run build --filter \"@trigger.dev/*\" --filter \"trigger.dev\""
 pnpm run build --filter "@trigger.dev/*" --filter "trigger.dev"


### PR DESCRIPTION
Previously subscribing to a single realtime stream would block other run updates and streams from being consumed, this update fixes it so multiple streams can be consumed at once and they don't block the run updates from being consumed.