### PR TITLE
RunTimeline: Fix for long file names wrapping instead of truncating

### DIFF
--- a/apps/webapp/app/components/run/RunTimeline.tsx
+++ b/apps/webapp/app/components/run/RunTimeline.tsx
@@ -345,11 +345,11 @@ export function RunTimelineEvent({
       <div className="relative flex flex-col items-center justify-center">
         <EventMarker variant={variant} state={state} style={style} />
       </div>
-      <div className="flex items-baseline justify-between gap-3">
+      <div className="flex min-w-0 items-baseline justify-between gap-3">
         <TooltipProvider disableHoverableContent>
           <Tooltip>
-            <TooltipTrigger className="cursor-default">
-              <span className="font-medium text-text-bright">{title}</span>
+            <TooltipTrigger className="min-w-0 max-w-full cursor-default text-left">
+              <div className="truncate font-medium text-text-bright">{title}</div>
             </TooltipTrigger>
             {helpText && (
               <TooltipContent className="flex items-center gap-1 text-xs">
@@ -359,7 +359,9 @@ export function RunTimelineEvent({
           </Tooltip>
         </TooltipProvider>
         {subtitle ? (
-          <span className="text-xs tabular-nums text-text-dimmed">{subtitle}</span>
+          <span className="whitespace-nowrap text-xs tabular-nums text-text-dimmed">
+            {subtitle}
+          </span>
         ) : null}
       </div>
     </div>


### PR DESCRIPTION
Long file names now truncate instead of wrap

![CleanShot 2025-04-07 at 15 59 13](https://github.com/user-attachments/assets/3dd3bb37-5605-4c85-9a7a-4bfb6637959d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced the visual presentation of timeline events for a more polished user experience.
	- Refined tooltip displays to handle text overflow gracefully, ensuring clear, concise information.
	- Updated subtitle formatting to maintain a consistent single-line presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->