### PR TITLE
Better error handling for failed emails

### DIFF
--- a/internal-packages/emails/src/index.tsx
+++ b/internal-packages/emails/src/index.tsx
@@ -127,13 +127,20 @@ export class EmailClient {
 
   async #sendEmail({ to, subject, react }: { to: string; subject: string; react: ReactElement }) {
     if (this.#client) {
-      await this.#client.emails.send({
+      const result = await this.#client.emails.send({
         from: this.#from,
         to,
         reply_to: this.#replyTo,
         subject,
         react,
       });
+
+      if (result.error) {
+        console.error(
+          `Failed to send email to ${to}, ${subject}. Error ${result.error.name}: ${result.error.message}`
+        );
+        throw new EmailError(result.error);
+      }
 
       return;
     }
@@ -145,5 +152,13 @@ ${render(react, {
   plainText: true,
 })}
     `);
+  }
+}
+
+//EmailError type where you can set the name and message
+export class EmailError extends Error {
+  constructor({ name, message }: { name: string; message: string }) {
+    super(message);
+    this.name = name;
   }
 }


### PR DESCRIPTION
If we got an email back from our email provider we weren't propagating that error back up, causing a retry. Their SDK changed to not throw errors at some point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a custom error handling mechanism for email sending operations.
	- Added a new `EmailError` class to enhance error clarity.

- **Bug Fixes**
	- Improved error handling during email sending to prevent unhandled exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->