### PR TITLE
Allow empty payloads in test runs

### DIFF
--- a/apps/webapp/app/components/code/codeMirrorSetup.ts
+++ b/apps/webapp/app/components/code/codeMirrorSetup.ts
@@ -2,18 +2,32 @@ import { closeBrackets } from "@codemirror/autocomplete";
 import { indentWithTab } from "@codemirror/commands";
 import { jsonParseLinter } from "@codemirror/lang-json";
 import { bracketMatching } from "@codemirror/language";
-import { lintGutter, lintKeymap, linter } from "@codemirror/lint";
+import { type Diagnostic, linter, lintGutter, lintKeymap } from "@codemirror/lint";
 import { highlightSelectionMatches } from "@codemirror/search";
 import { Prec, type Extension } from "@codemirror/state";
 import {
   drawSelection,
   dropCursor,
+  type EditorView,
   highlightActiveLine,
   highlightActiveLineGutter,
   highlightSpecialChars,
   keymap,
   lineNumbers,
 } from "@codemirror/view";
+
+function emptyAwareJsonLinter() {
+  return (view: EditorView): Diagnostic[] => {
+    const content = view.state.doc.toString().trim();
+
+    // return no errors if content is empty
+    if (!content) {
+      return [];
+    }
+
+    return jsonParseLinter()(view);
+  };
+}
 
 export function getEditorSetup(showLineNumbers = true, showHighlights = true): Array<Extension> {
   const options = [
@@ -22,7 +36,7 @@ export function getEditorSetup(showLineNumbers = true, showHighlights = true): A
     bracketMatching(),
     closeBrackets(),
     lintGutter(),
-    linter(jsonParseLinter()),
+    linter(emptyAwareJsonLinter()),
     Prec.highest(
       keymap.of([
         {

--- a/apps/webapp/app/components/code/codeMirrorSetup.ts
+++ b/apps/webapp/app/components/code/codeMirrorSetup.ts
@@ -1,14 +1,12 @@
 import { closeBrackets } from "@codemirror/autocomplete";
 import { indentWithTab } from "@codemirror/commands";
-import { jsonParseLinter } from "@codemirror/lang-json";
 import { bracketMatching } from "@codemirror/language";
-import { type Diagnostic, linter, lintGutter, lintKeymap } from "@codemirror/lint";
+import { lintKeymap } from "@codemirror/lint";
 import { highlightSelectionMatches } from "@codemirror/search";
 import { Prec, type Extension } from "@codemirror/state";
 import {
   drawSelection,
   dropCursor,
-  type EditorView,
   highlightActiveLine,
   highlightActiveLineGutter,
   highlightSpecialChars,
@@ -16,27 +14,12 @@ import {
   lineNumbers,
 } from "@codemirror/view";
 
-function emptyAwareJsonLinter() {
-  return (view: EditorView): Diagnostic[] => {
-    const content = view.state.doc.toString().trim();
-
-    // return no errors if content is empty
-    if (!content) {
-      return [];
-    }
-
-    return jsonParseLinter()(view);
-  };
-}
-
 export function getEditorSetup(showLineNumbers = true, showHighlights = true): Array<Extension> {
   const options = [
     drawSelection(),
     dropCursor(),
     bracketMatching(),
     closeBrackets(),
-    lintGutter(),
-    linter(emptyAwareJsonLinter()),
     Prec.highest(
       keymap.of([
         {

--- a/apps/webapp/app/components/code/codeMirrorTheme.ts
+++ b/apps/webapp/app/components/code/codeMirrorTheme.ts
@@ -39,6 +39,32 @@ export function darkTheme(): Extension {
         fontSize: "14px",
       },
 
+      ".cm-tooltip.cm-tooltip-lint": {
+        backgroundColor: tooltipBackground,
+      },
+
+      ".cm-diagnostic": {
+        padding: "4px 8px",
+        color: ivory,
+        fontFamily: "Geist Mono Variable",
+        fontSize: "12px",
+      },
+
+      ".cm-diagnostic-error": {
+        borderLeft: "2px solid #e11d48",
+      },
+
+      ".cm-lint-marker-error": {
+        content: "none",
+        backgroundColor: "#e11d48",
+        height: "100%",
+        width: "2px",
+      },
+
+      ".cm-lintPoint:after": {
+        borderBottom: "4px solid #e11d48",
+      },
+
       ".cm-cursor, .cm-dropCursor": { borderLeftColor: cursor },
       "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": {
         backgroundColor: selection,
@@ -82,6 +108,7 @@ export function darkTheme(): Extension {
 
       ".cm-tooltip": {
         border: "none",
+        marginTop: "6px",
         backgroundColor: tooltipBackground,
       },
       ".cm-tooltip .cm-tooltip-arrow:before": {

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.test.tasks.$taskParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.test.tasks.$taskParam/route.tsx
@@ -291,7 +291,6 @@ function StandardTaskForm({ task, runs }: { task: TestTask["task"]; runs: Standa
                 }}
                 height="100%"
                 autoFocus={!tab || tab === "payload"}
-                placeholder="{ }"
                 className={cn("h-full overflow-auto", tab === "metadata" && "hidden")}
               />
               <JSONEditor

--- a/apps/webapp/app/v3/testTask.ts
+++ b/apps/webapp/app/v3/testTask.ts
@@ -4,46 +4,42 @@ export const TestTaskData = z
   .discriminatedUnion("triggerSource", [
     z.object({
       triggerSource: z.literal("STANDARD"),
-      payload: z.string().transform((payload, ctx) => {
-        try {
-          const data = JSON.parse(payload);
-          return data as any;
-        } catch (e) {
-          console.log("parsing error", e);
-
-          if (e instanceof Error) {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: e.message,
-            });
-          } else {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: "This is invalid JSON",
-            });
+      payload: z
+        .string()
+        .optional()
+        .transform((val, ctx) => {
+          if (!val) {
+            return {};
           }
-        }
-      }),
-      metadata: z.string().transform((metadata, ctx) => {
-        try {
-          const data = JSON.parse(metadata);
-          return data as any;
-        } catch (e) {
-          console.log("parsing error", e);
 
-          if (e instanceof Error) {
+          try {
+            return JSON.parse(val);
+          } catch {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
-              message: e.message,
+              message: "Payload must be a valid JSON string",
             });
-          } else {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: "This is invalid JSON",
-            });
+            return z.NEVER;
           }
-        }
-      }),
+        }),
+      metadata: z
+        .string()
+        .optional()
+        .transform((val, ctx) => {
+          if (!val) {
+            return {};
+          }
+
+          try {
+            return JSON.parse(val);
+          } catch {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: "Metadata must be a valid JSON string",
+            });
+            return z.NEVER;
+          }
+        }),
     }),
     z.object({
       triggerSource: z.literal("SCHEDULED"),


### PR DESCRIPTION
Changes in this PR:

- adapted the code editor component to allow empty inputs
- exposed basic linter configs in the code editor component
- applied a couple of light touch ups to the error display elements in favor of consistency

## Screenshots

Previously:
<img width="1197" alt="Screenshot 2025-04-21 at 17 20 37" src="https://github.com/user-attachments/assets/9cdea079-dac3-498a-9339-33ae22f3204c" />

Now:
<img width="1197" alt="Screenshot 2025-04-21 at 17 21 17" src="https://github.com/user-attachments/assets/b074ab84-2bb4-4f01-8c79-dc154616929f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable linting options to the JSON editor, allowing users to enable or disable linting and permit empty content without errors.

- **Style**
  - Improved the visual appearance of linting errors and diagnostic messages in the editor for better readability.

- **Bug Fixes**
  - Enhanced validation error messages for JSON fields, providing clearer feedback when invalid JSON is entered.

- **Chores**
  - Removed placeholder text from the JSON editor in the task form for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->