### PR TITLE
Retry heartbeat timeouts by putting back in the queue

### DIFF
--- a/apps/webapp/app/v3/marqs/index.server.ts
+++ b/apps/webapp/app/v3/marqs/index.server.ts
@@ -638,7 +638,8 @@ export class MarQS {
   }
 
   /**
-   * Negative acknowledge a message, which will requeue the message
+   * Negative acknowledge a message, which will requeue the message.
+   * Returns whether it went back into the queue or not.
    */
   public async nackMessage(
     messageId: string,
@@ -657,7 +658,7 @@ export class MarQS {
             updates,
             service: this.name,
           });
-          return;
+          return false;
         }
 
         const nackCount = await this.#getNackCount(messageId);
@@ -676,7 +677,7 @@ export class MarQS {
 
           // If we have reached the maximum nack count, we will ack the message
           await this.acknowledgeMessage(messageId, "maximum nack count reached");
-          return;
+          return false;
         }
 
         span.setAttributes({
@@ -705,6 +706,8 @@ export class MarQS {
         });
 
         await this.options.subscriber?.messageNacked(message);
+
+        return true;
       },
       {
         kind: SpanKind.CONSUMER,


### PR DESCRIPTION
We use heartbeats to prevent stalled runs from getting stuck forever. If 15 mins passes without a successful heartbeat from the worker for your run, we need to do something about it.

Ordinarily this is a rare issue, but when there is a lot of contention it is more prevalent.

There a few situations where this can happen:
1. A run is scheduled in the cluster, but for some reason it is never actually picked up and started (networking, no available servers, misc unknown error)
2. A run is executing and the CPU is pegged at 100%. This is pretty rare given you get 15 mins to respond.

In almost all situations we now put the run back in the queue to retry (it has a maximum number of retries it will do). If it can't be put back in the queue, because it's exceeded the maximum, then we'll fail the run as we do now.

This still isn't ideal because 15 mins have passed from when it should have run, but it does drastically increase the likelihood it will get successfully executed. 

In Run Engine 2.0 the heartbeat/stall system has been reworked and we retry start failures much faster.

![CleanShot 2025-02-10 at 12 59 40](https://github.com/user-attachments/assets/691851be-1e47-4426-88e3-20792af4b301)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced task processing logic to ensure improved handling of requeue and failure scenarios.
  - Refined error and debug messages for clearer feedback during task state transitions.

- **Documentation**
  - Updated message handling descriptions to clearly indicate successful or failed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->