### PR TITLE
Prevent large outputs from overwriting each other

### DIFF
--- a/.changeset/spotty-pants-wink.md
+++ b/.changeset/spotty-pants-wink.md
@@ -1,0 +1,6 @@
+---
+"trigger.dev": patch
+"@trigger.dev/core": patch
+---
+
+Prevent large outputs from overwriting each other

--- a/packages/cli-v3/src/entryPoints/dev-run-controller.ts
+++ b/packages/cli-v3/src/entryPoints/dev-run-controller.ts
@@ -623,7 +623,7 @@ export class DevRunController {
     }).initialize();
 
     logger.debug("executing task run process", {
-      attemptId: execution.attempt.id,
+      attemptNumber: execution.attempt.number,
       runId: execution.run.id,
     });
 

--- a/packages/cli-v3/src/entryPoints/dev-run-worker.ts
+++ b/packages/cli-v3/src/entryPoints/dev-run-worker.ts
@@ -7,6 +7,7 @@ import {
   AnyOnStartHookFunction,
   AnyOnSuccessHookFunction,
   apiClientManager,
+  attemptKey,
   clock,
   ExecutorToWorkerMessageCatalog,
   type HandleErrorFunction,
@@ -546,7 +547,7 @@ const heartbeatInterval = parseInt(heartbeatIntervalMs ?? "30000", 10);
 for await (const _ of setInterval(heartbeatInterval)) {
   if (_isRunning && _execution) {
     try {
-      await zodIpc.send("TASK_HEARTBEAT", { id: _execution.attempt.id });
+      await zodIpc.send("TASK_HEARTBEAT", { id: attemptKey(_execution) });
     } catch (err) {
       logError("Failed to send HEARTBEAT message", err);
     }

--- a/packages/core/src/v3/idempotencyKeys.ts
+++ b/packages/core/src/v3/idempotencyKeys.ts
@@ -105,7 +105,7 @@ function injectScope(scope: "run" | "attempt" | "global"): string[] {
     }
     case "attempt": {
       if (taskContext?.ctx) {
-        return [taskContext.ctx.attempt.id];
+        return [taskContext.ctx.run.id, taskContext.ctx.attempt.number.toString()];
       }
       break;
     }
@@ -124,4 +124,18 @@ async function generateIdempotencyKey(keyMaterial: string[]) {
   return Array.from(new Uint8Array(hash))
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("");
+}
+
+type AttemptKeyMaterial = {
+  run: {
+    id: string;
+  };
+  attempt: {
+    number: number;
+  };
+};
+
+/** Creates a unique key for each attempt. */
+export function attemptKey(ctx: AttemptKeyMaterial): string {
+  return `${ctx.run.id}-${ctx.attempt.number}`;
 }

--- a/packages/core/src/v3/workers/taskExecutor.ts
+++ b/packages/core/src/v3/workers/taskExecutor.ts
@@ -12,6 +12,7 @@ import {
 } from "../errors.js";
 import {
   accessoryAttributes,
+  attemptKey,
   flattenAttributes,
   lifecycleHooks,
   runMetadata,
@@ -235,7 +236,7 @@ export class TaskExecutor {
             const [exportError, finalOutput] = await tryCatch(
               conditionallyExportPacket(
                 stringifiedOutput,
-                `${execution.attempt.id}/output`,
+                `${attemptKey(ctx)}/output`,
                 this._tracer
               )
             );


### PR DESCRIPTION
We still used the deprecated attempt ID to generate output keys - that won't work. Fixed by generating keys from run ID + attempt number in all cases.