### PR TITLE
[V4 beta] `batchTrigger` failed if the parent completed before they were queued.

### DIFF
--- a/apps/webapp/app/runEngine/services/triggerTask.server.ts
+++ b/apps/webapp/app/runEngine/services/triggerTask.server.ts
@@ -237,7 +237,11 @@ export class RunEngineTriggerTaskService extends WithRunEngine {
           })
         : undefined;
 
-      if (parentRun && isFinalRunStatus(parentRun.status)) {
+      if (
+        parentRun &&
+        isFinalRunStatus(parentRun.status) &&
+        body.options?.resumeParentOnCompletion
+      ) {
         logger.debug("Parent run is in a terminal state", {
           parentRun,
         });


### PR DESCRIPTION
We don't want to trigger child runs if the parent is completed and it's a `triggerAndWait` or `batchTriggerAndWait`.

The bug here was that we weren't checking that it was a `wait` variant. So if you used `batchTrigger` with a large batch and the parent run completed, the children wouldn't be triggered…

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved task triggering behavior to reduce unnecessary validation errors when resuming parent runs, ensuring errors are only shown when appropriate options are set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->