### PR TITLE
v4: allow disabling of the run engine worker via the RUN_ENGINE_WORKER_ENABLED env var

### DIFF
--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -573,6 +573,8 @@ const EnvironmentSchema = z.object({
   RUN_ENGINE_RELEASE_CONCURRENCY_POLL_INTERVAL: z.coerce.number().int().default(500),
   RUN_ENGINE_RELEASE_CONCURRENCY_BATCH_SIZE: z.coerce.number().int().default(10),
 
+  RUN_ENGINE_WORKER_ENABLED: z.string().default("1"),
+
   /** How long should the presence ttl last */
   DEV_PRESENCE_SSE_TIMEOUT: z.coerce.number().int().default(30_000),
   DEV_PRESENCE_TTL_MS: z.coerce.number().int().default(5_000),

--- a/apps/webapp/app/v3/runEngine.server.ts
+++ b/apps/webapp/app/v3/runEngine.server.ts
@@ -14,6 +14,7 @@ function createRunEngine() {
   const engine = new RunEngine({
     prisma,
     worker: {
+      disabled: env.RUN_ENGINE_WORKER_ENABLED === "0",
       workers: env.RUN_ENGINE_WORKER_COUNT,
       tasksPerWorker: env.RUN_ENGINE_TASKS_PER_WORKER,
       pollIntervalMs: env.RUN_ENGINE_WORKER_POLL_INTERVAL,

--- a/internal-packages/run-engine/src/engine/types.ts
+++ b/internal-packages/run-engine/src/engine/types.ts
@@ -10,6 +10,7 @@ import { workerCatalog } from "./workerCatalog.js";
 export type RunEngineOptions = {
   prisma: PrismaClient;
   worker: {
+    disabled?: boolean;
     redis: RedisOptions;
     pollIntervalMs?: number;
     immediatePollIntervalMs?: number;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new environment setting that allows users to enable or disable background processing. By default, background processes remain active unless configured otherwise.

- **Refactor**
  - Enhanced the initialization logic so that background processing only starts when explicitly enabled, ensuring more flexible and controlled deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->