### PR TITLE
Add the sha256 digest to the deployment image reference

### DIFF
--- a/apps/webapp/app/v3/services/finalizeDeploymentV2.server.ts
+++ b/apps/webapp/app/v3/services/finalizeDeploymentV2.server.ts
@@ -28,11 +28,14 @@ export class FinalizeDeploymentV2Service extends BaseService {
         friendlyId: id,
         environmentId: authenticatedEnv.id,
       },
-      include: {
+      select: {
+        status: true,
+        id: true,
+        version: true,
+        externalBuildData: true,
         environment: true,
         worker: {
-          include: {
-            tasks: true,
+          select: {
             project: true,
           },
         },
@@ -84,6 +87,14 @@ export class FinalizeDeploymentV2Service extends BaseService {
       throw new ServiceValidationError("Missing depot token");
     }
 
+    const digest = extractImageDigest(body.imageReference);
+
+    logger.debug("Pushing image to registry", {
+      id,
+      deployment,
+      digest,
+    });
+
     const pushResult = await executePushToRegistry(
       {
         depot: {
@@ -110,15 +121,37 @@ export class FinalizeDeploymentV2Service extends BaseService {
       throw new ServiceValidationError(pushResult.error);
     }
 
+    const fullImage = digest ? `${pushResult.image}@${digest}` : pushResult.image;
+
+    logger.debug("Image pushed to registry", {
+      id,
+      deployment,
+      body,
+      fullImage,
+    });
+
     const finalizeService = new FinalizeDeploymentService();
 
     const finalizedDeployment = await finalizeService.call(authenticatedEnv, id, {
-      imageReference: pushResult.image,
+      imageReference: fullImage,
       skipRegistryProxy: true,
     });
 
     return finalizedDeployment;
   }
+}
+
+// Extracts the sha256 digest from an image reference
+// For example the image ref "registry.depot.dev/gn57tl6chn:8qfjm8w83w@sha256:aa6fd2bdcbbd611556747e72d0b57797f03aa9b39dc910befc83eea2b08a5b85"
+// would return "sha256:aa6fd2bdcbbd611556747e72d0b57797f03aa9b39dc910befc83eea2b08a5b85"
+function extractImageDigest(image: string) {
+  const digestIndex = image.lastIndexOf("@");
+
+  if (digestIndex === -1) {
+    return;
+  }
+
+  return image.substring(digestIndex + 1);
 }
 
 type ExecutePushToRegistryOptions = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The deployment process now constructs a complete image reference by incorporating an image digest, enhancing deployment accuracy.
- **Bug Fixes**
  - Improved validation for deployment data ensures that only complete and valid build information is processed, reducing potential deployment issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->