### PR TITLE
formatDateTimeISO() fix

### DIFF
--- a/apps/webapp/app/components/primitives/DateTime.tsx
+++ b/apps/webapp/app/components/primitives/DateTime.tsx
@@ -133,7 +133,9 @@ export function formatDateTimeISO(date: Date, timeZone: string): string {
   // Format: YYYY-MM-DDThh:mm:ss.sss±hh:mm
   return (
     `${dateParts.year}-${dateParts.month}-${dateParts.day}T` +
-    `${dateParts.hour}:${dateParts.minute}:${dateParts.second}.000${offset}`
+    `${dateParts.hour}:${dateParts.minute}:${dateParts.second}.${String(
+      date.getMilliseconds()
+    ).padStart(3, "0")}${offset}`
   );
 }
 

--- a/apps/webapp/test/components/DateTime.test.ts
+++ b/apps/webapp/test/components/DateTime.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { formatDateTimeISO } from "~/components/primitives/DateTime";
+
+describe("formatDateTimeISO", () => {
+  it("should format UTC dates with Z suffix", () => {
+    const date = new Date("2025-04-29T14:01:19.000Z");
+    const result = formatDateTimeISO(date, "UTC");
+    expect(result).toBe("2025-04-29T14:01:19.000Z");
+  });
+
+  describe("British Time (Europe/London)", () => {
+    it("should format with +01:00 during BST (summer)", () => {
+      // BST - British Summer Time (last Sunday in March to last Sunday in October)
+      const summerDate = new Date("2025-07-15T14:01:19.000Z");
+      const result = formatDateTimeISO(summerDate, "Europe/London");
+      expect(result).toBe("2025-07-15T15:01:19.000+01:00");
+    });
+
+    it("should format with +00:00 during GMT (winter)", () => {
+      // GMT - Greenwich Mean Time (winter)
+      const winterDate = new Date("2025-01-15T14:01:19.000Z");
+      const result = formatDateTimeISO(winterDate, "Europe/London");
+      expect(result).toBe("2025-01-15T14:01:19.000+00:00");
+    });
+  });
+
+  describe("US Pacific Time (America/Los_Angeles)", () => {
+    it("should format with -07:00 during PDT (summer)", () => {
+      // PDT - Pacific Daylight Time (second Sunday in March to first Sunday in November)
+      const summerDate = new Date("2025-07-15T14:01:19.000Z");
+      const result = formatDateTimeISO(summerDate, "America/Los_Angeles");
+      expect(result).toBe("2025-07-15T07:01:19.000-07:00");
+    });
+
+    it("should format with -08:00 during PST (winter)", () => {
+      // PST - Pacific Standard Time (winter)
+      const winterDate = new Date("2025-01-15T14:01:19.000Z");
+      const result = formatDateTimeISO(winterDate, "America/Los_Angeles");
+      expect(result).toBe("2025-01-15T06:01:19.000-08:00");
+    });
+  });
+
+  it("should preserve milliseconds", () => {
+    const date = new Date("2025-04-29T14:01:19.123Z");
+    const result = formatDateTimeISO(date, "UTC");
+    expect(result).toBe("2025-04-29T14:01:19.123Z");
+  });
+});

--- a/apps/webapp/test/components/DateTime.test.ts
+++ b/apps/webapp/test/components/DateTime.test.ts
@@ -45,4 +45,10 @@ describe("formatDateTimeISO", () => {
     const result = formatDateTimeISO(date, "UTC");
     expect(result).toBe("2025-04-29T14:01:19.123Z");
   });
+
+  it("should preserve milliseconds, not UTC", () => {
+    const date = new Date("2025-04-29T14:01:19.123Z");
+    const result = formatDateTimeISO(date, "Europe/London");
+    expect(result).toBe("2025-04-29T15:01:19.123+01:00");
+  });
 });


### PR DESCRIPTION
We use the `formatDateTimeISO()` function to format dates in our new date tooltip which lets you copy ISO dates. 

They need to be in this format:

```
2025-01-15T06:01:19.000-08:00
2025-04-29T14:01:19.123Z
```

Previously they weren't respecting the timezone correctly and were in the wrong format too. I've added some tests as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved date and time formatting to correctly handle various time zones and daylight saving transitions, ensuring accurate ISO-like output.

- **Tests**
	- Added comprehensive tests to verify correct formatting across multiple time zones, including daylight saving periods and offset handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->