### PR TITLE
Fixes a padding issue on the org menu dropdown

### DIFF
--- a/apps/webapp/app/components/navigation/SideMenu.tsx
+++ b/apps/webapp/app/components/navigation/SideMenu.tsx
@@ -473,7 +473,7 @@ function SwitchOrganizations({
 
   return (
     <Popover onOpenChange={(open) => setMenuOpen(open)} open={isMenuOpen}>
-      <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+      <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} className="flex">
         <PopoverTrigger className="w-full justify-between overflow-hidden focus-custom">
           <ButtonContent
             variant="small-menu-item"


### PR DESCRIPTION
Fixes 1px of extra padding on the switch org menu:

Before:
![CleanShot 2025-04-09 at 13 45 50](https://github.com/user-attachments/assets/f5ef3b7f-e042-4679-a3e5-6dd47c1f0d7a)

After:
![CleanShot 2025-04-09 at 13 49 27](https://github.com/user-attachments/assets/b5fce198-2abe-45f5-87e6-228b2b7a060e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted the layout styling of an interactive element for improved visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->