### PR TITLE
Fixed issue with asResponse and withResponse not working on runs.retrieve

### DIFF
--- a/.changeset/lazy-carpets-reply.md
+++ b/.changeset/lazy-carpets-reply.md
@@ -1,0 +1,6 @@
+---
+"@trigger.dev/sdk": patch
+"@trigger.dev/core": patch
+---
+
+Fixed issue with asResponse and withResponse not working on runs.retrieve

--- a/packages/core/src/v3/apiClient/index.ts
+++ b/packages/core/src/v3/apiClient/index.ts
@@ -32,6 +32,7 @@ import {
 import { taskContext } from "../task-context-api.js";
 import { AnyRunTypes, TriggerJwtOptions } from "../types/tasks.js";
 import {
+  AnyZodFetchOptions,
   ApiRequestOptions,
   CursorPagePromise,
   ZodFetchOptions,
@@ -863,9 +864,9 @@ function createSearchQueryForListRuns(query?: ListRunsQueryParams): URLSearchPar
 }
 
 export function mergeRequestOptions(
-  defaultOptions: ZodFetchOptions,
+  defaultOptions: AnyZodFetchOptions,
   options?: ApiRequestOptions
-): ZodFetchOptions {
+): AnyZodFetchOptions {
   if (!options) {
     return defaultOptions;
   }

--- a/packages/trigger-sdk/src/v3/runs.ts
+++ b/packages/trigger-sdk/src/v3/runs.ts
@@ -14,9 +14,9 @@ import type {
   TaskRunShape,
   AnyBatchedRunHandle,
   AsyncIterableStream,
+  ApiPromise,
 } from "@trigger.dev/core/v3";
 import {
-  ApiPromise,
   CanceledRunResponse,
   CursorPagePromise,
   ListRunResponseItem,
@@ -187,15 +187,14 @@ function retrieveRun<TRunId extends AnyRunHandle | AnyBatchedRunHandle | AnyTask
           style: "codepath",
         }),
       },
+      prepareData: resolvePayloadAndOutputUrls,
     },
     requestOptions
   );
 
   const $runId = typeof runId === "string" ? runId : runId.id;
 
-  return apiClient.retrieveRun($runId, $requestOptions).then((retrievedRun) => {
-    return resolvePayloadAndOutputUrls(retrievedRun);
-  }) as ApiPromise<RetrieveRunResult<TRunId>>;
+  return apiClient.retrieveRun($runId, $requestOptions) as ApiPromise<RetrieveRunResult<TRunId>>;
 }
 
 async function resolvePayloadAndOutputUrls(run: AnyRetrieveRunResult) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
	- Patched `@trigger.dev/sdk` and `@trigger.dev/core`

- **Bug Fixes**
	- Resolved issues with `runs.retrieve` function
	- Improved data handling for API responses

- **Enhancements**
	- Added more flexible type handling for API client options
	- Simplified run retrieval process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->