### PR TITLE
New waitpoint token docs page + updates the URL and description for the waitpoint blank state in the app

### DIFF
--- a/apps/webapp/app/components/BlankStatePanels.tsx
+++ b/apps/webapp/app/components/BlankStatePanels.tsx
@@ -419,17 +419,15 @@ export function NoWaitpointTokens() {
       iconClassName="text-sky-500"
       panelClassName="max-w-md"
       accessory={
-        <LinkButton to={docsPath("wait")} variant="docs/small" LeadingIcon={BookOpenIcon}>
+        <LinkButton to={docsPath("wait-for-token")} variant="docs/small" LeadingIcon={BookOpenIcon}>
           Waitpoint docs
         </LinkButton>
       }
     >
       <Paragraph spacing variant="small">
-        Waitpoint tokens are used to pause runs until you complete the token so the run can
-        continue.
-      </Paragraph>
-      <Paragraph spacing variant="small">
-        You can build approval workflows using them, as well as other use cases.
+        Waitpoint tokens pause task runs until you complete the token. They're commonly used for
+        approval workflows and other scenarios where you need to wait for external confirmation,
+        such as human-in-the-loop processes.
       </Paragraph>
     </InfoPanel>
   );

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -40,7 +40,7 @@
               "errors-retrying",
               {
                 "group": "Wait",
-                "pages": ["wait", "wait-for", "wait-until", "wait-for-event", "wait-for-request"]
+                "pages": ["wait", "wait-for", "wait-until", "wait-for-token"]
               },
               "queue-concurrency",
               "versioning",

--- a/docs/upgrade-to-v4.mdx
+++ b/docs/upgrade-to-v4.mdx
@@ -1,0 +1,8 @@
+---
+title: "Upgrading to v4"
+description: "How to upgrade to v4."
+---
+
+<Note type="warning">
+  Upgrading to v4 docs are coming soon.
+</Note>

--- a/docs/wait-for-event.mdx
+++ b/docs/wait-for-event.mdx
@@ -1,8 +1,0 @@
----
-title: "Wait for event"
-description: "Wait until an event has been received, then continue execution."
----
-
-import ComingSoon from "/snippets/coming-soon-in-review.mdx"
-
-<ComingSoon />

--- a/docs/wait-for-request.mdx
+++ b/docs/wait-for-request.mdx
@@ -1,8 +1,0 @@
----
-title: "Wait for request"
-description: "Wait until a `Request` has been received at the provided URL, then continue execution."
----
-
-import ComingSoon from "/snippets/coming-soon-in-review.mdx"
-
-<ComingSoon />

--- a/docs/wait-for-token.mdx
+++ b/docs/wait-for-token.mdx
@@ -1,0 +1,10 @@
+---
+title: "Wait for token"
+description: "Wait until a token is completed."
+---
+
+import ComingSoon from "/snippets/coming-soon-generic.mdx"
+
+Waitpoint tokens pause task runs until you complete the token. They're commonly used for approval workflows and other scenarios where you need to wait for external confirmation, such as human-in-the-loop processes.
+
+<ComingSoon />

--- a/docs/wait.mdx
+++ b/docs/wait.mdx
@@ -10,9 +10,8 @@ Waiting allows you to write complex tasks as a set of async code, without having
 
 <PausedExecutionFree />
 
-| Function                                  | What it does                                                                              |
-| ----------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Function                               | What it does                                                                              |
+| :--------------------------------------| :---------------------------------------------------------------------------------------- |
 | [wait.for()](/wait-for)                | Waits for a specific period of time, e.g. 1 day.                                          |
 | [wait.until()](/wait-until)            | Waits until the provided `Date`.                                                          |
-| [wait.forRequest()](/wait-for-request) | Waits until a matching HTTP request is received, and gives you the data to continue with. |
-| [waitForEvent()](/wait-for-event)      | Waits for a matching event, like in the example above.                                    |
+| [wait.forToken()](/wait-for-token)     | Pauses task runs until a token is completed.                                              |


### PR DESCRIPTION
- Adds a new waitpoint token page in the docs
- Removes old wait-for coming soon pages
- Updates the app blank state copy for waitpoint tokens
- LInks the app blank state docs URL to the new waitpoint tokens page
- Adds a temporary "upgrade to v4" docs page