### PR TITLE
Docs typo fix cli-commands-deploy.mdx

### DIFF
--- a/docs/snippets/cli-commands-deploy.mdx
+++ b/docs/snippets/cli-commands-deploy.mdx
@@ -103,7 +103,7 @@ These options are typically used when [self-hosting](/open-source-self-hosting) 
   When using the `--self-hosted` flag, push the image to the registry.
 </ParamField>
 
-<ParamField body="Namespace" type="--namepsace">
+<ParamField body="Namespace" type="--namespace">
   The namespace to use when pushing the image to the registry. For example, if pushing to Docker
   Hub, the namespace is your Docker Hub username.
 </ParamField>


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Open https://trigger.dev/docs/cli-deploy#param-namespace

---

## Changelog

Just a small typo in docs for self-hosting

---

## Screenshots

![CleanShot 2025-02-25 at 01 24 20@2x](https://github.com/user-attachments/assets/ff71e4a7-cc49-4918-b1a9-8ce698334b99)

💯


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typographical error in the CLI documentation for the namespace argument, ensuring accurate instructions for specifying the namespace when pushing an image to the registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->