### PR TITLE
Adds a "dev connected" banner to the top of the Run and Runs list pages

### DIFF
--- a/apps/webapp/app/components/DevPresence.tsx
+++ b/apps/webapp/app/components/DevPresence.tsx
@@ -96,7 +96,13 @@ export function useDevPresence() {
 /**
  * We need this for the legacy v1 engine, where we show the banner after a delay if there are no events.
  */
-export function useCrossEngineIsConnected({ logCount }: { logCount: number }) {
+export function useCrossEngineIsConnected({
+  isCompleted,
+  logCount,
+}: {
+  isCompleted: boolean;
+  logCount: number;
+}) {
   const project = useProject();
   const environment = useEnvironment();
   const { isConnected } = useDevPresence();
@@ -111,6 +117,11 @@ export function useCrossEngineIsConnected({ logCount }: { logCount: number }) {
     }
 
     if (project.engine === "V1") {
+      if (isCompleted) {
+        setCrossEngineIsConnected(true);
+        return;
+      }
+
       if (logCount <= 1) {
         const timer = setTimeout(() => {
           setCrossEngineIsConnected(false);
@@ -120,7 +131,7 @@ export function useCrossEngineIsConnected({ logCount }: { logCount: number }) {
         setCrossEngineIsConnected(true);
       }
     }
-  }, [environment.type, project.engine, logCount, isConnected]);
+  }, [environment.type, project.engine, logCount, isConnected, isCompleted]);
 
   return crossEngineIsConnected;
 }

--- a/apps/webapp/app/components/DevPresence.tsx
+++ b/apps/webapp/app/components/DevPresence.tsx
@@ -184,25 +184,26 @@ export function DevDisconnectedBanner({ isConnected }: { isConnected: boolean | 
   return (
     <Dialog>
       <AnimatePresence>
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.3 }}
-          className="flex"
-        >
-          {isConnected === false && (
+        {isConnected === false && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3 }}
+            className="flex"
+          >
             <DialogTrigger asChild>
               <Button
                 variant="minimal/small"
-                className="py-1 pl-1 pr-2 text-error"
+                className="border border-error/20 bg-error/10 py-1 pl-1 pr-2 group-hover/button:border-error/30 group-hover/button:bg-error/20"
+                iconSpacing="gap-1"
                 LeadingIcon={<ConnectionIcon isConnected={false} />}
               >
                 Your local dev server is not connected to Trigger.dev
               </Button>
             </DialogTrigger>
-          )}
-        </motion.div>
+          </motion.div>
+        )}
       </AnimatePresence>
       <DevPresencePanel isConnected={isConnected} />
     </Dialog>

--- a/apps/webapp/app/components/DevPresence.tsx
+++ b/apps/webapp/app/components/DevPresence.tsx
@@ -1,8 +1,23 @@
+import { AnimatePresence, motion } from "framer-motion";
 import { createContext, type ReactNode, useContext, useEffect, useMemo, useState } from "react";
+import {
+  CheckingConnectionIcon,
+  ConnectedIcon,
+  DisconnectedIcon,
+} from "~/assets/icons/ConnectionIcons";
 import { useEnvironment } from "~/hooks/useEnvironment";
 import { useEventSource } from "~/hooks/useEventSource";
 import { useOrganization } from "~/hooks/useOrganizations";
 import { useProject } from "~/hooks/useProject";
+import { docsPath } from "~/utils/pathBuilder";
+import connectedImage from "../assets/images/cli-connected.png";
+import disconnectedImage from "../assets/images/cli-disconnected.png";
+import { InlineCode } from "./code/InlineCode";
+import { Button } from "./primitives/Buttons";
+import { Dialog, DialogContent, DialogHeader, DialogTrigger } from "./primitives/Dialog";
+import { Paragraph } from "./primitives/Paragraph";
+import { TextLink } from "./primitives/TextLink";
+import { PackageManagerProvider, TriggerDevStepV3 } from "./SetupCommands";
 
 // Define Context types
 type DevPresenceContextType = {
@@ -76,4 +91,101 @@ export function useDevPresence() {
     throw new Error("useDevPresence must be used within a DevPresenceProvider");
   }
   return context;
+}
+
+export function ConnectionIcon({ isConnected }: { isConnected: boolean | undefined }) {
+  if (isConnected === undefined) {
+    return <CheckingConnectionIcon className="size-5" />;
+  }
+  return isConnected ? (
+    <ConnectedIcon className="size-5" />
+  ) : (
+    <DisconnectedIcon className="size-5" />
+  );
+}
+
+export function DevConnection({
+  children,
+}: {
+  children: (props: { isConnected: boolean | undefined }) => React.ReactNode;
+}) {
+  const { isConnected } = useDevPresence();
+
+  return (
+    <Dialog>
+      {children({ isConnected })}
+      <DialogContent>
+        <DialogHeader>
+          {isConnected === undefined
+            ? "Checking connection..."
+            : isConnected
+            ? "Your dev server is connected"
+            : "Your dev server is not connected"}
+        </DialogHeader>
+        <div className="mt-2 flex flex-col gap-3 px-2">
+          <div className="flex flex-col items-center justify-center gap-6 px-6 py-10">
+            <img
+              src={isConnected === true ? connectedImage : disconnectedImage}
+              alt={isConnected === true ? "Connected" : "Disconnected"}
+              width={282}
+              height={45}
+            />
+            <Paragraph variant="small" className={isConnected ? "text-success" : "text-error"}>
+              {isConnected === undefined
+                ? "Checking connection..."
+                : isConnected
+                ? "Your local dev server is connected to Trigger.dev"
+                : "Your local dev server is not connected to Trigger.dev"}
+            </Paragraph>
+          </div>
+          {isConnected ? null : (
+            <div className="space-y-3">
+              <PackageManagerProvider>
+                <TriggerDevStepV3 title="Run this command to connect" />
+              </PackageManagerProvider>
+              <Paragraph variant="small">
+                Run this CLI <InlineCode variant="extra-small">dev</InlineCode> command to connect
+                to the Trigger.dev servers to start developing locally. Keep it running while you
+                develop to stay connected. Learn more in the{" "}
+                <TextLink to={docsPath("cli-dev")}>CLI docs</TextLink>.
+              </Paragraph>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function DevPresenceBanner() {
+  const environment = useEnvironment();
+  const { isConnected } = useDevPresence();
+
+  return (
+    <AnimatePresence>
+      {environment.type === "DEVELOPMENT" && !isConnected && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.3 }}
+          className="flex"
+        >
+          <DevConnection>
+            {({ isConnected }) => (
+              <DialogTrigger asChild>
+                <Button
+                  variant="minimal/small"
+                  className="py-1 pl-1 pr-2 text-error"
+                  LeadingIcon={<ConnectionIcon isConnected={isConnected} />}
+                >
+                  Your local dev server is not connected to Trigger.dev
+                </Button>
+              </DialogTrigger>
+            )}
+          </DevConnection>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
 }

--- a/apps/webapp/app/components/navigation/SideMenu.tsx
+++ b/apps/webapp/app/components/navigation/SideMenu.tsx
@@ -81,7 +81,7 @@ import { SideMenuSection } from "./SideMenuSection";
 type SideMenuUser = Pick<User, "email" | "admin"> & { isImpersonating: boolean };
 export type SideMenuProject = Pick<
   MatchedProject,
-  "id" | "name" | "slug" | "version" | "environments"
+  "id" | "name" | "slug" | "version" | "environments" | "engine"
 >;
 export type SideMenuEnvironment = MatchedEnvironment;
 
@@ -153,7 +153,7 @@ export function SideMenu({
                 project={project}
                 environment={environment}
               />
-              {environment.type === "DEVELOPMENT" && (
+              {environment.type === "DEVELOPMENT" && project.engine === "V2" && (
                 <DevConnection>
                   {({ isConnected }) => (
                     <TooltipProvider disableHoverableContent={true}>

--- a/apps/webapp/app/components/navigation/SideMenu.tsx
+++ b/apps/webapp/app/components/navigation/SideMenu.tsx
@@ -20,13 +20,9 @@ import {
 import { useNavigation } from "@remix-run/react";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import simplur from "simplur";
-import {
-  CheckingConnectionIcon,
-  ConnectedIcon,
-  DisconnectedIcon,
-} from "~/assets/icons/ConnectionIcons";
-import { RunsIconExtraSmall, RunsIconSmall } from "~/assets/icons/RunsIcon";
+import { RunsIconExtraSmall } from "~/assets/icons/RunsIcon";
 import { TaskIconSmall } from "~/assets/icons/TaskIcon";
+import { WaitpointTokenIcon } from "~/assets/icons/WaitpointTokenIcon";
 import { Avatar } from "~/components/primitives/Avatar";
 import { type MatchedEnvironment } from "~/hooks/useEnvironment";
 import { type MatchedOrganization } from "~/hooks/useOrganizations";
@@ -37,7 +33,6 @@ import { type FeedbackType } from "~/routes/resources.feedback";
 import { cn } from "~/utils/cn";
 import {
   accountPath,
-  docsPath,
   logoutPath,
   newOrganizationPath,
   newProjectPath,
@@ -60,14 +55,12 @@ import {
   v3UsagePath,
   v3WaitpointTokensPath,
 } from "~/utils/pathBuilder";
-import connectedImage from "../../assets/images/cli-connected.png";
-import disconnectedImage from "../../assets/images/cli-disconnected.png";
+
 import { FreePlanUsage } from "../billing/FreePlanUsage";
-import { InlineCode } from "../code/InlineCode";
-import { useDevPresence } from "../DevPresence";
+import { ConnectionIcon, DevConnection } from "../DevPresence";
 import { ImpersonationBanner } from "../ImpersonationBanner";
 import { Button, ButtonContent, LinkButton } from "../primitives/Buttons";
-import { Dialog, DialogContent, DialogHeader, DialogTrigger } from "../primitives/Dialog";
+import { DialogTrigger } from "../primitives/Dialog";
 import { Paragraph } from "../primitives/Paragraph";
 import {
   Popover,
@@ -78,15 +71,12 @@ import {
 } from "../primitives/Popover";
 import { TextLink } from "../primitives/TextLink";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../primitives/Tooltip";
-import { PackageManagerProvider, TriggerDevStepV3 } from "../SetupCommands";
 import { UserProfilePhoto } from "../UserProfilePhoto";
 import { EnvironmentSelector } from "./EnvironmentSelector";
 import { HelpAndFeedback } from "./HelpAndFeedbackPopover";
 import { SideMenuHeader } from "./SideMenuHeader";
 import { SideMenuItem } from "./SideMenuItem";
 import { SideMenuSection } from "./SideMenuSection";
-import { WaitpointTokenIcon } from "~/assets/icons/WaitpointTokenIcon";
-import { Spinner } from "../primitives/Spinner";
 
 type SideMenuUser = Pick<User, "email" | "admin"> & { isImpersonating: boolean };
 export type SideMenuProject = Pick<
@@ -163,7 +153,34 @@ export function SideMenu({
                 project={project}
                 environment={environment}
               />
-              {environment.type === "DEVELOPMENT" && <DevConnection />}
+              {environment.type === "DEVELOPMENT" && (
+                <DevConnection>
+                  {({ isConnected }) => (
+                    <TooltipProvider disableHoverableContent={true}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <div className="inline-flex">
+                            <DialogTrigger asChild>
+                              <Button
+                                variant="minimal/small"
+                                className="aspect-square h-7 p-1"
+                                LeadingIcon={<ConnectionIcon isConnected={isConnected} />}
+                              />
+                            </DialogTrigger>
+                          </div>
+                        </TooltipTrigger>
+                        <TooltipContent side="right" className={"text-xs"}>
+                          {isConnected === undefined
+                            ? "Checking connection..."
+                            : isConnected
+                            ? "Your dev server is connected"
+                            : "Your dev server is not connected"}
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  )}
+                </DevConnection>
+              )}
             </div>
           </div>
 
@@ -520,83 +537,5 @@ function SelectorDivider() {
         strokeLinecap="round"
       />
     </svg>
-  );
-}
-
-export function DevConnection() {
-  const { isConnected } = useDevPresence();
-
-  return (
-    <Dialog>
-      <TooltipProvider disableHoverableContent={true}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="inline-flex">
-              <DialogTrigger asChild>
-                <Button
-                  variant="minimal/small"
-                  className="aspect-square h-7 p-1"
-                  LeadingIcon={
-                    isConnected === undefined ? (
-                      <CheckingConnectionIcon className="size-5" />
-                    ) : isConnected ? (
-                      <ConnectedIcon className="size-5" />
-                    ) : (
-                      <DisconnectedIcon className="size-5" />
-                    )
-                  }
-                />
-              </DialogTrigger>
-            </div>
-          </TooltipTrigger>
-          <TooltipContent side="right" className={"text-xs"}>
-            {isConnected === undefined
-              ? "Checking connection..."
-              : isConnected
-              ? "Your dev server is connected"
-              : "Your dev server is not connected"}
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-      <DialogContent>
-        <DialogHeader>
-          {isConnected === undefined
-            ? "Checking connection..."
-            : isConnected
-            ? "Your dev server is connected"
-            : "Your dev server is not connected"}
-        </DialogHeader>
-        <div className="mt-2 flex flex-col gap-3 px-2">
-          <div className="flex flex-col items-center justify-center gap-6 px-6 py-10">
-            <img
-              src={isConnected === true ? connectedImage : disconnectedImage}
-              alt={isConnected === true ? "Connected" : "Disconnected"}
-              width={282}
-              height={45}
-            />
-            <Paragraph variant="small" className={isConnected ? "text-success" : "text-error"}>
-              {isConnected === undefined
-                ? "Checking connection..."
-                : isConnected
-                ? "Your local dev server is connected to Trigger.dev"
-                : "Your local dev server is not connected to Trigger.dev"}
-            </Paragraph>
-          </div>
-          {isConnected ? null : (
-            <div className="space-y-3">
-              <PackageManagerProvider>
-                <TriggerDevStepV3 title="Run this command to connect" />
-              </PackageManagerProvider>
-              <Paragraph variant="small">
-                Run this CLI <InlineCode variant="extra-small">dev</InlineCode> command to connect
-                to the Trigger.dev servers to start developing locally. Keep it running while you
-                develop to stay connected. Learn more in the{" "}
-                <TextLink to={docsPath("cli-dev")}>CLI docs</TextLink>.
-              </Paragraph>
-            </div>
-          )}
-        </div>
-      </DialogContent>
-    </Dialog>
   );
 }

--- a/apps/webapp/app/components/navigation/SideMenu.tsx
+++ b/apps/webapp/app/components/navigation/SideMenu.tsx
@@ -55,12 +55,11 @@ import {
   v3UsagePath,
   v3WaitpointTokensPath,
 } from "~/utils/pathBuilder";
-
 import { FreePlanUsage } from "../billing/FreePlanUsage";
-import { ConnectionIcon, DevConnection } from "../DevPresence";
+import { ConnectionIcon, DevPresencePanel, useDevPresence } from "../DevPresence";
 import { ImpersonationBanner } from "../ImpersonationBanner";
 import { Button, ButtonContent, LinkButton } from "../primitives/Buttons";
-import { DialogTrigger } from "../primitives/Dialog";
+import { Dialog, DialogTrigger } from "../primitives/Dialog";
 import { Paragraph } from "../primitives/Paragraph";
 import {
   Popover,
@@ -105,6 +104,7 @@ export function SideMenu({
   const borderRef = useRef<HTMLDivElement>(null);
   const [showHeaderDivider, setShowHeaderDivider] = useState(false);
   const currentPlan = useCurrentPlan();
+  const { isConnected } = useDevPresence();
   const isFreeUser = currentPlan?.v3Subscription?.isPaying === false;
 
   useEffect(() => {
@@ -154,32 +154,31 @@ export function SideMenu({
                 environment={environment}
               />
               {environment.type === "DEVELOPMENT" && project.engine === "V2" && (
-                <DevConnection>
-                  {({ isConnected }) => (
-                    <TooltipProvider disableHoverableContent={true}>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <div className="inline-flex">
-                            <DialogTrigger asChild>
-                              <Button
-                                variant="minimal/small"
-                                className="aspect-square h-7 p-1"
-                                LeadingIcon={<ConnectionIcon isConnected={isConnected} />}
-                              />
-                            </DialogTrigger>
-                          </div>
-                        </TooltipTrigger>
-                        <TooltipContent side="right" className={"text-xs"}>
-                          {isConnected === undefined
-                            ? "Checking connection..."
-                            : isConnected
-                            ? "Your dev server is connected"
-                            : "Your dev server is not connected"}
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  )}
-                </DevConnection>
+                <Dialog>
+                  <TooltipProvider disableHoverableContent={true}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <div className="inline-flex">
+                          <DialogTrigger asChild>
+                            <Button
+                              variant="minimal/small"
+                              className="aspect-square h-7 p-1"
+                              LeadingIcon={<ConnectionIcon isConnected={isConnected} />}
+                            />
+                          </DialogTrigger>
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent side="right" className={"text-xs"}>
+                        {isConnected === undefined
+                          ? "Checking connection..."
+                          : isConnected
+                          ? "Your dev server is connected"
+                          : "Your dev server is not connected"}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                  <DevPresencePanel isConnected={isConnected} />
+                </Dialog>
               )}
             </div>
           </div>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
@@ -188,7 +188,10 @@ export default function Page() {
   const organization = useOrganization();
   const project = useProject();
   const environment = useEnvironment();
-  const isConnected = useCrossEngineIsConnected({ logCount: trace?.events.length ?? 0 });
+  const isConnected = useCrossEngineIsConnected({
+    logCount: trace?.events.length ?? 0,
+    isCompleted: run.completedAt !== null,
+  });
 
   return (
     <>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
@@ -27,7 +27,11 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { DisconnectedIcon } from "~/assets/icons/ConnectionIcons";
 import { ShowParentIcon, ShowParentIconSelected } from "~/assets/icons/ShowParentIcon";
 import tileBgPath from "~/assets/images/error-banner-tile@2x.png";
-import { DevPresenceBanner, useDevPresence } from "~/components/DevPresence";
+import {
+  DevDisconnectedBanner,
+  useCrossEngineIsConnected,
+  useDevPresence,
+} from "~/components/DevPresence";
 import { AdminDebugTooltip } from "~/components/admin/debugTooltip";
 import { PageBody } from "~/components/layout/AppLayout";
 import { Badge } from "~/components/primitives/Badge";
@@ -184,6 +188,7 @@ export default function Page() {
   const organization = useOrganization();
   const project = useProject();
   const environment = useEnvironment();
+  const isConnected = useCrossEngineIsConnected({ logCount: trace?.events.length ?? 0 });
 
   return (
     <>
@@ -195,19 +200,7 @@ export default function Page() {
           }}
           title={`Run #${run.number}`}
         />
-        <AnimatePresence>
-          {environment.type === "DEVELOPMENT" && (
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.3 }}
-              className="flex"
-            >
-              <DevPresenceBanner />
-            </motion.div>
-          )}
-        </AnimatePresence>
+        {environment.type === "DEVELOPMENT" && <DevDisconnectedBanner isConnected={isConnected} />}
         <PageAccessories>
           <AdminDebugTooltip>
             <Property.Table>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
@@ -21,13 +21,13 @@ import {
   tryCatch,
 } from "@trigger.dev/core/v3";
 import { type RuntimeEnvironmentType } from "@trigger.dev/database";
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { DisconnectedIcon } from "~/assets/icons/ConnectionIcons";
 import { ShowParentIcon, ShowParentIconSelected } from "~/assets/icons/ShowParentIcon";
 import tileBgPath from "~/assets/images/error-banner-tile@2x.png";
-import { useDevPresence } from "~/components/DevPresence";
+import { DevPresenceBanner, useDevPresence } from "~/components/DevPresence";
 import { AdminDebugTooltip } from "~/components/admin/debugTooltip";
 import { PageBody } from "~/components/layout/AppLayout";
 import { Badge } from "~/components/primitives/Badge";
@@ -195,6 +195,19 @@ export default function Page() {
           }}
           title={`Run #${run.number}`}
         />
+        <AnimatePresence>
+          {environment.type === "DEVELOPMENT" && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.3 }}
+              className="flex"
+            >
+              <DevPresenceBanner />
+            </motion.div>
+          )}
+        </AnimatePresence>
         <PageAccessories>
           <AdminDebugTooltip>
             <Property.Table>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
@@ -672,9 +672,6 @@ function TasksTreeView({
                       </div>
                     </div>
                   </div>
-                  {!isCompleted &&
-                    environmentType === "DEVELOPMENT" &&
-                    index === displayEvents.length - 1 && <ConnectedDevWarning />}
                 </>
               )}
               onScroll={(scrollTop) => {
@@ -1273,32 +1270,6 @@ function CurrentTimeIndicator({
         );
       }}
     </Timeline.FollowCursor>
-  );
-}
-
-function ConnectedDevWarning() {
-  const { isConnected } = useDevPresence();
-
-  return (
-    <div
-      className={cn(
-        "flex items-center overflow-hidden pl-5 pr-2 transition-opacity duration-500",
-        isConnected ? "h-0 opacity-0" : "opacity-100"
-      )}
-    >
-      <Callout
-        variant="error"
-        icon={<DisconnectedIcon className="size-5 shrink-0" />}
-        className="mt-2"
-      >
-        <div className="flex flex-col gap-1">
-          <Paragraph variant="small" spacing>
-            Your local dev server is not connectedr. Check you're running the CLI:
-          </Paragraph>
-          <ClipboardField variant="secondary/small" value="npx trigger.dev@latest dev" />
-        </div>
-      </Callout>
-    </div>
   );
 }
 

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs._index/route.tsx
@@ -8,6 +8,7 @@ import { ListChecks, ListX } from "lucide-react";
 import { Suspense, useState } from "react";
 import { TypedAwait, typeddefer, useTypedLoaderData } from "remix-typedjson";
 import { TaskIcon } from "~/assets/icons/TaskIcon";
+import { DevPresenceBanner, useDevPresence } from "~/components/DevPresence";
 import { StepContentContainer } from "~/components/StepContentContainer";
 import { MainCenteredContainer, PageBody } from "~/components/layout/AppLayout";
 import { Button, LinkButton } from "~/components/primitives/Buttons";
@@ -161,11 +162,26 @@ export default function Page() {
   const { data, rootOnlyDefault } = useTypedLoaderData<typeof loader>();
   const navigation = useNavigation();
   const isLoading = navigation.state !== "idle";
+  const { isConnected } = useDevPresence();
+  const environment = useEnvironment();
 
   return (
     <>
       <NavBar>
         <PageTitle title="Runs" />
+        <AnimatePresence>
+          {environment.type === "DEVELOPMENT" && !isConnected && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.3 }}
+              className="flex"
+            >
+              <DevPresenceBanner />
+            </motion.div>
+          )}
+        </AnimatePresence>
         <PageAccessories>
           <LinkButton
             variant={"docs/small"}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs._index/route.tsx
@@ -8,7 +8,7 @@ import { ListChecks, ListX } from "lucide-react";
 import { Suspense, useState } from "react";
 import { TypedAwait, typeddefer, useTypedLoaderData } from "remix-typedjson";
 import { TaskIcon } from "~/assets/icons/TaskIcon";
-import { DevPresenceBanner, useDevPresence } from "~/components/DevPresence";
+import { DevDisconnectedBanner, useDevPresence } from "~/components/DevPresence";
 import { StepContentContainer } from "~/components/StepContentContainer";
 import { MainCenteredContainer, PageBody } from "~/components/layout/AppLayout";
 import { Button, LinkButton } from "~/components/primitives/Buttons";
@@ -163,25 +163,16 @@ export default function Page() {
   const navigation = useNavigation();
   const isLoading = navigation.state !== "idle";
   const { isConnected } = useDevPresence();
+  const project = useProject();
   const environment = useEnvironment();
 
   return (
     <>
       <NavBar>
         <PageTitle title="Runs" />
-        <AnimatePresence>
-          {environment.type === "DEVELOPMENT" && !isConnected && (
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.3 }}
-              className="flex"
-            >
-              <DevPresenceBanner />
-            </motion.div>
-          )}
-        </AnimatePresence>
+        {environment.type === "DEVELOPMENT" && project.engine === "V2" && (
+          <DevDisconnectedBanner isConnected={isConnected} />
+        )}
         <PageAccessories>
           <LinkButton
             variant={"docs/small"}


### PR DESCRIPTION
Adds a "Your local dev server is not connected to Trigger.dev" banner message to the top of the Run and Runs list pages

Also moves the functionality to the DevPresence.tsx file and makes the DevConnection component reusable.

![CleanShot 2025-03-31 at 14 07 02](https://github.com/user-attachments/assets/1fb5b468-d88f-4d92-9f27-d9feb2c31eca)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new components to visually represent the development server’s connection status, including icons and banners.
  - Added prompts that guide users on reconnecting to the server when disconnected.
  
- **Refactor**
  - Streamlined the connection status display by integrating it directly into the navigation and application pages, enhancing user experience.
  - Removed the old connection management component in favor of a more integrated inline solution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->