### PR TITLE
Fix: Extract the correct SDK version during build

### DIFF
--- a/.changeset/fuzzy-doors-know.md
+++ b/.changeset/fuzzy-doors-know.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Fix SDK version in build manifest for out-of-sync detection

--- a/apps/webapp/app/presenters/v3/DeploymentPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/DeploymentPresenter.server.ts
@@ -108,6 +108,7 @@ export class DeploymentPresenter {
               },
             },
             sdkVersion: true,
+            cliVersion: true,
           },
         },
         triggeredBy: {
@@ -145,6 +146,7 @@ export class DeploymentPresenter {
         },
         deployedBy: deployment.triggeredBy,
         sdkVersion: deployment.worker?.sdkVersion,
+        cliVersion: deployment.worker?.cliVersion,
         imageReference: deployment.imageReference,
         externalBuildData:
           externalBuildData && externalBuildData.success ? externalBuildData.data : undefined,

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.deployments.$deploymentParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.v3.$projectParam.deployments.$deploymentParam/route.tsx
@@ -152,6 +152,10 @@ export default function Page() {
               <Property.Value>{deployment.sdkVersion ? deployment.sdkVersion : "–"}</Property.Value>
             </Property.Item>
             <Property.Item>
+              <Property.Label>CLI Version</Property.Label>
+              <Property.Value>{deployment.cliVersion ? deployment.cliVersion : "–"}</Property.Value>
+            </Property.Item>
+            <Property.Item>
               <Property.Label>Started at</Property.Label>
               <Property.Value>
                 <DateTimeAccurate date={deployment.createdAt} /> UTC


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added "CLI Version" display in deployment details for enhanced visibility.
  - Integrated SDK version extraction into the build process for better version management.

- **Bug Fixes**
  - Updated SDK version in the build manifest to ensure compatibility.

- **Refactor**
  - Enhanced the `DeploymentPresenter` to include CLI version in deployment responses.

- **Chores**
  - Updated plugin handling in the build worker to streamline SDK version integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->