### PR TITLE
Adds friendly formatting for max duration values

### DIFF
--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -647,7 +647,12 @@ function RunBody({
                 <Property.Item>
                   <Property.Label>Max duration</Property.Label>
                   <Property.Value>
-                    {run.maxDurationInSeconds ? `${run.maxDurationInSeconds}s` : "–"}
+                    {run.maxDurationInSeconds
+                      ? `${run.maxDurationInSeconds}s (${formatDurationMilliseconds(
+                          run.maxDurationInSeconds * 1000,
+                          { style: "short" }
+                        )})`
+                      : "–"}
                   </Property.Value>
                 </Property.Item>
                 <Property.Item>


### PR DESCRIPTION
Formatting seconds into a friendly format in brackets for max duration in the run inspector Details tab

![CleanShot 2025-05-01 at 18 36 09@2x](https://github.com/user-attachments/assets/5ac8684c-8438-419c-9267-c59ffce0c75c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the display of the "Max duration" property by showing both the raw seconds value and a formatted duration string for easier readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->