### PR TITLE
Improve reliability of completion submission

### DIFF
--- a/.changeset/witty-jars-approve.md
+++ b/.changeset/witty-jars-approve.md
@@ -1,0 +1,6 @@
+---
+"@trigger.dev/core": patch
+---
+
+- Add new run completion submission message with ack
+- Add timeout support to sendWithAck

--- a/apps/coordinator/src/index.ts
+++ b/apps/coordinator/src/index.ts
@@ -783,7 +783,12 @@ class TaskCoordinator {
                       delay,
                       elapsedMs,
                     });
-                    return await sendCompletionWithAck();
+
+                    const success = await sendCompletionWithAck();
+
+                    if (!success) {
+                      throw new Error("Failed to send completion with ack");
+                    }
                   }
                 );
 

--- a/apps/coordinator/src/index.ts
+++ b/apps/coordinator/src/index.ts
@@ -33,7 +33,7 @@ const SECURE_CONNECTION = ["1", "true"].includes(process.env.SECURE_CONNECTION ?
 const TASK_RUN_COMPLETED_WITH_ACK_TIMEOUT_MS =
   parseInt(process.env.TASK_RUN_COMPLETED_WITH_ACK_TIMEOUT_MS || "") || 30_000;
 const TASK_RUN_COMPLETED_WITH_ACK_MAX_RETRIES =
-  parseInt(process.env.TASK_RUN_COMPLETED_WITH_ACK_MAX_RETRIES || "") || 5;
+  parseInt(process.env.TASK_RUN_COMPLETED_WITH_ACK_MAX_RETRIES || "") || 7;
 
 const logger = new SimpleStructuredLogger("coordinator", undefined, { nodeName: NODE_NAME });
 const chaosMonkey = new ChaosMonkey(
@@ -783,12 +783,7 @@ class TaskCoordinator {
                       delay,
                       elapsedMs,
                     });
-
-                    const success = await sendCompletionWithAck();
-
-                    if (!success) {
-                      throw new Error("Failed to send completion with ack");
-                    }
+                    return await sendCompletionWithAck();
                   }
                 );
 

--- a/apps/webapp/app/v3/handleSocketIo.server.ts
+++ b/apps/webapp/app/v3/handleSocketIo.server.ts
@@ -136,6 +136,44 @@ function createCoordinatorNamespace(io: Server) {
           checkpoint: message.checkpoint,
         });
       },
+      TASK_RUN_COMPLETED_WITH_ACK: async (message) => {
+        try {
+          const completeAttempt = new CompleteAttemptService({
+            supportsRetryCheckpoints: message.version === "v1",
+          });
+          await completeAttempt.call({
+            completion: message.completion,
+            execution: message.execution,
+            checkpoint: message.checkpoint,
+          });
+
+          return {
+            success: true,
+          };
+        } catch (error) {
+          const friendlyError =
+            error instanceof Error
+              ? {
+                  name: error.name,
+                  message: error.message,
+                  stack: error.stack,
+                }
+              : {
+                  name: "UnknownError",
+                  message: String(error),
+                };
+
+          logger.error("Error while completing attempt with ack", {
+            error: friendlyError,
+            message,
+          });
+
+          return {
+            success: false,
+            error: friendlyError,
+          };
+        }
+      },
       TASK_RUN_FAILED_TO_RUN: async (message) => {
         await sharedQueueTasks.taskRunFailed(message.completion);
       },

--- a/packages/core/src/v3/schemas/messages.ts
+++ b/packages/core/src/v3/schemas/messages.ts
@@ -435,6 +435,20 @@ export const CoordinatorToPlatformMessages = {
         .optional(),
     }),
   },
+  TASK_RUN_COMPLETED_WITH_ACK: {
+    message: z.object({
+      version: z.enum(["v1", "v2"]).default("v2"),
+      execution: ProdTaskRunExecution,
+      completion: TaskRunExecutionResult,
+      checkpoint: z
+        .object({
+          docker: z.boolean(),
+          location: z.string(),
+        })
+        .optional(),
+    }),
+    callback: AckCallbackResult,
+  },
   TASK_RUN_FAILED_TO_RUN: {
     message: z.object({
       version: z.literal("v1").default("v1"),

--- a/packages/core/src/v3/zodSocket.ts
+++ b/packages/core/src/v3/zodSocket.ts
@@ -293,7 +293,8 @@ export class ZodSocketMessageSender<TMessageCatalog extends ZodSocketMessageCata
 
   public async sendWithAck<K extends GetSocketMessagesWithCallback<TMessageCatalog>>(
     type: K,
-    payload: z.input<GetSocketMessageSchema<TMessageCatalog, K>>
+    payload: z.input<GetSocketMessageSchema<TMessageCatalog, K>>,
+    timeout?: number
   ): Promise<z.infer<GetSocketCallbackSchema<TMessageCatalog, K>>> {
     const schema = this.#schema[type]?.["message"];
 
@@ -307,8 +308,10 @@ export class ZodSocketMessageSender<TMessageCatalog extends ZodSocketMessageCata
       throw new Error(`Failed to parse message payload: ${JSON.stringify(parsedPayload.error)}`);
     }
 
+    const socket = timeout ? this.#socket.timeout(timeout) : this.#socket;
+
     // @ts-expect-error
-    const callbackResult = await this.#socket.emitWithAck(type, { payload, version: "v1" });
+    const callbackResult = await socket.emitWithAck(type, { payload, version: "v1" });
 
     return callbackResult;
   }


### PR DESCRIPTION
Retries were previously driven by the run controller exclusively. This change makes it possible for the coordinator to do the same. We retry with exponential backoff, by default for up to ~2m.

Timeout and max retries can be configured with the following env vars:
- `TASK_RUN_COMPLETED_WITH_ACK_TIMEOUT_MS`
- `TASK_RUN_COMPLETED_WITH_ACK_MAX_RETRIES`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a robust task completion acknowledgment mechanism with a retry strategy and enhanced error reporting.
  - Added support for configurable timeouts during message acknowledgments to strengthen communication reliability.

- **Refactor**
  - Updated the task completion flow to ensure acknowledgments are processed before finalizing completions, improving overall system resiliency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->