### PR TITLE
Fixes the task and schedule icon width squishing

### DIFF
--- a/apps/webapp/app/components/runs/v3/TaskTriggerSource.tsx
+++ b/apps/webapp/app/components/runs/v3/TaskTriggerSource.tsx
@@ -12,10 +12,12 @@ export function TaskTriggerSourceIcon({
 }) {
   switch (source) {
     case "STANDARD": {
-      return <TaskIconSmall className="size-[1.125rem] text-tasks" />;
+      return <TaskIconSmall className="size-[1.125rem] min-w-[1.125rem] text-tasks" />;
     }
     case "SCHEDULED": {
-      return <ClockIcon className={cn("size-[1.125rem] text-schedules", className)} />;
+      return (
+        <ClockIcon className={cn("size-[1.125rem] min-w-[1.125rem] text-schedules", className)} />
+      );
     }
   }
 }


### PR DESCRIPTION
Adds a min-width to the task and schedules icon in the task filter menu:

Before: 
![CleanShot 2025-05-02 at 09 44 12@2x](https://github.com/user-attachments/assets/09324fba-e4e2-461d-8671-060b4762e8aa)

After:
![CleanShot 2025-05-02 at 09 50 15@2x](https://github.com/user-attachments/assets/74c4c806-a81a-43bc-afb3-7c0ff1e9d47f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved icon alignment and consistency by adding a minimum width to task trigger source icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->