### PR TITLE
fix: default machine config indexing now works

### DIFF
--- a/.changeset/spotty-ducks-punch.md
+++ b/.changeset/spotty-ducks-punch.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+fix: default machine config indexing now works

--- a/packages/cli-v3/src/entryPoints/dev-index-worker.ts
+++ b/packages/cli-v3/src/entryPoints/dev-index-worker.ts
@@ -128,6 +128,22 @@ if (typeof config.maxDuration === "number") {
   });
 }
 
+// If the config has a machine preset, we need to apply it to all tasks that don't have a machine preset
+if (typeof config.machine === "string") {
+  tasks = tasks.map((task) => {
+    if (typeof task.machine?.preset !== "string") {
+      return {
+        ...task,
+        machine: {
+          preset: config.machine,
+        },
+      } satisfies TaskManifest;
+    }
+
+    return task;
+  });
+}
+
 await sendMessageInCatalog(
   indexerToWorkerMessages,
   "INDEX_COMPLETE",

--- a/packages/cli-v3/src/entryPoints/managed-index-worker.ts
+++ b/packages/cli-v3/src/entryPoints/managed-index-worker.ts
@@ -128,6 +128,22 @@ if (typeof config.maxDuration === "number") {
   });
 }
 
+// If the config has a machine preset, we need to apply it to all tasks that don't have a machine preset
+if (typeof config.machine === "string") {
+  tasks = tasks.map((task) => {
+    if (typeof task.machine?.preset !== "string") {
+      return {
+        ...task,
+        machine: {
+          preset: config.machine,
+        },
+      } satisfies TaskManifest;
+    }
+
+    return task;
+  });
+}
+
 await sendMessageInCatalog(
   indexerToWorkerMessages,
   "INDEX_COMPLETE",

--- a/references/hello-world/src/trigger/example.ts
+++ b/references/hello-world/src/trigger/example.ts
@@ -37,6 +37,7 @@ export const helloWorldTask = task({
 
 export const parentTask = task({
   id: "parent",
+  machine: "medium-1x",
   run: async (payload: any, { ctx }) => {
     logger.log("Hello, world from the parent", { payload });
     await childTask.triggerAndWait(

--- a/references/hello-world/trigger.config.ts
+++ b/references/hello-world/trigger.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       randomize: true,
     },
   },
+  machine: "large-1x",
   build: {
     extensions: [
       {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a machine type in task definitions and configuration.
  - Tasks without a defined machine preset now inherit the machine setting from the global configuration if available.

- **Bug Fixes**
  - Fixed an issue with default machine configuration indexing to ensure correct application of machine presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->