### PR TITLE
Run page improvements

### DIFF
--- a/apps/webapp/app/hooks/useReplaceSearchParams.ts
+++ b/apps/webapp/app/hooks/useReplaceSearchParams.ts
@@ -1,11 +1,16 @@
 import { useSearchParams } from "@remix-run/react";
 import { useCallback } from "react";
 
+type NavigateOptions = {
+  replace?: boolean;
+  preventScrollReset?: boolean;
+};
+
 export function useReplaceSearchParams() {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const replaceSearchParam = useCallback(
-    (key: string, value?: string) => {
+    (key: string, value?: string, navigateOpts?: NavigateOptions) => {
       setSearchParams((s) => {
         if (value) {
           s.set(key, value);
@@ -13,7 +18,7 @@ export function useReplaceSearchParams() {
           s.delete(key);
         }
         return s;
-      });
+      }, navigateOpts);
     },
     [searchParams]
   );

--- a/apps/webapp/app/presenters/v3/RunPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/RunPresenter.server.ts
@@ -159,7 +159,10 @@ export class RunPresenter {
           const offset = millisecondsToNanoseconds(
             n.data.startTime.getTime() - treeRootStartTimeMs
           );
-          totalDuration = Math.max(totalDuration, offset + n.data.duration);
+          //only let non-debug events extend the total duration
+          if (!n.data.isDebug) {
+            totalDuration = Math.max(totalDuration, offset + n.data.duration);
+          }
           return {
             ...n,
             data: {

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
@@ -306,7 +306,7 @@ function TraceView({ run, trace, maximumLiveReloadingSetting, resizable }: Loade
   const shouldLiveReload = events.length <= maximumLiveReloadingSetting;
 
   const changeToSpan = useDebounce((selectedSpan: string) => {
-    replaceSearchParam("span", selectedSpan);
+    replaceSearchParam("span", selectedSpan, { replace: true });
   }, 250);
 
   const revalidator = useRevalidator();


### PR DESCRIPTION
Two run page improvements
1. When selecting spans (with the mouse or keyboard), it won't add to the browser history.
2. Debug logs (only admins can see these), don't extend the period that the run timeline shows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced URL parameter handling now supports additional navigation options, offering smoother browser history management.
- **Bug Fixes**
  - Improved runtime calculations by ensuring only non-debug events contribute to total duration, resulting in more accurate display timings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->