### PR TITLE
fix: update migration with the "Drop/Add" index of SecretStore key

### DIFF
--- a/internal-packages/database/prisma/migrations/20250318163201_add_previous_snapshot_id_to_task_run_execution_snapshot/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250318163201_add_previous_snapshot_id_to_task_run_execution_snapshot/migration.sql
@@ -1,8 +1,5 @@
--- DropIndex
-DROP INDEX "SecretStore_key_idx";
-
 -- AlterTable
-ALTER TABLE "TaskRunExecutionSnapshot" ADD COLUMN     "previousSnapshotId" TEXT;
-
--- CreateIndex
-CREATE INDEX "SecretStore_key_idx" ON "SecretStore"("key" text_pattern_ops);
+ALTER TABLE
+  "TaskRunExecutionSnapshot"
+ADD
+  COLUMN "previousSnapshotId" TEXT;


### PR DESCRIPTION
The new checksum of the migration is `578158878714a085ae9804646fa114be4bf0f873fd9677112246537c4e5e6831`