### PR TITLE
Give helpful hint if you pass a bad directory when deploying

### DIFF
--- a/.changeset/wet-steaks-reflect.md
+++ b/.changeset/wet-steaks-reflect.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+If you pass a directory when calling deploy we validate it exists and give helpful hints


### PR DESCRIPTION
Closes #1990 

If you pass in a directory that isn't found, we tell you it doesn't exist and where we looked.

If you pass in `prod` `staging` `stg` or `production` we tell you how you should be running the command: `--env prod` or `--env staging`. Please note you don't need to pass `prod` it's the default.