### PR TITLE
Retry batch item completion

### DIFF
--- a/apps/webapp/app/db.server.ts
+++ b/apps/webapp/app/db.server.ts
@@ -111,6 +111,7 @@ function getClient() {
   const databaseUrl = extendQueryParams(DATABASE_URL, {
     connection_limit: env.DATABASE_CONNECTION_LIMIT.toString(),
     pool_timeout: env.DATABASE_POOL_TIMEOUT.toString(),
+    connection_timeout: env.DATABASE_CONNECTION_TIMEOUT.toString(),
   });
 
   console.log(`🔌 setting up prisma client to ${redactUrlSecrets(databaseUrl)}`);
@@ -162,6 +163,7 @@ function getReplicaClient() {
   const replicaUrl = extendQueryParams(env.DATABASE_READ_REPLICA_URL, {
     connection_limit: env.DATABASE_CONNECTION_LIMIT.toString(),
     pool_timeout: env.DATABASE_POOL_TIMEOUT.toString(),
+    connection_timeout: env.DATABASE_CONNECTION_TIMEOUT.toString(),
   });
 
   console.log(`🔌 setting up read replica connection to ${redactUrlSecrets(replicaUrl)}`);

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -13,6 +13,7 @@ const EnvironmentSchema = z.object({
     ),
   DATABASE_CONNECTION_LIMIT: z.coerce.number().int().default(10),
   DATABASE_POOL_TIMEOUT: z.coerce.number().int().default(60),
+  DATABASE_CONNECTION_TIMEOUT: z.coerce.number().int().default(20),
   DIRECT_URL: z
     .string()
     .refine(

--- a/apps/webapp/app/v3/services/batchTriggerV3.server.ts
+++ b/apps/webapp/app/v3/services/batchTriggerV3.server.ts
@@ -7,6 +7,7 @@ import {
 } from "@trigger.dev/core/v3";
 import {
   BatchTaskRun,
+  isPrismaRaceConditionError,
   isPrismaRetriableError,
   isUniqueConstraintError,
   Prisma,
@@ -1003,11 +1004,12 @@ export async function completeBatchTaskRunItemV3(
         }
       },
       {
-        timeout: 10000,
+        timeout: 10_000,
+        maxWait: 4_000,
       }
     );
   } catch (error) {
-    if (isPrismaRetriableError(error)) {
+    if (isPrismaRetriableError(error) || isPrismaRaceConditionError(error)) {
       logger.error("completeBatchTaskRunItemV3 failed with a Prisma Error, scheduling a retry", {
         itemId,
         batchTaskRunId,

--- a/internal-packages/database/src/transaction.ts
+++ b/internal-packages/database/src/transaction.ts
@@ -19,12 +19,30 @@ export function isPrismaKnownError(error: unknown): error is Prisma.PrismaClient
   );
 }
 
+/*
+•	P2024: Connection timeout errors
+•	P2028: Transaction timeout errors
+•	P2034: Transaction deadlock/conflict errors
+*/
+const retryCodes = ["P2024", "P2028", "P2034"];
+
 export function isPrismaRetriableError(error: unknown): boolean {
   if (!isPrismaKnownError(error)) {
     return false;
   }
 
   return retryCodes.includes(error.code);
+}
+
+/*
+•	P2025: Record not found errors (in race conditions) [not included for now]
+*/
+export function isPrismaRaceConditionError(error: unknown): boolean {
+  if (!isPrismaKnownError(error)) {
+    return false;
+  }
+
+  return error.code === "P2025";
 }
 
 export type PrismaTransactionOptions = {
@@ -46,9 +64,6 @@ export type PrismaTransactionOptions = {
    */
   maxRetries?: number;
 };
-
-//retry these Prisma error codes
-const retryCodes = ["P2034", "P2028"];
 
 export async function $transaction<R>(
   prisma: PrismaClientOrTransaction,

--- a/references/hello-world/src/trigger/example.ts
+++ b/references/hello-world/src/trigger/example.ts
@@ -68,3 +68,21 @@ export const maxDurationParentTask = task({
     return result;
   },
 });
+
+export const batchTask = task({
+  id: "batch",
+  run: async (payload: { count: number }, { ctx }) => {
+    logger.info("Starting batch task", { count: payload.count });
+
+    const items = Array.from({ length: payload.count }, (_, i) => ({
+      payload: { message: `Batch item ${i + 1}` },
+    }));
+
+    const results = await childTask.batchTriggerAndWait(items);
+
+    return {
+      batchCount: payload.count,
+      results,
+    };
+  },
+});


### PR DESCRIPTION
It was possible for a Postgres transaction error to cause a batch to permanently fail in some rare cases.

We now retry this for these Prisma codes
- P2024: Connection timeout errors
- P2028: Transaction timeout errors
- P2034: Transaction deadlock/conflict errors

We use the new Redis worker to reschedule the batch completion in the future. This is retried 10 times.

## Other changes
- Added Postgres connection_timeout with default 20s

## Details

### Error Handling & Retry Logic
- Added `isPrismaRetriableError()` helper function to identify retriable Prisma errors
- Implemented retry mechanism for `completeBatchTaskRunItem` on retriable Prisma errors
- Enhanced handling of race conditions and other retriable errors

### Database Improvements
- Added Postgres connection timeout configuration (default: 20 seconds)

## Testing Notes
- Verified that the retries work by manually introducing a relevant Prisma error, then removing it, and the batch completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
	- Added configurable database connection timeout settings, offering users more control over database stability.
	- Introduced enhanced batch processing that improves task completion reliability with refined error handling and retry support.
	- Provided a new sample batch task trigger that demonstrates batch execution and monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->