### PR TITLE
Removes hard coded “5” from “5 related runs” in the waitpoint tokens page inspector

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.waitpoints.tokens.$waitpointParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.waitpoints.tokens.$waitpointParam/route.tsx
@@ -110,7 +110,7 @@ export default function Page() {
         </div>
         <div className="flex flex-col gap-1 pt-6">
           <div className="mb-1 flex items-center gap-1 pl-3">
-            <Header3>5 related runs</Header3>
+            <Header3>Related runs</Header3>
             <InfoIconTooltip content="These runs have been blocked by this waitpoint." />
           </div>
           <TaskRunsTable


### PR DESCRIPTION
Removes hard coded “5” from “5 related runs” in the waitpoint tokens page inspector

![CleanShot 2025-04-09 at 12 19 30](https://github.com/user-attachments/assets/2b35d5cd-a3e9-43cc-bd52-0b68039c63f4)
