### PR TITLE
FEAT:proritizing trigger.config istead of package.json

### DIFF
--- a/packages/cli-v3/e2e/fixtures/monorepo-react-email/package.json
+++ b/packages/cli-v3/e2e/fixtures/monorepo-react-email/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monorepo-react-email",
   "private": true,
-  "packageManager": "pnpm@8.15.5+sha256.4b4efa12490e5055d59b9b9fc9438b7d581a6b7af3b5675eb5c5f447cee1a589",
+  "packageManager": "pnpm@8.15.5+sha512.b051a32c7e695833b84926d3b29b8cca57254b589f0649d899c6e9d0edb670b91ec7e2a43459bae73759bb5ce619c3266f116bf931ce22d1ef1759a7e45aa96f",
   "engines": {
     "pnpm": "8.15.5",
     "yarn": "4.2.2"


### PR DESCRIPTION
PR: Prioritize trigger.config.ts location for base path determination

Closes #1467 

## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [ ] The PR title follows the convention.
- [ ] I ran and tested the code works

---

## Testing

_[Describe the steps you took to test this change]_

---

## Changelog

_[Short description of what has changed]_
This PR fixes an issue with path resolution in monorepo setups that don't have individual package.json files in each workspace. The fix prioritizes finding the trigger.config.ts file to determine the "base" path instead of relying solely on package.json location.

Changes made:

Added a findTriggerConfigDir function to locate the directory containing trigger.config.ts
Updated the path resolution logic in resolveConfig to prioritize trigger.config.ts location over package.json 

// Prioritize trigger.config.ts location over package.json
const workingDir = result.configFile
  ? dirname(result.configFile)
  : configDir
  ? configDir
  : packageJsonPath
  ? dirname(packageJsonPath)
  : cwd;
---

## Screenshots

_[Screenshots]_

💯
