### PR TITLE
maintain proper context in metadata.root and parent getters

### DIFF
--- a/.changeset/two-tigers-dream.md
+++ b/.changeset/two-tigers-dream.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+maintain proper context in metadata.root and parent getters

--- a/packages/core/src/v3/runMetadata/manager.ts
+++ b/packages/core/src/v3/runMetadata/manager.ts
@@ -31,71 +31,83 @@ export class StandardMetadataManager implements RunMetadataManager {
   ) {}
 
   get parent(): RunMetadataUpdater {
-    return {
+    // Store a reference to 'this' to ensure proper context
+    const self = this;
+    
+    // Create the updater object and store it in a local variable
+    const parentUpdater: RunMetadataUpdater = {
       set: (key, value) => {
-        this.queuedParentOperations.add({ type: "set", key, value });
-        return this.parent;
+        self.queuedParentOperations.add({ type: "set", key, value });
+        return parentUpdater;
       },
       del: (key) => {
-        this.queuedParentOperations.add({ type: "delete", key });
-        return this.parent;
+        self.queuedParentOperations.add({ type: "delete", key });
+        return parentUpdater;
       },
       append: (key, value) => {
-        this.queuedParentOperations.add({ type: "append", key, value });
-        return this.parent;
+        self.queuedParentOperations.add({ type: "append", key, value });
+        return parentUpdater;
       },
       remove: (key, value) => {
-        this.queuedParentOperations.add({ type: "remove", key, value });
-        return this.parent;
+        self.queuedParentOperations.add({ type: "remove", key, value });
+        return parentUpdater;
       },
       increment: (key, value) => {
-        this.queuedParentOperations.add({ type: "increment", key, value });
-        return this.parent;
+        self.queuedParentOperations.add({ type: "increment", key, value });
+        return parentUpdater;
       },
       decrement: (key, value) => {
-        this.queuedParentOperations.add({ type: "increment", key, value: -Math.abs(value) });
-        return this.parent;
+        self.queuedParentOperations.add({ type: "increment", key, value: -Math.abs(value) });
+        return parentUpdater;
       },
       update: (value) => {
-        this.queuedParentOperations.add({ type: "update", value });
-        return this.parent;
+        self.queuedParentOperations.add({ type: "update", value });
+        return parentUpdater;
       },
-      stream: (key, value, signal) => this.doStream(key, value, "parent", this.parent, signal),
+      stream: (key, value, signal) => self.doStream(key, value, "parent", parentUpdater, signal),
     };
+    
+    return parentUpdater;
   }
 
   get root(): RunMetadataUpdater {
-    return {
+    // Store a reference to 'this' to ensure proper context
+    const self = this;
+    
+    // Create the updater object and store it in a local variable
+    const rootUpdater: RunMetadataUpdater = {
       set: (key, value) => {
-        this.queuedRootOperations.add({ type: "set", key, value });
-        return this.root;
+        self.queuedRootOperations.add({ type: "set", key, value });
+        return rootUpdater;
       },
       del: (key) => {
-        this.queuedRootOperations.add({ type: "delete", key });
-        return this.root;
+        self.queuedRootOperations.add({ type: "delete", key });
+        return rootUpdater;
       },
       append: (key, value) => {
-        this.queuedRootOperations.add({ type: "append", key, value });
-        return this.root;
+        self.queuedRootOperations.add({ type: "append", key, value });
+        return rootUpdater;
       },
       remove: (key, value) => {
-        this.queuedRootOperations.add({ type: "remove", key, value });
-        return this.root;
+        self.queuedRootOperations.add({ type: "remove", key, value });
+        return rootUpdater;
       },
       increment: (key, value) => {
-        this.queuedRootOperations.add({ type: "increment", key, value });
-        return this.root;
+        self.queuedRootOperations.add({ type: "increment", key, value });
+        return rootUpdater;
       },
       decrement: (key, value) => {
-        this.queuedRootOperations.add({ type: "increment", key, value: -Math.abs(value) });
-        return this.root;
+        self.queuedRootOperations.add({ type: "increment", key, value: -Math.abs(value) });
+        return rootUpdater;
       },
       update: (value) => {
-        this.queuedRootOperations.add({ type: "update", value });
-        return this.root;
+        self.queuedRootOperations.add({ type: "update", value });
+        return rootUpdater;
       },
-      stream: (key, value, signal) => this.doStream(key, value, "root", this.root, signal),
+      stream: (key, value, signal) => self.doStream(key, value, "root", rootUpdater, signal),
     };
+    
+    return rootUpdater;
   }
 
   public enterWithMetadata(metadata: Record<string, DeserializedJson>): void {

--- a/packages/core/src/v3/runMetadata/noopManager.ts
+++ b/packages/core/src/v3/runMetadata/noopManager.ts
@@ -46,38 +46,50 @@ export class NoopRunMetadataManager implements RunMetadataManager {
   }
 
   get parent(): RunMetadataUpdater {
-    return {
-      append: () => this.parent,
-      set: () => this.parent,
-      del: () => this.parent,
-      increment: () => this.parent,
-      decrement: () => this.parent,
-      remove: () => this.parent,
+    // Store a reference to this object
+    const self = this;
+    
+    // Create a local reference to ensure proper context
+    const parentUpdater: RunMetadataUpdater = {
+      append: () => parentUpdater,
+      set: () => parentUpdater,
+      del: () => parentUpdater,
+      increment: () => parentUpdater,
+      decrement: () => parentUpdater,
+      remove: () => parentUpdater,
       stream: () =>
         Promise.resolve({
           [Symbol.asyncIterator]: () => ({
             next: () => Promise.resolve({ done: true, value: undefined }),
           }),
         }),
-      update: () => this.parent,
+      update: () => parentUpdater,
     };
+    
+    return parentUpdater;
   }
 
   get root(): RunMetadataUpdater {
-    return {
-      append: () => this.root,
-      set: () => this.root,
-      del: () => this.root,
-      increment: () => this.root,
-      decrement: () => this.root,
-      remove: () => this.root,
+    // Store a reference to this object
+    const self = this;
+    
+    // Create a local reference to ensure proper context
+    const rootUpdater: RunMetadataUpdater = {
+      append: () => rootUpdater,
+      set: () => rootUpdater,
+      del: () => rootUpdater,
+      increment: () => rootUpdater,
+      decrement: () => rootUpdater,
+      remove: () => rootUpdater,
       stream: () =>
         Promise.resolve({
           [Symbol.asyncIterator]: () => ({
             next: () => Promise.resolve({ done: true, value: undefined }),
           }),
         }),
-      update: () => this.root,
+      update: () => rootUpdater,
     };
+    
+    return rootUpdater;
   }
 }


### PR DESCRIPTION
maintain proper context in metadata.root and parent getters

Closes #1904

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Created several test cases to validate the fix:
- Created a simple test that demonstrates the issue by showing how this-binding works in class methods
- Verified that our fix properly maintains context when methods are chained
- Confirmed that metadata operations are correctly captured regardless of where they're called from

---

## Changelog

Fixed an issue where metadata.root.set() and similar methods would fail when used inside JavaScript classes. The fix properly maintains context when chaining method calls by storing local references to return objects instead of using this.root and this.parent.

---

## Screenshots

N/A - This is an internal API fix with no visual changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced internal metadata update operations to provide more consistent method chaining.
  - No changes to public functionality—users will experience the same behavior with improved internal handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->