### PR TITLE
Throw an error for concurrent waits (with nice docs link)

### DIFF
--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -80,6 +80,21 @@ Your code is deployed separately from the rest of your app(s) so you need to mak
 
 Prisma uses code generation to create the client from your schema file. This means you need to add a bit of config so we can generate this file before your tasks run: [Read the guide](/config/config-file#prisma).
 
+### `Parallel waits are not supported`
+
+In the current version, you can't perform more that one "wait" in parallel.
+
+Waits include:
+- `wait.for()`
+- `wait.until()`
+- `task.triggerAndWait()`
+- `task.batchTriggerAndWait()`
+- And any of our functions with `wait` in the name.
+
+This restriction exists because we suspend the task server after a wait, and resume it when the wait is done. At the moment, if you do more than one wait, the run will never continue when deployed, so we throw this error instead.
+
+The most common situation this happens is if you're using `Promise.all` around some of our wait functions. Instead of doing this use our built-in functions for [triggering tasks](/triggering#triggering-from-inside-another-task). We have functions that allow you to trigger different tasks in parallel.
+
 ### When triggering subtasks the parent task finishes too soon
 
 Make sure that you always use `await` when you call `trigger`, `triggerAndWait`, `batchTrigger`, and `batchTriggerAndWait`. If you don't then it's likely the task(s) won't be triggered because the calling function process can be terminated before the networks calls are sent.

--- a/packages/core/src/v3/errors.ts
+++ b/packages/core/src/v3/errors.ts
@@ -31,6 +31,13 @@ export class TaskPayloadParsedError extends Error {
   }
 }
 
+export class ConcurrentWaitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConcurrentWaitError";
+  }
+}
+
 export function parseError(error: unknown): TaskRunError {
   if (error instanceof Error) {
     return {

--- a/packages/core/src/v3/errors.ts
+++ b/packages/core/src/v3/errors.ts
@@ -12,6 +12,37 @@ import { links } from "./links.js";
 import { ExceptionEventProperties } from "./schemas/openTelemetry.js";
 import { assertExhaustive } from "../utils.js";
 
+/**
+ * If you throw this, it will get converted into an INTERNAL_ERROR
+ */
+export class InternalError extends Error {
+  public readonly code: TaskRunErrorCodes;
+  public readonly skipRetrying: boolean;
+
+  constructor({
+    code,
+    message,
+    showStackTrace = true,
+    skipRetrying = false,
+  }: {
+    code: TaskRunErrorCodes;
+    message?: string;
+    showStackTrace?: boolean;
+    skipRetrying?: boolean;
+  }) {
+    super(`${code}: ${message ?? "No message"}`);
+    this.name = "InternalError";
+    this.code = code;
+    this.message = message ?? "InternalError";
+
+    if (!showStackTrace) {
+      this.stack = undefined;
+    }
+
+    this.skipRetrying = skipRetrying;
+  }
+}
+
 export class AbortTaskRunError extends Error {
   constructor(message: string) {
     super(message);
@@ -31,14 +62,16 @@ export class TaskPayloadParsedError extends Error {
   }
 }
 
-export class ConcurrentWaitError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ConcurrentWaitError";
-  }
-}
-
 export function parseError(error: unknown): TaskRunError {
+  if (error instanceof InternalError) {
+    return {
+      type: "INTERNAL_ERROR",
+      code: error.code,
+      message: error.message,
+      stackTrace: error.stack ?? "",
+    };
+  }
+
   if (error instanceof Error) {
     return {
       type: "BUILT_IN_ERROR",
@@ -175,6 +208,7 @@ export function shouldRetryError(error: TaskRunError): boolean {
         case "DISK_SPACE_EXCEEDED":
         case "TASK_RUN_HEARTBEAT_TIMEOUT":
         case "OUTDATED_SDK_VERSION":
+        case "TASK_DID_CONCURRENT_WAIT":
           return false;
 
         case "GRACEFUL_EXIT_TIMEOUT":
@@ -442,6 +476,14 @@ const prettyInternalErrors: Partial<
     link: {
       name: "Beta upgrade guide",
       href: links.docs.upgrade.beta,
+    },
+  },
+  TASK_DID_CONCURRENT_WAIT: {
+    message:
+      "Parallel waits are not supported, e.g. using Promise.all() around our wait functions.",
+    link: {
+      name: "Read the docs for solutions",
+      href: links.docs.troubleshooting.concurrentWaits,
     },
   },
 };

--- a/packages/core/src/v3/links.ts
+++ b/packages/core/src/v3/links.ts
@@ -12,6 +12,9 @@ export const links = {
     upgrade: {
       beta: "https://trigger.dev/docs/upgrading-beta",
     },
+    troubleshooting: {
+      concurrentWaits: "https://trigger.dev/docs/troubleshooting#parallel-waits-are-not-supported",
+    },
   },
   site: {
     home: "https://trigger.dev",

--- a/packages/core/src/v3/runtime/index.ts
+++ b/packages/core/src/v3/runtime/index.ts
@@ -12,8 +12,16 @@ import { usage } from "../usage-api.js";
 
 const NOOP_RUNTIME_MANAGER = new NoopRuntimeManager();
 
+const concurrentWaitErrorMessage =
+  "Parallel waits are not supported, e.g. using Promise.all() around our wait functions.";
+
+/**
+ * All state must be inside the RuntimeManager, do NOT store it on this class.
+ * This is because of the "dual package hazard", this can be bundled multiple times.
+ */
 export class RuntimeAPI {
   private static _instance?: RuntimeAPI;
+  private isExecutingWait = false;
 
   private constructor() {}
 
@@ -26,15 +34,21 @@ export class RuntimeAPI {
   }
 
   public waitForDuration(ms: number): Promise<void> {
-    return usage.pauseAsync(() => this.#getRuntimeManager().waitForDuration(ms));
+    return this.#preventConcurrentWaits(() =>
+      usage.pauseAsync(() => this.#getRuntimeManager().waitForDuration(ms))
+    );
   }
 
   public waitUntil(date: Date): Promise<void> {
-    return usage.pauseAsync(() => this.#getRuntimeManager().waitUntil(date));
+    return this.#preventConcurrentWaits(() =>
+      usage.pauseAsync(() => this.#getRuntimeManager().waitUntil(date))
+    );
   }
 
   public waitForTask(params: { id: string; ctx: TaskRunContext }): Promise<TaskRunExecutionResult> {
-    return usage.pauseAsync(() => this.#getRuntimeManager().waitForTask(params));
+    return this.#preventConcurrentWaits(() =>
+      usage.pauseAsync(() => this.#getRuntimeManager().waitForTask(params))
+    );
   }
 
   public waitForBatch(params: {
@@ -42,7 +56,9 @@ export class RuntimeAPI {
     runs: string[];
     ctx: TaskRunContext;
   }): Promise<BatchTaskRunExecutionResult> {
-    return usage.pauseAsync(() => this.#getRuntimeManager().waitForBatch(params));
+    return this.#preventConcurrentWaits(() =>
+      usage.pauseAsync(() => this.#getRuntimeManager().waitForBatch(params))
+    );
   }
 
   public setGlobalRuntimeManager(runtimeManager: RuntimeManager): boolean {
@@ -56,5 +72,20 @@ export class RuntimeAPI {
 
   #getRuntimeManager(): RuntimeManager {
     return getGlobal(API_NAME) ?? NOOP_RUNTIME_MANAGER;
+  }
+
+  async #preventConcurrentWaits<T>(cb: () => Promise<T>): Promise<T> {
+    if (this.isExecutingWait) {
+      console.error(concurrentWaitErrorMessage);
+      throw new Error(concurrentWaitErrorMessage);
+    }
+
+    this.isExecutingWait = true;
+
+    try {
+      return await cb();
+    } finally {
+      this.isExecutingWait = false;
+    }
   }
 }

--- a/packages/core/src/v3/runtime/preventMultipleWaits.ts
+++ b/packages/core/src/v3/runtime/preventMultipleWaits.ts
@@ -1,4 +1,5 @@
-import { ConcurrentWaitError } from "../errors.js";
+import { InternalError } from "../errors.js";
+import { TaskRunErrorCodes } from "../schemas/common.js";
 
 const concurrentWaitErrorMessage =
   "Parallel waits are not supported, e.g. using Promise.all() around our wait functions.";
@@ -9,7 +10,12 @@ export function preventMultipleWaits() {
   return async <T>(cb: () => Promise<T>): Promise<T> => {
     if (isExecutingWait) {
       console.error(concurrentWaitErrorMessage);
-      throw new ConcurrentWaitError(concurrentWaitErrorMessage);
+      throw new InternalError({
+        code: TaskRunErrorCodes.TASK_DID_CONCURRENT_WAIT,
+        message: concurrentWaitErrorMessage,
+        skipRetrying: true,
+        showStackTrace: false,
+      });
     }
 
     isExecutingWait = true;

--- a/packages/core/src/v3/runtime/preventMultipleWaits.ts
+++ b/packages/core/src/v3/runtime/preventMultipleWaits.ts
@@ -1,0 +1,23 @@
+import { ConcurrentWaitError } from "../errors.js";
+
+const concurrentWaitErrorMessage =
+  "Parallel waits are not supported, e.g. using Promise.all() around our wait functions.";
+
+export function preventMultipleWaits() {
+  let isExecutingWait = false;
+
+  return async <T>(cb: () => Promise<T>): Promise<T> => {
+    if (isExecutingWait) {
+      console.error(concurrentWaitErrorMessage);
+      throw new ConcurrentWaitError(concurrentWaitErrorMessage);
+    }
+
+    isExecutingWait = true;
+
+    try {
+      return await cb();
+    } finally {
+      isExecutingWait = false;
+    }
+  };
+}

--- a/packages/core/src/v3/schemas/common.ts
+++ b/packages/core/src/v3/schemas/common.ts
@@ -171,6 +171,7 @@ export const TaskRunInternalError = z.object({
     "POD_EVICTED",
     "POD_UNKNOWN_ERROR",
     "OUTDATED_SDK_VERSION",
+    "TASK_DID_CONCURRENT_WAIT",
   ]),
   message: z.string().optional(),
   stackTrace: z.string().optional(),
@@ -179,6 +180,7 @@ export const TaskRunInternalError = z.object({
 export type TaskRunInternalError = z.infer<typeof TaskRunInternalError>;
 
 export const TaskRunErrorCodes = TaskRunInternalError.shape.code.enum;
+export type TaskRunErrorCodes = TaskRunInternalError["code"];
 
 export const TaskRunError = z.discriminatedUnion("type", [
   TaskRunBuiltInError,

--- a/packages/core/src/v3/workers/taskExecutor.ts
+++ b/packages/core/src/v3/workers/taskExecutor.ts
@@ -2,7 +2,7 @@ import { SpanKind } from "@opentelemetry/api";
 import { VERSION } from "../../version.js";
 import { ApiError, RateLimitError } from "../apiClient/errors.js";
 import { ConsoleInterceptor } from "../consoleInterceptor.js";
-import { parseError, sanitizeError, TaskPayloadParsedError } from "../errors.js";
+import { InternalError, parseError, sanitizeError, TaskPayloadParsedError } from "../errors.js";
 import { runMetadata, TriggerConfig, waitUntil } from "../index.js";
 import { recordSpanException, TracingSDK } from "../otel/index.js";
 import {
@@ -538,9 +538,9 @@ export class TaskExecutor {
       error instanceof Error &&
       (error.name === "AbortTaskRunError" ||
         error.name === "TaskPayloadParsedError" ||
-        error.name === "ConcurrentWaitError")
+        ("skipRetrying" in error && error.skipRetrying === true))
     ) {
-      return { status: "skipped" };
+      return { status: "skipped", error: error instanceof InternalError ? error : undefined };
     }
 
     if (execution.run.maxAttempts) {

--- a/packages/core/src/v3/workers/taskExecutor.ts
+++ b/packages/core/src/v3/workers/taskExecutor.ts
@@ -536,7 +536,9 @@ export class TaskExecutor {
 
     if (
       error instanceof Error &&
-      (error.name === "AbortTaskRunError" || error.name === "TaskPayloadParsedError")
+      (error.name === "AbortTaskRunError" ||
+        error.name === "TaskPayloadParsedError" ||
+        error.name === "ConcurrentWaitError")
     ) {
       return { status: "skipped" };
     }

--- a/references/hello-world/src/trigger/parallel-waits.ts
+++ b/references/hello-world/src/trigger/parallel-waits.ts
@@ -1,0 +1,22 @@
+import { logger, task, wait } from "@trigger.dev/sdk/v3";
+import { childTask } from "./example.js";
+
+/*
+ * These aren't currently supported, and so should throw clear errors
+ */
+export const parallelWaits = task({
+  id: "parallel-waits",
+  run: async (payload: any, { ctx }) => {
+    //parallel wait for 5/10 seconds
+    await Promise.all([
+      wait.for({ seconds: 5 }),
+      wait.until({ date: new Date(Date.now() + 10_000) }),
+    ]);
+
+    //parallel task call
+    await Promise.all([
+      childTask.triggerAndWait({ message: "Hello, world!" }),
+      childTask.batchTriggerAndWait([{ payload: { message: "Hello, world!" } }]),
+    ]);
+  },
+});


### PR DESCRIPTION
## Problem

In the current version, you can't perform more that one "wait" in parallel.

Waits include:
- `wait.for()`
- `wait.until()`
- `task.triggerAndWait()`
- `task.batchTriggerAndWait()`
- And any of our functions with `wait` in the name.

This restriction exists because we suspend the task server after a wait, and resume it when the wait is done. At the moment, if you do more than one wait, the run will never continue when deployed, so we throw this error instead.

The most common situation this happens is if you're using `Promise.all` around some of our wait functions. Instead of doing this use our built-in functions for [triggering tasks](/triggering#triggering-from-inside-another-task). We have functions that allow you to trigger different tasks in parallel.

## Solution

Up until now we had some docs about this, but we didn't actually do anything at runtime to stop you doing this.

This PR adds an error when we detect two waits are called simultaneously. It has a link to a new section of our troubleshooting docs.

It also adds a nicer way of preventing retrying runs and hydrating errors into JSON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added troubleshooting guidance for parallel wait operations
	- Clarified limitations of concurrent wait functions
	- Explained why multiple wait operations are not supported

- **New Features**
	- Introduced error handling for concurrent wait scenarios
	- Added specific error code for parallel wait attempts

- **Bug Fixes**
	- Prevented multiple simultaneous wait operations across runtime managers
	- Enhanced error reporting for concurrent wait issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->