### PR TITLE
Fix: handling keys with periods when flattening/unflattening

### DIFF
--- a/packages/core/src/v3/utils/flattenAttributes.ts
+++ b/packages/core/src/v3/utils/flattenAttributes.ts
@@ -3,6 +3,17 @@ import { Attributes } from "@opentelemetry/api";
 export const NULL_SENTINEL = "$@null((";
 export const CIRCULAR_REFERENCE_SENTINEL = "$@circular((";
 
+const DOT = "__DOT__";
+
+function escapeKey(key: string) {
+  return key.replace(/\./g, DOT); // Replace . with __DOT__
+}
+
+function unescapeKey(key: string) {
+  let re = new RegExp(DOT, "g");
+  return key.replace(re, '.'); // Replace __DOT__ back with . (dot)
+}
+
 export function flattenAttributes(
   obj: Record<string, unknown> | Array<unknown> | string | boolean | number | null | undefined,
   prefix?: string ,
@@ -53,7 +64,8 @@ export function flattenAttributes(
 
 
   for (const [key, value] of Object.entries(obj)) {
-    const newPrefix = `${prefix ? `${prefix}.` : ""}${Array.isArray(obj) ? `[${key}]` : key}`;
+    const escapedKey = escapeKey(key);
+    const newPrefix = `${prefix ? `${prefix}.` : ""}${Array.isArray(obj) ? `[${key}]` : escapedKey}`;
     if (Array.isArray(value)) {
       for (let i = 0; i < value.length; i++) {
         if (typeof value[i] === "object" && value[i] !== null) {
@@ -118,10 +130,10 @@ export function unflattenAttributes(
             acc.push(parseInt(match[1]));
           } else {
             // Remove brackets for non-numeric array keys
-            acc.push(part.slice(1, -1));
+            acc.push(unescapeKey(part.slice(1, -1)));
           }
         } else {
-          acc.push(part);
+          acc.push(unescapeKey(part));
         }
         return acc;
       },

--- a/packages/core/test/flattenAttributes.test.ts
+++ b/packages/core/test/flattenAttributes.test.ts
@@ -179,6 +179,38 @@ describe("flattenAttributes", () => {
       "friends.[0]": "$@circular((",
     });
   });
+
+  it("handles . (dot) in keys correctly", () => { 
+    const obj = {
+      "Key 0.002mm": 31.4,
+    };
+    const expected = { "Key 0__DOT__002mm": 31.4 };
+    expect(flattenAttributes(obj)).toEqual(expected);
+    expect(unflattenAttributes(expected)).toEqual(obj);
+
+    const obj2 = {
+      level1: {
+        level2: {
+          value: "test",
+          "level3.key": "value",
+        },
+        array: [1, 2, 3],
+      },
+    };
+    const expected2 = {
+      "level1.level2.value": "test",
+      "level1.level2.level3__DOT__key": "value",
+      "level1.array.[0]": 1,
+      "level1.array.[1]": 2,
+      "level1.array.[2]": 3,
+    };
+    expect(flattenAttributes(obj2)).toEqual(expected2);
+
+    const PI = 3.14159265359;
+    const result = flattenAttributes(PI);
+    expect(result).toEqual({ "": PI });
+    expect(unflattenAttributes(result)).toEqual(PI);
+  });
 });
 
 describe("unflattenAttributes", () => {
@@ -259,5 +291,25 @@ describe("unflattenAttributes", () => {
       name: "Alice",
       blogPosts: [{ title: "Post 1", author: "[Circular Reference]" }],
     });
+  });
+
+  it("handles espacaped . (dot) in keys correctly and returns original object", () => {
+    const flattened = {
+      "level1.level2.value": "test",
+      "level1.level2.level3__DOT__key": "value",
+      "level1.array.[0]": 1,
+      "level1.array.[1]": 2,
+      "level1.array.[2]": 3,
+    };
+    const original = {
+      level1: {
+        level2: {
+          value: "test",
+          "level3.key": "value",
+        },
+        array: [1, 2, 3],
+      },
+    };
+    expect(unflattenAttributes(flattened)).toEqual(original);
   });
 });


### PR DESCRIPTION
Closes #1510 

## ✅ Checklist

- ✅ I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- ✅ The PR title follows the convention.
- ✅ I ran and tested the code works

---

## Description
It addresses the issue- Objects with keys with periods in doesn't render properly.
Eg-
```
{
  "Key 0.002mm": 31.4,
} 
```
Objects like this when unflattening will not become this
```
{
  "Key 0": {
      "002mm": 31.4
  }
}
```
Instead it will be unflattening to its original condition.

## Tests
Tests have been added for this change and all passed successfully.

## Screenshots

<img width="934" alt="Screenshot-tests" src="https://github.com/user-attachments/assets/b3164eb9-4eaa-48a7-b821-38863d5d31e2" />
 
💯


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced key handling in attribute flattening and unflattening processes
	- Added support for keys containing dots without losing structural information

- **Tests**
	- Added comprehensive test cases for handling complex key structures
	- Verified preservation of object structure during flattening and unflattening

<!-- end of auto-generated comment: release notes by coderabbit.ai -->