### PR TITLE
Code blocks have an optional text-wrap toggle

### DIFF
--- a/apps/webapp/app/assets/icons/TextInlineIcon.tsx
+++ b/apps/webapp/app/assets/icons/TextInlineIcon.tsx
@@ -1,0 +1,41 @@
+export function TextInlineIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M3 3V21"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M13 21L13 16"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M13 8L13 3"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M7 12L20 12"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M17.5 15.5L21 12L17.5 8.5"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/apps/webapp/app/assets/icons/TextWrapIcon.tsx
+++ b/apps/webapp/app/assets/icons/TextWrapIcon.tsx
@@ -1,0 +1,34 @@
+export function TextWrapIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M3 3V21"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M21 21V3"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M7 7H14C15.6569 7 17 8.34315 17 10V13C17 14.6569 15.6569 16 14 16H9"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M11 13L8 16L11 19"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/apps/webapp/app/components/code/CodeBlock.tsx
+++ b/apps/webapp/app/components/code/CodeBlock.tsx
@@ -354,7 +354,7 @@ export const CodeBlock = forwardRef<HTMLDivElement, CodeBlockProps>(
               <pre
                 className={cn(
                   "relative mr-2 p-2 font-mono text-xs leading-relaxed",
-                  isWrapped && "[&_span]:whitespace-pre-wrap [&_span]:break-all"
+                  isWrapped && "[&_span]:whitespace-pre-wrap [&_span]:break-words"
                 )}
                 dir="ltr"
               >
@@ -483,7 +483,7 @@ function HighlightCode({
   const preClasses = cn(
     "relative mr-2 font-mono leading-relaxed",
     preClassName,
-    isWrapped && "[&_span]:whitespace-pre-wrap [&_span]:break-all"
+    isWrapped && "[&_span]:whitespace-pre-wrap [&_span]:break-words"
   );
 
   if (!isLoaded) {

--- a/apps/webapp/app/components/code/CodeBlock.tsx
+++ b/apps/webapp/app/components/code/CodeBlock.tsx
@@ -188,7 +188,7 @@ export const CodeBlock = forwardRef<HTMLDivElement, CodeBlockProps>(
   (
     {
       showCopyButton = true,
-      showTextWrapping = true,
+      showTextWrapping = false,
       showLineNumbers = true,
       showOpenInModal = true,
       highlightedRanges,

--- a/apps/webapp/app/components/code/CodeBlock.tsx
+++ b/apps/webapp/app/components/code/CodeBlock.tsx
@@ -284,7 +284,7 @@ export const CodeBlock = forwardRef<HTMLDivElement, CodeBlockProps>(
                     )}
                   </TooltipTrigger>
                   <TooltipContent side="left" className="text-xs">
-                    {isWrapped ? "Inline text" : "Wrap text"}
+                    {isWrapped ? "Unwrap" : "Wrap"}
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>

--- a/apps/webapp/app/components/runs/v3/PacketDisplay.tsx
+++ b/apps/webapp/app/components/runs/v3/PacketDisplay.tsx
@@ -44,6 +44,7 @@ export function PacketDisplay({
           code={data}
           maxLines={20}
           showLineNumbers={false}
+          showTextWrapping
         />
       );
     }


### PR DESCRIPTION
User requested improvement: CodeBlock component has a button that toggles between "Text wrap" and "Text inline".

Notes: 
- It sets classes like `whitespace-pre-wrap` and `break-word` using isWrapped
- This option doesn't display on the full modal view
- It doesn't honor any code indentation when it wraps annoyingly

![CleanShot 2025-05-01 at 13 45 40@2x](https://github.com/user-attachments/assets/fc916b0e-38a4-45f8-92c1-b4d55a581ce2)

![CleanShot 2025-05-01 at 13 50 13@2x](https://github.com/user-attachments/assets/321709fd-bd36-43e0-a3f9-b9437d2ef511)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a toggle button to code blocks for enabling or disabling text wrapping, improving readability for long lines of code.
	- Introduced new inline and wrap icons for visual feedback when toggling text wrapping in code blocks.

- **Enhancements**
	- Code blocks now support an optional text wrapping feature, which can be enabled by developers as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->