### PR TITLE
Fix long retry delays

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,14 +56,14 @@ jobs:
     secrets: inherit
 
   publish-webapp:
-    needs: [typecheck]
+    needs: [typecheck, units]
     uses: ./.github/workflows/publish-webapp.yml
     secrets: inherit
     with:
       image_tag: ${{ inputs.image_tag }}
 
   publish-worker:
-    needs: [typecheck]
+    needs: [typecheck, units]
     uses: ./.github/workflows/publish-worker.yml
     secrets: inherit
     with:

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -460,6 +460,7 @@ const EnvironmentSchema = z.object({
   RUN_ENGINE_REUSE_SNAPSHOT_COUNT: z.coerce.number().int().default(0),
   RUN_ENGINE_MAXIMUM_ENV_COUNT: z.coerce.number().int().optional(),
   RUN_ENGINE_WORKER_SHUTDOWN_TIMEOUT_MS: z.coerce.number().int().default(60_000),
+  RUN_ENGINE_RETRY_WARM_START_THRESHOLD_MS: z.coerce.number().int().default(30_000),
 
   RUN_ENGINE_WORKER_REDIS_HOST: z
     .string()
@@ -717,7 +718,7 @@ const EnvironmentSchema = z.object({
 
   SLACK_BOT_TOKEN: z.string().optional(),
   SLACK_SIGNUP_REASON_CHANNEL_ID: z.string().optional(),
-  
+
   // kapa.ai
   KAPA_AI_WEBSITE_ID: z.string().optional(),
 });

--- a/apps/webapp/app/v3/runEngine.server.ts
+++ b/apps/webapp/app/v3/runEngine.server.ts
@@ -95,6 +95,7 @@ function createRunEngine() {
         ...(env.RUN_ENGINE_RUN_QUEUE_REDIS_TLS_DISABLED === "true" ? {} : { tls: {} }),
       },
     },
+    retryWarmStartThresholdMs: env.RUN_ENGINE_RETRY_WARM_START_THRESHOLD_MS,
   });
 
   return engine;

--- a/internal-packages/run-engine/src/engine/index.ts
+++ b/internal-packages/run-engine/src/engine/index.ts
@@ -304,6 +304,7 @@ export class RunEngine {
       waitpointSystem: this.waitpointSystem,
       delayedRunSystem: this.delayedRunSystem,
       machines: this.options.machines,
+      retryWarmStartThresholdMs: this.options.retryWarmStartThresholdMs,
     });
 
     this.dequeueSystem = new DequeueSystem({

--- a/internal-packages/run-engine/src/run-queue/index.ts
+++ b/internal-packages/run-engine/src/run-queue/index.ts
@@ -541,7 +541,7 @@ export class RunQueue {
           }
         }
 
-        await this.#callNackMessage({ message });
+        await this.#callNackMessage({ message, retryAt });
 
         return true;
       },

--- a/internal-packages/testcontainers/src/index.ts
+++ b/internal-packages/testcontainers/src/index.ts
@@ -53,7 +53,9 @@ const postgresContainer = async (
   try {
     await use(container);
   } finally {
-    await container.stop();
+    // WARNING: Testcontainers by default will not wait until the container has stopped. It will simply issue the stop command and return immediately.
+    // If you need to wait for the container to be stopped, you can provide a timeout. The unit of timeout option here is second
+    await container.stop({ timeout: 10 });
   }
 };
 
@@ -92,7 +94,9 @@ const redisContainer = async (
   try {
     await use(container);
   } finally {
-    await container.stop();
+    // WARNING: Testcontainers by default will not wait until the container has stopped. It will simply issue the stop command and return immediately.
+    // If you need to wait for the container to be stopped, you can provide a timeout. The unit of timeout option here is second
+    await container.stop({ timeout: 10 });
   }
 };
 
@@ -142,7 +146,9 @@ const electricOrigin = async (
   try {
     await use(origin);
   } finally {
-    await container.stop();
+    // WARNING: Testcontainers by default will not wait until the container has stopped. It will simply issue the stop command and return immediately.
+    // If you need to wait for the container to be stopped, you can provide a timeout. The unit of timeout option here is second
+    await container.stop({ timeout: 10 });
   }
 };
 


### PR DESCRIPTION
v4 runs with delays >1m currently display very strange behaviour, with duplicate attempt spans and delays not being respected.

This was caused by two things, both fixed:
- we didn't pass the `retryWarmStartThresholdMs` through, we also didn't set it anywhere
- the run queue `nackMessage` method didn't respect `retryAt`

This PR also re-enables unit test requirements for our publish workflow after fixing the testcontainers issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new environment variable to configure retry warm start thresholds for the run engine.

- **Bug Fixes**
	- Improved message requeueing in the run queue to support scheduling retries at specific times.

- **Tests**
	- Added a test to verify correct scheduling of message retries in the run queue.

- **Chores**
	- Updated workflow dependencies to ensure unit tests pass before publishing.
	- Improved container stop logic to wait for full termination during test cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->