### PR TITLE
Don't show queue time in the run timeline by default

### DIFF
--- a/apps/webapp/app/presenters/v3/RunPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/RunPresenter.server.ts
@@ -50,6 +50,7 @@ export class RunPresenter {
         spanId: true,
         friendlyId: true,
         status: true,
+        startedAt: true,
         completedAt: true,
         logsDeletedAt: true,
         rootTaskRun: {
@@ -104,6 +105,7 @@ export class RunPresenter {
       spanId: run.spanId,
       status: run.status,
       isFinished: isFinalRunStatus(run.status),
+      startedAt: run.startedAt,
       completedAt: run.completedAt,
       logsDeletedAt: showDeletedLogs ? null : run.logsDeletedAt,
       rootTaskRun: run.rootTaskRun,
@@ -201,6 +203,10 @@ export class RunPresenter {
           tree?.id === traceSummary.rootSpan.id ? undefined : traceSummary.rootSpan.runId,
         duration: totalDuration,
         rootStartedAt: tree?.data.startTime,
+        startedAt: run.startedAt,
+        queuedDuration: run.startedAt
+          ? millisecondsToNanoseconds(run.startedAt.getTime() - run.createdAt.getTime())
+          : undefined,
       },
     };
   }

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
@@ -1239,19 +1239,22 @@ function SpanWithDuration({
             style={{ backgroundImage: `url(${tileBgPath})`, backgroundSize: "8px 8px" }}
           />
         )}
-        <div
+        <motion.div
           className={cn(
-            "sticky left-0 z-10 transition group-hover:opacity-100",
+            "sticky left-0 z-10 transition-opacity group-hover:opacity-100",
             !showDuration && "opacity-0"
           )}
         >
-          <div className="whitespace-nowrap rounded-sm px-1 py-0.5 text-xxs text-text-bright text-shadow-custom">
+          <motion.div
+            className="whitespace-nowrap rounded-sm px-1 py-0.5 text-xxs text-text-bright text-shadow-custom"
+            layout="position"
+          >
             {formatDurationMilliseconds(props.durationMs, {
               style: "short",
               maxDecimalPoints: props.durationMs < 1000 ? 0 : 1,
             })}
-          </div>
-        </div>
+          </motion.div>
+        </motion.div>
       </motion.div>
     </Timeline.Span>
   );

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
@@ -1024,8 +1024,15 @@ function TimelineView({
                           )}
                           durationMs={
                             node.data.duration
-                              ? nanosecondsToMilliseconds(Math.min(node.data.duration, duration))
-                              : nanosecondsToMilliseconds(duration - node.data.offset)
+                              ? //completed
+                                nanosecondsToMilliseconds(Math.min(node.data.duration, duration))
+                              : //in progress
+                                nanosecondsToMilliseconds(
+                                  Math.min(
+                                    duration + (queuedDuration ?? 0) - node.data.offset,
+                                    duration
+                                  )
+                                )
                           }
                           node={node}
                           fadeLeft={isTopSpan && queuedDuration !== undefined}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
@@ -1017,11 +1017,11 @@ function TimelineView({
                         <SpanWithDuration
                           showDuration={state.selected ? true : showDurations}
                           startMs={nanosecondsToMilliseconds(
-                            queueAdjustedNs(node.data.offset, queuedDuration)
+                            Math.max(queueAdjustedNs(node.data.offset, queuedDuration), 0)
                           )}
                           durationMs={
                             node.data.duration
-                              ? nanosecondsToMilliseconds(node.data.duration)
+                              ? nanosecondsToMilliseconds(Math.min(node.data.duration, duration))
                               : nanosecondsToMilliseconds(duration - node.data.offset)
                           }
                           node={node}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
@@ -567,6 +567,7 @@ function TasksTreeView({
           label="Queue time"
           checked={showQueueTime}
           onCheckedChange={(e) => setShowQueueTime(e.valueOf())}
+          shortcut={{ key: "Q" }}
         />
         <Switch
           variant="small"
@@ -1357,6 +1358,7 @@ function KeyboardShortcuts({
         title="Collapse all"
       />
       <NumberShortcuts toggleLevel={(number) => toggleExpandLevel(number)} />
+      <ShortcutWithAction shortcut={{ key: "Q" }} title="Queue time" action={() => {}} />
     </>
   );
 }

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
@@ -942,6 +942,8 @@ function TimelineView({
               getTreeProps={getTreeProps}
               parentClassName="h-full scrollbar-hide"
               renderNode={({ node, state, index, virtualizer, virtualItem }) => {
+                const isTopSpan = node.id === events[0]?.id;
+
                 return (
                   <Timeline.Row
                     key={index}
@@ -988,7 +990,7 @@ function TimelineView({
                               {(ms) => (
                                 <motion.div
                                   className={cn(
-                                    "-ml-1 size-[0.3125rem] rounded-full border bg-background-bright",
+                                    "-ml-[0.1562rem] size-[0.3125rem] rounded-full border bg-background-bright",
                                     eventBorderClassName(node.data)
                                   )}
                                   layoutId={`${node.id}-${event.name}`}
@@ -1025,6 +1027,7 @@ function TimelineView({
                               : nanosecondsToMilliseconds(duration - node.data.offset)
                           }
                           node={node}
+                          fadeLeft={isTopSpan && queuedDuration !== undefined}
                         />
                       </>
                     ) : (
@@ -1036,7 +1039,7 @@ function TimelineView({
                         {(ms) => (
                           <motion.div
                             className={cn(
-                              "-ml-1 size-3 rounded-full border-2 border-background-bright",
+                              "-ml-0.5 size-3 rounded-full border-2 border-background-bright",
                               eventBackgroundClassName(node.data)
                             )}
                             layoutId={node.id}
@@ -1222,15 +1225,18 @@ function PulsingDot() {
 function SpanWithDuration({
   showDuration,
   node,
+  fadeLeft,
   ...props
-}: Timeline.SpanProps & { node: TraceEvent; showDuration: boolean }) {
+}: Timeline.SpanProps & { node: TraceEvent; showDuration: boolean; fadeLeft: boolean }) {
   return (
     <Timeline.Span {...props}>
       <motion.div
         className={cn(
-          "relative flex h-4 w-full min-w-0.5 items-center rounded-sm",
-          eventBackgroundClassName(node.data)
+          "relative flex h-4 w-full min-w-0.5 items-center",
+          eventBackgroundClassName(node.data),
+          fadeLeft ? "rounded-r-sm bg-gradient-to-r from-black/50 to-transparent" : "rounded-sm"
         )}
+        style={{ backgroundSize: "20px 100%", backgroundRepeat: "no-repeat" }}
         layoutId={node.id}
       >
         {node.data.isPartial && (

--- a/apps/webapp/app/v3/runEngineHandlers.server.ts
+++ b/apps/webapp/app/v3/runEngineHandlers.server.ts
@@ -333,6 +333,7 @@ export function registerRunEngineEventBusHandlers() {
       }
 
       await eventRepository.recordEvent(retryMessage, {
+        startTime: BigInt(time.getTime() * 1000000),
         taskSlug: run.taskIdentifier,
         environment,
         attributes: {
@@ -347,7 +348,6 @@ export function registerRunEngineEventBusHandlers() {
           queueName: run.queue,
         },
         context: run.traceContext as Record<string, string | undefined>,
-        spanIdSeed: `retry-${run.attemptNumber + 1}`,
         endTime: retryAt,
       });
     } catch (error) {


### PR DESCRIPTION
If you have concurrency limits set you can end up with queue times greater than a few seconds if you add many items to your queue.

This makes the run timeline really annoying because the queue time dominates the horizontal space, making it hard to tell what happened when your code started executing.

This PR makes it so this queue time is hidden by default, and can be turned back on using a toggle (or pressing "Q" on the keyboard).

Fixes
- The v4 retry attempt spans getting placed in the wrong order in the tree.
- The duration numbers expanded/squished while the timeline was animating, this is now fixed.