### PR TITLE
Add the keyPrefix option when redis is not in cluster mode

### DIFF
--- a/apps/webapp/app/redis.server.ts
+++ b/apps/webapp/app/redis.server.ts
@@ -68,6 +68,7 @@ export function createRedisClient(
       username: options.username,
       password: options.password,
       enableAutoPipelining: true,
+      keyPrefix: options.keyPrefix,
       ...(options.tlsDisabled ? {} : { tls: {} }),
     });
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Redis client configuration to support key prefix option in both cluster and non-cluster modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->