### PR TITLE
Adds more org names to the alert emails

### DIFF
--- a/internal-packages/emails/emails/deployment-failure.tsx
+++ b/internal-packages/emails/emails/deployment-failure.tsx
@@ -54,7 +54,9 @@ export default function Email(props: z.infer<typeof AlertDeploymentFailureEmailS
       <Preview>{`[${organization}] Deployment ${version} [${environment}] failed: ${error.name}`}</Preview>
       <Body style={main}>
         <Container style={container}>
-          <Text style={h1}>{`An error occurred deploying ${version} in ${environment}`}</Text>
+          <Text
+            style={h1}
+          >{`An error occurred deploying ${version} in ${environment} in your ${organization} organization`}</Text>
           <Text style={paragraphLight}>
             {error.name} {error.message}
           </Text>

--- a/internal-packages/emails/emails/deployment-success.tsx
+++ b/internal-packages/emails/emails/deployment-success.tsx
@@ -39,7 +39,7 @@ export default function Email(props: z.infer<typeof AlertDeploymentSuccessEmailS
         <Container style={container}>
           <Text
             style={h1}
-          >{`Version ${version} successfully deployed ${taskCount} tasks in ${environment}`}</Text>
+          >{`Version ${version} successfully deployed ${taskCount} tasks in ${environment} in your ${organization} organization`}</Text>
 
           <Link
             href={deploymentLink}

--- a/internal-packages/emails/src/index.tsx
+++ b/internal-packages/emails/src/index.tsx
@@ -100,25 +100,25 @@ export class EmailClient {
         };
       case "alert-attempt": {
         return {
-          subject: `Error on ${data.taskIdentifier} [${data.version}.${data.environment}] ${data.error.message}`,
+          subject: `[${data.organization}] Error on ${data.taskIdentifier} [${data.version}.${data.environment}] ${data.error.message}`,
           component: <AlertAttemptFailureEmail {...data} />,
         };
       }
       case "alert-run": {
         return {
-          subject: `Run ${data.runId} failed for ${data.taskIdentifier} [${data.version}.${data.environment}] ${data.error.message}`,
+          subject: `[${data.organization}] Run ${data.runId} failed for ${data.taskIdentifier} [${data.version}.${data.environment}] ${data.error.message}`,
           component: <AlertRunFailureEmail {...data} />,
         };
       }
       case "alert-deployment-failure": {
         return {
-          subject: `Deployment ${data.version} [${data.environment}] failed: ${data.error.name}`,
+          subject: `[${data.organization}] Deployment ${data.version} [${data.environment}] failed: ${data.error.name}`,
           component: <AlertDeploymentFailureEmail {...data} />,
         };
       }
       case "alert-deployment-success": {
         return {
-          subject: `Deployment ${data.version} [${data.environment}] succeeded`,
+          subject: `[${data.organization}] Deployment ${data.version} [${data.environment}] succeeded`,
           component: <AlertDeploymentSuccessEmail {...data} />,
         };
       }


### PR DESCRIPTION
Adding more org name info to the alert emails. 

- Added org name to the subject line
- Added org name to the body of the deploy success and fail emails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced email notifications for deployment successes and failures by including the organization name in the message body.
	- Updated subject lines for email templates to include the organization name for better context.

- **Bug Fixes**
	- Improved clarity in email messages related to deployment outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->