### PR TITLE
Support solo buttons in table row

### DIFF
--- a/apps/webapp/app/components/primitives/Table.tsx
+++ b/apps/webapp/app/components/primitives/Table.tsx
@@ -368,18 +368,6 @@ export const TableCellMenu = forwardRef<
                 </PopoverContent>
               </Popover>
             )}
-            {/* Optionally pass in children to render in a popover */}
-            {!visibleButtons && !hiddenButtons && !popoverContent && (
-              <Popover onOpenChange={(open) => setIsOpen(open)}>
-                <PopoverVerticalEllipseTrigger isOpen={isOpen} />
-                <PopoverContent
-                  className="w-fit max-w-[10rem] overflow-y-auto p-0 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600"
-                  align="end"
-                >
-                  <div className="flex flex-col gap-1 p-1">{children}</div>
-                </PopoverContent>
-              </Popover>
-            )}
           </div>
         </div>
       </TableCell>

--- a/apps/webapp/app/components/primitives/Table.tsx
+++ b/apps/webapp/app/components/primitives/Table.tsx
@@ -21,7 +21,7 @@ const variants = {
     stickyCell: "group-hover/table-row:bg-charcoal-800",
     menuButton:
       "bg-background-dimmed group-hover/table-row:bg-charcoal-800 group-hover/table-row:ring-grid-bright group-has-[[tabindex='0']:focus]/table-row:bg-background-bright",
-    menuButtonDivider: "group-hover/table-row:border-grid-dimmed",
+    menuButtonDivider: "group-hover/table-row:border-grid-bright",
     rowSelected: "bg-charcoal-750 group-hover/table-row:bg-charcoal-750",
   },
 } as const;
@@ -302,7 +302,6 @@ export const TableCellMenu = forwardRef<
     onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
     visibleButtons?: ReactNode;
     hiddenButtons?: ReactNode;
-    hiddenSoloButton?: ReactNode;
     popoverContent?: ReactNode;
     children?: ReactNode;
     isSelected?: boolean;
@@ -315,7 +314,6 @@ export const TableCellMenu = forwardRef<
       onClick,
       visibleButtons,
       hiddenButtons,
-      hiddenSoloButton,
       popoverContent,
       children,
       isSelected,
@@ -346,16 +344,13 @@ export const TableCellMenu = forwardRef<
             {hiddenButtons && (
               <div
                 className={cn(
-                  "hidden pr-0.5 group-hover/table-row:block group-hover/table-row:border-r",
+                  "hidden group-hover/table-row:block",
+                  popoverContent && "pr-0.5 group-hover/table-row:border-r",
                   variants[variant].menuButtonDivider
                 )}
               >
-                {hiddenButtons}
+                <div className={cn("flex items-center gap-x-0.5")}>{hiddenButtons}</div>
               </div>
-            )}
-            {/* Hidden solo button that shows on hover. To be used without the ellipsis popover content */}
-            {hiddenSoloButton && (
-              <div className={cn("hidden group-hover/table-row:block")}>{hiddenSoloButton}</div>
             )}
             {/* Always visible buttons  */}
             {visibleButtons}

--- a/apps/webapp/app/components/primitives/Table.tsx
+++ b/apps/webapp/app/components/primitives/Table.tsx
@@ -1,6 +1,6 @@
 import { ChevronRightIcon } from "@heroicons/react/24/solid";
 import { Link } from "@remix-run/react";
-import React, { ReactNode, forwardRef, useState, useContext, createContext } from "react";
+import React, { type ReactNode, forwardRef, useState, useContext, createContext } from "react";
 import { cn } from "~/utils/cn";
 import { Popover, PopoverContent, PopoverVerticalEllipseTrigger } from "./Popover";
 import { InfoIconTooltip } from "./Tooltip";
@@ -302,6 +302,7 @@ export const TableCellMenu = forwardRef<
     onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
     visibleButtons?: ReactNode;
     hiddenButtons?: ReactNode;
+    hiddenSoloButton?: ReactNode;
     popoverContent?: ReactNode;
     children?: ReactNode;
     isSelected?: boolean;
@@ -314,6 +315,7 @@ export const TableCellMenu = forwardRef<
       onClick,
       visibleButtons,
       hiddenButtons,
+      hiddenSoloButton,
       popoverContent,
       children,
       isSelected,
@@ -350,6 +352,10 @@ export const TableCellMenu = forwardRef<
               >
                 {hiddenButtons}
               </div>
+            )}
+            {/* Hidden solo button that shows on hover. To be used without the ellipsis popover content */}
+            {hiddenSoloButton && (
+              <div className={cn("hidden group-hover/table-row:block")}>{hiddenSoloButton}</div>
             )}
             {/* Always visible buttons  */}
             {visibleButtons}

--- a/apps/webapp/app/components/runs/v3/TaskRunsTable.tsx
+++ b/apps/webapp/app/components/runs/v3/TaskRunsTable.tsx
@@ -472,7 +472,7 @@ function RunActionsCell({ run, path }: { run: RunListItem; path: string }) {
         </>
       }
       hiddenButtons={
-        <div className="flex items-center">
+        <>
           {run.isCancellable && (
             <SimpleTooltip
               button={
@@ -518,7 +518,7 @@ function RunActionsCell({ run, path }: { run: RunListItem; path: string }) {
               disableHoverableContent
             />
           )}
-        </div>
+        </>
       }
     />
   );

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -399,7 +399,9 @@ export default function Page() {
                         <TableCellMenu
                           isSticky
                           visibleButtons={queue.paused && <QueuePauseResumeButton queue={queue} />}
-                          hiddenButtons={!queue.paused && <QueuePauseResumeButton queue={queue} />}
+                          hiddenSoloButton={
+                            !queue.paused && <QueuePauseResumeButton queue={queue} />
+                          }
                         />
                       </TableRow>
                     ))

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -399,9 +399,7 @@ export default function Page() {
                         <TableCellMenu
                           isSticky
                           visibleButtons={queue.paused && <QueuePauseResumeButton queue={queue} />}
-                          hiddenSoloButton={
-                            !queue.paused && <QueuePauseResumeButton queue={queue} />
-                          }
+                          hiddenButtons={!queue.paused && <QueuePauseResumeButton queue={queue} />}
                         />
                       </TableRow>
                     ))

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.schedules.$scheduleParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.schedules.$scheduleParam/route.tsx
@@ -358,8 +358,12 @@ export default function Page() {
                 iconClassName="text-indigo-500"
                 variant="info"
                 accessory={
-                  <LinkButton to="https://trigger.dev/docs/v3/tasks-scheduled" variant="docs/small">
-                    Docs
+                  <LinkButton
+                    to="https://trigger.dev/docs/v3/tasks-scheduled"
+                    variant="docs/small"
+                    LeadingIcon={BookOpenIcon}
+                  >
+                    Schedules docs
                   </LinkButton>
                 }
                 panelClassName="max-w-full"


### PR DESCRIPTION
Adds a new option for displaying a single button that shows on hover in a table cell.

Also removes an old fallback condition for making sure v2 tables still worked

Before:
![CleanShot 2025-03-28 at 12 38 01@2x](https://github.com/user-attachments/assets/02dbdc11-f5eb-43ed-b75e-543b6cdf06c5)

After:
![CleanShot 2025-03-28 at 12 35 07@2x](https://github.com/user-attachments/assets/07a9260d-38a9-4ff9-9876-3a5c2467f331)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The schedules page now features an updated link button with an icon and clearer labeling ("Schedules docs") for improved usability.
  
- **Style**
  - Enhanced table menus with refined hover effects and consistent spacing for a cleaner, more responsive look.
  - Simplified the display of extra button options for a streamlined interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->