### PR TITLE
Run Engine 2: reschedule heartbeats and added a test to check it works

### DIFF
--- a/internal-packages/run-engine/src/engine/index.ts
+++ b/internal-packages/run-engine/src/engine/index.ts
@@ -2431,8 +2431,11 @@ export class RunEngine {
       },
     });
 
-    //extending is the same as creating a new heartbeat
-    await this.#setHeartbeatDeadline({ runId, snapshotId, status: latestSnapshot.executionStatus });
+    //extending the heartbeat
+    const intervalMs = this.#getHeartbeatIntervalMs(latestSnapshot.executionStatus);
+    if (intervalMs !== null) {
+      await this.worker.reschedule(`heartbeatSnapshot.${runId}`, new Date(Date.now() + intervalMs));
+    }
 
     return executionResultFromSnapshot(latestSnapshot);
   }
@@ -3636,11 +3639,15 @@ export class RunEngine {
 
     if (!error) {
       //set heartbeat (if relevant)
-      await this.#setHeartbeatDeadline({
-        status: newSnapshot.executionStatus,
-        runId: run.id,
-        snapshotId: newSnapshot.id,
-      });
+      const intervalMs = this.#getHeartbeatIntervalMs(newSnapshot.executionStatus);
+      if (intervalMs !== null) {
+        await this.worker.enqueue({
+          id: `heartbeatSnapshot.${run.id}`,
+          job: "heartbeatSnapshot",
+          payload: { snapshotId: newSnapshot.id, runId: run.id },
+          availableAt: new Date(Date.now() + intervalMs),
+        });
+      }
     }
 
     this.eventBus.emit("executionSnapshotCreated", {
@@ -3684,29 +3691,6 @@ export class RunEngine {
   //#endregion
 
   //#region Heartbeat
-  async #setHeartbeatDeadline({
-    runId,
-    snapshotId,
-    status,
-  }: {
-    runId: string;
-    snapshotId: string;
-    status: TaskRunExecutionStatus;
-  }) {
-    const intervalMs = this.#getHeartbeatIntervalMs(status);
-
-    if (intervalMs === null) {
-      return;
-    }
-
-    await this.worker.enqueue({
-      id: `heartbeatSnapshot.${runId}`,
-      job: "heartbeatSnapshot",
-      payload: { snapshotId, runId },
-      availableAt: new Date(Date.now() + intervalMs),
-    });
-  }
-
   async #handleStalledSnapshot({
     runId,
     snapshotId,


### PR DESCRIPTION
This pull request includes changes to improve the heartbeat mechanism in the `RunEngine` class and adds a new test to ensure the functionality of the heartbeat system. The most important changes include refactoring the heartbeat scheduling logic and adding a comprehensive test case.

Improvements to heartbeat mechanism:

* [`internal-packages/run-engine/src/engine/index.ts`](diffhunk://#diff-d29236a78d70dd8a019a2ec308d8eab0eda9f5fbf116d19d5c99b8f573a1b5dfL2434-R2438): Refactored the heartbeat scheduling logic by removing the `#setHeartbeatDeadline` method and directly scheduling heartbeats using `this.worker.enqueue` and `this.worker.reschedule` methods. [[1]](diffhunk://#diff-d29236a78d70dd8a019a2ec308d8eab0eda9f5fbf116d19d5c99b8f573a1b5dfL2434-R2438) [[2]](diffhunk://#diff-d29236a78d70dd8a019a2ec308d8eab0eda9f5fbf116d19d5c99b8f573a1b5dfL3639-R3651) [[3]](diffhunk://#diff-d29236a78d70dd8a019a2ec308d8eab0eda9f5fbf116d19d5c99b8f573a1b5dfL3687-L3709)

Addition of new test:

* [`internal-packages/run-engine/src/engine/tests/heartbeats.test.ts`](diffhunk://#diff-3f72e8ba06b9a80193bfb66b4e613dcac4560a7a2ec7f146aff6164d64c3fb6fR493-R611): Added a new test case "Heartbeat keeps run alive" to verify that the heartbeat mechanism correctly keeps the run alive and transitions to the queued state after the timeout period when heartbeats are no longer sent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the process for scheduling periodic signals to maintain continuous task execution.
- **Tests**
  - Added a new test validating that ongoing signals correctly keep tasks active and that execution status transitions as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->