### PR TITLE
Fix: Show data for the last day of the month for usage graphs

### DIFF
--- a/apps/webapp/app/utils/graphs.ts
+++ b/apps/webapp/app/utils/graphs.ts
@@ -8,7 +8,7 @@ type Options<R> = {
 export function createTimeSeriesData<R>({ startDate, endDate, window = "DAY", data }: Options<R>) {
   const outputData: Array<{ date: Date; value?: R }> = [];
   const periodLength = periodLengthMs(window);
-  const periodCount = Math.floor((endDate.getTime() - startDate.getTime()) / periodLength);
+  const periodCount = Math.round((endDate.getTime() - startDate.getTime()) / periodLength);
 
   for (let i = 0; i < periodCount; i++) {
     const periodStart = new Date(startDate);


### PR DESCRIPTION
Fix for #1997 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy in calculating the number of periods between selected dates, ensuring more precise results when viewing time-based data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->