### PR TITLE
missing construction option in `AudioWaveformExtension`

### DIFF
--- a/.changeset/lemon-fireants-repair.md
+++ b/.changeset/lemon-fireants-repair.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/build": patch
+---
+
+Missing construction option in `AudioWaveformExtension`

--- a/packages/build/src/extensions/audioWaveform.ts
+++ b/packages/build/src/extensions/audioWaveform.ts
@@ -11,7 +11,7 @@ const AUDIOWAVEFORM_CHECKSUM =
   "sha256:00b41ea4d6e7a5b4affcfe4ac99951ec89da81a8cba40af19e9b98c3a8f9b4b8";
 
 export function audioWaveform(options: AudioWaveformOptions = {}): BuildExtension {
-  return new AudioWaveformExtension();
+  return new AudioWaveformExtension(options);
 }
 
 class AudioWaveformExtension implements BuildExtension {


### PR DESCRIPTION
Small fix for a missing argument.

## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [ ] The PR title follows the convention.
- [ ] I ran and tested the code works

It's a tiny change. I admit I have not bothered testing it. 

> The PR title follows the convention.

What convention? Where is it? Couldn't find in the CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features  
  - The audio waveform functionality now accepts custom configuration options, allowing users to specify values such as version and checksum for a more tailored audio experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->