### PR TITLE
Detect ffmpeg OOM errors, added manual OutOfMemoryError

### DIFF
--- a/.changeset/eighty-spies-knock.md
+++ b/.changeset/eighty-spies-knock.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+Detect ffmpeg OOM errors, added manual OutOfMemoryError

--- a/packages/trigger-sdk/src/v3/index.ts
+++ b/packages/trigger-sdk/src/v3/index.ts
@@ -31,6 +31,7 @@ export {
   RateLimitError,
   UnprocessableEntityError,
   AbortTaskRunError,
+  OutOfMemoryError,
   logger,
   type LogLevel,
 } from "@trigger.dev/core/v3";

--- a/references/hello-world/src/trigger/oom.ts
+++ b/references/hello-world/src/trigger/oom.ts
@@ -1,3 +1,4 @@
+import { OutOfMemoryError } from "@trigger.dev/sdk/v3";
 import { logger, task } from "@trigger.dev/sdk/v3";
 import { setTimeout } from "timers/promises";
 
@@ -9,7 +10,14 @@ export const oomTask = task({
       machine: "small-1x",
     },
   },
-  run: async ({ succeedOnLargerMachine }: { succeedOnLargerMachine: boolean }, { ctx }) => {
+  run: async (
+    {
+      succeedOnLargerMachine = false,
+      ffmpeg = false,
+      manual = false,
+    }: { succeedOnLargerMachine?: boolean; ffmpeg?: boolean; manual?: boolean },
+    { ctx }
+  ) => {
     logger.info("running out of memory below this line");
 
     logger.info(`Running on ${ctx.machine?.name}`);
@@ -21,6 +29,14 @@ export const oomTask = task({
       return {
         success: true,
       };
+    }
+
+    if (manual) {
+      throw new OutOfMemoryError();
+    }
+
+    if (ffmpeg) {
+      throw new Error("ffmpeg was killed with signal SIGKILL");
     }
 
     let a = "a";


### PR DESCRIPTION
Added `OutOfMemoryError` that can be thrown. This causes an Out Of Memory error on the run (if it's uncaught). This can be useful if you use a native package that detects it's run out of memory but doesn't kill Node.js

Also fixed a bug where ffmpeg's weird OOM error is now detected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error detection and handling for out-of-memory scenarios during media processing.
  - Introduced refined error responses that provide more precise feedback when memory issues occur.
  - Updated task controls with additional options to manage execution under specific error conditions.

- **Chores**
  - Updated dependencies to support the improved error-handling mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->