### PR TITLE
Fix "crypto is not defined error" on Node.js 18 in dev

### DIFF
--- a/.changeset/green-cheetahs-scream.md
+++ b/.changeset/green-cheetahs-scream.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Add --experimental-global-webcrypto node option fix "crypto is not defined error" on Node.js 18 in dev

--- a/packages/core/src/v3/build/runtime.ts
+++ b/packages/core/src/v3/build/runtime.ts
@@ -48,7 +48,12 @@ export function execOptionsForRuntime(runtime: BuildRuntime, options: ExecOption
 
       const conditions = options.customConditions?.map((condition) => `--conditions=${condition}`);
 
-      return [importEntryPoint, conditions, process.env.NODE_OPTIONS]
+      return [
+        importEntryPoint,
+        conditions,
+        process.env.NODE_OPTIONS,
+        "--experimental-global-webcrypto",
+      ]
         .filter(Boolean)
         .flat()
         .join(" ");

--- a/packages/core/src/v3/build/runtime.ts
+++ b/packages/core/src/v3/build/runtime.ts
@@ -63,3 +63,12 @@ export function execOptionsForRuntime(runtime: BuildRuntime, options: ExecOption
     }
   }
 }
+
+// Detect if we are using node v18, since we don't support lower than 18, and we only need to enable the flag for v18
+function nodeRuntimeNeedsGlobalWebCryptoFlag(): boolean {
+  try {
+    return process.versions.node.startsWith("18.");
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/v3/build/runtime.ts
+++ b/packages/core/src/v3/build/runtime.ts
@@ -52,7 +52,7 @@ export function execOptionsForRuntime(runtime: BuildRuntime, options: ExecOption
         importEntryPoint,
         conditions,
         process.env.NODE_OPTIONS,
-        "--experimental-global-webcrypto",
+        nodeRuntimeNeedsGlobalWebCryptoFlag() ? "--experimental-global-webcrypto" : undefined,
       ]
         .filter(Boolean)
         .flat()


### PR DESCRIPTION
fixes #1622

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved "crypto is not defined" error for Node.js version 18 in development environments.
	- Added `--experimental-global-webcrypto` option to ensure web crypto API availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->