### PR TITLE
Changeset for the envvar function isSecret support

### DIFF
--- a/.changeset/green-lions-relate.md
+++ b/.changeset/green-lions-relate.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+The envvars.list() and retrieve() functions receive isSecret for each value. Secret values are always redacted.


### PR DESCRIPTION
The envvars.list() and retrieve() functions receive isSecret for each value. Secret values are always redacted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Environment variable values now include an `isSecret` flag and are always redacted if marked as secret, improving protection of sensitive information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->