### PR TITLE
Docs: Corrects the number of schedules on Free tier from 5 to 10

### DIFF
--- a/docs/limits.mdx
+++ b/docs/limits.mdx
@@ -39,7 +39,7 @@ The number of queued tasks by environment.
 
 | Pricing tier | Limit              |
 | :----------- | :----------------- |
-| Free         | 5 per project      |
+| Free         | 10 per project      |
 | Hobby        | 100 per project    |
 | Pro          | 1,000+ per project |
 


### PR DESCRIPTION
Text update: corrects the number of schedules on Free tier from 5 to 10 on the limits page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Free tier scheduling limit from 5 to 10 per project, giving users on the Free plan enhanced scheduling capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->