### PR TITLE
Add links to and from deployments

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments.$deploymentParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments.$deploymentParam/route.tsx
@@ -28,7 +28,7 @@ import { useUser } from "~/hooks/useUser";
 import { DeploymentPresenter } from "~/presenters/v3/DeploymentPresenter.server";
 import { requireUserId } from "~/services/session.server";
 import { cn } from "~/utils/cn";
-import { v3DeploymentParams, v3DeploymentsPath } from "~/utils/pathBuilder";
+import { v3DeploymentParams, v3DeploymentsPath, v3RunsPath } from "~/utils/pathBuilder";
 import { capitalizeWord } from "~/utils/string";
 
 export const loader = async ({ request, params }: LoaderFunctionArgs) => {
@@ -231,16 +231,19 @@ export default function Page() {
                 </TableHeader>
                 <TableBody>
                   {deployment.tasks.map((t) => {
+                    const path = v3RunsPath(organization, project, environment, {
+                      tasks: [t.slug],
+                    });
                     return (
                       <TableRow key={t.slug}>
-                        <TableCell>
+                        <TableCell to={path}>
                           <div className="inline-flex flex-col gap-0.5">
                             <Paragraph variant="extra-small" className="text-text-dimmed">
                               {t.slug}
                             </Paragraph>
                           </div>
                         </TableCell>
-                        <TableCell>{t.filePath}</TableCell>
+                        <TableCell to={path}>{t.filePath}</TableCell>
                       </TableRow>
                     );
                   })}

--- a/apps/webapp/app/routes/projects.v3.$projectRef.deployments.$deploymentParam.ts
+++ b/apps/webapp/app/routes/projects.v3.$projectRef.deployments.$deploymentParam.ts
@@ -33,7 +33,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     return new Response("Not found", { status: 404 });
   }
 
-  // Redirect to the project's runs page
+  // Redirect to the project's deployments page
   return redirect(
     `/orgs/${project.organization.slug}/projects/${project.slug}/deployments/${validatedParams.deploymentParam}`
   );

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -528,22 +528,26 @@ function RunBody({
                   <Property.Label>Version</Property.Label>
                   <Property.Value>
                     {run.version ? (
-                      <SimpleTooltip
-                        button={
-                          <TextLink
-                            to={v3DeploymentVersionPath(
-                              organization,
-                              project,
-                              environment,
-                              run.version
-                            )}
-                            className="group flex flex-wrap items-center gap-x-1 gap-y-0"
-                          >
-                            {run.version}
-                          </TextLink>
-                        }
-                        content={"Jump to deployment"}
-                      />
+                      environment.type === "DEVELOPMENT" ? (
+                        run.version
+                      ) : (
+                        <SimpleTooltip
+                          button={
+                            <TextLink
+                              to={v3DeploymentVersionPath(
+                                organization,
+                                project,
+                                environment,
+                                run.version
+                              )}
+                              className="group flex flex-wrap items-center gap-x-1 gap-y-0"
+                            >
+                              {run.version}
+                            </TextLink>
+                          }
+                          content={"Jump to deployment"}
+                        />
+                      )
                     ) : (
                       <span className="flex items-center gap-1">
                         <span>Never started</span>

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -59,6 +59,7 @@ import { formatCurrencyAccurate } from "~/utils/numberFormatter";
 import {
   docsPath,
   v3BatchPath,
+  v3DeploymentVersionPath,
   v3RunDownloadLogsPath,
   v3RunPath,
   v3RunSpanPath,
@@ -527,7 +528,22 @@ function RunBody({
                   <Property.Label>Version</Property.Label>
                   <Property.Value>
                     {run.version ? (
-                      run.version
+                      <SimpleTooltip
+                        button={
+                          <TextLink
+                            to={v3DeploymentVersionPath(
+                              organization,
+                              project,
+                              environment,
+                              run.version
+                            )}
+                            className="group flex flex-wrap items-center gap-x-1 gap-y-0"
+                          >
+                            {run.version}
+                          </TextLink>
+                        }
+                        content={"Jump to deployment"}
+                      />
                     ) : (
                       <span className="flex items-center gap-1">
                         <span>Never started</span>

--- a/apps/webapp/app/utils/pathBuilder.ts
+++ b/apps/webapp/app/utils/pathBuilder.ts
@@ -395,6 +395,15 @@ export function v3DeploymentPath(
   return `${v3DeploymentsPath(organization, project, environment)}/${deployment.shortCode}${query}`;
 }
 
+export function v3DeploymentVersionPath(
+  organization: OrgForPath,
+  project: ProjectForPath,
+  environment: EnvironmentForPath,
+  version: string
+) {
+  return `${v3DeploymentsPath(organization, project, environment)}?version=${version}`;
+}
+
 export function v3BillingPath(organization: OrgForPath, message?: string) {
   return `${organizationPath(organization)}/settings/billing${
     message ? `?message=${encodeURIComponent(message)}` : ""


### PR DESCRIPTION
You can now click on tasks in the Deployments side panel, which will take you to the Runs page filtered by the task name:
![image](https://github.com/user-attachments/assets/56f3b266-022d-4712-b973-27bc9bfa37c3)


The Detail tab on a run now also has a link back to the specific deployment:
![image](https://github.com/user-attachments/assets/238905bf-2dc3-4d0d-91e2-4678684c431c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added version-based pagination to track deployments relative to a selected version.
  - Enhanced navigation with interactive links on deployment and run views, allowing users to easily access detailed deployment pages.
  - Improved URL handling that dynamically updates the selected deployment, ensuring a smoother and more intuitive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->