### PR TITLE
Change schedule indexes to be created non-concurrently

### DIFF
--- a/internal-packages/database/prisma/migrations/20250417135530_task_schedule_dashboard_indexes/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250417135530_task_schedule_dashboard_indexes/migration.sql
@@ -1,5 +1,5 @@
 -- CreateIndex
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "TaskSchedule_projectId_idx" ON "TaskSchedule" ("projectId");
+CREATE INDEX IF NOT EXISTS "TaskSchedule_projectId_idx" ON "TaskSchedule" ("projectId");
 
 -- CreateIndex
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "TaskSchedule_projectId_createdAt_idx" ON "TaskSchedule" ("projectId", "createdAt" DESC);
+CREATE INDEX IF NOT EXISTS "TaskSchedule_projectId_createdAt_idx" ON "TaskSchedule" ("projectId", "createdAt" DESC);


### PR DESCRIPTION
They've already been applied and Prisma won't apply two in a single file…