### PR TITLE
We weren’t copying the batch info when suspending a run

### DIFF
--- a/internal-packages/run-engine/src/engine/systems/checkpointSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/checkpointSystem.ts
@@ -194,6 +194,11 @@ export class CheckpointSystem {
             metadata: snapshot.metadata,
           },
           previousSnapshotId: snapshot.id,
+          batchId: snapshot.batchId ?? undefined,
+          completedWaitpoints: snapshot.completedWaitpoints.map((waitpoint) => ({
+            id: waitpoint.id,
+            index: waitpoint.index,
+          })),
           environmentId: snapshot.environmentId,
           environmentType: snapshot.environmentType,
           projectId: snapshot.projectId,


### PR DESCRIPTION
This should fix resuming runs after a batchTriggerAndWait where we've done a checkpoint