### PR TITLE
re2: add ability to selectively disable release concurrency queue consumers via env var

### DIFF
--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -567,6 +567,7 @@ const EnvironmentSchema = z.object({
   RUN_ENGINE_RATE_LIMIT_LIMITER_LOGS_ENABLED: z.string().default("0"),
 
   RUN_ENGINE_RELEASE_CONCURRENCY_ENABLED: z.string().default("0"),
+  RUN_ENGINE_RELEASE_CONCURRENCY_DISABLE_CONSUMERS: z.string().default("0"),
   RUN_ENGINE_RELEASE_CONCURRENCY_MAX_TOKENS_RATIO: z.coerce.number().default(1),
   RUN_ENGINE_RELEASE_CONCURRENCY_MAX_RETRIES: z.coerce.number().int().default(3),
   RUN_ENGINE_RELEASE_CONCURRENCY_CONSUMERS_COUNT: z.coerce.number().int().default(1),

--- a/apps/webapp/app/v3/runEngine.server.ts
+++ b/apps/webapp/app/v3/runEngine.server.ts
@@ -77,6 +77,7 @@ function createRunEngine() {
     },
     releaseConcurrency: {
       disabled: env.RUN_ENGINE_RELEASE_CONCURRENCY_ENABLED === "0",
+      disableConsumers: env.RUN_ENGINE_RELEASE_CONCURRENCY_DISABLE_CONSUMERS === "1",
       maxTokensRatio: env.RUN_ENGINE_RELEASE_CONCURRENCY_MAX_TOKENS_RATIO,
       maxRetries: env.RUN_ENGINE_RELEASE_CONCURRENCY_MAX_RETRIES,
       consumersCount: env.RUN_ENGINE_RELEASE_CONCURRENCY_CONSUMERS_COUNT,

--- a/internal-packages/run-engine/src/engine/index.ts
+++ b/internal-packages/run-engine/src/engine/index.ts
@@ -201,6 +201,7 @@ export class RunEngine {
         options.releaseConcurrency.disabled
           ? undefined
           : {
+              disableConsumers: options.releaseConcurrency?.disableConsumers,
               redis: {
                 ...options.queue.redis, // Use base queue redis options
                 ...options.releaseConcurrency?.redis, // Allow overrides

--- a/internal-packages/run-engine/src/engine/types.ts
+++ b/internal-packages/run-engine/src/engine/types.ts
@@ -51,6 +51,7 @@ export type RunEngineOptions = {
       maxDelay?: number; // Defaults to 60000
       factor?: number; // Defaults to 2
     };
+    disableConsumers?: boolean;
   };
 };
 

--- a/packages/cli-v3/e2e/utils.ts
+++ b/packages/cli-v3/e2e/utils.ts
@@ -314,6 +314,15 @@ export async function executeTestCaseRun({
         version: "1.0.0",
         contentHash,
       },
+      machine: {
+        name: "small-1x",
+        cpu: 1,
+        memory: 256,
+        centsPerMs: 0.0000001,
+      },
+    }).initialize();
+
+    const result = await taskRunProcess.execute({
       payload: {
         traceContext: {
           traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
@@ -373,10 +382,6 @@ export async function executeTestCaseRun({
       },
       messageId: "run_1234",
     });
-
-    await taskRunProcess.initialize();
-
-    const result = await taskRunProcess.execute();
 
     await taskRunProcess.cleanup(true);
 


### PR DESCRIPTION
Also added some additional logging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option that allows users to disable consumer processing within the release concurrency system, providing enhanced control over release operations without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->