### PR TITLE
Fix v4 restore race condition

### DIFF
--- a/packages/cli-v3/src/entryPoints/managed-run-controller.ts
+++ b/packages/cli-v3/src/entryPoints/managed-run-controller.ts
@@ -485,7 +485,8 @@ class ManagedRunController {
           return;
         }
         case "FINISHED": {
-          console.log("Run is finished, nothing to do");
+          console.log("Run is finished, will wait for next run");
+          this.waitForNextRun();
           return;
         }
         case "QUEUED_EXECUTING":


### PR DESCRIPTION
There was a race condition that could cause a suspended run to have a brief delay before shutting down. If it's alerted of a snapshot change in this time, it's possible for it to finish the run, even though there was a restore queued. If worker notifications fail and we fall back to polling, the SUSPENDED and QUEUED statuses may be skipped due to timing, so it goes straight to PENDING_EXECUTING again.

This is all fine, but the restored run will come up and its next snapshot change will be FINISHED. We didn't handle that case. Now we do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the system behavior so that after a task completes, it now automatically enters a waiting mode for the next operation. This change enhances responsiveness by transitioning seamlessly from completion to readiness, providing clearer feedback on the process flow for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->