### PR TITLE
Added the Attempt span error back (and properties)

### DIFF
--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -959,7 +959,16 @@ function SpanEntity({ span }: { span: Span }) {
             <WarmStartCombo
               isWarmStart={span.entity.object.isWarmStart}
               showTooltip
-              className="mt-3"
+              className="my-3"
+            />
+          ) : null}
+          {span.events.length > 0 && <SpanEvents spanEvents={span.events} />}
+          {span.properties !== undefined ? (
+            <CodeBlock
+              rowTitle="Properties"
+              code={span.properties}
+              maxLines={20}
+              showLineNumbers={false}
             />
           ) : null}
         </div>


### PR DESCRIPTION
I accidentally removed the Attempt span error block when I created the separate component to render attempts… this brings it back

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced span detail display now conditionally shows event information and properties when available.
- **Style**
  - Adjusted component spacing to improve vertical layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->