### PR TITLE
Fix redis worker debounce

### DIFF
--- a/packages/redis-worker/src/queue.ts
+++ b/packages/redis-worker/src/queue.ts
@@ -208,12 +208,16 @@ export class SimpleQueue<TMessageCatalog extends MessageCatalogSchema> {
   async ack(id: string, deduplicationKey?: string): Promise<void> {
     try {
       const result = await this.redis.ackItem(`queue`, `items`, id, deduplicationKey ?? "");
-      if (result === 0) {
-        this.logger.error(`SimpleQueue ${this.name}.ack(): ack operation returned 0`, {
-          queue: this.name,
-          id,
-          deduplicationKey,
-        });
+      if (result !== 1) {
+        this.logger.debug(
+          `SimpleQueue ${this.name}.ack(): ack operation returned ${result}. This means it was not removed from the queue.`,
+          {
+            queue: this.name,
+            id,
+            deduplicationKey,
+            result,
+          }
+        );
       }
     } catch (e) {
       this.logger.error(`SimpleQueue ${this.name}.ack(): error acknowledging item`, {


### PR DESCRIPTION
When using the "debounce" pattern with our (internal) Redis worker it was possible that we acked a job by mistake.

Example sequence:
1. Add a job with `id: "job-a"`
2. While that is running, add another `id: "job-a"` but with `availableAt` in the future.
3. The first instance of the job completes before the `availableAt`
4. We `ack()` the job id, before the new one starts.

This means that second one will never execute. This is a race condition.

This fix means that we will only `ack` an item if the item in the queue has the same `deduplicationKey`, i.e. is the exact same item. So if you've added another item with the same id we won't ack it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a deduplication key mechanism for queue items, improving reliability when processing and acknowledging jobs.
- **Bug Fixes**
  - Enhanced queue cleanup to ensure completed jobs are properly removed from both present and future queues.
- **Tests**
  - Added integration tests for job deduplication, scheduling, and queue cleanup to verify correct behavior in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->