### PR TITLE
Adds a new entry in the help and feedback modal to request more concurrency

### DIFF
--- a/apps/webapp/app/components/Feedback.tsx
+++ b/apps/webapp/app/components/Feedback.tsx
@@ -1,6 +1,6 @@
 import { conform, useForm } from "@conform-to/react";
 import { parse } from "@conform-to/zod";
-import { InformationCircleIcon } from "@heroicons/react/20/solid";
+import { InformationCircleIcon, ArrowUpCircleIcon } from "@heroicons/react/20/solid";
 import { EnvelopeIcon } from "@heroicons/react/24/solid";
 import { Form, useActionData, useLocation, useNavigation } from "@remix-run/react";
 import { type ReactNode, useEffect, useState } from "react";
@@ -64,7 +64,9 @@ export function Feedback({ button, defaultValue = "bug" }: FeedbackProps) {
               How can we help? We read every message and will respond as quickly as we can.
             </Paragraph>
           </div>
-          <hr className="border-charcoal-800" />
+          {!(type === "feature" || type === "help" || type === "concurrency") && (
+            <hr className="border-grid-dimmed" />
+          )}
           <Form method="post" action="/resources/feedback" {...form.props} className="w-full">
             <Fieldset className="max-w-full gap-y-3">
               <input value={location.pathname} {...conform.input(path, { type: "hidden" })} />
@@ -94,6 +96,19 @@ export function Feedback({ button, defaultValue = "bug" }: FeedbackProps) {
                     <Paragraph variant="small">
                       The quickest way to get answers from the Trigger.dev team and community is to{" "}
                       <TextLink to="https://trigger.dev/discord">ask in our Discord</TextLink>.
+                    </Paragraph>
+                  </InfoPanel>
+                )}
+                {type === "concurrency" && (
+                  <InfoPanel
+                    icon={ArrowUpCircleIcon}
+                    iconClassName="text-indigo-500"
+                    panelClassName="w-full mb-2"
+                  >
+                    <Paragraph variant="small">
+                      How much extra concurrency do you need? You can add bundles of 50 for
+                      $50/month each. To help us advise you, please let us know what your tasks do,
+                      your typical run volume, and if your workload is spiky (many runs at once).
                     </Paragraph>
                   </InfoPanel>
                 )}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -262,10 +262,10 @@ export default function Page() {
                           LeadingIcon={ChatBubbleLeftEllipsisIcon}
                           leadingIconClassName="text-indigo-500"
                         >
-                          Increase limit
+                          Increase limit…
                         </Button>
                       }
-                      defaultValue="help"
+                      defaultValue="concurrency"
                     />
                   ) : (
                     <LinkButton

--- a/apps/webapp/app/routes/resources.feedback.ts
+++ b/apps/webapp/app/routes/resources.feedback.ts
@@ -1,9 +1,7 @@
 import { parse } from "@conform-to/zod";
-import { ActionFunctionArgs, json } from "@remix-run/server-runtime";
-import { PlainClient, uiComponent } from "@team-plain/typescript-sdk";
-import { inspect } from "util";
+import { type ActionFunctionArgs, json } from "@remix-run/server-runtime";
+import { type PlainClient, uiComponent } from "@team-plain/typescript-sdk";
 import { z } from "zod";
-import { env } from "~/env.server";
 import { redirectWithSuccessMessage } from "~/models/message.server";
 import { requireUser } from "~/services/session.server";
 import { sendToPlain } from "~/utils/plain.server";
@@ -16,6 +14,7 @@ export const feedbackTypeLabel = {
   help: "Help me out",
   enterprise: "Enterprise enquiry",
   feedback: "General feedback",
+  concurrency: "Increase my concurrency",
 };
 
 export type FeedbackType = keyof typeof feedbackTypeLabel;


### PR DESCRIPTION
- Adds a new entry that submits to Slack as "Increase my concurrency"
- New wording shown in the modal to explain the pricing and more info to provide
- Tweaks the modal layout slightly

![CleanShot 2025-04-17 at 14 45 33](https://github.com/user-attachments/assets/3153a418-964a-46f1-9d30-7665e8468c4a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new "concurrency" feedback option with specific guidance and information for users requesting increased concurrency.
- **Improvements**
  - Updated button text to "Increase limit…" for clarity.
  - Adjusted default feedback category to "concurrency" for relevant actions.
- **Bug Fixes**
  - Improved conditional display of information panels and separators based on feedback type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->