### PR TITLE
Fix run container exits after OOM retries

### DIFF
--- a/apps/webapp/app/v3/services/completeAttempt.server.ts
+++ b/apps/webapp/app/v3/services/completeAttempt.server.ts
@@ -317,7 +317,7 @@ export class CompleteAttemptService extends BaseService {
 
     // The attempt has failed and we won't retry
 
-    if (isOOMAttempt && isOnMaxOOMMachine) {
+    if (isOOMAttempt && isOnMaxOOMMachine && environment.type !== "DEVELOPMENT") {
       // The attempt failed due to an OOM error but we're already on the machine we should retry on
       exitRun(taskRunAttempt.taskRunId);
     }

--- a/apps/webapp/app/v3/services/completeAttempt.server.ts
+++ b/apps/webapp/app/v3/services/completeAttempt.server.ts
@@ -8,9 +8,7 @@ import {
   TaskRunExecutionRetry,
   TaskRunFailedExecutionResult,
   TaskRunSuccessfulExecutionResult,
-  exceptionEventEnhancer,
   flattenAttributes,
-  internalErrorFromUnexpectedExit,
   isManualOutOfMemoryError,
   sanitizeError,
   shouldRetryError,
@@ -32,7 +30,6 @@ import { CancelAttemptService } from "./cancelAttempt.server";
 import { CreateCheckpointService } from "./createCheckpoint.server";
 import { FinalizeTaskRunService } from "./finalizeTaskRun.server";
 import { RetryAttemptService } from "./retryAttempt.server";
-import { updateMetadataService } from "~/services/metadata/updateMetadata.server";
 import { getTaskEventStoreTableForRun } from "../taskEventStore.server";
 
 type FoundAttempt = Awaited<ReturnType<typeof findAttempt>>;


### PR DESCRIPTION
The deploy run controller is unaware of attempt submission outcomes, especially after OOM errors. The decision to retry on a larger machine is made by the webapp and there is no direct two-way communication.

To fix this, we'll send the same graceful exit request to the run that is also used in other places. Retry delay spans have also been improved with additional info.