### PR TITLE
Explain TTL even better so the LLMs hopefully understand it

### DIFF
--- a/docs/runs.mdx
+++ b/docs/runs.mdx
@@ -127,7 +127,7 @@ When a run is canceled:
 
 ### Time-to-live (TTL)
 
-You can set a TTL when triggering a run:
+TTL is a time-to-live setting that defines the maximum duration a run can remain in a queued state before being automatically expired. You can set a TTL when triggering a run:
 
 ```ts
 await yourTask.trigger({ foo: "bar" }, { ttl: "10m" });


### PR DESCRIPTION
Adds a bit more descriptive text to the TTL explanation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced the TTL feature description with a more detailed explanation, clarifying how it limits the maximum duration a run can stay queued before auto-expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->