### PR TITLE
fix: refill release concurrency token bucket queue when runs resume before checkpoints are created

### DIFF
--- a/internal-packages/run-engine/package.json
+++ b/internal-packages/run-engine/package.json
@@ -36,8 +36,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "typecheck": "tsc --noEmit -p tsconfig.build.json",
-    "test": "vitest --sequence.concurrent=false --no-file-parallelism --run",
-    "test:dev": "vitest --sequence.concurrent=false --no-file-parallelism",
+    "test": "vitest --sequence.concurrent=false --no-file-parallelism",
     "test:coverage": "vitest --sequence.concurrent=false --no-file-parallelism --coverage.enabled",
     "build": "pnpm run clean && tsc -p tsconfig.build.json",
     "dev": "tsc --watch  -p tsconfig.build.json"

--- a/internal-packages/run-engine/package.json
+++ b/internal-packages/run-engine/package.json
@@ -36,7 +36,8 @@
   "scripts": {
     "clean": "rimraf dist",
     "typecheck": "tsc --noEmit -p tsconfig.build.json",
-    "test": "vitest --sequence.concurrent=false --no-file-parallelism",
+    "test": "vitest --sequence.concurrent=false --no-file-parallelism --run",
+    "test:dev": "vitest --sequence.concurrent=false --no-file-parallelism",
     "test:coverage": "vitest --sequence.concurrent=false --no-file-parallelism --coverage.enabled",
     "build": "pnpm run clean && tsc -p tsconfig.build.json",
     "dev": "tsc --watch  -p tsconfig.build.json"

--- a/internal-packages/run-engine/src/engine/index.ts
+++ b/internal-packages/run-engine/src/engine/index.ts
@@ -305,6 +305,7 @@ export class RunEngine {
       executionSnapshotSystem: this.executionSnapshotSystem,
       runAttemptSystem: this.runAttemptSystem,
       machines: this.options.machines,
+      releaseConcurrencySystem: this.releaseConcurrencySystem,
     });
   }
 

--- a/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
@@ -510,11 +510,6 @@ export class WaitpointSystem {
     await this.$.runLock.lock([runId], 5000, async () => {
       const snapshot = await getLatestExecutionSnapshot(this.$.prisma, runId);
 
-      this.$.logger.debug("continueRunIfUnblocked", {
-        runId,
-        snapshot,
-      });
-
       //run is still executing, send a message to the worker
       if (isExecuting(snapshot.executionStatus)) {
         const result = await this.$.runQueue.reacquireConcurrency(

--- a/internal-packages/run-engine/src/engine/tests/releaseConcurrencyTokenBucketQueue.test.ts
+++ b/internal-packages/run-engine/src/engine/tests/releaseConcurrencyTokenBucketQueue.test.ts
@@ -713,4 +713,114 @@ describe("ReleaseConcurrencyQueue", () => {
       await queue.quit();
     }
   );
+
+  redisTest(
+    "refillTokenIfNotInQueue should refill token when releaserId is not in queue",
+    async ({ redisContainer }) => {
+      const { queue, executedRuns } = createReleaseConcurrencyQueue(redisContainer, 2);
+
+      try {
+        // Use up all tokens
+        await queue.attemptToRelease({ name: "test-queue" }, "run1");
+        await queue.attemptToRelease({ name: "test-queue" }, "run2");
+
+        // Verify tokens were used
+        expect(executedRuns).toHaveLength(2);
+
+        // Try to refill token for a releaserId that's not in queue
+        const wasRefilled = await queue.refillTokenIfNotInQueue({ name: "test-queue" }, "run3");
+        expect(wasRefilled).toBe(true);
+
+        // Verify we can now execute a new run
+        await queue.attemptToRelease({ name: "test-queue" }, "run3");
+        await setTimeout(100);
+        expect(executedRuns).toHaveLength(3);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
+    "refillTokenIfNotInQueue should not refill token when releaserId is in queue",
+    async ({ redisContainer }) => {
+      const { queue, executedRuns } = createReleaseConcurrencyQueue(redisContainer, 1);
+
+      try {
+        // Use the only token
+        await queue.attemptToRelease({ name: "test-queue" }, "run1");
+        expect(executedRuns).toHaveLength(1);
+
+        // Queue up run2
+        await queue.attemptToRelease({ name: "test-queue" }, "run2");
+        expect(executedRuns).toHaveLength(1); // run2 is queued
+
+        // Try to refill token for run2 which is in queue
+        const wasRefilled = await queue.refillTokenIfNotInQueue({ name: "test-queue" }, "run2");
+        expect(wasRefilled).toBe(false);
+
+        // Verify run2 is still queued by refilling a token normally
+        await queue.refillTokens({ name: "test-queue" }, 1);
+        await setTimeout(100);
+        expect(executedRuns).toHaveLength(2);
+        expect(executedRuns[1]).toEqual({ releaseQueue: "test-queue", runId: "run2" });
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
+    "refillTokenIfNotInQueue should handle multiple queues independently",
+    async ({ redisContainer }) => {
+      const { queue, executedRuns } = createReleaseConcurrencyQueue(redisContainer, 1);
+
+      try {
+        // Use tokens in both queues
+        await queue.attemptToRelease({ name: "queue1" }, "run1");
+        await queue.attemptToRelease({ name: "queue2" }, "run2");
+        expect(executedRuns).toHaveLength(2);
+
+        // Queue up more runs
+        await queue.attemptToRelease({ name: "queue1" }, "run3");
+        await queue.attemptToRelease({ name: "queue2" }, "run4");
+        expect(executedRuns).toHaveLength(2); // run3 and run4 are queued
+
+        // Try to refill tokens for different releaserIds
+        const wasRefilled1 = await queue.refillTokenIfNotInQueue({ name: "queue1" }, "run5");
+        const wasRefilled2 = await queue.refillTokenIfNotInQueue({ name: "queue2" }, "run4");
+
+        expect(wasRefilled1).toBe(true); // run5 not in queue1
+        expect(wasRefilled2).toBe(false); // run4 is in queue2
+
+        // Verify queue1 can execute a new run with the refilled token
+        await queue.attemptToRelease({ name: "queue1" }, "run5");
+        await setTimeout(100);
+        expect(executedRuns).toHaveLength(3);
+        expect(executedRuns[2]).toEqual({ releaseQueue: "queue1", runId: "run5" });
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest("refillTokenIfNotInQueue should not exceed maxTokens", async ({ redisContainer }) => {
+    const { queue } = createReleaseConcurrencyQueue(redisContainer, 1);
+
+    try {
+      // First refill should work
+      const firstRefill = await queue.refillTokenIfNotInQueue({ name: "test-queue" }, "run1");
+      expect(firstRefill).toBe(true);
+
+      // Second refill should work but not exceed maxTokens
+      const secondRefill = await queue.refillTokenIfNotInQueue({ name: "test-queue" }, "run2");
+      expect(secondRefill).toBe(true);
+
+      // Get metrics to verify token count
+      const metrics = await queue.getReleaseQueueMetrics({ name: "test-queue" });
+      expect(metrics.currentTokens).toBe(1); // Should not exceed maxTokens
+    } finally {
+      await queue.quit();
+    }
+  });
 });


### PR DESCRIPTION
This PR fixes an issue where the release concurrency queue could get permanently stuck because runs that were in EXECUTING_WITH_WAITPOINT snapshot status would get resumed before the checkpoint was created. This would cause a token of the release concurrency bucket to be consumed (when the run was first blocked), but the token would never get returned, to the bucket, because the checkpoint would never get created. This now adds token returning when a run goes from EXECUTING_WITH_WAITPOINT -> EXECUTING, and EXECUTING_WITH_WAITPOINT -> QUEUED_EXECUTING -> EXECUTING, but only if the snapshot is not in the release concurrency queue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to refill concurrency tokens only if not already queued, improving concurrency management.
  - Introduced new methods for retrieving concurrency queue metrics and conditional token refilling.
  - Integrated concurrency token refilling into run continuation and dequeue processes to ensure accurate concurrency handling.
- **Bug Fixes**
  - Enhanced handling of concurrency tokens during run state transitions, especially after waitpoints.
- **Tests**
  - Added comprehensive tests for concurrency token refilling and queue behavior in complex scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->