### PR TITLE
Side menu: style fixes, small improvements and better Info Panel component props

### DIFF
--- a/apps/webapp/app/components/BlankStatePanels.tsx
+++ b/apps/webapp/app/components/BlankStatePanels.tsx
@@ -82,10 +82,15 @@ export function HasNoTasksDeployed({ environment }: { environment: MinimumEnviro
       icon={TaskIcon}
       iconClassName="text-blue-500"
       panelClassName="max-w-full"
-      to={docsPath("deployment/overview")}
-      buttonLabel="How to deploy tasks"
-      buttonVariant="docs/small"
-      buttonLeadingIcon={BookOpenIcon}
+      accessory={
+        <LinkButton
+          to={docsPath("deployment/overview")}
+          variant="docs/small"
+          LeadingIcon={BookOpenIcon}
+        >
+          How to deploy tasks
+        </LinkButton>
+      }
     >
       <Paragraph spacing variant="small">
         Run the <TextLink to={docsPath("deployment/overview")}>CLI deploy command</TextLink> to
@@ -102,10 +107,15 @@ export function SchedulesNoPossibleTaskPanel() {
       icon={ClockIcon}
       iconClassName="text-sun-500"
       panelClassName="max-w-full"
-      to={docsPath("v3/tasks-scheduled")}
-      buttonLabel="How to schedule tasks"
-      buttonVariant="docs/small"
-      buttonLeadingIcon={BookOpenIcon}
+      accessory={
+        <LinkButton
+          to={docsPath("v3/tasks-scheduled")}
+          variant="docs/small"
+          LeadingIcon={BookOpenIcon}
+        >
+          How to schedule tasks
+        </LinkButton>
+      }
     >
       <Paragraph spacing variant="small">
         You have no scheduled tasks in your project. Before you can schedule a task you need to
@@ -135,15 +145,16 @@ export function SchedulesNoneAttached() {
       <div className="flex gap-2">
         <LinkButton
           to={`${v3NewSchedulePath(organization, project, environment)}${location.search}`}
-          variant="primary/small"
+          variant="secondary/medium"
           LeadingIcon={RectangleGroupIcon}
           className="inline-flex"
+          leadingIconClassName="text-sun-500"
         >
           Use the dashboard
         </LinkButton>
         <LinkButton
           to={docsPath("v3/tasks-scheduled")}
-          variant="primary/small"
+          variant="docs/medium"
           LeadingIcon={BookOpenIcon}
           className="inline-flex"
         >
@@ -161,10 +172,11 @@ export function BatchesNone() {
       icon={Squares2X2Icon}
       iconClassName="text-blue-500"
       panelClassName="max-w-full"
-      to={docsPath("triggering")}
-      buttonLabel="How to trigger batches"
-      buttonVariant="docs/small"
-      buttonLeadingIcon={BookOpenIcon}
+      accessory={
+        <LinkButton to={docsPath("triggering")} variant="docs/small" LeadingIcon={BookOpenIcon}>
+          How to trigger batches
+        </LinkButton>
+      }
     >
       <Paragraph spacing variant="small">
         You have no batches in this environment. You can trigger batches from your backend or from
@@ -184,8 +196,15 @@ export function TestHasNoTasks() {
       icon={BeakerIcon}
       iconClassName="text-lime-500"
       panelClassName="max-w-full"
-      to={v3EnvironmentPath(organization, project, environment)}
-      buttonLabel="Create a task"
+      accessory={
+        <LinkButton
+          to={v3EnvironmentPath(organization, project, environment)}
+          variant="secondary/small"
+          LeadingIcon={PlusIcon}
+        >
+          Create a task
+        </LinkButton>
+      }
     >
       <Paragraph spacing variant="small">
         Before testing a task, you must first create one. Follow the instructions on the{" "}
@@ -373,8 +392,15 @@ export function QueuesHasNoTasks() {
       icon={RectangleStackIcon}
       iconClassName="text-blue-500"
       panelClassName="max-w-md"
-      to={v3EnvironmentPath(organization, project, environment)}
-      buttonLabel="Create a task"
+      accessory={
+        <LinkButton
+          to={v3EnvironmentPath(organization, project, environment)}
+          variant="secondary/small"
+          LeadingIcon={PlusIcon}
+        >
+          Create a task
+        </LinkButton>
+      }
     >
       <Paragraph spacing variant="small">
         Queues will appear here when you have created a task in this environment. Follow the

--- a/apps/webapp/app/components/BlankStatePanels.tsx
+++ b/apps/webapp/app/components/BlankStatePanels.tsx
@@ -346,7 +346,15 @@ export function AlertsNoneDeployed() {
           and webhooks.
         </Paragraph>
 
-        <div className="flex gap-3">
+        <div className="flex items-center justify-between gap-3">
+          <LinkButton
+            to={docsPath("troubleshooting-alerts")}
+            variant="docs/medium"
+            LeadingIcon={BookOpenIcon}
+            className="inline-flex"
+          >
+            Alerts docs
+          </LinkButton>
           <LinkButton
             to={v3NewProjectAlertPath(organization, project, environment)}
             variant="primary/medium"
@@ -354,14 +362,6 @@ export function AlertsNoneDeployed() {
             shortcut={{ key: "n" }}
           >
             New alert
-          </LinkButton>
-          <LinkButton
-            to={docsPath("troubleshooting-alerts")}
-            variant="docs/medium"
-            LeadingIcon={BookOpenIcon}
-            className="inline-flex"
-          >
-            Alert docs
           </LinkButton>
         </div>
       </InfoPanel>

--- a/apps/webapp/app/components/BlankStatePanels.tsx
+++ b/apps/webapp/app/components/BlankStatePanels.tsx
@@ -378,7 +378,7 @@ export function QueuesHasNoTasks() {
     <InfoPanel
       title="You have no queues"
       icon={RectangleStackIcon}
-      iconClassName="text-purple-500"
+      iconClassName="text-blue-500"
       panelClassName="max-w-full"
     >
       <Paragraph spacing variant="small">

--- a/apps/webapp/app/components/BlankStatePanels.tsx
+++ b/apps/webapp/app/components/BlankStatePanels.tsx
@@ -10,7 +10,11 @@ import {
   ServerStackIcon,
   Squares2X2Icon,
 } from "@heroicons/react/20/solid";
+import { useLocation } from "react-use";
 import { TaskIcon } from "~/assets/icons/TaskIcon";
+import { useEnvironment } from "~/hooks/useEnvironment";
+import { useOrganization } from "~/hooks/useOrganizations";
+import { useProject } from "~/hooks/useProject";
 import { type MinimumEnvironment } from "~/presenters/SelectBestEnvironmentPresenter.server";
 import {
   docsPath,
@@ -22,20 +26,15 @@ import {
 import { InlineCode } from "./code/InlineCode";
 import { environmentFullTitle } from "./environments/EnvironmentLabel";
 import { Feedback } from "./Feedback";
+import { EnvironmentSelector } from "./navigation/EnvironmentSelector";
 import { Button, LinkButton } from "./primitives/Buttons";
 import { Header1 } from "./primitives/Headers";
 import { InfoPanel } from "./primitives/InfoPanel";
 import { Paragraph } from "./primitives/Paragraph";
 import { StepNumber } from "./primitives/StepNumber";
+import { TextLink } from "./primitives/TextLink";
 import { InitCommandV3, PackageManagerProvider, TriggerDevStepV3 } from "./SetupCommands";
 import { StepContentContainer } from "./StepContentContainer";
-import { useLocation } from "react-use";
-import { useEnvironment } from "~/hooks/useEnvironment";
-import { useOrganization } from "~/hooks/useOrganizations";
-import { useProject } from "~/hooks/useProject";
-import { TextLink } from "./primitives/TextLink";
-import { EnvironmentSelector } from "./navigation/EnvironmentSelector";
-import { Pi } from "lucide-react";
 
 export function HasNoTasksDev() {
   return (
@@ -104,18 +103,15 @@ export function SchedulesNoPossibleTaskPanel() {
       icon={ClockIcon}
       iconClassName="text-sun-500"
       panelClassName="max-w-full"
+      to={docsPath("v3/tasks-scheduled")}
+      buttonLabel="How to schedule tasks"
+      buttonVariant="docs/small"
+      buttonLeadingIcon={BookOpenIcon}
     >
       <Paragraph spacing variant="small">
         You have no scheduled tasks in your project. Before you can schedule a task you need to
         create a <InlineCode>schedules.task</InlineCode>.
       </Paragraph>
-      <LinkButton
-        to={docsPath("v3/tasks-scheduled")}
-        variant="docs/medium"
-        LeadingIcon={BookOpenIcon}
-      >
-        View the docs
-      </LinkButton>
     </InfoPanel>
   );
 }
@@ -166,14 +162,15 @@ export function BatchesNone() {
       icon={Squares2X2Icon}
       iconClassName="text-blue-500"
       panelClassName="max-w-full"
+      to={docsPath("triggering")}
+      buttonLabel="How to trigger batches"
+      buttonVariant="docs/small"
+      buttonLeadingIcon={BookOpenIcon}
     >
       <Paragraph spacing variant="small">
         You have no batches in this environment. You can trigger batches from your backend or from
         inside other tasks.
       </Paragraph>
-      <LinkButton to={docsPath("triggering")} variant="docs/medium" LeadingIcon={BookOpenIcon}>
-        How to trigger batches
-      </LinkButton>
     </InfoPanel>
   );
 }
@@ -182,23 +179,20 @@ export function TestHasNoTasks() {
   const organization = useOrganization();
   const project = useProject();
   const environment = useEnvironment();
-
   return (
     <InfoPanel
-      title="No tasks to test"
+      title="You don't have any tasks to test"
       icon={BeakerIcon}
       iconClassName="text-lime-500"
       panelClassName="max-w-full"
+      to={v3EnvironmentPath(organization, project, environment)}
+      buttonLabel="Create a task"
     >
       <Paragraph spacing variant="small">
-        You have no tasks in this environment.
+        Before testing a task, you must first create one. Follow the instructions on the{" "}
+        <TextLink to={v3EnvironmentPath(organization, project, environment)}>Tasks page</TextLink>{" "}
+        to create a task, then return here to test it.
       </Paragraph>
-      <LinkButton
-        to={v3EnvironmentPath(organization, project, environment)}
-        variant="tertiary/medium"
-      >
-        Add tasks
-      </LinkButton>
     </InfoPanel>
   );
 }
@@ -376,20 +370,19 @@ export function QueuesHasNoTasks() {
 
   return (
     <InfoPanel
-      title="You have no queues"
+      title="You don't have any queues"
       icon={RectangleStackIcon}
       iconClassName="text-blue-500"
-      panelClassName="max-w-full"
+      panelClassName="max-w-md"
+      to={v3EnvironmentPath(organization, project, environment)}
+      buttonLabel="Create a task"
     >
       <Paragraph spacing variant="small">
-        This means you haven't got any tasks yet in this environment.
+        Queues will appear here when you have created a task in this environment. Follow the
+        instructions on the{" "}
+        <TextLink to={v3EnvironmentPath(organization, project, environment)}>Tasks page</TextLink>{" "}
+        to create a task, then return here to see its queue.
       </Paragraph>
-      <LinkButton
-        to={v3EnvironmentPath(organization, project, environment)}
-        variant="tertiary/medium"
-      >
-        Add tasks
-      </LinkButton>
     </InfoPanel>
   );
 }

--- a/apps/webapp/app/components/BlankStatePanels.tsx
+++ b/apps/webapp/app/components/BlankStatePanels.tsx
@@ -78,20 +78,19 @@ export function HasNoTasksDev() {
 export function HasNoTasksDeployed({ environment }: { environment: MinimumEnvironment }) {
   return (
     <InfoPanel
-      title="You don't have any deployed tasks"
+      title={`You don't have any deployed tasks in ${environmentFullTitle(environment)}`}
       icon={TaskIcon}
       iconClassName="text-blue-500"
+      panelClassName="max-w-full"
+      to={docsPath("deployment/overview")}
+      buttonLabel="How to deploy tasks"
+      buttonVariant="docs/small"
+      buttonLeadingIcon={BookOpenIcon}
     >
       <Paragraph spacing variant="small">
-        You don't have any deployed tasks in {environmentFullTitle(environment)}.
+        Run the <TextLink to={docsPath("deployment/overview")}>CLI deploy command</TextLink> to
+        deploy your tasks to the {environmentFullTitle(environment)} environment.
       </Paragraph>
-      <LinkButton
-        to={docsPath("deployment/overview")}
-        variant="docs/medium"
-        LeadingIcon={BookOpenIcon}
-      >
-        How to deploy tasks
-      </LinkButton>
     </InfoPanel>
   );
 }

--- a/apps/webapp/app/components/navigation/SideMenu.tsx
+++ b/apps/webapp/app/components/navigation/SideMenu.tsx
@@ -449,7 +449,7 @@ function SwitchOrganizations({
   return (
     <Popover onOpenChange={(open) => setMenuOpen(open)} open={isMenuOpen}>
       <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
-        <PopoverTrigger className="h-7 w-full justify-between overflow-hidden focus-custom">
+        <PopoverTrigger className="w-full justify-between overflow-hidden focus-custom">
           <ButtonContent
             variant="small-menu-item"
             className="hover:bg-charcoal-750"

--- a/apps/webapp/app/components/navigation/SideMenu.tsx
+++ b/apps/webapp/app/components/navigation/SideMenu.tsx
@@ -473,7 +473,7 @@ function SwitchOrganizations({
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
         >
-          <div className="p-1">
+          <div className="flex flex-col gap-1 p-1">
             {organizations.map((org) => (
               <PopoverMenuItem
                 key={org.id}

--- a/apps/webapp/app/components/navigation/SideMenu.tsx
+++ b/apps/webapp/app/components/navigation/SideMenu.tsx
@@ -3,7 +3,6 @@ import {
   ArrowRightOnRectangleIcon,
   BeakerIcon,
   BellAlertIcon,
-  BookOpenIcon,
   ChartBarIcon,
   ChevronRightIcon,
   ClockIcon,
@@ -59,16 +58,11 @@ import {
 import connectedImage from "../../assets/images/cli-connected.png";
 import disconnectedImage from "../../assets/images/cli-disconnected.png";
 import { FreePlanUsage } from "../billing/FreePlanUsage";
+import { InlineCode } from "../code/InlineCode";
 import { useDevPresence } from "../DevPresence";
 import { ImpersonationBanner } from "../ImpersonationBanner";
 import { Button, ButtonContent, LinkButton } from "../primitives/Buttons";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTrigger,
-} from "../primitives/Dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTrigger } from "../primitives/Dialog";
 import { Paragraph } from "../primitives/Paragraph";
 import {
   Popover,
@@ -86,7 +80,6 @@ import { HelpAndFeedback } from "./HelpAndFeedbackPopover";
 import { SideMenuHeader } from "./SideMenuHeader";
 import { SideMenuItem } from "./SideMenuItem";
 import { SideMenuSection } from "./SideMenuSection";
-import { InlineCode } from "../code/InlineCode";
 
 type SideMenuUser = Pick<User, "email" | "admin"> & { isImpersonating: boolean };
 export type SideMenuProject = Pick<
@@ -280,7 +273,7 @@ function ProjectSelector({
 
   let plan: string | undefined = undefined;
   if (currentPlan?.v3Subscription?.isPaying === false) {
-    plan = "Free plan";
+    plan = "Free";
   } else if (currentPlan?.v3Subscription?.isPaying === true) {
     plan = currentPlan.v3Subscription.plan?.title;
   }
@@ -326,7 +319,7 @@ function ProjectSelector({
                     className="text-xs"
                     to={v3BillingPath(organization)}
                   >
-                    {plan} {plan !== "Free plan" && "plan"}
+                    {plan} plan
                   </TextLink>
                 )}
                 <TextLink

--- a/apps/webapp/app/components/navigation/SideMenu.tsx
+++ b/apps/webapp/app/components/navigation/SideMenu.tsx
@@ -326,7 +326,7 @@ function ProjectSelector({
                     className="text-xs"
                     to={v3BillingPath(organization)}
                   >
-                    {plan}
+                    {plan} {plan !== "Free plan" && "plan"}
                   </TextLink>
                 )}
                 <TextLink

--- a/apps/webapp/app/components/navigation/SideMenuItem.tsx
+++ b/apps/webapp/app/components/navigation/SideMenuItem.tsx
@@ -56,7 +56,7 @@ export function SideMenuItem({
 
 export function MenuCount({ count }: { count: number | string }) {
   return (
-    <div className="rounded-full bg-charcoal-900 px-2 py-1 text-xxs uppercase tracking-wider text-text-dimmed">
+    <div className="rounded border border-charcoal-650 bg-background-dimmed/70 px-1.5 py-1 text-xxs uppercase tracking-wider text-text-dimmed">
       {count}
     </div>
   );

--- a/apps/webapp/app/components/navigation/SideMenuSection.tsx
+++ b/apps/webapp/app/components/navigation/SideMenuSection.tsx
@@ -29,7 +29,7 @@ export function SideMenuSection({
   return (
     <div>
       <div
-        className="flex cursor-pointer items-center gap-1 rounded-sm py-1 pl-1 text-text-dimmed hover:bg-charcoal-750 hover:text-text-bright"
+        className="flex cursor-pointer items-center gap-1 rounded-sm py-1 pl-1 text-text-dimmed transition hover:bg-charcoal-750 hover:text-text-bright"
         onClick={handleToggle}
       >
         <h2 className="text-xs">{title}</h2>

--- a/apps/webapp/app/components/primitives/InfoPanel.tsx
+++ b/apps/webapp/app/components/primitives/InfoPanel.tsx
@@ -1,7 +1,7 @@
 import { cn } from "~/utils/cn";
-import { LinkButton } from "./Buttons";
 import { Header2 } from "./Headers";
 import { Paragraph } from "./Paragraph";
+import { type ReactNode } from "react";
 
 const variants = {
   info: {
@@ -20,10 +20,7 @@ type InfoPanelVariant = keyof typeof variants;
 type Props = {
   title?: string;
   children: React.ReactNode;
-  to?: string;
-  buttonLabel?: string;
-  buttonVariant?: React.ComponentProps<typeof LinkButton>["variant"];
-  buttonLeadingIcon?: React.ComponentProps<typeof LinkButton>["LeadingIcon"];
+  accessory?: ReactNode;
   icon: React.ComponentType<any>;
   iconClassName?: string;
   variant?: InfoPanelVariant;
@@ -33,10 +30,7 @@ type Props = {
 export function InfoPanel({
   title,
   children,
-  to,
-  buttonLabel,
-  buttonVariant = "secondary/small",
-  buttonLeadingIcon,
+  accessory,
   icon,
   iconClassName,
   variant = "info",
@@ -54,14 +48,10 @@ export function InfoPanel({
         panelClassName
       )}
     >
-      <div className={cn("flex items-center gap-2", to ? "w-full justify-between" : "")}>
+      <div className={cn("flex items-center gap-2", accessory ? "w-full justify-between" : "")}>
         <Icon className={cn("size-5", iconClassName)} />
 
-        {to && (
-          <LinkButton to={to} variant={buttonVariant} LeadingIcon={buttonLeadingIcon}>
-            {buttonLabel}
-          </LinkButton>
-        )}
+        {accessory}
       </div>
       <div className="flex flex-col gap-1">
         {title && <Header2 className="text-text-bright">{title}</Header2>}

--- a/apps/webapp/app/components/primitives/InfoPanel.tsx
+++ b/apps/webapp/app/components/primitives/InfoPanel.tsx
@@ -22,6 +22,8 @@ type Props = {
   children: React.ReactNode;
   to?: string;
   buttonLabel?: string;
+  buttonVariant?: React.ComponentProps<typeof LinkButton>["variant"];
+  buttonLeadingIcon?: React.ComponentProps<typeof LinkButton>["LeadingIcon"];
   icon: React.ComponentType<any>;
   iconClassName?: string;
   variant?: InfoPanelVariant;
@@ -33,6 +35,8 @@ export function InfoPanel({
   children,
   to,
   buttonLabel,
+  buttonVariant = "secondary/small",
+  buttonLeadingIcon,
   icon,
   iconClassName,
   variant = "info",
@@ -54,7 +58,7 @@ export function InfoPanel({
         <Icon className={cn("size-5", iconClassName)} />
 
         {to && (
-          <LinkButton to={to} variant="secondary/small">
+          <LinkButton to={to} variant={buttonVariant} LeadingIcon={buttonLeadingIcon}>
             {buttonLabel}
           </LinkButton>
         )}

--- a/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
@@ -50,10 +50,7 @@ export class ScheduleListPresenter extends BasePresenter {
     pageSize = DEFAULT_PAGE_SIZE,
   }: ScheduleListOptions) {
     const hasFilters =
-      type !== undefined ||
-      tasks !== undefined ||
-      environments !== undefined ||
-      (search !== undefined && search !== "");
+      type !== undefined || tasks !== undefined || (search !== undefined && search !== "");
 
     const filterType =
       type === "declarative" ? "DECLARATIVE" : type === "imperative" ? "IMPERATIVE" : undefined;

--- a/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
@@ -1,11 +1,11 @@
-import { Prisma, RuntimeEnvironmentType, ScheduleType } from "@trigger.dev/database";
-import { ScheduleListFilters } from "~/components/runs/v3/ScheduleFilters";
+import { Prisma, type RuntimeEnvironmentType, type ScheduleType } from "@trigger.dev/database";
+import { type ScheduleListFilters } from "~/components/runs/v3/ScheduleFilters";
 import { sqlDatabaseSchema } from "~/db.server";
 import { displayableEnvironment } from "~/models/runtimeEnvironment.server";
-import { getCurrentPlan, getLimit, getLimits } from "~/services/platform.v3.server";
+import { getLimit } from "~/services/platform.v3.server";
+import { CheckScheduleService } from "~/v3/services/checkSchedule.server";
 import { calculateNextScheduledTimestamp } from "~/v3/utils/calculateNextSchedule.server";
 import { BasePresenter } from "./basePresenter.server";
-import { CheckScheduleService } from "~/v3/services/checkSchedule.server";
 
 type ScheduleListOptions = {
   projectId: string;

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.invite/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.invite/route.tsx
@@ -153,8 +153,11 @@ export default function Page() {
             icon={LockOpenIcon}
             iconClassName="text-indigo-500"
             title="Unlock more team members"
-            to={v3BillingPath(organization)}
-            buttonLabel="Upgrade"
+            accessory={
+              <LinkButton to={v3BillingPath(organization)} variant="secondary/small">
+                Upgrade
+              </LinkButton>
+            }
             panelClassName="mb-4"
           >
             <Paragraph variant="small">

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.apikeys/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.apikeys/route.tsx
@@ -1,10 +1,9 @@
-import { BookOpenIcon, InformationCircleIcon, LockOpenIcon } from "@heroicons/react/20/solid";
-import { ArrowUpCircleIcon } from "@heroicons/react/24/outline";
+import { ArrowUpCircleIcon, BookOpenIcon, InformationCircleIcon } from "@heroicons/react/20/solid";
 import { type MetaFunction } from "@remix-run/react";
 import { type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { AdminDebugTooltip } from "~/components/admin/debugTooltip";
-import { environmentTitle, EnvironmentCombo } from "~/components/environments/EnvironmentLabel";
+import { EnvironmentCombo, environmentTitle } from "~/components/environments/EnvironmentLabel";
 import { RegenerateApiKeyModal } from "~/components/environments/RegenerateApiKeyModal";
 import { PageBody, PageContainer } from "~/components/layout/AppLayout";
 import { LinkButton } from "~/components/primitives/Buttons";
@@ -144,6 +143,7 @@ export default function Page() {
                       )}
                       variant="secondary/small"
                       LeadingIcon={ArrowUpCircleIcon}
+                      leadingIconClassName="text-indigo-500"
                     >
                       Upgrade to get staging environment
                     </LinkButton>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -405,9 +405,9 @@ export default function Page() {
                     ))
                   ) : (
                     <TableRow>
-                      <TableCell colSpan={5}>
+                      <TableCell colSpan={6}>
                         <div className="grid place-items-center py-6 text-text-dimmed">
-                          No queues found
+                          <Paragraph>No queues found</Paragraph>
                         </div>
                       </TableCell>
                     </TableRow>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
@@ -23,15 +23,16 @@ import { type RuntimeEnvironmentType } from "@trigger.dev/database";
 import { motion } from "framer-motion";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { DisconnectedIcon } from "~/assets/icons/ConnectionIcons";
 import { ShowParentIcon, ShowParentIconSelected } from "~/assets/icons/ShowParentIcon";
 import tileBgPath from "~/assets/images/error-banner-tile@2x.png";
+import { useDevPresence } from "~/components/DevPresence";
 import { AdminDebugTooltip } from "~/components/admin/debugTooltip";
-import { InlineCode } from "~/components/code/InlineCode";
-import { EnvironmentCombo } from "~/components/environments/EnvironmentLabel";
 import { PageBody } from "~/components/layout/AppLayout";
 import { Badge } from "~/components/primitives/Badge";
 import { Button, LinkButton } from "~/components/primitives/Buttons";
 import { Callout } from "~/components/primitives/Callout";
+import { ClipboardField } from "~/components/primitives/ClipboardField";
 import { DateTimeShort } from "~/components/primitives/DateTime";
 import { Dialog, DialogTrigger } from "~/components/primitives/Dialog";
 import { Header3 } from "~/components/primitives/Headers";
@@ -93,9 +94,6 @@ import {
 } from "~/utils/pathBuilder";
 import { useCurrentPlan } from "../_app.orgs.$organizationSlug/route";
 import { SpanView } from "../resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route";
-import { useDevPresence } from "~/components/DevPresence";
-import { DisconnectedIcon } from "~/assets/icons/ConnectionIcons";
-import { ClipboardField } from "~/components/primitives/ClipboardField";
 
 const resizableSettings = {
   parent: {
@@ -404,8 +402,11 @@ function NoLogsView({ run, resizable }: LoaderData) {
                 icon={LockOpenIcon}
                 iconClassName="text-indigo-500"
                 title="Unlock longer log retention"
-                to={v3BillingPath(organization)}
-                buttonLabel="Upgrade"
+                accessory={
+                  <LinkButton to={v3BillingPath(organization)} variant="secondary/small">
+                    Upgrade
+                  </LinkButton>
+                }
               >
                 <Paragraph variant="small">
                   The logs for this run have been deleted because the run completed{" "}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs._index/route.tsx
@@ -33,9 +33,11 @@ import { TextLink } from "~/components/primitives/TextLink";
 import { RunsFilters, TaskRunListSearchFilters } from "~/components/runs/v3/RunFilters";
 import { TaskRunsTable } from "~/components/runs/v3/TaskRunsTable";
 import { BULK_ACTION_RUN_LIMIT } from "~/consts";
+import { useEnvironment } from "~/hooks/useEnvironment";
 import { useOrganization } from "~/hooks/useOrganizations";
 import { useProject } from "~/hooks/useProject";
 import { findProjectBySlug } from "~/models/project.server";
+import { findEnvironmentBySlug } from "~/models/runtimeEnvironment.server";
 import { RunListPresenter } from "~/presenters/v3/RunListPresenter.server";
 import {
   getRootOnlyFilterPreference,
@@ -47,15 +49,11 @@ import { cn } from "~/utils/cn";
 import {
   docsPath,
   EnvironmentParamSchema,
-  ProjectParamSchema,
   v3ProjectPath,
   v3RunsPath,
   v3TestPath,
 } from "~/utils/pathBuilder";
 import { ListPagination } from "../../components/ListPagination";
-import { prisma } from "~/db.server";
-import { useEnvironment } from "~/hooks/useEnvironment";
-import { findEnvironmentBySlug } from "~/models/runtimeEnvironment.server";
 
 export const meta: MetaFunction = () => {
   return [
@@ -438,8 +436,11 @@ function CreateFirstTaskInstructions() {
         iconClassName="text-blue-500"
         panelClassName="max-full"
         title="Create your first task"
-        to={v3ProjectPath(organization, project)}
-        buttonLabel="Create a task"
+        accessory={
+          <LinkButton to={v3ProjectPath(organization, project)} variant="primary/small">
+            Create a task
+          </LinkButton>
+        }
       >
         <Paragraph variant="small">
           Before running a task, you must first create one. Follow the instructions on the{" "}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.schedules.$scheduleParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.schedules.$scheduleParam/route.tsx
@@ -357,8 +357,11 @@ export default function Page() {
                 icon={BookOpenIcon}
                 iconClassName="text-indigo-500"
                 variant="info"
-                buttonLabel="Docs"
-                to="https://trigger.dev/docs/v3/tasks-scheduled"
+                accessory={
+                  <LinkButton to="https://trigger.dev/docs/v3/tasks-scheduled" variant="docs/small">
+                    Docs
+                  </LinkButton>
+                }
                 panelClassName="max-w-full"
               >
                 You can only edit a declarative schedule by updating your schedules.task and then

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.schedules/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.schedules/route.tsx
@@ -1,9 +1,9 @@
-import { ClockIcon, PlusIcon, RectangleGroupIcon } from "@heroicons/react/20/solid";
-import { ArrowUpCircleIcon } from "@heroicons/react/24/outline";
+import { ArrowUpCircleIcon, PlusIcon } from "@heroicons/react/20/solid";
 import { BookOpenIcon } from "@heroicons/react/24/solid";
 import { type MetaFunction, Outlet, useLocation, useParams } from "@remix-run/react";
 import { type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
+import { SchedulesNoneAttached, SchedulesNoPossibleTaskPanel } from "~/components/BlankStatePanels";
 import { Feedback } from "~/components/Feedback";
 import { AdminDebugTooltip } from "~/components/admin/debugTooltip";
 import { InlineCode } from "~/components/code/InlineCode";
@@ -20,7 +20,6 @@ import {
   DialogTrigger,
 } from "~/components/primitives/Dialog";
 import { Header3 } from "~/components/primitives/Headers";
-import { InfoPanel } from "~/components/primitives/InfoPanel";
 import { NavBar, PageAccessories, PageTitle } from "~/components/primitives/PageHeader";
 import { PaginationControls } from "~/components/primitives/Pagination";
 import { Paragraph } from "~/components/primitives/Paragraph";
@@ -47,11 +46,13 @@ import {
   ScheduleTypeIcon,
   scheduleTypeName,
 } from "~/components/runs/v3/ScheduleType";
+import { useEnvironment } from "~/hooks/useEnvironment";
 import { useOrganization } from "~/hooks/useOrganizations";
 import { usePathName } from "~/hooks/usePathName";
 import { useProject } from "~/hooks/useProject";
 import { redirectWithErrorMessage } from "~/models/message.server";
 import { findProjectBySlug } from "~/models/project.server";
+import { findEnvironmentBySlug } from "~/models/runtimeEnvironment.server";
 import {
   type ScheduleListItem,
   ScheduleListPresenter,
@@ -59,16 +60,13 @@ import {
 import { requireUserId } from "~/services/session.server";
 import { cn } from "~/utils/cn";
 import {
-  EnvironmentParamSchema,
   docsPath,
+  EnvironmentParamSchema,
   v3BillingPath,
   v3NewSchedulePath,
   v3SchedulePath,
 } from "~/utils/pathBuilder";
 import { useCurrentPlan } from "../_app.orgs.$organizationSlug/route";
-import { findEnvironmentBySlug } from "~/models/runtimeEnvironment.server";
-import { useEnvironment } from "~/hooks/useEnvironment";
-import { SchedulesNoneAttached, SchedulesNoPossibleTaskPanel } from "~/components/BlankStatePanels";
 
 export const meta: MetaFunction = () => {
   return [

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings/route.tsx
@@ -16,6 +16,7 @@ import { ClipboardField } from "~/components/primitives/ClipboardField";
 import { Fieldset } from "~/components/primitives/Fieldset";
 import { FormButtons } from "~/components/primitives/FormButtons";
 import { FormError } from "~/components/primitives/FormError";
+import { Header2 } from "~/components/primitives/Headers";
 import { Hint } from "~/components/primitives/Hint";
 import { Input } from "~/components/primitives/Input";
 import { InputGroup } from "~/components/primitives/InputGroup";
@@ -149,48 +150,50 @@ export default function Page() {
 
       <PageBody>
         <MainHorizontallyCenteredContainer>
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-4">
-              <Fieldset>
-                <InputGroup>
-                  <Label>Project ref</Label>
-                  <ClipboardField value={project.externalRef} variant={"secondary/small"} />
-                  <Hint>
-                    This goes in your{" "}
-                    <InlineCode variant="extra-extra-small">trigger.config</InlineCode> file.
-                  </Hint>
-                </InputGroup>
-              </Fieldset>
+          <div className="mb-3 border-b border-grid-dimmed pb-3">
+            <Header2>Project settings</Header2>
+          </div>
+          <div className="flex flex-col gap-6">
+            <Fieldset>
+              <InputGroup fullWidth>
+                <Label>Project ref</Label>
+                <ClipboardField value={project.externalRef} variant={"secondary/medium"} />
+                <Hint>
+                  This goes in your{" "}
+                  <InlineCode variant="extra-extra-small">trigger.config</InlineCode> file.
+                </Hint>
+              </InputGroup>
+            </Fieldset>
 
-              <Form method="post" {...renameForm.props} className="max-w-md">
-                <input type="hidden" name="action" value="rename" />
-                <Fieldset>
-                  <InputGroup>
-                    <Label htmlFor={projectName.id}>Rename your project</Label>
-                    <Input
-                      {...conform.input(projectName, { type: "text" })}
-                      defaultValue={project.name}
-                      placeholder="Your project name"
-                      icon={FolderIcon}
-                      autoFocus
-                    />
-                    <FormError id={projectName.errorId}>{projectName.error}</FormError>
-                  </InputGroup>
-                  <FormButtons
-                    confirmButton={
-                      <Button
-                        type="submit"
-                        variant={"primary/small"}
-                        disabled={isRenameLoading}
-                        LeadingIcon={isRenameLoading ? SpinnerWhite : undefined}
-                      >
-                        Rename project
-                      </Button>
-                    }
+            <Form method="post" {...renameForm.props}>
+              <input type="hidden" name="action" value="rename" />
+              <Fieldset className="gap-y-0">
+                <InputGroup fullWidth>
+                  <Label htmlFor={projectName.id}>Rename your project</Label>
+                  <Input
+                    {...conform.input(projectName, { type: "text" })}
+                    defaultValue={project.name}
+                    placeholder="Your project name"
+                    icon={FolderIcon}
+                    autoFocus
                   />
-                </Fieldset>
-              </Form>
-            </div>
+                  <FormError id={projectName.errorId}>{projectName.error}</FormError>
+                </InputGroup>
+                <FormButtons
+                  confirmButton={
+                    <Button
+                      type="submit"
+                      variant={"secondary/small"}
+                      disabled={isRenameLoading}
+                      LeadingIcon={isRenameLoading ? SpinnerWhite : undefined}
+                    >
+                      Rename project
+                    </Button>
+                  }
+                  className="border-t-0"
+                />
+              </Fieldset>
+            </Form>
           </div>
         </MainHorizontallyCenteredContainer>
       </PageBody>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.settings.team/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.settings.team/route.tsx
@@ -226,8 +226,11 @@ export default function Page() {
               icon={LockOpenIcon}
               iconClassName="text-indigo-500"
               title="Unlock more team members"
-              to={v3BillingPath(organization)}
-              buttonLabel="Upgrade"
+              accessory={
+                <LinkButton to={v3BillingPath(organization)} variant="secondary/small">
+                  Upgrade
+                </LinkButton>
+              }
               panelClassName="mt-4"
             >
               <Paragraph variant="small">

--- a/apps/webapp/app/routes/storybook.info-panel/route.tsx
+++ b/apps/webapp/app/routes/storybook.info-panel/route.tsx
@@ -11,6 +11,7 @@ import {
 } from "@heroicons/react/20/solid";
 import { InfoPanel } from "~/components/primitives/InfoPanel";
 import { TaskIcon } from "~/assets/icons/TaskIcon";
+import { LinkButton } from "~/components/primitives/Buttons";
 
 export default function Story() {
   return (
@@ -30,8 +31,11 @@ export default function Story() {
           title="Info with Button"
           icon={InformationCircleIcon}
           iconClassName="text-blue-500"
-          to="#"
-          buttonLabel="Learn More"
+          accessory={
+            <LinkButton to="#" variant="secondary/small">
+              Learn More
+            </LinkButton>
+          }
         >
           This panel includes a button in the top-right corner
         </InfoPanel>
@@ -42,8 +46,11 @@ export default function Story() {
           icon={BellAlertIcon}
           iconClassName="text-red-500"
           variant="upgrade"
-          to="#"
-          buttonLabel="Upgrade Now"
+          accessory={
+            <LinkButton to="#" variant="secondary/small">
+              Upgrade Now
+            </LinkButton>
+          }
         >
           This panel uses the upgrade variant with a call-to-action button
         </InfoPanel>
@@ -58,8 +65,11 @@ export default function Story() {
           title="Task Status"
           icon={TaskIcon}
           iconClassName="text-blue-500"
-          to="#"
-          buttonLabel="View Tasks"
+          accessory={
+            <LinkButton to="#" variant="secondary/small">
+              View Tasks
+            </LinkButton>
+          }
         >
           A panel showing task information with a view action
         </InfoPanel>
@@ -69,8 +79,11 @@ export default function Story() {
           title="Getting Started"
           icon={RocketLaunchIcon}
           iconClassName="text-purple-500"
-          to="#"
-          buttonLabel="Start Tutorial"
+          accessory={
+            <LinkButton to="#" variant="secondary/small">
+              Start Tutorial
+            </LinkButton>
+          }
         >
           Begin your journey with our quick start guide
         </InfoPanel>
@@ -80,8 +93,11 @@ export default function Story() {
           title="Deployment Status"
           icon={ServerStackIcon}
           iconClassName="text-indigo-500"
-          to="#"
-          buttonLabel="Deploy Now"
+          accessory={
+            <LinkButton to="#" variant="secondary/small">
+              Deploy Now
+            </LinkButton>
+          }
         >
           Ready to deploy your changes to production
         </InfoPanel>
@@ -91,8 +107,11 @@ export default function Story() {
           title="Create New"
           icon={PlusIcon}
           iconClassName="text-green-500"
-          to="#"
-          buttonLabel="New Project"
+          accessory={
+            <LinkButton to="#" variant="secondary/small">
+              New Project
+            </LinkButton>
+          }
         >
           Start a new project with our guided setup
         </InfoPanel>
@@ -107,8 +126,11 @@ export default function Story() {
           title="Documentation"
           icon={BookOpenIcon}
           iconClassName="text-green-500"
-          to="#"
-          buttonLabel="View Docs"
+          accessory={
+            <LinkButton to="#" variant="secondary/small">
+              View Docs
+            </LinkButton>
+          }
         >
           Access our comprehensive documentation
         </InfoPanel>


### PR DESCRIPTION
## Style fixes: 
- Adds gap between buttons in the Switch Orgs sub menu
- Removes an unnecessary height class to the menu item button
- "Hobby", "Pro" badge looks a bit nicer

## Improvements: 
- Info Panel component takes a React Node 'accessory' which replaces the Link button previously there. All routes that use the Info Panel have been updated and type check passed.
- Made some consistency improvements to the button placements in the blank state Info Panel
- Made some copy improvements to the blank states
- Adds the word 'plan' to the Org menu plan names so they're consistent

![CleanShot 2025-03-22 at 12 17 37@2x](https://github.com/user-attachments/assets/224cf268-094e-4d13-a5cd-db9c5474daa1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced interactive buttons that now provide direct links for actions such as upgrading, deploying tasks, and accessing documentation.
- **Style**
  - Improved visual clarity with refined text, updated button appearances, and smoother transition effects across various components.
- **Refactor**
  - Streamlined component configurations for a more consistent interface and simplified navigation, resulting in an improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->