### PR TITLE
Max duration error referenced ms when it should seconds

### DIFF
--- a/packages/core/src/v3/workers/taskExecutor.ts
+++ b/packages/core/src/v3/workers/taskExecutor.ts
@@ -383,7 +383,7 @@ export class TaskExecutor {
             reject(
               new InternalError({
                 code: TaskRunErrorCodes.MAX_DURATION_EXCEEDED,
-                message: `Task execution exceeded maximum duration of ${maxDuration}ms`,
+                message: `Run exceeded maximum compute time (maxDuration) of ${maxDuration} seconds`,
               })
             );
           });

--- a/packages/core/test/taskExecutor.test.ts
+++ b/packages/core/test/taskExecutor.test.ts
@@ -1417,7 +1417,7 @@ describe("TaskExecutor", () => {
 
   test("should handle max duration abort signal and call hooks in correct order", async () => {
     const executionOrder: string[] = [];
-    const maxDurationMs = 1000;
+    const maxDurationSeconds = 1000;
 
     // Create an abort controller that we'll trigger manually
     const controller = new AbortController();
@@ -1439,7 +1439,7 @@ describe("TaskExecutor", () => {
       fn: async ({ error }) => {
         executionOrder.push("failure");
         expect((error as Error).message).toBe(
-          `Task execution exceeded maximum duration of ${maxDurationMs}ms`
+          `Run exceeded maximum compute time (maxDuration) of ${maxDurationSeconds} seconds`
         );
       },
     });
@@ -1494,7 +1494,7 @@ describe("TaskExecutor", () => {
         error: {
           type: "INTERNAL_ERROR",
           code: TaskRunErrorCodes.MAX_DURATION_EXCEEDED,
-          message: "Task execution exceeded maximum duration of 1000ms",
+          message: "Run exceeded maximum compute time (maxDuration) of 1000 seconds",
           stackTrace: expect.any(String),
         },
         skippedRetrying: false,


### PR DESCRIPTION
The Max duration error referenced ms when it should seconds. Improved the test slightly too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refined error notifications for task timeouts to display compute time in seconds, enhancing clarity when tasks exceed allowed durations.
  
- **Tests**
  - Updated test validations to remain consistent with the revised error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->