### PR TITLE
If there’s no queue concurrency limit, default to the env concurrency limit

### DIFF
--- a/apps/webapp/app/v3/marqs/index.server.ts
+++ b/apps/webapp/app/v3/marqs/index.server.ts
@@ -1264,7 +1264,7 @@ end
 
 -- Check current queue concurrency against the limit
 local currentConcurrency = tonumber(redis.call('SCARD', currentConcurrencyKey) or '0')
-local concurrencyLimit = tonumber(redis.call('GET', concurrencyLimitKey) or '1000000')
+local concurrencyLimit = tonumber(redis.call('GET', concurrencyLimitKey) or envConcurrencyLimit)
 
 -- Check condition only if concurrencyLimit exists
 if currentConcurrency >= concurrencyLimit then
@@ -1434,7 +1434,7 @@ local currentEnvConcurrency = tonumber(redis.call('SCARD', currentEnvConcurrency
 
 local currentConcurrency = tonumber(redis.call('SCARD', currentConcurrencyKey) or '0')
 
-return { currentOrgConcurrency, currentEnvConcurrency, currentConcurrency } 
+return { currentOrgConcurrency, currentEnvConcurrency, currentConcurrency }
       `,
     });
 


### PR DESCRIPTION
When dequeuing a run we check that there's enough concurrency to execute it.

Concurrency limits exist at a few layers
- Org concurrency limit (this will be removed with Run Engine 2+)
- Environment concurrency limit (this is the limit users pay for, e.g. Hobby is 25)
- Task/queue concurrency limit (this is defined by users using `concurrencyLimit`).

If you didn't set `concurrencyLimit` on your task/custom queue then we previously defaulted it to 1M. This seemed reasonable, as you would be limited by the environment concurrency limit…

But there's an edge case with `triggerAndWait` where you could accidentally spin up a lot of containers if you hadn't set a `concurrencyLimit` on the parent and a few other conditions were true. This is related to when we release the concurrency to make runs start as fast as possible for people. 

This change defaults the task/queue concurrencyLimit to the environment, if it's not set. This limits the amount of possible containers running to 2x the env concurrency limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated message processing logic to use dynamic deployment settings for determining concurrency limits.
- **Style**
	- Standardized code formatting for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->