### PR TITLE
Increase v4 visibility timeouts & don't try continue finished runs

### DIFF
--- a/internal-packages/run-engine/src/engine/statuses.ts
+++ b/internal-packages/run-engine/src/engine/statuses.ts
@@ -31,6 +31,11 @@ export function isCheckpointable(status: TaskRunExecutionStatus): boolean {
   return checkpointableStatuses.includes(status);
 }
 
+export function isFinishedOrPendingFinished(status: TaskRunExecutionStatus): boolean {
+  const finishedStatuses: TaskRunExecutionStatus[] = ["FINISHED", "PENDING_CANCEL"];
+  return finishedStatuses.includes(status);
+}
+
 export function isFinalRunStatus(status: TaskRunStatus): boolean {
   const finalStatuses: TaskRunStatus[] = [
     "CANCELED",

--- a/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
@@ -573,6 +573,11 @@ export class WaitpointSystem {
       } else {
         if (snapshot.executionStatus !== "RUN_CREATED" && !snapshot.checkpointId) {
           // TODO: We're screwed, should probably fail the run immediately
+          this.$.logger.error(`#continueRunIfUnblocked: run has no checkpoint`, {
+            runId: run.id,
+            snapshot,
+            blockingWaitpoints,
+          });
           throw new Error(`#continueRunIfUnblocked: run has no checkpoint: ${run.id}`);
         }
 

--- a/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
@@ -10,7 +10,7 @@ import {
 } from "@trigger.dev/database";
 import { nanoid } from "nanoid";
 import { sendNotificationToWorker } from "../eventBus.js";
-import { isExecuting } from "../statuses.js";
+import { isExecuting, isFinishedOrPendingFinished } from "../statuses.js";
 import { EnqueueSystem } from "./enqueueSystem.js";
 import { ExecutionSnapshotSystem, getLatestExecutionSnapshot } from "./executionSnapshotSystem.js";
 import { SystemResources } from "./systems.js";
@@ -511,6 +511,14 @@ export class WaitpointSystem {
     //4. Continue the run whether it's executing or not
     await this.$.runLock.lock([runId], 5000, async () => {
       const snapshot = await getLatestExecutionSnapshot(this.$.prisma, runId);
+
+      if (isFinishedOrPendingFinished(snapshot.executionStatus)) {
+        this.$.logger.debug(`#continueRunIfUnblocked: run is finished, skipping`, {
+          runId,
+          snapshot,
+        });
+        return;
+      }
 
       //run is still executing, send a message to the worker
       if (isExecuting(snapshot.executionStatus)) {

--- a/internal-packages/run-engine/src/engine/workerCatalog.ts
+++ b/internal-packages/run-engine/src/engine/workerCatalog.ts
@@ -6,20 +6,20 @@ export const workerCatalog = {
       waitpointId: z.string(),
       error: z.string().optional(),
     }),
-    visibilityTimeoutMs: 5000,
+    visibilityTimeoutMs: 30_000,
   },
   heartbeatSnapshot: {
     schema: z.object({
       runId: z.string(),
       snapshotId: z.string(),
     }),
-    visibilityTimeoutMs: 5000,
+    visibilityTimeoutMs: 30_000,
   },
   expireRun: {
     schema: z.object({
       runId: z.string(),
     }),
-    visibilityTimeoutMs: 5000,
+    visibilityTimeoutMs: 30_000,
   },
   cancelRun: {
     schema: z.object({
@@ -27,30 +27,30 @@ export const workerCatalog = {
       completedAt: z.coerce.date(),
       reason: z.string().optional(),
     }),
-    visibilityTimeoutMs: 5000,
+    visibilityTimeoutMs: 30_000,
   },
   queueRunsPendingVersion: {
     schema: z.object({
       backgroundWorkerId: z.string(),
     }),
-    visibilityTimeoutMs: 5000,
+    visibilityTimeoutMs: 60_000,
   },
   tryCompleteBatch: {
     schema: z.object({
       batchId: z.string(),
     }),
-    visibilityTimeoutMs: 10_000,
+    visibilityTimeoutMs: 30_000,
   },
   continueRunIfUnblocked: {
     schema: z.object({
       runId: z.string(),
     }),
-    visibilityTimeoutMs: 10_000,
+    visibilityTimeoutMs: 30_000,
   },
   enqueueDelayedRun: {
     schema: z.object({
       runId: z.string(),
     }),
-    visibilityTimeoutMs: 10_000,
+    visibilityTimeoutMs: 30_000,
   },
 };


### PR DESCRIPTION
This pull request introduces new functionality to handle specific task run statuses, improves error handling in the `WaitpointSystem`, and adjusts visibility timeouts in the `workerCatalog`. These changes aim to enhance the reliability and maintainability of the run engine.

### New functionality for task run statuses:
* Added a new function, `isFinishedOrPendingFinished`, to determine if a task run status is either "FINISHED" or "PENDING_CANCEL". This function is now used in the `WaitpointSystem` to prevent unnecessary processing of completed runs. (`internal-packages/run-engine/src/engine/statuses.ts`, [internal-packages/run-engine/src/engine/statuses.tsR34-R38](diffhunk://#diff-b52e23919f06f0c638f5f2ff7fa1aac223443d7f2a17ff6ded914367a1397c2cR34-R38))

### Improvements to the `WaitpointSystem`:
* Incorporated the `isFinishedOrPendingFinished` function in the `WaitpointSystem` to skip processing for runs that are already finished, improving efficiency. (`internal-packages/run-engine/src/engine/systems/waitpointSystem.ts`, [internal-packages/run-engine/src/engine/systems/waitpointSystem.tsR515-R522](diffhunk://#diff-18bdabc2533cc85221b94d4292bdd96c0e035ae336748f18ce978efb957c1efdR515-R522))
* Enhanced error handling by logging detailed error information when a run lacks a checkpoint, making debugging easier. (`internal-packages/run-engine/src/engine/systems/waitpointSystem.ts`, [internal-packages/run-engine/src/engine/systems/waitpointSystem.tsR584-R588](diffhunk://#diff-18bdabc2533cc85221b94d4292bdd96c0e035ae336748f18ce978efb957c1efdR584-R588))

### Adjustments to visibility timeouts:
* Increased the visibility timeout for several worker operations in the `workerCatalog` to reduce the likelihood of premature task retries. Most timeouts were adjusted from 5,000ms or 10,000ms to 30,000ms, with `queueRunsPendingVersion` updated to 60,000ms. (`internal-packages/run-engine/src/engine/workerCatalog.ts`, [internal-packages/run-engine/src/engine/workerCatalog.tsL9-R54](diffhunk://#diff-55ab20d8af33b3a592f976001330dcd40c0bc15eae84b6e6a75d2d1c45f7c9e4L9-R54))