### PR TITLE
Fixes the avatar squishing if the project name is too long

### DIFF
--- a/apps/webapp/app/components/primitives/Avatar.tsx
+++ b/apps/webapp/app/components/primitives/Avatar.tsx
@@ -135,7 +135,7 @@ function AvatarLetters({
 
   return (
     <span
-      className="grid place-items-center overflow-hidden text-charcoal-750"
+      className="grid shrink-0 place-items-center overflow-hidden text-charcoal-750"
       style={styleFromSize(size)}
     >
       {/* This is the square container */}


### PR DESCRIPTION
Adds `shink-0` to prevent the avatar squishing if the project name is too long

Before:
![CleanShot 2025-04-01 at 17 13 33@2x](https://github.com/user-attachments/assets/259016cd-77f1-4f39-912d-9c9a82e3fb0e)

After:
![CleanShot 2025-04-01 at 17 14 03@2x](https://github.com/user-attachments/assets/912e58cc-74c4-4932-9a69-12d1838ae3ea)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the avatar component's layout to preserve a consistent size in various display contexts, ensuring a stable and uniform presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->