### PR TITLE
v4: implement onCancel callbacks

### DIFF
--- a/.changeset/real-rats-drop.md
+++ b/.changeset/real-rats-drop.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+Add onCancel lifecycle hook

--- a/apps/webapp/app/components/runs/v3/RunIcon.tsx
+++ b/apps/webapp/app/components/runs/v3/RunIcon.tsx
@@ -97,6 +97,7 @@ export function RunIcon({ name, className, spanName }: TaskIconProps) {
     case "task-hook-onResume":
     case "task-hook-onComplete":
     case "task-hook-cleanup":
+    case "task-hook-onCancel":
       return <FunctionIcon className={cn(className, "text-text-dimmed")} />;
     case "task-hook-onFailure":
     case "task-hook-catchError":

--- a/apps/webapp/app/v3/services/cancelTaskRun.server.ts
+++ b/apps/webapp/app/v3/services/cancelTaskRun.server.ts
@@ -47,29 +47,6 @@ export class CancelTaskRunService extends BaseService {
       tx: this._prisma,
     });
 
-    const inProgressEvents = await eventRepository.queryIncompleteEvents(
-      getTaskEventStoreTableForRun(taskRun),
-      {
-        runId: taskRun.friendlyId,
-      },
-      taskRun.createdAt,
-      taskRun.completedAt ?? undefined
-    );
-
-    logger.debug("Cancelling in-progress events", {
-      inProgressEvents: inProgressEvents.map((event) => event.id),
-    });
-
-    await Promise.all(
-      inProgressEvents.map((event) => {
-        return eventRepository.cancelEvent(
-          event,
-          options?.cancelledAt ?? new Date(),
-          options?.reason ?? "Run cancelled"
-        );
-      })
-    );
-
     return {
       id: result.run.id,
     };

--- a/packages/cli-v3/src/entryPoints/dev-run-worker.ts
+++ b/packages/cli-v3/src/entryPoints/dev-run-worker.ts
@@ -409,27 +409,11 @@ const zodIpc = new ZodIpcConnection({
 
           _executionMeasurement = usage.start();
 
-          // This lives outside of the executor because this will eventually be moved to the controller level
           const timeoutController = timeout.abortAfterTimeout(execution.run.maxDuration);
 
-          timeoutController.signal.addEventListener("abort", () => {
-            if (_isCancelled) {
-              return;
-            }
+          const signal = AbortSignal.any([cancelController.signal, timeoutController.signal]);
 
-            if (cancelController.signal.aborted) {
-              return;
-            }
-
-            cancelController.abort(timeoutController.signal.reason);
-          });
-
-          const { result } = await executor.execute(
-            execution,
-            metadata,
-            traceContext,
-            cancelController.signal
-          );
+          const { result } = await executor.execute(execution, metadata, traceContext, signal);
 
           if (_isRunning && !_isCancelled) {
             const usageSample = usage.stop(_executionMeasurement);

--- a/packages/cli-v3/src/entryPoints/dev-run-worker.ts
+++ b/packages/cli-v3/src/entryPoints/dev-run-worker.ts
@@ -23,6 +23,7 @@ import {
   TaskRunExecution,
   timeout,
   TriggerConfig,
+  UsageMeasurement,
   waitUntil,
   WorkerManifest,
   WorkerToExecutorMessageCatalog,
@@ -232,7 +233,10 @@ async function bootstrap() {
 
 let _execution: TaskRunExecution | undefined;
 let _isRunning = false;
+let _isCancelled = false;
 let _tracingSDK: TracingSDK | undefined;
+let _executionMeasurement: UsageMeasurement | undefined;
+const cancelController = new AbortController();
 
 const zodIpc = new ZodIpcConnection({
   listenSchema: WorkerToExecutorMessageCatalog,
@@ -403,18 +407,33 @@ const zodIpc = new ZodIpcConnection({
             getNumberEnvVar("TRIGGER_RUN_METADATA_FLUSH_INTERVAL", 1000)
           );
 
-          const measurement = usage.start();
+          _executionMeasurement = usage.start();
 
           // This lives outside of the executor because this will eventually be moved to the controller level
-          const signal = execution.run.maxDuration
-            ? timeout.abortAfterTimeout(execution.run.maxDuration)
-            : undefined;
+          const timeoutController = timeout.abortAfterTimeout(execution.run.maxDuration);
 
-          const { result } = await executor.execute(execution, metadata, traceContext, signal);
+          timeoutController.signal.addEventListener("abort", () => {
+            if (_isCancelled) {
+              return;
+            }
 
-          const usageSample = usage.stop(measurement);
+            if (cancelController.signal.aborted) {
+              return;
+            }
 
-          if (_isRunning) {
+            cancelController.abort(timeoutController.signal.reason);
+          });
+
+          const { result } = await executor.execute(
+            execution,
+            metadata,
+            traceContext,
+            cancelController.signal
+          );
+
+          if (_isRunning && !_isCancelled) {
+            const usageSample = usage.stop(_executionMeasurement);
+
             return sender.send("TASK_RUN_COMPLETED", {
               execution,
               result: {
@@ -458,7 +477,16 @@ const zodIpc = new ZodIpcConnection({
     WAIT_COMPLETED_NOTIFICATION: async () => {
       await managedWorkerRuntime.completeWaitpoints([]);
     },
-    FLUSH: async ({ timeoutInMs }, sender) => {
+    CANCEL: async ({ timeoutInMs }) => {
+      _isCancelled = true;
+      cancelController.abort("run cancelled");
+      await callCancelHooks(timeoutInMs);
+      if (_executionMeasurement) {
+        usage.stop(_executionMeasurement);
+      }
+      await flushAll(timeoutInMs);
+    },
+    FLUSH: async ({ timeoutInMs }) => {
       await flushAll(timeoutInMs);
     },
     WAITPOINT_CREATED: async ({ wait, waitpoint }) => {
@@ -469,6 +497,18 @@ const zodIpc = new ZodIpcConnection({
     },
   },
 });
+
+async function callCancelHooks(timeoutInMs: number = 10_000) {
+  const now = performance.now();
+
+  try {
+    await Promise.race([lifecycleHooks.callOnCancelHookListeners(), setTimeout(timeoutInMs)]);
+  } finally {
+    const duration = performance.now() - now;
+
+    log(`Called cancel hooks in ${duration}ms`);
+  }
+}
 
 async function flushAll(timeoutInMs: number = 10_000) {
   const now = performance.now();

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -16,3 +16,25 @@ export async function tryCatch<T, E = Error>(
     return [error as E, null];
   }
 }
+
+export type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: any) => void;
+};
+
+export function promiseWithResolvers<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: any) => void;
+
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  });
+
+  return {
+    promise,
+    resolve,
+    reject,
+  };
+}

--- a/packages/core/src/v3/lifecycle-hooks-api.ts
+++ b/packages/core/src/v3/lifecycle-hooks-api.ts
@@ -32,4 +32,7 @@ export type {
   AnyOnCleanupHookFunction,
   TaskCleanupHookParams,
   TaskWait,
+  TaskCancelHookParams,
+  OnCancelHookFunction,
+  AnyOnCancelHookFunction,
 } from "./lifecycleHooks/types.js";

--- a/packages/core/src/v3/lifecycleHooks/index.ts
+++ b/packages/core/src/v3/lifecycleHooks/index.ts
@@ -13,6 +13,7 @@ import {
   AnyOnStartHookFunction,
   AnyOnSuccessHookFunction,
   AnyOnWaitHookFunction,
+  AnyOnCancelHookFunction,
   RegisteredHookFunction,
   RegisterHookFunctionParams,
   TaskWait,
@@ -258,6 +259,33 @@ export class LifecycleHooksAPI {
 
   public registerOnResumeHookListener(listener: (wait: TaskWait) => Promise<void>): void {
     this.#getManager().registerOnResumeHookListener(listener);
+  }
+
+  public registerGlobalCancelHook(hook: RegisterHookFunctionParams<AnyOnCancelHookFunction>): void {
+    this.#getManager().registerGlobalCancelHook(hook);
+  }
+
+  public registerTaskCancelHook(
+    taskId: string,
+    hook: RegisterHookFunctionParams<AnyOnCancelHookFunction>
+  ): void {
+    this.#getManager().registerTaskCancelHook(taskId, hook);
+  }
+
+  public getTaskCancelHook(taskId: string): AnyOnCancelHookFunction | undefined {
+    return this.#getManager().getTaskCancelHook(taskId);
+  }
+
+  public getGlobalCancelHooks(): RegisteredHookFunction<AnyOnCancelHookFunction>[] {
+    return this.#getManager().getGlobalCancelHooks();
+  }
+
+  public callOnCancelHookListeners(): Promise<void> {
+    return this.#getManager().callOnCancelHookListeners();
+  }
+
+  public registerOnCancelHookListener(listener: () => Promise<void>): void {
+    this.#getManager().registerOnCancelHookListener(listener);
   }
 
   #getManager(): LifecycleHooksManager {

--- a/packages/core/src/v3/lifecycleHooks/types.ts
+++ b/packages/core/src/v3/lifecycleHooks/types.ts
@@ -7,7 +7,7 @@ export type TaskInitHookParams<TPayload = unknown> = {
   ctx: TaskRunContext;
   payload: TPayload;
   task: string;
-  signal?: AbortSignal;
+  signal: AbortSignal;
 };
 
 export type OnInitHookFunction<TPayload, TInitOutput extends TaskInitOutput> = (
@@ -23,7 +23,7 @@ export type TaskStartHookParams<
   ctx: TaskRunContext;
   payload: TPayload;
   task: string;
-  signal?: AbortSignal;
+  signal: AbortSignal;
   init?: TInitOutput;
 };
 
@@ -60,7 +60,7 @@ export type TaskWaitHookParams<
   ctx: TaskRunContext;
   payload: TPayload;
   task: string;
-  signal?: AbortSignal;
+  signal: AbortSignal;
   init?: TInitOutput;
 };
 
@@ -78,7 +78,7 @@ export type TaskResumeHookParams<
   wait: TaskWait;
   payload: TPayload;
   task: string;
-  signal?: AbortSignal;
+  signal: AbortSignal;
   init?: TInitOutput;
 };
 
@@ -96,7 +96,7 @@ export type TaskFailureHookParams<
   payload: TPayload;
   task: string;
   error: unknown;
-  signal?: AbortSignal;
+  signal: AbortSignal;
   init?: TInitOutput;
 };
 
@@ -115,7 +115,7 @@ export type TaskSuccessHookParams<
   payload: TPayload;
   task: string;
   output: TOutput;
-  signal?: AbortSignal;
+  signal: AbortSignal;
   init?: TInitOutput;
 };
 
@@ -152,7 +152,7 @@ export type TaskCompleteHookParams<
   payload: TPayload;
   task: string;
   result: TaskCompleteResult<TOutput>;
-  signal?: AbortSignal;
+  signal: AbortSignal;
   init?: TInitOutput;
 };
 
@@ -188,7 +188,7 @@ export type TaskCatchErrorHookParams<
   retry?: RetryOptions;
   retryAt?: Date;
   retryDelayInMs?: number;
-  signal?: AbortSignal;
+  signal: AbortSignal;
   init?: TInitOutput;
 };
 
@@ -203,7 +203,7 @@ export type TaskMiddlewareHookParams<TPayload = unknown> = {
   ctx: TaskRunContext;
   payload: TPayload;
   task: string;
-  signal?: AbortSignal;
+  signal: AbortSignal;
   next: () => Promise<void>;
 };
 
@@ -220,7 +220,7 @@ export type TaskCleanupHookParams<
   ctx: TaskRunContext;
   payload: TPayload;
   task: string;
-  signal?: AbortSignal;
+  signal: AbortSignal;
   init?: TInitOutput;
 };
 
@@ -229,6 +229,29 @@ export type OnCleanupHookFunction<TPayload, TInitOutput extends TaskInitOutput =
 ) => undefined | void | Promise<undefined | void>;
 
 export type AnyOnCleanupHookFunction = OnCleanupHookFunction<unknown, TaskInitOutput>;
+
+export type TaskCancelHookParams<
+  TPayload = unknown,
+  TRunOutput = any,
+  TInitOutput extends TaskInitOutput = TaskInitOutput,
+> = {
+  ctx: TaskRunContext;
+  payload: TPayload;
+  task: string;
+  runPromise: Promise<TRunOutput>;
+  init?: TInitOutput;
+  signal: AbortSignal;
+};
+
+export type OnCancelHookFunction<
+  TPayload,
+  TRunOutput = any,
+  TInitOutput extends TaskInitOutput = TaskInitOutput,
+> = (
+  params: TaskCancelHookParams<TPayload, TRunOutput, TInitOutput>
+) => undefined | void | Promise<undefined | void>;
+
+export type AnyOnCancelHookFunction = OnCancelHookFunction<unknown, unknown, TaskInitOutput>;
 
 export interface LifecycleHooksManager {
   registerGlobalInitHook(hook: RegisterHookFunctionParams<AnyOnInitHookFunction>): void;
@@ -307,4 +330,15 @@ export interface LifecycleHooksManager {
 
   callOnResumeHookListeners(wait: TaskWait): Promise<void>;
   registerOnResumeHookListener(listener: (wait: TaskWait) => Promise<void>): void;
+
+  registerGlobalCancelHook(hook: RegisterHookFunctionParams<AnyOnCancelHookFunction>): void;
+  registerTaskCancelHook(
+    taskId: string,
+    hook: RegisterHookFunctionParams<AnyOnCancelHookFunction>
+  ): void;
+  getGlobalCancelHooks(): RegisteredHookFunction<AnyOnCancelHookFunction>[];
+  getTaskCancelHook(taskId: string): AnyOnCancelHookFunction | undefined;
+
+  registerOnCancelHookListener(listener: () => Promise<void>): void;
+  callOnCancelHookListeners(): Promise<void>;
 }

--- a/packages/core/src/v3/schemas/messages.ts
+++ b/packages/core/src/v3/schemas/messages.ts
@@ -243,6 +243,12 @@ export const WorkerToExecutorMessageCatalog = {
     }),
     callback: z.void(),
   },
+  CANCEL: {
+    message: z.object({
+      timeoutInMs: z.number(),
+    }),
+    callback: z.void(),
+  },
   WAITPOINT_CREATED: {
     message: z.object({
       version: z.literal("v1").default("v1"),

--- a/packages/core/src/v3/timeout/api.ts
+++ b/packages/core/src/v3/timeout/api.ts
@@ -4,8 +4,8 @@ import { TimeoutManager } from "./types.js";
 const API_NAME = "timeout";
 
 class NoopTimeoutManager implements TimeoutManager {
-  abortAfterTimeout(timeoutInSeconds: number): AbortSignal {
-    return new AbortController().signal;
+  abortAfterTimeout(timeoutInSeconds?: number): AbortController {
+    return new AbortController();
   }
 }
 
@@ -25,11 +25,11 @@ export class TimeoutAPI implements TimeoutManager {
   }
 
   public get signal(): AbortSignal | undefined {
-    return this.#getManagerManager().signal;
+    return this.#getManager().signal;
   }
 
-  public abortAfterTimeout(timeoutInSeconds: number): AbortSignal {
-    return this.#getManagerManager().abortAfterTimeout(timeoutInSeconds);
+  public abortAfterTimeout(timeoutInSeconds?: number): AbortController {
+    return this.#getManager().abortAfterTimeout(timeoutInSeconds);
   }
 
   public setGlobalManager(manager: TimeoutManager): boolean {
@@ -40,7 +40,7 @@ export class TimeoutAPI implements TimeoutManager {
     unregisterGlobal(API_NAME);
   }
 
-  #getManagerManager(): TimeoutManager {
+  #getManager(): TimeoutManager {
     return getGlobal(API_NAME) ?? NOOP_TIMEOUT_MANAGER;
   }
 }

--- a/packages/core/src/v3/timeout/types.ts
+++ b/packages/core/src/v3/timeout/types.ts
@@ -1,5 +1,5 @@
 export interface TimeoutManager {
-  abortAfterTimeout: (timeoutInSeconds: number) => AbortSignal;
+  abortAfterTimeout: (timeoutInSeconds?: number) => AbortController;
   signal?: AbortSignal;
 }
 

--- a/packages/core/src/v3/timeout/usageTimeoutManager.ts
+++ b/packages/core/src/v3/timeout/usageTimeoutManager.ts
@@ -4,6 +4,7 @@ import { TaskRunExceededMaxDuration, TimeoutManager } from "./types.js";
 export class UsageTimeoutManager implements TimeoutManager {
   private _abortController: AbortController;
   private _abortSignal: AbortSignal | undefined;
+  private _intervalId: NodeJS.Timeout | undefined;
 
   constructor(private readonly usageManager: UsageManager) {
     this._abortController = new AbortController();
@@ -13,15 +14,19 @@ export class UsageTimeoutManager implements TimeoutManager {
     return this._abortSignal;
   }
 
-  abortAfterTimeout(timeoutInSeconds: number): AbortSignal {
+  abortAfterTimeout(timeoutInSeconds?: number): AbortController {
     this._abortSignal = this._abortController.signal;
 
+    if (!timeoutInSeconds) {
+      return this._abortController;
+    }
+
     // Now we need to start an interval that will measure usage and abort the signal if the usage is too high
-    const intervalId = setInterval(() => {
+    this._intervalId = setInterval(() => {
       const sample = this.usageManager.sample();
       if (sample) {
         if (sample.cpuTime > timeoutInSeconds * 1000) {
-          clearInterval(intervalId);
+          clearInterval(this._intervalId);
 
           this._abortController.abort(
             new TaskRunExceededMaxDuration(timeoutInSeconds, sample.cpuTime / 1000)
@@ -30,6 +35,6 @@ export class UsageTimeoutManager implements TimeoutManager {
       }
     }, 1000);
 
-    return this._abortSignal;
+    return this._abortController;
   }
 }

--- a/packages/core/src/v3/timeout/usageTimeoutManager.ts
+++ b/packages/core/src/v3/timeout/usageTimeoutManager.ts
@@ -21,6 +21,10 @@ export class UsageTimeoutManager implements TimeoutManager {
       return this._abortController;
     }
 
+    if (this._intervalId) {
+      clearInterval(this._intervalId);
+    }
+
     // Now we need to start an interval that will measure usage and abort the signal if the usage is too high
     this._intervalId = setInterval(() => {
       const sample = this.usageManager.sample();

--- a/packages/core/src/v3/types/tasks.ts
+++ b/packages/core/src/v3/types/tasks.ts
@@ -117,6 +117,7 @@ export type CancelFnParams = Prettify<{
   ctx: Context;
   /** Abort signal that is aborted when a task run exceeds it's maxDuration or if the task run is cancelled. Can be used to automatically cancel downstream requests */
   signal: AbortSignal;
+  runPromise: Promise<unknown>;
   init?: InitOutput;
 }>;
 

--- a/packages/core/src/v3/types/tasks.ts
+++ b/packages/core/src/v3/types/tasks.ts
@@ -12,6 +12,7 @@ import {
   OnStartHookFunction,
   OnSuccessHookFunction,
   OnWaitHookFunction,
+  OnCancelHookFunction,
 } from "../lifecycleHooks/types.js";
 import { RunTags } from "../schemas/api.js";
 import {
@@ -88,28 +89,35 @@ export type RunFnParams<TInitOutput extends InitOutput> = Prettify<{
   ctx: Context;
   /** If you use the `init` function, this will be whatever you returned. */
   init?: TInitOutput;
-  /** Abort signal that is aborted when a task run exceeds it's maxDuration. Can be used to automatically cancel downstream requests */
-  signal?: AbortSignal;
+  /** Abort signal that is aborted when a task run exceeds it's maxDuration or if the task run is cancelled. Can be used to automatically cancel downstream requests */
+  signal: AbortSignal;
 }>;
 
 export type MiddlewareFnParams = Prettify<{
   ctx: Context;
   next: () => Promise<void>;
-  /** Abort signal that is aborted when a task run exceeds it's maxDuration. Can be used to automatically cancel downstream requests */
-  signal?: AbortSignal;
+  /** Abort signal that is aborted when a task run exceeds it's maxDuration or if the task run is cancelled. Can be used to automatically cancel downstream requests */
+  signal: AbortSignal;
 }>;
 
 export type InitFnParams = Prettify<{
   ctx: Context;
-  /** Abort signal that is aborted when a task run exceeds it's maxDuration. Can be used to automatically cancel downstream requests */
-  signal?: AbortSignal;
+  /** Abort signal that is aborted when a task run exceeds it's maxDuration or if the task run is cancelled. Can be used to automatically cancel downstream requests */
+  signal: AbortSignal;
 }>;
 
 export type StartFnParams = Prettify<{
   ctx: Context;
   init?: InitOutput;
-  /** Abort signal that is aborted when a task run exceeds it's maxDuration. Can be used to automatically cancel downstream requests */
-  signal?: AbortSignal;
+  /** Abort signal that is aborted when a task run exceeds it's maxDuration or if the task run is cancelled. Can be used to automatically cancel downstream requests */
+  signal: AbortSignal;
+}>;
+
+export type CancelFnParams = Prettify<{
+  ctx: Context;
+  /** Abort signal that is aborted when a task run exceeds it's maxDuration or if the task run is cancelled. Can be used to automatically cancel downstream requests */
+  signal: AbortSignal;
+  init?: InitOutput;
 }>;
 
 export type Context = TaskRunContext;
@@ -296,6 +304,7 @@ type CommonTaskOptions<
   onResume?: OnResumeHookFunction<TPayload>;
   onWait?: OnWaitHookFunction<TPayload>;
   onComplete?: OnCompleteHookFunction<TPayload, TOutput>;
+  onCancel?: OnCancelHookFunction<TPayload, TOutput, TInitOutput>;
 
   /**
    * middleware allows you to run code "around" the run function. This can be useful for logging, metrics, or other cross-cutting concerns.

--- a/packages/core/src/v3/usage-api.ts
+++ b/packages/core/src/v3/usage-api.ts
@@ -3,3 +3,5 @@
 import { UsageAPI } from "./usage/api.js";
 /** Entrypoint for usage API */
 export const usage = UsageAPI.getInstance();
+
+export type { UsageMeasurement, UsageSample } from "./usage/types.js";

--- a/packages/core/src/v3/usage/devUsageManager.ts
+++ b/packages/core/src/v3/usage/devUsageManager.ts
@@ -74,7 +74,9 @@ export class DevUsageManager implements UsageManager {
 
     const sample = measurement.sample();
 
-    this._currentMeasurements.delete(measurement.id);
+    if (this._currentMeasurements.has(measurement.id)) {
+      this._currentMeasurements.delete(measurement.id);
+    }
 
     return sample;
   }

--- a/packages/core/test/taskExecutor.test.ts
+++ b/packages/core/test/taskExecutor.test.ts
@@ -1905,5 +1905,7 @@ function executeTask(
     engine: "V2",
   };
 
-  return executor.execute(execution, worker, {}, signal);
+  const $signal = signal ? signal : new AbortController().signal;
+
+  return executor.execute(execution, worker, {}, $signal);
 }

--- a/packages/trigger-sdk/src/v3/hooks.ts
+++ b/packages/trigger-sdk/src/v3/hooks.ts
@@ -11,6 +11,7 @@ import {
   type AnyOnResumeHookFunction,
   type AnyOnCatchErrorHookFunction,
   type AnyOnMiddlewareHookFunction,
+  type AnyOnCancelHookFunction,
 } from "@trigger.dev/core/v3";
 
 export type {
@@ -25,6 +26,7 @@ export type {
   AnyOnResumeHookFunction,
   AnyOnCatchErrorHookFunction,
   AnyOnMiddlewareHookFunction,
+  AnyOnCancelHookFunction,
 };
 
 export function onStart(name: string, fn: AnyOnStartHookFunction): void;
@@ -127,6 +129,18 @@ export function middleware(
   fn?: AnyOnMiddlewareHookFunction
 ): void {
   lifecycleHooks.registerGlobalMiddlewareHook({
+    id: typeof fnOrName === "string" ? fnOrName : fnOrName.name ? fnOrName.name : undefined,
+    fn: typeof fnOrName === "function" ? fnOrName : fn!,
+  });
+}
+
+export function onCancel(name: string, fn: AnyOnCancelHookFunction): void;
+export function onCancel(fn: AnyOnCancelHookFunction): void;
+export function onCancel(
+  fnOrName: string | AnyOnCancelHookFunction,
+  fn?: AnyOnCancelHookFunction
+): void {
+  lifecycleHooks.registerGlobalCancelHook({
     id: typeof fnOrName === "string" ? fnOrName : fnOrName.name ? fnOrName.name : undefined,
     fn: typeof fnOrName === "function" ? fnOrName : fn!,
   });

--- a/packages/trigger-sdk/src/v3/shared.ts
+++ b/packages/trigger-sdk/src/v3/shared.ts
@@ -42,6 +42,7 @@ import type {
   AnyOnStartHookFunction,
   AnyOnSuccessHookFunction,
   AnyOnWaitHookFunction,
+  AnyOnCancelHookFunction,
   AnyRunHandle,
   AnyRunTypes,
   AnyTask,
@@ -1635,6 +1636,12 @@ function registerTaskLifecycleHooks<
   if (params.cleanup) {
     lifecycleHooks.registerTaskCleanupHook(taskId, {
       fn: params.cleanup as AnyOnCleanupHookFunction,
+    });
+  }
+
+  if (params.onCancel) {
+    lifecycleHooks.registerTaskCancelHook(taskId, {
+      fn: params.onCancel as AnyOnCancelHookFunction,
     });
   }
 }

--- a/packages/trigger-sdk/src/v3/tasks.ts
+++ b/packages/trigger-sdk/src/v3/tasks.ts
@@ -8,6 +8,7 @@ import {
   onHandleError,
   onCatchError,
   middleware,
+  onCancel,
 } from "./hooks.js";
 import {
   batchTrigger,
@@ -95,6 +96,7 @@ export const tasks = {
   onComplete,
   onWait,
   onResume,
+  onCancel,
   /** @deprecated Use catchError instead */
   handleError: onHandleError,
   catchError: onCatchError,

--- a/references/hello-world/src/trigger/init.ts
+++ b/references/hello-world/src/trigger/init.ts
@@ -6,6 +6,10 @@ tasks.middleware("db", ({ ctx, payload, next }) => {
   return next();
 });
 
+tasks.onCancel(async ({ ctx, payload }) => {
+  logger.info("Hello, world from the global cancel", { ctx, payload });
+});
+
 // tasks.onSuccess(({ ctx, payload, output }) => {
 //   logger.info("Hello, world from the success", { ctx, payload });
 // });


### PR DESCRIPTION
This PR adds the `onCancel` lifecycle hook, that allows you to do work when a run is cancelled:

```ts
export const cancelExampleTask = task({
  id: "cancel-example",
  // Signal will be aborted when the task is cancelled 👇
  run: async (payload: { message: string }, { signal }) => {
    logger.info("Hello, world from the cancel task", { message: payload.message });

    // This is a global hook that will be called if the task is cancelled
    tasks.onCancel(async () => {
      logger.info("global task onCancel hook but inside of the run function baby!");
    });

    await logger.trace("10s timeout", async (span) => {
      try {
        // We pass the signal to setTimeout to abort the timeout if the task is cancelled
        await setTimeout(10_000, undefined, { signal });
      } catch (error) {
        // If the timeout is aborted, this error will be thrown, we can handle it here
        logger.error("Timeout error", { error });
      }
    });

    logger.info("Hello, world from the cancel task after the timeout", {
      message: payload.message,
    });

    return {
      message: "Hello, world!",
    };
  },
  onCancel: async ({ payload, runPromise }) => {
    logger.info("Hello, world from the onCancel hook", { payload });
    // You can await the runPromise to get the output of the task
    const output = await runPromise;
    
    logger.info("Hello, world from the onCancel hook after the run", { payload, output });

    // You can do work inside the onCancel hook, up to 30 seconds
    await setTimeout(10_000);
    
    logger.info("Hello, world from the onCancel hook after the timeout", { payload });
  },
});
```

You can use the `onCancel` hook along with the `signal` passed into the run function to interrupt a call to an external service, for example using the [streamText](https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text) function from the AI SDK:

```ts
export const interruptibleChat = schemaTask({
  id: "interruptible-chat",
  description: "Chat with the AI",
  schema: z.object({
    prompt: z.string().describe("The prompt to chat with the AI"),
  }),
  run: async ({ prompt }, { signal }) => {
    const chunks: TextStreamPart<{}>[] = [];

    // 👇 This is a global onCancel hook, but it's inside of the run function
    tasks.onCancel(async () => {
      // We have access to the chunks here
      logger.info("interruptible-chat: task cancelled with chunks", { chunks });

      await saveChunksToDatabase(chunks);
    });

    try {
      const result = streamText({
        model: getModel(),
        prompt,
        experimental_telemetry: {
          isEnabled: true,
        },
        tools: {},
        abortSignal: signal,
        onChunk: ({ chunk }) => {
          chunks.push(chunk);
        },
      });

      const textParts = [];

      for await (const part of result.textStream) {
        textParts.push(part);
      }

      return textParts.join("");
    } catch (error) {
      if (error instanceof Error && error.name === "AbortError") {
        // streamText will throw an AbortError if the signal is aborted, so we can handle it here
      } else {
        throw error;
      }
    }
  },
});
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new lifecycle hook, `onCancel`, enabling tasks to handle cancellation events with custom logic.
  - Added support for registering global and task-specific cancellation handlers.
  - Enhanced tasks to receive an abort signal for improved cancellation and timeout handling.
  - Updated sample tasks to demonstrate cancellation handling and logging.

- **Bug Fixes**
  - Improved internal cleanup and resource management when tasks are cancelled.

- **Documentation**
  - Expanded type exports and updated sample code to illustrate new cancellation features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->