### PR TITLE
fix: add user-agent to the websocket request

### DIFF
--- a/.changeset/pretty-squids-shop.md
+++ b/.changeset/pretty-squids-shop.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+fix: add user-agent to the websocket request

--- a/packages/cli-v3/src/dev/workerRuntime.ts
+++ b/packages/cli-v3/src/dev/workerRuntime.ts
@@ -26,6 +26,7 @@ import { logger } from "../utilities/logger.js";
 import { resolveSourceFiles } from "../utilities/sourceFiles.js";
 import { BackgroundWorker, BackgroundWorkerCoordinator } from "./backgroundWorker.js";
 import { sanitizeEnvVars } from "../utilities/sanitizeEnvVars.js";
+import { VERSION } from "../version.js";
 
 export interface WorkerRuntime {
   shutdown(): Promise<void>;
@@ -325,7 +326,13 @@ class DevWorkerRuntime implements WorkerRuntime {
 function WebsocketFactory(apiKey: string) {
   return class extends wsWebSocket {
     constructor(address: string | URL, options?: ClientOptions | ClientRequestArgs) {
-      super(address, { ...(options ?? {}), headers: { Authorization: `Bearer ${apiKey}` } });
+      super(address, {
+        ...(options ?? {}),
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "User-Agent": `trigger.dev-cli/${VERSION}`,
+        },
+      });
     }
   };
 }


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

The Cloudflare WAF managed rule likes to block requests that are missing a User Agent. We ran into exactly that and were able to mitigate by adding a user agent here! I tested using a patched version and before I would get a WAF block 403, and after everything worked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced websocket connection by adding a user-agent header that includes version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->