### PR TITLE
Fix for queue indexing not updating concurrencyLimit/removing it

### DIFF
--- a/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
@@ -365,10 +365,12 @@ async function createWorkerQueue(
 
   const taskQueue = await upsertWorkerQueueRecord(
     queueName,
-    concurrencyLimit ?? undefined,
+    concurrencyLimit ?? null,
     orderableName,
     queueType,
-    queue.releaseConcurrencyOnWaitpoint,
+    typeof queue.releaseConcurrencyOnWaitpoint === "boolean"
+      ? queue.releaseConcurrencyOnWaitpoint
+      : false,
     worker,
     prisma
   );
@@ -400,10 +402,10 @@ async function createWorkerQueue(
 
 async function upsertWorkerQueueRecord(
   queueName: string,
-  concurrencyLimit: number | undefined,
+  concurrencyLimit: number | null,
   orderableName: string,
   queueType: TaskQueueType,
-  releaseConcurrencyOnWaitpoint: boolean | undefined,
+  releaseConcurrencyOnWaitpoint: boolean,
   worker: BackgroundWorker,
   prisma: PrismaClientOrTransaction,
   attempt: number = 0
@@ -428,10 +430,10 @@ async function upsertWorkerQueueRecord(
           name: queueName,
           orderableName,
           concurrencyLimit,
+          releaseConcurrencyOnWaitpoint,
           runtimeEnvironmentId: worker.runtimeEnvironmentId,
           projectId: worker.projectId,
           type: queueType,
-          releaseConcurrencyOnWaitpoint,
           workers: {
             connect: {
               id: worker.id,
@@ -448,6 +450,7 @@ async function upsertWorkerQueueRecord(
           workers: { connect: { id: worker.id } },
           version: "V2",
           orderableName,
+          concurrencyLimit,
           releaseConcurrencyOnWaitpoint,
         },
       });


### PR DESCRIPTION
When updating a queue the concurrencyLimit wasn't getting updated/removed. Made sure that `releaseConcurrencyOnWaitpoint` is set correctly to false if it's omitted (in an update)