### PR TITLE
Multiple queue consumers and dev engine URL changesets

### DIFF
--- a/.changeset/blue-eyes-tickle.md
+++ b/.changeset/blue-eyes-tickle.md
@@ -1,0 +1,6 @@
+---
+"trigger.dev": patch
+"@trigger.dev/core": patch
+---
+
+The dev command will now use the platform-provided engine URL

--- a/.changeset/eighty-rings-divide.md
+++ b/.changeset/eighty-rings-divide.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Configurable queue consumer count in supervisor session


### PR DESCRIPTION
Missing changesets for:
- https://github.com/triggerdotdev/trigger.dev/pull/1947
- https://github.com/triggerdotdev/trigger.dev/pull/1948

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to configure the number of queue consumers in the supervisor session, providing more control over processing concurrency.

- **Chores**
  - Updated the development command to use the platform-provided engine URL for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->