### PR TITLE
Don't expire enqueued runs if they have lockedAt set

### DIFF
--- a/apps/webapp/app/v3/services/expireEnqueuedRun.server.ts
+++ b/apps/webapp/app/v3/services/expireEnqueuedRun.server.ts
@@ -49,6 +49,14 @@ export class ExpireEnqueuedRunService extends BaseService {
       return;
     }
 
+    if (run.lockedAt) {
+      logger.debug("Run cannot be expired because it's locked", {
+        run,
+      });
+
+      return;
+    }
+
     logger.debug("Expiring enqueued run", {
       run,
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for expiring enqueued runs to prevent locked runs from being expired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->