### PR TITLE
Chore: upgrade remix-auth-email-link to 2.1.1, crypto-js to 4.2.0

### DIFF
--- a/apps/webapp/app/services/email.server.ts
+++ b/apps/webapp/app/services/email.server.ts
@@ -32,8 +32,10 @@ const alertsClient = singleton(
 );
 
 function buildTransportOptions(alerts?: boolean): MailTransportOptions {
-  const transportType = alerts ? env.ALERT_EMAIL_TRANSPORT : env.EMAIL_TRANSPORT
-  logger.debug(`Constructing email transport '${transportType}' for usage '${alerts?'alerts':'general'}'`)
+  const transportType = alerts ? env.ALERT_EMAIL_TRANSPORT : env.EMAIL_TRANSPORT;
+  logger.debug(
+    `Constructing email transport '${transportType}' for usage '${alerts ? "alerts" : "general"}'`
+  );
 
   switch (transportType) {
     case "aws-ses":
@@ -43,8 +45,8 @@ function buildTransportOptions(alerts?: boolean): MailTransportOptions {
         type: "resend",
         config: {
           apiKey: alerts ? env.ALERT_RESEND_API_KEY : env.RESEND_API_KEY,
-        }
-      }
+        },
+      };
     case "smtp":
       return {
         type: "smtp",
@@ -54,9 +56,9 @@ function buildTransportOptions(alerts?: boolean): MailTransportOptions {
           secure: alerts ? env.ALERT_SMTP_SECURE : env.SMTP_SECURE,
           auth: {
             user: alerts ? env.ALERT_SMTP_USER : env.SMTP_USER,
-            pass: alerts ? env.ALERT_SMTP_PASSWORD : env.SMTP_PASSWORD
-          }
-        }
+            pass: alerts ? env.ALERT_SMTP_PASSWORD : env.SMTP_PASSWORD,
+          },
+        },
       };
     default:
       return { type: undefined };
@@ -64,10 +66,10 @@ function buildTransportOptions(alerts?: boolean): MailTransportOptions {
 }
 
 export async function sendMagicLinkEmail(options: SendEmailOptions<AuthUser>): Promise<void> {
-  // Auto redirect when in development mode
-  if (env.NODE_ENV === "development") {
-    throw redirect(options.magicLink);
-  }
+  // // Auto redirect when in development mode
+  // if (env.NODE_ENV === "development") {
+  //   throw redirect(options.magicLink);
+  // }
 
   logger.debug("Sending magic link email", { emailAddress: options.emailAddress });
 

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -164,7 +164,7 @@
     "recharts": "^2.12.6",
     "regression": "^2.0.1",
     "remix-auth": "^3.6.0",
-    "remix-auth-email-link": "2.0.2",
+    "remix-auth-email-link": "2.1.1",
     "remix-auth-github": "^1.6.0",
     "remix-typedjson": "0.3.1",
     "remix-utils": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -586,8 +586,8 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0(@remix-run/react@2.1.0)(@remix-run/server-runtime@2.1.0)
       remix-auth-email-link:
-        specifier: 2.0.2
-        version: 2.0.2(@remix-run/server-runtime@2.1.0)(remix-auth@3.6.0)
+        specifier: 2.1.1
+        version: 2.1.1(@remix-run/server-runtime@2.1.0)(remix-auth@3.6.0)
       remix-auth-github:
         specifier: ^1.6.0
         version: 1.6.0(@remix-run/server-runtime@2.1.0)(remix-auth@3.6.0)
@@ -20157,10 +20157,6 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  /crypto-js@4.1.1:
-    resolution: {integrity: sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==}
-    dev: false
-
   /crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
     dev: false
@@ -28794,14 +28790,14 @@ packages:
       unified: 10.1.2
     dev: true
 
-  /remix-auth-email-link@2.0.2(@remix-run/server-runtime@2.1.0)(remix-auth@3.6.0):
-    resolution: {integrity: sha512-Lze9c50fsqBpixXQKe37wI2Dm4rlYYkNA6Eskxk8erQ7tbyN8xiFXOgo7Y3Al0SSjzkezw8au3uc2vCLJ8A5mQ==}
+  /remix-auth-email-link@2.1.1(@remix-run/server-runtime@2.1.0)(remix-auth@3.6.0):
+    resolution: {integrity: sha512-NNz9Wk9sxWUhuDTkcLbhsVdiUpyrGFf9yIkZG74PgOMTAYsIIsfGvBr2wJCgYcH/JWxg5VbTulgNO7/KXHJcsg==}
     peerDependencies:
-      '@remix-run/server-runtime': ^1.1.1
-      remix-auth: ^3.2.1
+      '@remix-run/server-runtime': ^2.0.1
+      remix-auth: ^3.6.0
     dependencies:
       '@remix-run/server-runtime': 2.1.0(typescript@5.2.2)
-      crypto-js: 4.1.1
+      crypto-js: 4.2.0
       remix-auth: 3.6.0(@remix-run/react@2.1.0)(@remix-run/server-runtime@2.1.0)
     dev: false
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced internal handling for email services to improve overall readability and consistency.
  - Upgraded the email authentication dependency to version 2.1.1, ensuring more reliable functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->