### PR TITLE
Fix for deployment version comparison

### DIFF
--- a/apps/webapp/app/v3/utils/deploymentVersions.ts
+++ b/apps/webapp/app/v3/utils/deploymentVersions.ts
@@ -12,11 +12,15 @@ export function compareDeploymentVersions(versionA: string, versionB: string) {
     return 1;
   }
 
-  if (numberA < numberB) {
+  // Convert to numbers before comparing
+  const numA = Number(numberA);
+  const numB = Number(numberB);
+
+  if (numA < numB) {
     return -1;
   }
 
-  if (numberA > numberB) {
+  if (numA > numB) {
     return 1;
   }
 


### PR DESCRIPTION
If you're on >= 10 deploys in a day the comparison doesn't work because we were comparing them as strings… 🤦 

This meant new deploys weren't being promoted, and it was impossible to promote a new one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the logic for comparing version numbers, ensuring deployment versions are now ordered accurately using numerical comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->