### PR TITLE
Fixed runs page filter bug

### DIFF
--- a/apps/webapp/app/components/runs/v3/RunFilters.tsx
+++ b/apps/webapp/app/components/runs/v3/RunFilters.tsx
@@ -444,7 +444,7 @@ function TasksDropdown({
         <SelectList>
           {filtered.map((item, index) => (
             <SelectItem
-              key={item.slug}
+              key={`${item.triggerSource}-${item.slug}`}
               value={item.slug}
               icon={
                 <TaskTriggerSourceIcon source={item.triggerSource} className="size-4 flex-none" />


### PR DESCRIPTION
When filtering by task on the runs page, sometime you can have a scheduled task and normal task that have the same name. This caused the list filtering to create weird ghost items because the keys weren't unique. 

This fix adds more info to the key so it's aways unique.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the uniqueness of items in task selection lists, enhancing the stability and reliability of the filtering interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->