### PR TITLE
Remove Bun version warning

### DIFF
--- a/docs/guides/frameworks/bun.mdx
+++ b/docs/guides/frameworks/bun.mdx
@@ -9,8 +9,6 @@ import Prerequisites from "/snippets/framework-prerequisites.mdx";
 import CliRunTestStep from "/snippets/step-run-test.mdx";
 import CliViewRunStep from "/snippets/step-view-run.mdx";
 
-<Warning>A specific Bun version is currently required for the dev command to work. This is due to a [bug](https://github.com/oven-sh/bun/issues/13799) with IPC. Please use Bun version 1.1.24 or lower: `curl -fsSL https://bun.sh/install | bash -s -- bun-v1.1.24`</Warning>
-
 We now have experimental support for Bun. This guide will show you have to setup Trigger.dev in your existing Bun project, test an example task, and view the run.
 
 <Warn>


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Changelog

- [Remove Bun version warning because issue was resolved](https://github.com/oven-sh/bun/issues/13799)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed outdated warnings about specific Bun version requirements.
  - Updated guidance to streamline the setup process for Trigger.dev in Bun projects.
  - Introduced experimental support for Bun, simplifying the setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->