### PR TITLE
v4 engine version selection logic updated

### DIFF
--- a/apps/webapp/app/v3/engineVersion.server.ts
+++ b/apps/webapp/app/v3/engineVersion.server.ts
@@ -1,9 +1,9 @@
 import { RunEngineVersion, type RuntimeEnvironmentType } from "@trigger.dev/database";
-import {
-  findCurrentWorkerDeploymentWithoutTasks,
-  findCurrentWorkerFromEnvironment,
-} from "./models/workerDeployment.server";
 import { $replica } from "~/db.server";
+import {
+  findCurrentWorkerFromEnvironment,
+  getCurrentWorkerDeploymentEngineVersion,
+} from "./models/workerDeployment.server";
 
 type Environment = {
   id: string;
@@ -65,10 +65,12 @@ export async function determineEngineVersion({
   }
 
   // Deployed: use the latest deployed BackgroundWorker
-  const currentDeployment = await findCurrentWorkerDeploymentWithoutTasks(environment.id);
-  if (currentDeployment?.type === "V1") {
-    return "V1";
+  const currentDeploymentEngineVersion = await getCurrentWorkerDeploymentEngineVersion(
+    environment.id
+  );
+  if (currentDeploymentEngineVersion) {
+    return currentDeploymentEngineVersion;
   }
 
-  return "V2";
+  return environment.project.engine;
 }

--- a/packages/core/src/v3/apiClient/index.ts
+++ b/packages/core/src/v3/apiClient/index.ts
@@ -973,7 +973,7 @@ export class ApiClient {
       "Content-Type": "application/json",
       Authorization: `Bearer ${this.accessToken}`,
       "trigger-version": VERSION,
-      "x-trigger-engine-version": taskContext.worker?.engine ?? "V2",
+      "x-trigger-engine-version": "V2",
       ...Object.entries(additionalHeaders ?? {}).reduce(
         (acc, [key, value]) => {
           if (value !== undefined) {


### PR DESCRIPTION
We now hardcode engine version `V2` when using the v4 packages, and now we'll fallback to using the project engine version when all these conditions are met:

- The engine version is NOT passed to the trigger task service (e.g. using an older SDK or doing an raw HTTP request
- A non-development environment
- There is no current version deployed

Previously it defaulted to `V1` in that case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the process for determining the worker deployment engine version, ensuring that the system now dynamically derives the value from project settings rather than relying on fixed defaults.
  - Streamlined API communications by consistently setting the engine version header, contributing to more reliable and predictable deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->