### PR TITLE
Fix: Prevent some attempt creation retries from causing system failures

### DIFF
--- a/apps/webapp/app/v3/handleSocketIo.server.ts
+++ b/apps/webapp/app/v3/handleSocketIo.server.ts
@@ -207,6 +207,7 @@ function createCoordinatorNamespace(io: Server) {
           const payload = await sharedQueueTasks.getExecutionPayloadFromAttempt({
             id: attempt.id,
             setToExecuting: true,
+            skipStatusChecks: true,
           });
 
           if (!payload) {


### PR DESCRIPTION
If lazy attempt creation and payload retrieval failed after the attempt status was already set to `EXECUTING`, the retry would previously fail due to status checks.