### PR TITLE
Fix worker deployment engine version

### DIFF
--- a/apps/webapp/app/v3/services/createDeployedBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createDeployedBackgroundWorker.server.ts
@@ -101,6 +101,7 @@ export class CreateDeployedBackgroundWorkerService extends BaseService {
           status: "DEPLOYED",
           workerId: backgroundWorker.id,
           deployedAt: new Date(),
+          type: backgroundWorker.engine === "V2" ? "MANAGED" : "V1",
         },
       });
 

--- a/apps/webapp/app/v3/services/createDeploymentBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createDeploymentBackgroundWorker.server.ts
@@ -130,6 +130,7 @@ export class CreateDeploymentBackgroundWorkerService extends BaseService {
           status: "DEPLOYING",
           workerId: backgroundWorker.id,
           builtAt: new Date(),
+          type: backgroundWorker.engine === "V2" ? "MANAGED" : "V1",
         },
       });
 

--- a/packages/cli-v3/src/config.ts
+++ b/packages/cli-v3/src/config.ts
@@ -169,7 +169,9 @@ async function resolveConfig(
 
   dirs = dirs.map((dir) => resolveTriggerDir(dir, workingDir));
 
-  const features = featuresFromCompatibilityFlags(config.compatibilityFlags ?? []);
+  const features = featuresFromCompatibilityFlags(
+    ["run_engine_v2" as const].concat(config.compatibilityFlags ?? [])
+  );
 
   const defaultRuntime: BuildRuntime = features.run_engine_v2 ? "node-22" : DEFAULT_RUNTIME;
 


### PR DESCRIPTION
The new CLI will default to RE2 deploys. Also, as a safeguard, the background worker version will now determine the worker deployment type. Previously, it was possible for the CLI to send conflicting values for each which would break prod runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Background worker deployments now display improved categorization based on the underlying engine version, providing more consistent management.
	- The CLI configuration has been enhanced to automatically include a key compatibility setting, ensuring support for the latest engine functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->