### PR TITLE
Improve worker deployment queries

### DIFF
--- a/apps/webapp/app/presenters/v3/TestTaskPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/TestTaskPresenter.server.ts
@@ -3,7 +3,10 @@ import { BackgroundWorkerTask, RuntimeEnvironmentType, TaskRunStatus } from "@tr
 import { PrismaClient, prisma, sqlDatabaseSchema } from "~/db.server";
 import { getTimezones } from "~/utils/timezones.server";
 import { getUsername } from "~/utils/username";
-import { findCurrentWorkerDeployment } from "~/v3/models/workerDeployment.server";
+import {
+  BackgroundWorkerTaskSlim,
+  findCurrentWorkerDeployment,
+} from "~/v3/models/workerDeployment.server";
 
 type TestTaskOptions = {
   userId: string;
@@ -113,7 +116,7 @@ export class TestTaskPresenter {
       },
     });
 
-    let task: BackgroundWorkerTask | null = null;
+    let task: BackgroundWorkerTaskSlim | null = null;
     if (environment.type !== "DEVELOPMENT") {
       const deployment = await findCurrentWorkerDeployment(environment.id);
       if (deployment) {

--- a/apps/webapp/app/v3/models/workerDeployment.server.ts
+++ b/apps/webapp/app/v3/models/workerDeployment.server.ts
@@ -8,6 +8,19 @@ export type CurrentWorkerDeployment = Prettify<
   NonNullable<Awaited<ReturnType<typeof findCurrentWorkerDeployment>>>
 >;
 
+export type BackgroundWorkerTaskSlim = Prisma.BackgroundWorkerTaskGetPayload<{
+  select: {
+    id: true;
+    friendlyId: true;
+    slug: true;
+    filePath: true;
+    exportName: true;
+    triggerSource: true;
+    machineConfig: true;
+    maxDurationInSeconds: true;
+  };
+}>;
+
 type WorkerDeploymentWithWorkerTasks = Prisma.WorkerDeploymentGetPayload<{
   select: {
     id: true;
@@ -21,7 +34,18 @@ type WorkerDeploymentWithWorkerTasks = Prisma.WorkerDeploymentGetPayload<{
         sdkVersion: true;
         cliVersion: true;
         supportsLazyAttempts: true;
-        tasks: true;
+        tasks: {
+          select: {
+            id: true;
+            friendlyId: true;
+            slug: true;
+            filePath: true;
+            exportName: true;
+            triggerSource: true;
+            machineConfig: true;
+            maxDurationInSeconds: true;
+          };
+        };
       };
     };
   };

--- a/apps/webapp/app/v3/models/workerDeployment.server.ts
+++ b/apps/webapp/app/v3/models/workerDeployment.server.ts
@@ -9,9 +9,18 @@ export type CurrentWorkerDeployment = Prettify<
 >;
 
 type WorkerDeploymentWithWorkerTasks = Prisma.WorkerDeploymentGetPayload<{
-  include: {
+  select: {
+    id: true;
+    imageReference: true;
+    version: true;
     worker: {
-      include: {
+      select: {
+        id: true;
+        friendlyId: true;
+        version: true;
+        sdkVersion: true;
+        cliVersion: true;
+        supportsLazyAttempts: true;
         tasks: true;
       };
     };
@@ -26,11 +35,20 @@ export async function findCurrentWorkerDeployment(
       environmentId,
       label: CURRENT_DEPLOYMENT_LABEL,
     },
-    include: {
+    select: {
       deployment: {
-        include: {
+        select: {
+          id: true,
+          imageReference: true,
+          version: true,
           worker: {
-            include: {
+            select: {
+              id: true,
+              friendlyId: true,
+              version: true,
+              sdkVersion: true,
+              cliVersion: true,
+              supportsLazyAttempts: true,
               tasks: true,
             },
           },
@@ -44,7 +62,10 @@ export async function findCurrentWorkerDeployment(
 
 export async function findCurrentWorkerFromEnvironment(
   environment: Pick<AuthenticatedEnvironment, "id" | "type">
-): Promise<BackgroundWorker | null> {
+): Promise<Pick<
+  BackgroundWorker,
+  "id" | "friendlyId" | "version" | "sdkVersion" | "cliVersion" | "supportsLazyAttempts"
+> | null> {
   if (environment.type === "DEVELOPMENT") {
     const latestDevWorker = await prisma.backgroundWorker.findFirst({
       where: {

--- a/apps/webapp/app/v3/models/workerDeployment.server.ts
+++ b/apps/webapp/app/v3/models/workerDeployment.server.ts
@@ -21,12 +21,10 @@ type WorkerDeploymentWithWorkerTasks = Prisma.WorkerDeploymentGetPayload<{
 export async function findCurrentWorkerDeployment(
   environmentId: string
 ): Promise<WorkerDeploymentWithWorkerTasks | undefined> {
-  const promotion = await prisma.workerDeploymentPromotion.findUnique({
+  const promotion = await prisma.workerDeploymentPromotion.findFirst({
     where: {
-      environmentId_label: {
-        environmentId,
-        label: CURRENT_DEPLOYMENT_LABEL,
-      },
+      environmentId,
+      label: CURRENT_DEPLOYMENT_LABEL,
     },
     include: {
       deployment: {
@@ -66,7 +64,7 @@ export async function findCurrentWorkerFromEnvironment(
 export async function getWorkerDeploymentFromWorker(
   workerId: string
 ): Promise<WorkerDeploymentWithWorkerTasks | undefined> {
-  const worker = await prisma.backgroundWorker.findUnique({
+  const worker = await prisma.backgroundWorker.findFirst({
     where: {
       id: workerId,
     },
@@ -91,7 +89,7 @@ export async function getWorkerDeploymentFromWorker(
 export async function getWorkerDeploymentFromWorkerTask(
   workerTaskId: string
 ): Promise<WorkerDeploymentWithWorkerTasks | undefined> {
-  const workerTask = await prisma.backgroundWorkerTask.findUnique({
+  const workerTask = await prisma.backgroundWorkerTask.findFirst({
     where: {
       id: workerTaskId,
     },


### PR DESCRIPTION
When dequeuing runs, and in a couple of other places, we get details about the current worker deployment.

These queries were using `findUnique` and includes, which is a VERY BAD thing to do with Prisma because it changes the queries it produces to very bad ones when run concurrently.

Also we were selecting a lot of columns we don't need.

This PR changes to `findFirst` and only selecting relevant columns, for big query performance improvements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Optimization**
	- Refined data retrieval strategy for worker deployments.
	- Optimized data structure for task handling by introducing a slimmer type.
	- Improved data fetching efficiency and reduced unnecessary data transfer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->