### PR TITLE
Fix: Mini task page graphs were missing Timed out and Expired

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam._index/route.tsx
@@ -545,6 +545,8 @@ function TaskActivityGraph({ activity }: { activity: TaskActivity }) {
         <Bar dataKey="SYSTEM_FAILURE" fill="#F43F5E" stackId="a" strokeWidth={0} barSize={10} />
         <Bar dataKey="PAUSED" fill="#FCD34D" stackId="a" strokeWidth={0} barSize={10} />
         <Bar dataKey="CRASHED" fill="#F43F5E" stackId="a" strokeWidth={0} barSize={10} />
+        <Bar dataKey="EXPIRED" fill="#F43F5E" stackId="a" strokeWidth={0} barSize={10} />
+        <Bar dataKey="TIMED_OUT" fill="#F43F5E" stackId="a" strokeWidth={0} barSize={10} />
       </BarChart>
     </ResponsiveContainer>
   );


### PR DESCRIPTION
The mini graphs we show on the Tasks page weren't showing Timed out or Expired. These statuses were added elsewhere but not assigned a bar + color here… 🤦 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the task activity chart by adding visual indicators for expired and timed-out events, providing more detailed insights into task performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->