### PR TITLE
Alert emails now contain the Org name

### DIFF
--- a/apps/webapp/app/v3/services/alerts/deliverAlert.server.ts
+++ b/apps/webapp/app/v3/services/alerts/deliverAlert.server.ts
@@ -219,6 +219,7 @@ export class DeliverAlertService extends BaseService {
             environment: alert.environment.slug,
             error: createJsonErrorObject(taskRunError),
             attemptLink: `${env.APP_ORIGIN}/projects/v3/${alert.project.externalRef}/runs/${alert.taskRunAttempt.taskRun.friendlyId}`,
+            organization: alert.project.organization.title,
           });
         } else {
           logger.error("[DeliverAlert] Task run attempt not found", {
@@ -244,6 +245,7 @@ export class DeliverAlertService extends BaseService {
             environment: alert.environment.slug,
             error: createJsonErrorObject(taskRunError),
             runLink: `${env.APP_ORIGIN}/projects/v3/${alert.project.externalRef}/runs/${alert.taskRun.friendlyId}`,
+            organization: alert.project.organization.title,
           });
         } else {
           logger.error("[DeliverAlert] Task run not found", {
@@ -276,6 +278,7 @@ export class DeliverAlertService extends BaseService {
             failedAt: alert.workerDeployment.failedAt ?? new Date(),
             error: preparedError,
             deploymentLink: `${env.APP_ORIGIN}/projects/v3/${alert.project.externalRef}/deployments/${alert.workerDeployment.shortCode}`,
+            organization: alert.project.organization.title,
           });
         } else {
           logger.error("[DeliverAlert] Worker deployment not found", {
@@ -296,6 +299,7 @@ export class DeliverAlertService extends BaseService {
             deployedAt: alert.workerDeployment.deployedAt ?? new Date(),
             deploymentLink: `${env.APP_ORIGIN}/projects/v3/${alert.project.externalRef}/deployments/${alert.workerDeployment.shortCode}`,
             taskCount: alert.workerDeployment.worker?.tasks.length ?? 0,
+            organization: alert.project.organization.title,
           });
         } else {
           logger.error("[DeliverAlert] Worker deployment not found", {

--- a/internal-packages/emails/emails/alert-attempt-failure.tsx
+++ b/internal-packages/emails/emails/alert-attempt-failure.tsx
@@ -27,6 +27,7 @@ export const AlertAttemptEmailSchema = z.object({
     stackTrace: z.string().optional(),
   }),
   attemptLink: z.string().url(),
+  organization: z.string(),
 });
 
 const previewDefaults = {
@@ -44,7 +45,16 @@ const previewDefaults = {
 };
 
 export default function Email(props: z.infer<typeof AlertAttemptEmailSchema>) {
-  const { taskIdentifier, fileName, exportName, version, environment, error, attemptLink } = {
+  const {
+    taskIdentifier,
+    fileName,
+    exportName,
+    version,
+    environment,
+    error,
+    attemptLink,
+    organization,
+  } = {
     ...previewDefaults,
     ...props,
   };
@@ -52,7 +62,7 @@ export default function Email(props: z.infer<typeof AlertAttemptEmailSchema>) {
   return (
     <Html>
       <Head />
-      <Preview>{`[${version}.${environment} ${taskIdentifier}] ${error.message}`}</Preview>
+      <Preview>{`${organization}: [${version}.${environment} ${taskIdentifier}] ${error.message}`}</Preview>
       <Body style={main}>
         <Container style={container}>
           <Text style={h1}>There's been an error on `{taskIdentifier}`</Text>
@@ -61,6 +71,7 @@ export default function Email(props: z.infer<typeof AlertAttemptEmailSchema>) {
           <Text style={paragraphTight}>Function: {exportName}()</Text>
           <Text style={paragraphTight}>Version: {version}</Text>
           <Text style={paragraphTight}>Environment: {environment}</Text>
+          <Text style={paragraphTight}>Organization: {organization}</Text>
 
           <Text style={paragraphLight}>{error.message}</Text>
           {error.stackTrace && (

--- a/internal-packages/emails/emails/alert-run-failure.tsx
+++ b/internal-packages/emails/emails/alert-run-failure.tsx
@@ -30,6 +30,7 @@ export const AlertRunEmailSchema = z.object({
     stackTrace: z.string().optional(),
   }),
   runLink: z.string().url(),
+  organization: z.string(),
 });
 
 type AlertRunEmailProps = z.infer<typeof AlertRunEmailSchema>;
@@ -49,6 +50,7 @@ const previewDefaults: AlertRunEmailProps = {
     stackTrace: "Error stack trace",
   },
   runLink: "https://trigger.dev",
+  organization: "my-organization",
 };
 
 export default function Email(props: AlertRunEmailProps) {
@@ -62,6 +64,7 @@ export default function Email(props: AlertRunEmailProps) {
     environment,
     error,
     runLink,
+    organization,
   } = {
     ...previewDefaults,
     ...props,
@@ -70,10 +73,11 @@ export default function Email(props: AlertRunEmailProps) {
   return (
     <Html>
       <Head />
-      <Preview>{`[${version}.${environment} ${taskIdentifier}] ${error.message}`}</Preview>
+      <Preview>{`${organization}: [${version}.${environment} ${taskIdentifier}] ${error.message}`}</Preview>
       <Body style={main}>
         <Container style={container}>
           <Text style={h1}>Run `{runId}` failed</Text>
+          <Text style={paragraphTight}>Organization: {organization}</Text>
           <Text style={paragraphTight}>Project: {project}</Text>
           <Text style={paragraphTight}>Task ID: {taskIdentifier}</Text>
           <Text style={paragraphTight}>Filename: {fileName}</Text>

--- a/internal-packages/emails/emails/deployment-failure.tsx
+++ b/internal-packages/emails/emails/deployment-failure.tsx
@@ -18,6 +18,7 @@ export const AlertDeploymentFailureEmailSchema = z.object({
   email: z.literal("alert-deployment-failure"),
   version: z.string(),
   environment: z.string(),
+  organization: z.string(),
   shortCode: z.string(),
   failedAt: z.date(),
   error: z.object({
@@ -31,6 +32,7 @@ export const AlertDeploymentFailureEmailSchema = z.object({
 const previewDefaults = {
   version: "v1",
   environment: "production",
+  organization: "My Organization",
   shortCode: "abc123",
   failedAt: new Date().toISOString(),
   error: {
@@ -41,7 +43,7 @@ const previewDefaults = {
 };
 
 export default function Email(props: z.infer<typeof AlertDeploymentFailureEmailSchema>) {
-  const { version, environment, shortCode, failedAt, error, deploymentLink } = {
+  const { version, environment, organization, shortCode, failedAt, error, deploymentLink } = {
     ...previewDefaults,
     ...props,
   };
@@ -49,7 +51,7 @@ export default function Email(props: z.infer<typeof AlertDeploymentFailureEmailS
   return (
     <Html>
       <Head />
-      <Preview>{`Deployment ${version} [${environment}] failed: ${error.name}`}</Preview>
+      <Preview>{`[${organization}] Deployment ${version} [${environment}] failed: ${error.name}`}</Preview>
       <Body style={main}>
         <Container style={container}>
           <Text style={h1}>{`An error occurred deploying ${version} in ${environment}`}</Text>

--- a/internal-packages/emails/emails/deployment-success.tsx
+++ b/internal-packages/emails/emails/deployment-success.tsx
@@ -8,6 +8,7 @@ export const AlertDeploymentSuccessEmailSchema = z.object({
   email: z.literal("alert-deployment-success"),
   version: z.string(),
   environment: z.string(),
+  organization: z.string(),
   shortCode: z.string(),
   deployedAt: z.date(),
   taskCount: z.number(),
@@ -17,6 +18,7 @@ export const AlertDeploymentSuccessEmailSchema = z.object({
 const previewDefaults = {
   version: "v1",
   environment: "production",
+  organization: "My Organization",
   shortCode: "abc123",
   deployedAt: new Date().toISOString(),
   taskCount: 3,
@@ -24,7 +26,7 @@ const previewDefaults = {
 };
 
 export default function Email(props: z.infer<typeof AlertDeploymentSuccessEmailSchema>) {
-  const { version, environment, shortCode, deployedAt, taskCount, deploymentLink } = {
+  const { version, environment, organization, shortCode, deployedAt, taskCount, deploymentLink } = {
     ...previewDefaults,
     ...props,
   };
@@ -32,7 +34,7 @@ export default function Email(props: z.infer<typeof AlertDeploymentSuccessEmailS
   return (
     <Html>
       <Head />
-      <Preview>{`Deployment ${version} [${environment}] succeeded`}</Preview>
+      <Preview>{`[${organization}] Deployment ${version} [${environment}] succeeded`}</Preview>
       <Body style={main}>
         <Container style={container}>
           <Text


### PR DESCRIPTION
Added the Org name to the alert emails. This was from a customer with multiple orgs who couldn't tell where the errors were coming from easily.

Org name has been added to: 
- attempt failed email
- run failed email
- deployment failed email
- deployment succeeded email

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added an `organization` property to various email schemas, enhancing email content with organizational context.
	- Updated email previews to include the organization name in the message format for alert attempts, runs, and deployments (both success and failure).
	- Enhanced alert delivery methods to include the organization in notifications sent via email, webhook, and Slack.

- **Bug Fixes**
	- Ensured consistent display of the organization name across all relevant email notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->