### PR TITLE
Fixes missing truncation on the project name text

### DIFF
--- a/apps/webapp/app/components/navigation/SideMenu.tsx
+++ b/apps/webapp/app/components/navigation/SideMenu.tsx
@@ -139,7 +139,7 @@ export function SideMenu({
     >
       <div
         className={cn(
-          "flex items-center justify-between border-b px-1 py-1 transition duration-300",
+          "flex items-center justify-between overflow-hidden border-b px-1 py-1 transition duration-300",
           showHeaderDivider ? "border-grid-bright" : "border-transparent"
         )}
       >
@@ -304,7 +304,7 @@ function ProjectSelector({
         isOpen={isOrgMenuOpen}
         overflowHidden
         className={cn(
-          "h-8 w-full justify-between overflow-hidden py-1 pl-1.5",
+          "h-8 w-full justify-between py-1 pl-1.5",
           user.isImpersonating && "border border-dashed border-amber-400"
         )}
       >

--- a/apps/webapp/app/components/primitives/Popover.tsx
+++ b/apps/webapp/app/components/primitives/Popover.tsx
@@ -175,7 +175,7 @@ function PopoverArrowTrigger({
       >
         {children}
       </Paragraph>
-      <DropdownIcon className="size-4 min-w-[0.75rem] text-text-dimmed transition group-hover:text-text-bright" />
+      <DropdownIcon className="size-4 min-w-4 text-text-dimmed transition group-hover:text-text-bright" />
     </PopoverTrigger>
   );
 }


### PR DESCRIPTION
Fixes the truncation when project names are too long.

Also prevents the dropdown chevron icon getting too small

![CleanShot 2025-03-31 at 14 46 46](https://github.com/user-attachments/assets/90d2e848-1592-4ba8-bb40-7077eebf76c5)
