### PR TITLE
fix invalid yaml in rules globs

### DIFF
--- a/.cursor/rules/writing-tasks.mdc
+++ b/.cursor/rules/writing-tasks.mdc
@@ -1,5 +1,5 @@
 ---
-globs: **/trigger/**/*.ts, **/trigger/**/*.tsx,**/trigger/**/*.js,**/trigger/**/*.jsx
+globs: [ '**/trigger/**/*.ts', '**/trigger/**/*.tsx', '**/trigger/**/*.js', '**/trigger/**/*.jsx' ]
 description: Guidelines for writing Trigger.dev tasks
 alwaysApply: false
 ---


### PR DESCRIPTION
Just saw your blog post and noticed the frontmatter isn't quite correct. 

I've also [asked on the cursor forum](https://forum.cursor.com/t/correct-way-to-specify-rules-globs/71752) to verify this but essentially the format for the globs is invalid YAML currently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the configuration file to use an array structure for file pattern definitions, improving clarity and consistency while maintaining the same functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->