### PR TITLE
Fix cancelled runs breaking realtime subscriptions

### DIFF
--- a/.changeset/shaggy-donkeys-hammer.md
+++ b/.changeset/shaggy-donkeys-hammer.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Fix an issue that caused errors when using realtime with a run that is cancelled

--- a/packages/core/src/v3/apiClient/runStream.ts
+++ b/packages/core/src/v3/apiClient/runStream.ts
@@ -1,4 +1,5 @@
 import { DeserializedJson } from "../../schemas/json.js";
+import { createJsonErrorObject } from "../errors.js";
 import { RunStatus, SubscribeRunRawShape } from "../schemas/api.js";
 import { SerializedError } from "../schemas/common.js";
 import { AnyRunTypes, AnyTask, InferRunTypes } from "../types/tasks.js";
@@ -347,7 +348,7 @@ export class RunSubscription<TRunTypes extends AnyRunTypes> {
       startedAt: row.startedAt ?? undefined,
       delayedUntil: row.delayUntil ?? undefined,
       queuedAt: row.queuedAt ?? undefined,
-      error: row.error ?? undefined,
+      error: row.error ? createJsonErrorObject(row.error) : undefined,
       isTest: row.isTest,
       metadata,
     } as RunShape<TRunTypes>;

--- a/packages/core/src/v3/schemas/api.ts
+++ b/packages/core/src/v3/schemas/api.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { DeserializedJsonSchema } from "../../schemas/json.js";
-import { SerializedError } from "./common.js";
+import { SerializedError, TaskRunError } from "./common.js";
 import { BackgroundWorkerMetadata } from "./resources.js";
 import { QueueOptions } from "./schemas.js";
 
@@ -708,7 +708,7 @@ export const SubscribeRunRawShape = z.object({
   output: z.string().nullish(),
   outputType: z.string().nullish(),
   runTags: z.array(z.string()).nullish().default([]),
-  error: SerializedError.nullish(),
+  error: TaskRunError.nullish(),
 });
 
 export type SubscribeRunRawShape = z.infer<typeof SubscribeRunRawShape>;

--- a/references/nextjs-realtime/src/trigger/example.ts
+++ b/references/nextjs-realtime/src/trigger/example.ts
@@ -15,7 +15,12 @@ export const exampleTask = schemaTask({
 
     metadata.set("status", { type: "started", progress: 0.1 });
 
-    await setTimeout(2000);
+    if (Math.random() < 0.9) {
+      // Simulate a failure
+      throw new Error("Random failure");
+    }
+
+    await setTimeout(20000);
 
     metadata.set("status", { type: "processing", progress: 0.5 });
 


### PR DESCRIPTION
This fixes an issue with cancelled runs and other runs in an error state that would cause realtime to throw an error because we weren't using the correct schema for the `error` column. I've also made setting the final run status and error atomic to prevent realtime from closing the subscription too early.