### PR TITLE
Fix snapshot status for short retry delays

### DIFF
--- a/internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
@@ -739,7 +739,7 @@ export class RunAttemptSystem {
                 {
                   run,
                   snapshot: {
-                    executionStatus: "PENDING_EXECUTING",
+                    executionStatus: "EXECUTING",
                     description: "Attempt failed with a short delay, starting a new attempt",
                   },
                   previousSnapshotId: latestSnapshot.id,

--- a/internal-packages/run-engine/src/engine/tests/attemptFailures.test.ts
+++ b/internal-packages/run-engine/src/engine/tests/attemptFailures.test.ts
@@ -104,13 +104,13 @@ describe("RunEngine attempt failures", () => {
         },
       });
       expect(result.attemptStatus).toBe("RETRY_IMMEDIATELY");
-      expect(result.snapshot.executionStatus).toBe("PENDING_EXECUTING");
+      expect(result.snapshot.executionStatus).toBe("EXECUTING");
       expect(result.run.status).toBe("RETRYING_AFTER_FAILURE");
 
       //state should be pending
       const executionData3 = await engine.getRunExecutionData({ runId: run.id });
       assertNonNullable(executionData3);
-      expect(executionData3.snapshot.executionStatus).toBe("PENDING_EXECUTING");
+      expect(executionData3.snapshot.executionStatus).toBe("EXECUTING");
       //only when the new attempt is created, should the attempt be increased
       expect(executionData3.run.attemptNumber).toBe(1);
       expect(executionData3.run.status).toBe("RETRYING_AFTER_FAILURE");

--- a/internal-packages/run-engine/src/engine/tests/waitpoints.test.ts
+++ b/internal-packages/run-engine/src/engine/tests/waitpoints.test.ts
@@ -239,13 +239,13 @@ describe("RunEngine Waitpoints", () => {
         },
       });
       expect(failResult.attemptStatus).toBe("RETRY_IMMEDIATELY");
-      expect(failResult.snapshot.executionStatus).toBe("PENDING_EXECUTING");
+      expect(failResult.snapshot.executionStatus).toBe("EXECUTING");
       expect(failResult.run.attemptNumber).toBe(1);
       expect(failResult.run.status).toBe("RETRYING_AFTER_FAILURE");
 
       const executionData2 = await engine.getRunExecutionData({ runId: run.id });
       assertNonNullable(executionData2);
-      expect(executionData2.snapshot.executionStatus).toBe("PENDING_EXECUTING");
+      expect(executionData2.snapshot.executionStatus).toBe("EXECUTING");
       expect(executionData2.run.attemptNumber).toBe(1);
       expect(executionData2.run.status).toBe("RETRYING_AFTER_FAILURE");
       expect(executionData2.completedWaitpoints.length).toBe(0);


### PR DESCRIPTION
The status is now `EXECUTING` as it should be. Previously `PENDING_EXECUTING`.