### PR TITLE
Fixes a docs link and tweaks some wording for the triggering task blank state

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs._index/route.tsx
@@ -462,13 +462,13 @@ function RunTaskInstructions() {
       <StepNumber stepNumber="A" title="Trigger a test run" />
       <StepContentContainer>
         <Paragraph spacing>
-          You can perform a Run with any payload you want, or use one of our examples on the test
-          page.
+          Perform a test run with a payload directly from the dashboard.
         </Paragraph>
         <LinkButton
           to={v3TestPath(organization, project, environment)}
-          variant="primary/medium"
+          variant="secondary/medium"
           LeadingIcon={BeakerIcon}
+          leadingIconClassName="text-lime-500"
           className="inline-flex"
         >
           Test
@@ -483,15 +483,15 @@ function RunTaskInstructions() {
       <StepNumber stepNumber="B" title="Trigger your task for real" />
       <StepContentContainer>
         <Paragraph spacing>
-          Performing a real run depends on the type of Trigger your Task is using.
+          Performing a real run depends on the type of trigger your task is using.
         </Paragraph>
         <LinkButton
-          to="https://trigger.dev/docs"
-          variant="primary/medium"
+          to={docsPath("/triggering")}
+          variant="docs/medium"
           LeadingIcon={BookOpenIcon}
           className="inline-flex"
         >
-          How to run a task
+          How to trigger a task
         </LinkButton>
       </StepContentContainer>
     </MainCenteredContainer>


### PR DESCRIPTION
On the Runs list page when you have a task but haven't done a run yet: 

- Fixes a docs link to point to the "triggering" docs page
- Improves the wording on the blank state
- Updates the button styles to be consistent

![CleanShot 2025-03-31 at 14 28 28](https://github.com/user-attachments/assets/2ad1321e-4137-4246-8f2e-66100977a73f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Revised on-page instructions to clearly guide users when performing test runs and triggering tasks.
  - Updated text for improved clarity and consistency in messaging.

- **Style**
  - Refined button appearances with updated styles and icon colors.
  - Adjusted navigation links to direct users to the appropriate resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->