### PR TITLE
Fix for v4 run failed alerts missing error

### DIFF
--- a/apps/webapp/app/v3/services/alerts/performTaskRunAlerts.server.ts
+++ b/apps/webapp/app/v3/services/alerts/performTaskRunAlerts.server.ts
@@ -1,10 +1,8 @@
 import { type Prisma, type ProjectAlertChannel } from "@trigger.dev/database";
-import { $transaction, type PrismaClientOrTransaction, type prisma } from "~/db.server";
-import { workerQueue } from "~/services/worker.server";
-import { generateFriendlyId } from "~/v3/friendlyIdentifiers";
+import { type prisma } from "~/db.server";
+import { commonWorker } from "~/v3/commonWorker.server";
 import { BaseService } from "../baseService.server";
 import { DeliverAlertService } from "./deliverAlert.server";
-import { commonWorker } from "~/v3/commonWorker.server";
 
 type FoundRun = Prisma.Result<
   typeof prisma.taskRun,


### PR DESCRIPTION
About 6 months ago we added the `error` column to `TaskRun`. Previously they were only on the `TaskRunAttempt`.

So for the first version of run alerts we used the attempt error. 

We can just use the `TaskRun` now and attempt database records don't exist in v4… so it meant all v4 run alerts were missing the error on them.

This is faster and more compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified alert error handling by removing dependencies on task run attempts and relying solely on task run error information.
  - Cleaned up and reorganized imports for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->