### PR TITLE
Tooltip to explain dev schedules not counting towards your limit

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.schedules/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.schedules/route.tsx
@@ -38,7 +38,7 @@ import {
   TableHeaderCell,
   TableRow,
 } from "~/components/primitives/Table";
-import { SimpleTooltip } from "~/components/primitives/Tooltip";
+import { InfoIconTooltip, SimpleTooltip } from "~/components/primitives/Tooltip";
 import { EnabledStatus } from "~/components/runs/v3/EnabledStatus";
 import { ScheduleFilters, ScheduleListFilters } from "~/components/runs/v3/ScheduleFilters";
 import {
@@ -274,9 +274,12 @@ export default function Page() {
                             plan to enable more.
                           </Header3>
                         ) : (
-                          <Header3>
-                            You've used {limits.used}/{limits.limit} of your schedules.
-                          </Header3>
+                          <div className="flex items-center gap-1">
+                            <Header3>
+                              You've used {limits.used}/{limits.limit} of your schedules
+                            </Header3>
+                            <InfoIconTooltip content="Schedules created in Dev don't count towards your limit." />
+                          </div>
                         )}
 
                         {canUpgrade ? (
@@ -284,6 +287,7 @@ export default function Page() {
                             to={v3BillingPath(organization)}
                             variant="secondary/small"
                             LeadingIcon={ArrowUpCircleIcon}
+                            leadingIconClassName="text-indigo-500"
                           >
                             Upgrade
                           </LinkButton>


### PR DESCRIPTION
A small update to make it clear why it might say "You've used 0/x of your schedules" while you're in Dev, where you might have created some.

I've added a tooltip to explain schedules in Dev don't count towards your schedules limit. 

![CleanShot 2025-05-01 at 08 51 15@2x](https://github.com/user-attachments/assets/ece060f5-f47d-4ea1-b234-971fc72e5502)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an informational tooltip next to the schedule usage text to clarify that schedules created in Dev do not count towards the limit.

- **Style**
  - Enhanced the visual styling of the "Upgrade" button icon for improved appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->