### PR TITLE
Changes the spinner in buttons to white now we have purple primary buttons

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -610,7 +610,9 @@ function EnvironmentPauseResumeButton({
                   type="submit"
                   disabled={isLoading}
                   variant={env.paused ? "primary/medium" : "danger/medium"}
-                  LeadingIcon={isLoading ? <Spinner /> : env.paused ? PlayIcon : PauseIcon}
+                  LeadingIcon={
+                    isLoading ? <Spinner color="white" /> : env.paused ? PlayIcon : PauseIcon
+                  }
                   shortcut={{ modifiers: ["mod"], key: "enter" }}
                 >
                   {env.paused ? "Resume environment" : "Pause environment"}

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.select-plan.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.select-plan.tsx
@@ -678,7 +678,7 @@ export function TierPro({
                   <Button
                     variant="primary/medium"
                     disabled={isLoading}
-                    LeadingIcon={isLoading ? () => <Spinner color="dark" /> : undefined}
+                    LeadingIcon={isLoading ? () => <Spinner color="white" /> : undefined}
                     form="subscribe-pro"
                   >
                     {`Upgrade to ${plan.title}`}


### PR DESCRIPTION
When we changed the primary button color to purple, the loading spinners when used inside some buttons also needed to change from "dark" to "white".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the loading spinner color to white on the "Pause/Resume Environment" and "Upgrade to Pro" buttons for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->