### PR TITLE
Dashboard: Org menu improvements for admins

### DIFF
--- a/apps/webapp/app/components/ImpersonationBanner.tsx
+++ b/apps/webapp/app/components/ImpersonationBanner.tsx
@@ -16,7 +16,7 @@ export function ImpersonationBanner() {
                 LeadingIcon={UserMinusIcon}
                 fullWidth
                 textAlignLeft
-                className="bg-amber-400 text-background-bright group-hover/button:bg-amber-300"
+                className="text-amber-400"
               />
             </TooltipTrigger>
             <TooltipContent side="bottom" className={"text-xs"}>

--- a/apps/webapp/app/components/ImpersonationBanner.tsx
+++ b/apps/webapp/app/components/ImpersonationBanner.tsx
@@ -1,21 +1,29 @@
 import { UserMinusIcon } from "@heroicons/react/20/solid";
 import { Form } from "@remix-run/react";
 import { Button } from "./primitives/Buttons";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./primitives/Tooltip";
 
 export function ImpersonationBanner() {
   return (
-    <div className="w-full">
-      <Form action="/resources/impersonation" method="delete" reloadDocument className="w-full">
-        <Button
-          type="submit"
-          variant="small-menu-item"
-          LeadingIcon={UserMinusIcon}
-          fullWidth
-          textAlignLeft
-          className="text-amber-400"
-        >
-          Stop impersonating
-        </Button>
+    <div>
+      <Form action="/resources/impersonation" method="delete" reloadDocument>
+        <TooltipProvider disableHoverableContent={true}>
+          <Tooltip>
+            <TooltipTrigger>
+              <Button
+                type="submit"
+                variant="small-menu-item"
+                LeadingIcon={UserMinusIcon}
+                fullWidth
+                textAlignLeft
+                className="bg-amber-400 text-background-bright group-hover/button:bg-amber-300"
+              />
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className={"text-xs"}>
+              Stop impersonating
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       </Form>
     </div>
   );

--- a/apps/webapp/app/components/navigation/SideMenu.tsx
+++ b/apps/webapp/app/components/navigation/SideMenu.tsx
@@ -16,6 +16,7 @@ import {
   RectangleStackIcon,
   ServerStackIcon,
   Squares2X2Icon,
+  UsersIcon,
 } from "@heroicons/react/20/solid";
 import { useNavigation } from "@remix-run/react";
 import { useEffect, useRef, useState, type ReactNode } from "react";
@@ -27,6 +28,7 @@ import { Avatar } from "~/components/primitives/Avatar";
 import { type MatchedEnvironment } from "~/hooks/useEnvironment";
 import { type MatchedOrganization } from "~/hooks/useOrganizations";
 import { type MatchedProject } from "~/hooks/useProject";
+import { useHasAdminAccess } from "~/hooks/useUser";
 import { type User } from "~/models/user.server";
 import { useCurrentPlan } from "~/routes/_app.orgs.$organizationSlug/route";
 import { type FeedbackType } from "~/routes/resources.feedback";
@@ -77,7 +79,6 @@ import { HelpAndFeedback } from "./HelpAndFeedbackPopover";
 import { SideMenuHeader } from "./SideMenuHeader";
 import { SideMenuItem } from "./SideMenuItem";
 import { SideMenuSection } from "./SideMenuSection";
-import { useHasAdminAccess } from "~/hooks/useUser";
 
 type SideMenuUser = Pick<User, "email" | "admin"> & { isImpersonating: boolean };
 export type SideMenuProject = Pick<
@@ -133,8 +134,7 @@ export function SideMenu({
       <div
         className={cn(
           "flex items-center justify-between overflow-hidden border-b px-1 py-1 transition duration-300",
-          showHeaderDivider ? "border-grid-bright" : "border-transparent",
-          user.isImpersonating && "rounded-md border border-dashed border-amber-400"
+          showHeaderDivider ? "border-grid-bright" : "border-transparent"
         )}
       >
         <ProjectSelector
@@ -143,23 +143,20 @@ export function SideMenu({
           project={project}
           user={user}
         />
-        {isAdmin && (
+        {isAdmin && !user.isImpersonating ? (
           <TooltipProvider disableHoverableContent={true}>
             <Tooltip>
               <TooltipTrigger>
-                <LinkButton
-                  variant="minimal/medium"
-                  to={adminPath()}
-                  TrailingIcon={Cog8ToothIcon}
-                />
+                <LinkButton variant="minimal/medium" to={adminPath()} TrailingIcon={UsersIcon} />
               </TooltipTrigger>
               <TooltipContent side="bottom" className={"text-xs"}>
                 Admin dashboard
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
-        )}
-        {user.isImpersonating && <ImpersonationBanner />}
+        ) : isAdmin && user.isImpersonating ? (
+          <ImpersonationBanner />
+        ) : null}
       </div>
       <div
         className="overflow-hidden overflow-y-auto pt-2 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600"

--- a/apps/webapp/app/utils/pathBuilder.ts
+++ b/apps/webapp/app/utils/pathBuilder.ts
@@ -430,3 +430,7 @@ export function docsPath(path: string) {
 export function docsTroubleshootingPath(path: string) {
   return `${docsRoot()}/v3/troubleshooting`;
 }
+
+export function adminPath() {
+  return `/@`;
+}


### PR DESCRIPTION
Only show the "Switch organization" menu when you have multiple orgs, otherwise show a "New organization" button

![CleanShot 2025-04-23 at 16 22 14](https://github.com/user-attachments/assets/98348dcd-5f9b-4cc4-b9d4-c5d4536a0775)

Adds a button to get back to the admin dashboard if you're an admin

![CleanShot 2025-04-23 at 16 08 38](https://github.com/user-attachments/assets/70bb9987-3bd1-484e-a00e-bb583b55373b)

No buttons visible if you're not an admin

![CleanShot 2025-04-23 at 16 08 24](https://github.com/user-attachments/assets/cdbe71ea-2bf6-4f7b-8163-2af19a2dde32)

Moves impersonation link from the menu dropdown to the main side menu

![CleanShot 2025-04-23 at 16 08 48](https://github.com/user-attachments/assets/c7a33f9b-cb3c-40f7-a269-34bdf8282ad2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an admin dashboard link to the side menu for users with admin access, accessible via a tooltip and users icon.
- **Improvements**
  - Updated impersonation banner to show a tooltip on hover instead of visible text, with enhanced styling and placement.
  - Refined organization switcher menu to adjust labeling and display based on the number of organizations.
  - Adjusted visual cues for impersonation status in the side menu header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->