### PR TITLE
Fix current worker deployment getter

### DIFF
--- a/apps/webapp/app/presenters/v3/TestPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/TestPresenter.server.ts
@@ -56,7 +56,7 @@ export class TestPresenter extends BasePresenter {
         JOIN ${sqlDatabaseSchema}."BackgroundWorkerTask" bwt ON bwt."workerId" = latest_workers.id
         ORDER BY slug ASC;`;
     } else {
-      const currentDeployment = await findCurrentWorkerDeployment(envId);
+      const currentDeployment = await findCurrentWorkerDeployment({ environmentId: envId });
       return currentDeployment?.worker?.tasks ?? [];
     }
   }

--- a/apps/webapp/app/presenters/v3/TestTaskPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/TestTaskPresenter.server.ts
@@ -88,7 +88,7 @@ export class TestTaskPresenter {
   }: TestTaskOptions): Promise<TestTaskResult> {
     let task: BackgroundWorkerTaskSlim | null = null;
     if (environment.type !== "DEVELOPMENT") {
-      const deployment = await findCurrentWorkerDeployment(environment.id);
+      const deployment = await findCurrentWorkerDeployment({ environmentId: environment.id });
       if (deployment) {
         task = deployment.worker?.tasks.find((t) => t.slug === taskIdentifier) ?? null;
       }

--- a/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
+++ b/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
@@ -612,7 +612,10 @@ export class SharedQueueConsumer {
         ? await getWorkerDeploymentFromWorkerTask(existingTaskRun.lockedById)
         : existingTaskRun.lockedToVersionId
         ? await getWorkerDeploymentFromWorker(existingTaskRun.lockedToVersionId)
-        : await findCurrentWorkerDeployment(existingTaskRun.runtimeEnvironmentId);
+        : await findCurrentWorkerDeployment({
+            environmentId: existingTaskRun.runtimeEnvironmentId,
+            type: "V1",
+          });
     });
 
     const worker = deployment?.worker;

--- a/apps/webapp/app/v3/services/triggerScheduledTask.server.ts
+++ b/apps/webapp/app/v3/services/triggerScheduledTask.server.ts
@@ -73,7 +73,9 @@ export class TriggerScheduledTaskService extends BaseService {
 
       if (instance.environment.type !== "DEVELOPMENT") {
         // Get the current backgroundWorker for this environment
-        const currentWorkerDeployment = await findCurrentWorkerDeployment(instance.environment.id);
+        const currentWorkerDeployment = await findCurrentWorkerDeployment({
+          environmentId: instance.environment.id,
+        });
 
         if (!currentWorkerDeployment) {
           logger.debug("No current worker deployment found, skipping task trigger", {

--- a/internal-packages/run-engine/src/engine/db/worker.ts
+++ b/internal-packages/run-engine/src/engine/db/worker.ts
@@ -100,7 +100,7 @@ export async function getRunWithBackgroundWorkerTasks(
   } else {
     workerWithTasks = workerId
       ? await getWorkerDeploymentFromWorker(prisma, workerId)
-      : await getWorkerFromCurrentlyPromotedDeployment(prisma, run.runtimeEnvironmentId);
+      : await getManagedWorkerFromCurrentlyPromotedDeployment(prisma, run.runtimeEnvironmentId);
   }
 
   if (!workerWithTasks) {
@@ -260,7 +260,7 @@ export async function getWorkerById(
   return { worker, tasks: worker.tasks, queues: worker.queues, deployment: worker.deployment };
 }
 
-export async function getWorkerFromCurrentlyPromotedDeployment(
+export async function getManagedWorkerFromCurrentlyPromotedDeployment(
   prisma: PrismaClientOrTransaction,
   environmentId: string
 ): Promise<WorkerDeploymentWithWorkerTasks | null> {


### PR DESCRIPTION
We should only lock to V1 deployments when in the (legacy) shared queue consumer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the worker deployment retrieval process by transitioning from simple string parameters to structured objects, enhancing flexibility and extensibility.
  - Improved consistency in handling tasks and scheduled workflows across the application.
  - Renamed a worker retrieval method to clearly denote its focus on managed deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->