### PR TITLE
Security update of nanoid from 3.3.4 to 3.3.8

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -141,7 +141,7 @@
     "marked": "^4.0.18",
     "match-sorter": "^6.3.4",
     "morgan": "^1.10.0",
-    "nanoid": "^3.3.4",
+    "nanoid": "3.3.8",
     "non.geist": "^1.0.2",
     "ohash": "^1.1.3",
     "openai": "^4.33.1",

--- a/internal-packages/run-engine/package.json
+++ b/internal-packages/run-engine/package.json
@@ -21,7 +21,7 @@
     "@trigger.dev/database": "workspace:*",
     "@unkey/cache": "^1.5.0",
     "assert-never": "^1.2.1",
-    "nanoid": "^3.3.4",
+    "nanoid": "3.3.8",
     "redlock": "5.0.0-beta.2",
     "seedrandom": "^3.0.5",
     "zod": "3.23.8"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -188,7 +188,7 @@
     "execa": "^8.0.1",
     "humanize-duration": "^3.27.3",
     "jose": "^5.4.0",
-    "nanoid": "5.0.6",
+    "nanoid": "3.3.8",
     "prom-client": "^15.1.0",
     "socket.io": "4.7.4",
     "socket.io-client": "4.7.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -526,8 +526,8 @@ importers:
         specifier: ^1.10.0
         version: 1.10.0
       nanoid:
-        specifier: ^3.3.4
-        version: 3.3.4
+        specifier: 3.3.8
+        version: 3.3.8
       non.geist:
         specifier: ^1.0.2
         version: 1.0.2
@@ -968,8 +968,8 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1
       nanoid:
-        specifier: ^3.3.4
-        version: 3.3.7
+        specifier: 3.3.8
+        version: 3.3.8
       redlock:
         specifier: 5.0.0-beta.2
         version: 5.0.0-beta.2(patch_hash=rwyegdki7iserrd7fgjwxkhnlu)
@@ -1409,8 +1409,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0
       nanoid:
-        specifier: ^3.3.4
-        version: 3.3.7
+        specifier: 3.3.8
+        version: 3.3.8
       prom-client:
         specifier: ^15.1.0
         version: 15.1.0
@@ -2357,7 +2357,7 @@ packages:
     dependencies:
       '@ai-sdk/provider': 0.0.26
       eventsource-parser: 1.1.2
-      nanoid: 3.3.11
+      nanoid: 3.3.8
       secure-json-parse: 2.7.0
       zod: 3.23.8
     dev: true
@@ -2385,7 +2385,7 @@ packages:
       zod: ^3.23.8
     dependencies:
       '@ai-sdk/provider': 1.1.0
-      nanoid: 3.3.11
+      nanoid: 3.3.8
       secure-json-parse: 2.7.0
       zod: 3.23.8
 
@@ -2396,7 +2396,7 @@ packages:
       zod: ^3.23.8
     dependencies:
       '@ai-sdk/provider': 1.1.0
-      nanoid: 3.3.11
+      nanoid: 3.3.8
       secure-json-parse: 2.7.0
       zod: 3.23.8
     dev: false
@@ -28036,28 +28036,16 @@ packages:
       stylis: 4.3.0
     dev: false
 
-  /nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  /nanoid@3.3.4:
-    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-    dev: false
-
   /nanoid@3.3.6:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: false
 
-  /nanoid@3.3.7:
-    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
+  /nanoid@3.3.8:
+    resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: false
 
   /nanoid@5.0.6:
     resolution: {integrity: sha512-rRq0eMHoGZxlvaFOUdK1Ev83Bd1IgzzR+WJ3IbDJ7QOSdAxYjlurSPqFs9s4lJg29RT6nPwizFtJhQS6V5xgiA==}
@@ -29797,7 +29785,7 @@ packages:
     resolution: {integrity: sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.8
       picocolors: 1.1.1
       source-map-js: 1.2.1
     dev: true
@@ -29806,7 +29794,7 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.8
       picocolors: 1.1.1
       source-map-js: 1.2.1
     dev: false
@@ -29815,7 +29803,7 @@ packages:
     resolution: {integrity: sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.8
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -29823,7 +29811,7 @@ packages:
     resolution: {integrity: sha512-Aweb9unOEpQ3ezu4Q00DPvvM2ZTUitJdNKeP/+uQgr1IBIqu574IaZoURId7BKtWMREwzKa9OgzPzezWGPWFQw==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.8
       picocolors: 1.1.1
       source-map-js: 1.2.0
     dev: true
@@ -29832,7 +29820,7 @@ packages:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.8
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -35699,7 +35687,7 @@ packages:
       date-fns: 3.6.0
       esbuild: 0.17.19
       miniflare: 3.20240806.0
-      nanoid: 3.3.11
+      nanoid: 3.3.8
       path-to-regexp: 6.2.1
       resolve: 1.22.8
       resolve.exports: 2.0.2


### PR DESCRIPTION
Related to #1763

nanoid 5 is ESM only which is more difficult to upgrade to, so we're using the security patched version 3.3.8 instead.

This has been applied to `@trigger.dev/core` as well as the webapp and engine.