### PR TITLE
Docs improvements: clearing build cache, concurrently running next + trigger, trouble shooting pino

### DIFF
--- a/docs/config/config-file.mdx
+++ b/docs/config/config-file.mdx
@@ -129,7 +129,6 @@ Some ones we recommend:
 
 | Package                                 | Description                                                                                                              |
 | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `@opentelemetry/instrumentation-undici` | Logs all fetch calls (inc. Undici fetch)                                                                                 |
 | `@opentelemetry/instrumentation-http`   | Logs all HTTP calls                                                                                                      |
 | `@prisma/instrumentation`               | Logs all Prisma calls, you need to [enable tracing](https://github.com/prisma/prisma/tree/main/packages/instrumentation) |
 | `@traceloop/instrumentation-openai`     | Logs all OpenAI calls                                                                                                    |

--- a/docs/config/config-file.mdx
+++ b/docs/config/config-file.mdx
@@ -137,6 +137,37 @@ Some ones we recommend:
   `@opentelemetry/instrumentation-fs` which logs all file system calls is currently not supported.
 </Note>
 
+### Exporters
+
+You can also configure custom exporters to send your telemetry data to other services. For example, you can send your logs to [Axiom](https://axiom.co/docs/guides/opentelemetry-nodejs#exporter-instrumentation-ts):
+
+```ts trigger.config.ts
+import { defineConfig } from "@trigger.dev/sdk/v3";
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
+
+// Initialize OTLP trace exporter with the endpoint URL and headers
+const axiomExporter = new OTLPTraceExporter({
+  url: 'https://api.axiom.co/v1/traces',
+  headers: {
+    'Authorization': `Bearer ${process.env.AXIOM_API_TOKEN}`,
+    'X-Axiom-Dataset': process.env.AXIOM_DATASET
+  },
+});
+
+export default defineConfig({
+  project: "<project ref>",
+  // Your other config settings...
+  telemetry: {
+    instrumentations: [
+      // Your instrumentations here
+    ],
+    exporters: [axiomExporter],
+  },
+});
+```
+
+Make sure to set the `AXIOM_API_TOKEN` and `AXIOM_DATASET` environment variables in your project.
+
 ## Runtime
 
 We currently only officially support the `node` runtime, but you can try our experimental `bun` runtime by setting the `runtime` option in your config file:

--- a/docs/deployment/overview.mdx
+++ b/docs/deployment/overview.mdx
@@ -4,6 +4,8 @@ sidebarTitle: "Overview"
 description: "Learn how to deploy your tasks to Trigger.dev."
 ---
 
+import CorepackError from "/snippets/corepack-error.mdx";
+
 Before you can run production workloads on Trigger.dev, you need to deploy your tasks. The only way to do this at the moment is through the [deploy CLI command](/cli-deploy):
 
 <CodeGroup>
@@ -231,3 +233,4 @@ export default defineConfig({
   },
 });
 ```
+<CorepackError />

--- a/docs/guides/frameworks/nextjs.mdx
+++ b/docs/guides/frameworks/nextjs.mdx
@@ -19,6 +19,8 @@ import AddEnvironmentVariables from "/snippets/add-environment-variables.mdx";
 import DeployingYourTask from "/snippets/deplopying-your-task.mdx";
 import VercelDocsCards from "/snippets/vercel-docs-cards.mdx";
 
+import RunDevAndNextConcurrently from "/snippets/run-dev-and-next-concurrently.mdx";
+
 <Note>This guide can be followed for both App and Pages router as well as Server Actions.</Note>
 
 <Prerequisites framework="Next.js" />
@@ -31,6 +33,8 @@ import VercelDocsCards from "/snippets/vercel-docs-cards.mdx";
   <CliRunTestStep />
   <CliViewRunStep />
 </Steps>
+
+<RunDevAndNextConcurrently />
 
 ## Set your secret key locally
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -85,6 +85,21 @@ We provide everything you need to build and manage background tasks: a CLI and S
   <Card title="Firecrawl" img="/images/intro-firecrawl.jpg" href="/guides/examples/firecrawl-url-crawl"/>
 </CardGroup>
 
+## Explore by build extension
+
+| Extension | What it does | Docs |
+|:----------|:------------|:--------------|
+| prismaExtension | Use Prisma with Trigger.dev | [Learn more](/config/extensions/prismaExtension) |
+| pythonExtension | Execute Python scripts in Trigger.dev | [Learn more](/config/extensions/pythonExtension) |
+| puppeteer | Use Puppeteer with Trigger.dev | [Learn more](/config/extensions/puppeteer) |
+| ffmpeg | Use FFmpeg with Trigger.dev | [Learn more](/config/extensions/ffmpeg) |
+| aptGet | Install system packages with aptGet | [Learn more](/config/extensions/aptGet) |
+| additionalFiles | Copy additional files to the build directory | [Learn more](/config/extensions/additionalFiles) |
+| additionalPackages | Include additional packages in the build | [Learn more](/config/extensions/additionalPackages) |
+| syncEnvVars | Automatically sync environment variables to Trigger.dev | [Learn more](/config/extensions/syncEnvVars) |
+| esbuildPlugin | Add existing or custom esbuild plugins to your build process | [Learn more](/config/extensions/esbuildPlugin) |
+| emitDecoratorMetadata | Support for the emitDecoratorMetadata TypeScript compiler | [Learn more](/config/extensions/emitDecoratorMetadata) |
+| audioWaveform | Support for Audio Waveform in your project | [Learn more](/config/extensions/audioWaveform) |
 
 ## Getting help
 

--- a/docs/logging.mdx
+++ b/docs/logging.mdx
@@ -38,9 +38,9 @@ Tracing is a way to follow the flow of your code. It's very useful for debugging
 Trigger.dev uses OpenTelemetry tracing under the hood. With automatic tracing for many things like task triggering, task attempts, HTTP requests, and more.
 
 | Name          | Description                      |
-| ------------- | -------------------------------- |
-| Task triggers | Task triggers.                   |
-| Task attempts | Task attempts.                   |
+| :------------ | :------------------------------- |
+| Task triggers | Task triggers                    |
+| Task attempts | Task attempts                    |
 | HTTP requests | HTTP requests made by your code. |
 
 ### Adding instrumentations

--- a/docs/machines.mdx
+++ b/docs/machines.mdx
@@ -31,7 +31,7 @@ export const config: TriggerConfig = {
 ## Machine configurations
 
 | Preset              | vCPU | Memory | Disk space |
-| ------------------- | ---- | ------ | ---------- |
+| :------------------ | :--- | :----- | :--------- |
 | micro               | 0.25 | 0.25   | 10GB       |
 | small-1x (default)  | 0.5  | 0.5    | 10GB       |
 | small-2x            | 1    | 1      | 10GB       |

--- a/docs/snippets/corepack-error.mdx
+++ b/docs/snippets/corepack-error.mdx
@@ -1,0 +1,8 @@
+### `Cannot find matching keyid`
+
+This error occurs when using Node.js v22 with corepack, as it's not yet compatible with the latest package manager signatures. To fix this, either:
+
+1. Downgrade to Node.js v20 (LTS), or
+2. Install corepack globally: `npm i -g corepack@latest`
+
+The corepack bug and workaround are detailed in [this issue](https://github.com/npm/cli/issues/8075).

--- a/docs/snippets/run-dev-and-next-concurrently.mdx
+++ b/docs/snippets/run-dev-and-next-concurrently.mdx
@@ -1,0 +1,20 @@
+<Tip>
+  Instead of running your Next.js app and Trigger.dev dev server in separate terminals, you can run them concurrently. First, add these scripts to your `package.json`:
+
+  ```json
+  {
+    "scripts": {
+      "trigger:dev": "npx trigger.dev@latest dev",
+      "dev": "npx concurrently --kill-others --names \"next,trigger\" --prefix-colors \"yellow,blue\" \"next dev\" \"npm run trigger:dev\""
+    }
+  }
+  ```
+
+  Then, in your terminal, you can start both servers with a single command:
+
+  ```bash
+  npm run dev
+  ```
+
+  This will run both your Next.js app and Trigger.dev dev server in the same terminal window, with color-coded output to distinguish between them.
+</Tip>

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -29,6 +29,10 @@ Then change the permissions of the npm folder (if 1 doesn't work):
 sudo chown -R $(whoami) ~/.npm
 ```
 
+### Clear the build cache
+
+Ensure you have stopped your local dev server then locate the hidden `.trigger` folder in your project and delete it. You can then restart your local dev server.
+
 ## Deployment
 
 Running the [trigger.dev deploy] command builds and deploys your code. Sometimes there can be issues building your code.

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -67,6 +67,10 @@ export default defineConfig({
 });
 ```
 
+### `Cannot find module '/app/lib/worker.js"` when using pino
+
+If you see this error, add pino (and any other associated packages) to your `external` build settings in your `trigger.config.ts` file. Learn more about the `external` setting in the [config docs](/config/config-file#external).
+
 ## Project setup issues
 
 ### `The requested module 'node:events' does not provide an export named 'addAbortListener'`

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -6,6 +6,7 @@ description: "Some common problems you might experience and their solutions"
 import NextjsTroubleshootingMissingApiKey from "/snippets/nextjs-missing-api-key.mdx";
 import NextjsTroubleshootingButtonSyntax from "/snippets/nextjs-button-syntax.mdx";
 import RateLimitHitUseBatchTrigger from "/snippets/rate-limit-hit-use-batchtrigger.mdx";
+import CorepackError from "/snippets/corepack-error.mdx";
 
 ## Development
 
@@ -70,6 +71,9 @@ export default defineConfig({
 ### `Cannot find module '/app/lib/worker.js"` when using pino
 
 If you see this error, add pino (and any other associated packages) to your `external` build settings in your `trigger.config.ts` file. Learn more about the `external` setting in the [config docs](/config/config-file#external).
+
+<CorepackError />
+
 
 ## Project setup issues
 


### PR DESCRIPTION
A range of docs improvements: 

- Adds “Explore by build extension” to the intro page
- Adds instructions for clearing the build cache\
- Add a tip for running trigger dev + next dev concurrently
- left align table headers
- Adds trouble shooting for pino
- Adds corepack bug and workaround
- Removes reference to undici as it messes with spans
- Adds example for exporting logs to Axiom

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Introduced a new section with configuration examples for telemetry exporters.
  - Added guidance on handling Corepack errors and troubleshooting deployment issues, including cache clearing and external package settings.
  - Enhanced the Next.js guide with instructions for running development servers concurrently.
  - Expanded the introduction with a table of build extensions.
  - Improved table formatting in logging and machine configurations for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->