### PR TITLE
Batch filter UI fix for longer ids

### DIFF
--- a/apps/webapp/app/components/runs/v3/RunFilters.tsx
+++ b/apps/webapp/app/components/runs/v3/RunFilters.tsx
@@ -841,8 +841,8 @@ function BatchIdDropdown({
   if (batchId) {
     if (!batchId.startsWith("batch_")) {
       error = "Batch IDs start with 'batch_'";
-    } else if (batchId.length !== 27) {
-      error = "Batch IDs are 27 characters long";
+    } else if (batchId.length !== 27 && batchId.length !== 31) {
+      error = "Batch IDs are 27 or 31 characters long";
     }
   }
 


### PR DESCRIPTION
The new batch ids are longer, the dashboard was complaining about them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for batch IDs in filters to accept both 27- and 31-character formats, with updated error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->