### PR TITLE
Fixes runLimiter check on #dequeueRuns

### DIFF
--- a/.changeset/polite-impalas-care.md
+++ b/.changeset/polite-impalas-care.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Fixes runLimiter check on #dequeueRuns

--- a/packages/cli-v3/src/dev/devSupervisor.ts
+++ b/packages/cli-v3/src/dev/devSupervisor.ts
@@ -206,6 +206,7 @@ class DevSupervisor implements WorkerRuntime {
     ) {
       logger.debug(`[DevSupervisor] dequeueRuns. Run limit reached, trying again later`);
       setTimeout(() => this.#dequeueRuns(), this.config.dequeueIntervalWithoutRun);
+      return;
     }
 
     //get relevant versions


### PR DESCRIPTION
This was causing issues in the dev environment with logs being spammed with `[DevSupervisor] dequeueRuns. Run limit reached, trying again later` and making the worker unresponsive and lose connection.

Closes #<issue>

## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [ ] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

- Running the patched version locally, in development.

---

## Changelog

_[Short description of what has changed]_

---

## Screenshots

_[Screenshots]_

💯


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when the run concurrency limit is reached to prevent unintended additional processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->