### PR TITLE
Fix for Schedules list page slow loading

### DIFF
--- a/apps/webapp/app/components/runs/v3/ScheduleFilters.tsx
+++ b/apps/webapp/app/components/runs/v3/ScheduleFilters.tsx
@@ -24,10 +24,6 @@ export const ScheduleListFilters = z.object({
     .string()
     .optional()
     .transform((value) => (value ? value.split(",") : undefined)),
-  environments: z
-    .string()
-    .optional()
-    .transform((value) => (value ? value.split(",") : undefined)),
   type: z.union([z.literal("declarative"), z.literal("imperative")]).optional(),
   search: z.string().optional(),
 });
@@ -44,7 +40,7 @@ export function ScheduleFilters({ possibleTasks }: ScheduleFiltersProps) {
   const navigate = useNavigate();
   const location = useOptimisticLocation();
   const searchParams = new URLSearchParams(location.search);
-  const { environments, tasks, page, search, type } = ScheduleListFilters.parse(
+  const { tasks, page, search, type } = ScheduleListFilters.parse(
     Object.fromEntries(searchParams.entries())
   );
 

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.schedules.edit.$scheduleParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.schedules.edit.$scheduleParam/route.tsx
@@ -15,6 +15,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const result = await presenter.call({
     userId,
     projectSlug: projectParam,
+    environmentSlug: envParam,
     friendlyId: scheduleParam,
   });
 

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.schedules.new/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.schedules.new/route.tsx
@@ -2,18 +2,19 @@ import { type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { EditSchedulePresenter } from "~/presenters/v3/EditSchedulePresenter.server";
 import { requireUserId } from "~/services/session.server";
-import { ProjectParamSchema } from "~/utils/pathBuilder";
+import { EnvironmentParamSchema } from "~/utils/pathBuilder";
 import { humanToCronSupported } from "~/v3/humanToCron.server";
 import { UpsertScheduleForm } from "../resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.schedules.new/route";
 
 export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const userId = await requireUserId(request);
-  const { projectParam, organizationSlug } = ProjectParamSchema.parse(params);
+  const { projectParam, envParam, organizationSlug } = EnvironmentParamSchema.parse(params);
 
   const presenter = new EditSchedulePresenter();
   const result = await presenter.call({
     userId,
     projectSlug: projectParam,
+    environmentSlug: envParam,
   });
 
   return typedjson({ ...result, showGenerateField: humanToCronSupported });

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.schedules/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.schedules/route.tsx
@@ -93,12 +93,12 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const url = new URL(request.url);
   const s = Object.fromEntries(url.searchParams.entries());
   const filters = ScheduleListFilters.parse(s);
-  filters.environments = [environment.id];
 
   const presenter = new ScheduleListPresenter();
   const list = await presenter.call({
     userId,
     projectId: project.id,
+    environmentId: environment.id,
     ...filters,
   });
 
@@ -106,15 +106,8 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
 };
 
 export default function Page() {
-  const {
-    schedules,
-    possibleTasks,
-    possibleEnvironments,
-    hasFilters,
-    limits,
-    currentPage,
-    totalPages,
-  } = useTypedLoaderData<typeof loader>();
+  const { schedules, possibleTasks, hasFilters, limits, currentPage, totalPages } =
+    useTypedLoaderData<typeof loader>();
   const location = useLocation();
   const organization = useOrganization();
   const project = useProject();

--- a/apps/webapp/app/routes/api.v1.schedules.ts
+++ b/apps/webapp/app/routes/api.v1.schedules.ts
@@ -100,9 +100,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const result = await presenter.call({
     projectId: authenticationResult.environment.projectId,
+    environmentId: authenticationResult.environment.id,
     page: params.data.page ?? 1,
     pageSize: params.data.perPage,
-    environments: [authenticationResult.environment.id],
   });
 
   return {

--- a/internal-packages/database/prisma/migrations/20250429100819_background_worker_index_environment_id_and_created_at/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250429100819_background_worker_index_environment_id_and_created_at/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "BackgroundWorker_runtimeEnvironmentId_createdAt_idx" ON "BackgroundWorker" ("runtimeEnvironmentId", "createdAt" DESC);

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -1627,6 +1627,8 @@ model BackgroundWorker {
 
   @@unique([projectId, runtimeEnvironmentId, version])
   @@index([runtimeEnvironmentId])
+  // Get the latest worker for a given environment
+  @@index([runtimeEnvironmentId, createdAt(sort: Desc)])
 }
 
 model BackgroundWorkerFile {


### PR DESCRIPTION
The Schedules list page was slow to load because we were getting the possible `BackgroundWorkerTask`.

This had become very slow because `distinct` Prisma wasn't use the Postgres DISTINCT feature – it was loading all of them into memory… this could be millions in some cases if you had a lot of versions.

- [ ] The concurrently index needs applying manually in Test
- [ ] The concurrently index needs applying manually in Prod

```sql
-- CreateIndex
CREATE INDEX CONCURRENTLY IF NOT EXISTS "BackgroundWorker_runtimeEnvironmentId_createdAt_idx" ON "BackgroundWorker" ("runtimeEnvironmentId", "createdAt" DESC);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved performance for environment-based schedule queries by adding a new database index to quickly retrieve the latest background worker for a given environment.
- **Refactor**
	- Updated schedule filtering to use a single environment context instead of supporting multiple environments.
	- Simplified filter options and responses by removing multi-environment selection and related data from the schedule list.
	- Enhanced validation to ensure schedules are tied to a valid environment.
- **Chores**
	- Database schema updated to include a new index for optimized queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->