### PR TITLE
Add missing imports to overview.mdx

### DIFF
--- a/docs/frontend/overview.mdx
+++ b/docs/frontend/overview.mdx
@@ -11,6 +11,8 @@ You can use our [React hooks](/frontend/react-hooks) in your frontend applicatio
 To create a Public Access Token, you can use the `auth.createPublicToken` function in your **backend** code:
 
 ```tsx
+import { auth } from "@trigger.dev/sdk/v3";
+
 const publicToken = await auth.createPublicToken(); // 👈 this public access token has no permissions, so is pretty useless!
 ```
 
@@ -19,6 +21,8 @@ const publicToken = await auth.createPublicToken(); // 👈 this public access t
 By default a Public Access Token has no permissions. You must specify the scopes you need when creating a Public Access Token:
 
 ```ts
+import { auth } from "@trigger.dev/sdk/v3";
+
 const publicToken = await auth.createPublicToken({
   scopes: {
     read: {
@@ -31,6 +35,8 @@ const publicToken = await auth.createPublicToken({
 This will allow the token to read all runs, which is probably not what you want. You can specify only certain runs by passing an array of run IDs:
 
 ```ts
+import { auth } from "@trigger.dev/sdk/v3";
+
 const publicToken = await auth.createPublicToken({
   scopes: {
     read: {
@@ -43,6 +49,8 @@ const publicToken = await auth.createPublicToken({
 You can scope the token to only read certain tasks:
 
 ```ts
+import { auth } from "@trigger.dev/sdk/v3";
+
 const publicToken = await auth.createPublicToken({
   scopes: {
     read: {
@@ -55,6 +63,8 @@ const publicToken = await auth.createPublicToken({
 Or tags:
 
 ```ts
+import { auth } from "@trigger.dev/sdk/v3";
+
 const publicToken = await auth.createPublicToken({
   scopes: {
     read: {
@@ -67,6 +77,8 @@ const publicToken = await auth.createPublicToken({
 Or a specific batch of runs:
 
 ```ts
+import { auth } from "@trigger.dev/sdk/v3";
+
 const publicToken = await auth.createPublicToken({
   scopes: {
     read: {
@@ -79,6 +91,8 @@ const publicToken = await auth.createPublicToken({
 You can also combine scopes. For example, to read runs with specific tags and for specific tasks:
 
 ```ts
+import { auth } from "@trigger.dev/sdk/v3";
+
 const publicToken = await auth.createPublicToken({
   scopes: {
     read: {
@@ -94,6 +108,8 @@ const publicToken = await auth.createPublicToken({
 By default, Public Access Token's expire after 15 minutes. You can specify a different expiration time when creating a Public Access Token:
 
 ```ts
+import { auth } from "@trigger.dev/sdk/v3";
+
 const publicToken = await auth.createPublicToken({
   expirationTime: "1hr",
 });
@@ -120,6 +136,8 @@ console.log(handle.publicAccessToken);
 By default, tokens returned from the `trigger` function expire after 15 minutes and have a read scope for that specific run. You can customize the expiration of the auto-generated tokens by passing a `publicTokenOptions` object to the `trigger` function:
 
 ```ts
+import { tasks } from "@trigger.dev/sdk/v3";
+
 const handle = await tasks.trigger(
   "my-task",
   { some: "data" },


### PR DESCRIPTION
Added missing imports in the Overview & Auth (Frontend usage) page:

import { auth } from "@trigger.dev/sdk/v3";
import { tasks } from "@trigger.dev/sdk/v3";

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Open https://trigger.dev/docs/frontend/overview

---

## Changelog

Just added the missing imports where needed.

---

## Screenshots

<img width="696" alt="Screenshot 2025-02-25 at 17 57 06" src="https://github.com/user-attachments/assets/6c1a9fb1-582b-4481-81dd-36ed32e5cd8b" />

💯


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced documentation by updating code examples to include the necessary module imports. This ensures that public token usage and related code demonstrations are complete and easier for users to follow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->