### PR TITLE
Schedules list performance

### DIFF
--- a/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
@@ -163,6 +163,7 @@ export class ScheduleListPresenter extends BasePresenter {
         },
         active: true,
         lastRunTriggeredAt: true,
+        createdAt: true,
       },
       where: {
         projectId: project.id,
@@ -205,6 +206,9 @@ export class ScheduleListPresenter extends BasePresenter {
               ],
             }
           : undefined,
+      },
+      orderBy: {
+        createdAt: "desc",
       },
       take: pageSize,
       skip: (page - 1) * pageSize,

--- a/internal-packages/database/prisma/migrations/20250417135530_task_schedule_dashboard_indexes/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250417135530_task_schedule_dashboard_indexes/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "TaskSchedule_projectId_idx" ON "TaskSchedule" ("projectId");
+
+-- CreateIndex
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "TaskSchedule_projectId_createdAt_idx" ON "TaskSchedule" ("projectId", "createdAt" DESC);

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -2933,6 +2933,9 @@ model TaskSchedule {
   active Boolean @default(true)
 
   @@unique([projectId, deduplicationKey])
+  /// Dashboard list view
+  @@index([projectId])
+  @@index([projectId, createdAt(sort: Desc)])
 }
 
 enum ScheduleType {


### PR DESCRIPTION
Added some indexes to improve the performance of the Schedules page/list function

These should be run before we deploy to avoid Prisma applying them non-concurrently and blocking db updates:

```sql
-- CreateIndex
CREATE INDEX CONCURRENTLY IF NOT EXISTS "TaskSchedule_projectId_idx" ON "TaskSchedule" ("projectId");

-- CreateIndex
CREATE INDEX CONCURRENTLY IF NOT EXISTS "TaskSchedule_projectId_createdAt_idx" ON "TaskSchedule" ("projectId", "createdAt" DESC);
```
