### PR TITLE
Fixes bug on Safari preventing Queues and Schedules tables from scrolling

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -285,7 +285,7 @@ export default function Page() {
           {success ? (
             <div
               className={cn(
-                "grid h-fit max-h-full min-h-full grid-rows-[1fr] overflow-x-auto",
+                "grid max-h-full min-h-full grid-rows-[1fr] overflow-x-auto",
                 pagination.totalPages > 1 && "grid-rows-[1fr_auto]"
               )}
             >

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.schedules/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.schedules/route.tsx
@@ -229,7 +229,7 @@ export default function Page() {
 
                   <div
                     className={cn(
-                      "grid h-fit max-h-full min-h-full overflow-x-auto",
+                      "grid max-h-full min-h-full overflow-x-auto",
                       totalPages > 1 ? "grid-rows-[1fr_auto]" : "grid-rows-[1fr]"
                     )}
                   >


### PR DESCRIPTION
Tables weren't scrollable on some pages in Safari only.

Bug was discovered on the Queues table but tested other pages and found the Schedules table also needed fixing. 

Retested the Safari fix on Chromium browsers too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the height styling of the containers for the queues and schedules tables, which may affect how these sections are displayed visually. No changes to functionality or controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->