### PR TITLE
Add missing dependency to supervisor Containerfile

### DIFF
--- a/apps/supervisor/Containerfile
+++ b/apps/supervisor/Containerfile
@@ -9,7 +9,7 @@ RUN npx -q turbo@1.10.9 prune --scope=supervisor --docker
 
 FROM node-22-alpine AS base
 
-RUN apk add --no-cache dumb-init
+RUN apk add --no-cache dumb-init docker
 
 COPY --chown=node:node .gitignore .gitignore
 COPY --from=pruner --chown=node:node /app/out/json/ .


### PR DESCRIPTION
Without the `docker` package being installed, the supervisor is unable to start runs when deployed on a Docker platform.

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Added docker on top of the published image and confirmed it starts runs.

https://canary.discord.com/channels/1066956501299777596/1363644206089769142/1363644207717154978

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the container environment to include the Docker CLI tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->