### PR TITLE
Support scopes packages in externals when found in a transitive dep #1552

### DIFF
--- a/.changeset/kind-plants-tap.md
+++ b/.changeset/kind-plants-tap.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Fix externals from monorepo packages with scoped package names #1552

--- a/packages/cli-v3/src/build/externals.ts
+++ b/packages/cli-v3/src/build/externals.ts
@@ -45,6 +45,20 @@ async function linkExternal(external: CollectedExternal, resolveDir: string, log
     external,
   });
 
+  // For scoped packages, we need to ensure the scope directory exists
+  if (external.name.startsWith("@")) {
+    // Get the scope part (e.g., '@huggingface')
+    const scopeDir = external.name.split("/")[0];
+    const scopePath = join(destinationPath, scopeDir);
+
+    logger.debug("[externals] Ensure scope directory exists", {
+      scopeDir,
+      scopePath,
+    });
+
+    await mkdir(scopePath, { recursive: true });
+  }
+
   const symbolicLinkPath = join(destinationPath, external.name);
 
   // Make sure the symbolic link does not exist

--- a/packages/cli-v3/src/build/externals.ts
+++ b/packages/cli-v3/src/build/externals.ts
@@ -49,14 +49,21 @@ async function linkExternal(external: CollectedExternal, resolveDir: string, log
   if (external.name.startsWith("@")) {
     // Get the scope part (e.g., '@huggingface')
     const scopeDir = external.name.split("/")[0];
-    const scopePath = join(destinationPath, scopeDir);
 
-    logger.debug("[externals] Ensure scope directory exists", {
-      scopeDir,
-      scopePath,
-    });
+    if (scopeDir) {
+      const scopePath = join(destinationPath, scopeDir);
 
-    await mkdir(scopePath, { recursive: true });
+      logger.debug("[externals] Ensure scope directory exists", {
+        scopeDir,
+        scopePath,
+      });
+
+      await mkdir(scopePath, { recursive: true });
+    } else {
+      logger.debug("[externals] Unable to get the scope directory", {
+        external,
+      });
+    }
   }
 
   const symbolicLinkPath = join(destinationPath, external.name);


### PR DESCRIPTION
This fixes #1552. The issue turned out to be marking an external dependency with a scoped name (e.g. `@huggingface/transformers`), when it was being imported through another package. This was happening because we create a symlink from the trigger build node_modules dir to the actual location of the dependency (in dev), but that was failing because the `@huggingface` directory didn't exist. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved issues with the handling of scoped packages in the "trigger.dev" configuration.
	- Improved error handling and logging for the creation of symbolic links for scoped packages.

- **New Features**
	- Enhanced functionality to automatically create necessary directories for scoped packages within the `node_modules` path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->