### PR TITLE
Remove V2 countdown from sidebar

### DIFF
--- a/apps/webapp/app/components/navigation/SideMenu.tsx
+++ b/apps/webapp/app/components/navigation/SideMenu.tsx
@@ -90,34 +90,6 @@ type SideMenuProps = {
   defaultValue?: FeedbackType;
 };
 
-function V2Countdown() {
-  const [days, setDays] = useState(0);
-
-  useEffect(() => {
-    const targetDate = new Date("2025-01-31T00:00:00Z");
-
-    const calculateDays = () => {
-      const now = new Date();
-      const difference = targetDate.getTime() - now.getTime();
-      return Math.floor(difference / (1000 * 60 * 60 * 24));
-    };
-
-    const timer = setInterval(() => {
-      setDays(calculateDays());
-    }, 1000 * 60 * 60); // Update every hour
-
-    setDays(calculateDays()); // Initial calculation
-
-    return () => clearInterval(timer);
-  }, []);
-
-  return (
-    <Header2 className="flex-wrap gap-4 text-error">
-      V2 goes offline in <span className="tabular-nums">{days}d</span>
-    </Header2>
-  );
-}
-
 export function SideMenu({ user, project, organization, organizations }: SideMenuProps) {
   const borderRef = useRef<HTMLDivElement>(null);
   const [showHeaderDivider, setShowHeaderDivider] = useState(false);
@@ -239,30 +211,6 @@ export function SideMenu({ user, project, organization, organizations }: SideMen
               data-action="organization-settings"
             />
           </div>
-        </div>
-        <div className="m-2">
-          {project.version === "V2" && (
-            <div className="flex flex-col gap-3 rounded border border-error/50 bg-error/5 p-3">
-              <V2Countdown />
-              <Paragraph variant="small/bright">
-                This is a v2 project. V2 will be deprecated on January 31, 2025.{" "}
-                <TextLink
-                  className="text-text-bright underline decoration-text-dimmed underline-offset-2 transition hover:text-text-bright hover:decoration-text-bright"
-                  to="https://trigger.dev/blog/v2-end-of-life-announcement"
-                >
-                  Learn more
-                </TextLink>
-                .
-              </Paragraph>
-              <LinkButton
-                variant="primary/medium"
-                to="https://trigger.dev/docs/v3/upgrading-from-v2"
-                fullWidth
-              >
-                Upgrade to v3
-              </LinkButton>
-            </div>
-          )}
         </div>
         <div className="flex flex-col gap-1 border-t border-grid-bright p-1">
           <HelpAndFeedback />


### PR DESCRIPTION
Per discord discussion: https://discord.com/channels/1066956501299777596/1066956844553207828/1336607145604546580

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

1. Launch app with a fresh db
2. Navigate to project page for a v2 project

---

## Changelog

- Removed V2Countdown component and accompanying section from sidebar.

---

## Screenshots

![image](https://github.com/user-attachments/assets/8605e3ec-1f3b-48cb-b73e-a444e184666f)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the deprecation countdown display and its related messaging, streamlining the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->