### PR TITLE
@trigger.dev/react-hooks now works with React 19

### DIFF
--- a/.changeset/fuzzy-coins-cross.md
+++ b/.changeset/fuzzy-coins-cross.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/react-hooks": patch
+---
+
+Now compatible with React 19

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -51,8 +51,8 @@
     "typescript": "^5.5.4"
   },
   "peerDependencies": {
-    "react": ">=18 || >=19.0.0-beta",
-    "react-dom": ">=18 || >=19.0.0-beta"
+    "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
   },
   "engines": {
     "node": ">=18.20.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1393,10 +1393,10 @@ importers:
         specifier: workspace:^3.3.6
         version: link:../core
       react:
-        specifier: '>=18 || >=19.0.0-beta'
+        specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 18.3.1
       react-dom:
-        specifier: '>=18 || >=19.0.0-beta'
+        specifier: ^18.0 || ^19.0 || ^19.0.0-rc
         version: 18.2.0(react@18.3.1)
       swr:
         specifier: ^2.2.5


### PR DESCRIPTION
For full compat we will need to update `swr` to 2.2.6 when it's released: https://github.com/vercel/swr/issues/3051

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `@trigger.dev/react-hooks` package for compatibility with React 19.
	- Expanded exports to include specific paths for import and require scenarios.

- **Bug Fixes**
	- Adjusted peer dependency versions for `react` and `react-dom` to ensure compatibility with newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->