### PR TITLE
Add external log exporters and fix missing external trace exporters in deployed tasks

### DIFF
--- a/.changeset/cuddly-boats-press.md
+++ b/.changeset/cuddly-boats-press.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Add external log exporters and fix missing external trace exporters in deployed tasks

--- a/packages/cli-v3/src/entryPoints/dev-run-worker.ts
+++ b/packages/cli-v3/src/entryPoints/dev-run-worker.ts
@@ -175,7 +175,8 @@ async function bootstrap() {
   const tracer = new TriggerTracer({ tracer: otelTracer, logger: otelLogger });
   const consoleInterceptor = new ConsoleInterceptor(
     otelLogger,
-    typeof config.enableConsoleLogging === "boolean" ? config.enableConsoleLogging : true
+    typeof config.enableConsoleLogging === "boolean" ? config.enableConsoleLogging : true,
+    typeof config.disableConsoleInterceptor === "boolean" ? config.disableConsoleInterceptor : false
   );
 
   const configLogLevel = triggerLogLevel ?? config.logLevel ?? "info";

--- a/packages/cli-v3/src/entryPoints/dev-run-worker.ts
+++ b/packages/cli-v3/src/entryPoints/dev-run-worker.ts
@@ -164,6 +164,7 @@ async function bootstrap() {
     url: env.OTEL_EXPORTER_OTLP_ENDPOINT ?? "http://0.0.0.0:4318",
     instrumentations: config.telemetry?.instrumentations ?? config.instrumentations ?? [],
     exporters: config.telemetry?.exporters ?? [],
+    logExporters: config.telemetry?.logExporters ?? [],
     diagLogLevel: (env.OTEL_LOG_LEVEL as TracingDiagnosticLogLevel) ?? "none",
     forceFlushTimeoutMillis: 30_000,
   });

--- a/packages/cli-v3/src/entryPoints/managed-run-worker.ts
+++ b/packages/cli-v3/src/entryPoints/managed-run-worker.ts
@@ -163,6 +163,8 @@ async function bootstrap() {
     instrumentations: config.instrumentations ?? [],
     diagLogLevel: (env.OTEL_LOG_LEVEL as TracingDiagnosticLogLevel) ?? "none",
     forceFlushTimeoutMillis: 30_000,
+    exporters: config.telemetry?.exporters ?? [],
+    logExporters: config.telemetry?.logExporters ?? [],
   });
 
   const otelTracer: Tracer = tracingSDK.getTracer("trigger-dev-worker", VERSION);

--- a/packages/cli-v3/src/entryPoints/managed-run-worker.ts
+++ b/packages/cli-v3/src/entryPoints/managed-run-worker.ts
@@ -173,7 +173,8 @@ async function bootstrap() {
   const tracer = new TriggerTracer({ tracer: otelTracer, logger: otelLogger });
   const consoleInterceptor = new ConsoleInterceptor(
     otelLogger,
-    typeof config.enableConsoleLogging === "boolean" ? config.enableConsoleLogging : true
+    typeof config.enableConsoleLogging === "boolean" ? config.enableConsoleLogging : true,
+    typeof config.disableConsoleInterceptor === "boolean" ? config.disableConsoleInterceptor : false
   );
 
   const configLogLevel = triggerLogLevel ?? config.logLevel ?? "info";

--- a/packages/core/src/v3/config.ts
+++ b/packages/core/src/v3/config.ts
@@ -11,6 +11,7 @@ import type {
 } from "./index.js";
 import type { LogLevel } from "./logger/taskLogger.js";
 import type { MachinePresetName } from "./schemas/common.js";
+import { LogRecordExporter } from "@opentelemetry/sdk-logs";
 
 export type CompatibilityFlag = "run_engine_v2";
 
@@ -80,6 +81,13 @@ export type TriggerConfig = {
      * @see https://trigger.dev/docs/config/config-file#exporters
      */
     exporters?: Array<SpanExporter>;
+
+    /**
+     * Log exporters to use for OpenTelemetry. This is useful if you want to add custom log exporters to your tasks.
+     *
+     * @see https://trigger.dev/docs/config/config-file#exporters
+     */
+    logExporters?: Array<LogRecordExporter>;
   };
 
   /**

--- a/packages/core/src/v3/config.ts
+++ b/packages/core/src/v3/config.ts
@@ -139,6 +139,11 @@ export type TriggerConfig = {
    */
   enableConsoleLogging?: boolean;
 
+  /**
+   * Disable the console interceptor. This will prevent logs from being sent to the trigger.dev backend.
+   */
+  disableConsoleInterceptor?: boolean;
+
   build?: {
     /**
      * Add custom conditions to the esbuild build. For example, if you are importing `ai/rsc`, you'll need to add "react-server" condition.

--- a/packages/core/src/v3/consoleInterceptor.ts
+++ b/packages/core/src/v3/consoleInterceptor.ts
@@ -10,12 +10,17 @@ import { clock } from "./clock-api.js";
 export class ConsoleInterceptor {
   constructor(
     private readonly logger: logsAPI.Logger,
-    private readonly sendToStdIO: boolean
+    private readonly sendToStdIO: boolean,
+    private readonly interceptingDisabled: boolean
   ) {}
 
   // Intercept the console and send logs to the OpenTelemetry logger
   // during the execution of the callback
   async intercept<T>(console: Console, callback: () => Promise<T>): Promise<T> {
+    if (this.interceptingDisabled) {
+      return await callback();
+    }
+
     // Save the original console methods
     const originalConsole = {
       log: console.log,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1831,6 +1831,9 @@ importers:
       '@opentelemetry/exporter-logs-otlp-http':
         specifier: 0.52.1
         version: 0.52.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: 0.52.1
+        version: 0.52.1(@opentelemetry/api@1.9.0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.3
         version: 1.1.3(@types/react-dom@19.0.4)(@types/react@19.0.12)(react-dom@19.0.0)(react@19.0.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1828,6 +1828,9 @@ importers:
       '@e2b/code-interpreter':
         specifier: ^1.1.0
         version: 1.1.0
+      '@opentelemetry/exporter-logs-otlp-http':
+        specifier: 0.52.1
+        version: 0.52.1(@opentelemetry/api@1.9.0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.3
         version: 1.1.3(@types/react-dom@19.0.4)(@types/react@19.0.12)(react-dom@19.0.0)(react@19.0.0)
@@ -1866,7 +1869,7 @@ importers:
         version: 5.1.5
       next:
         specifier: 15.2.4
-        version: 15.2.4(@playwright/test@1.37.0)(react-dom@19.0.0)(react@19.0.0)
+        version: 15.2.4(@opentelemetry/api@1.9.0)(@playwright/test@1.37.0)(react-dom@19.0.0)(react@19.0.0)
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -1954,7 +1957,7 @@ importers:
         version: 5.1.5
       next:
         specifier: 15.2.4
-        version: 15.2.4(@playwright/test@1.37.0)(react-dom@19.0.0)(react@19.0.0)
+        version: 15.2.4(@opentelemetry/api@1.9.0)(@playwright/test@1.37.0)(react-dom@19.0.0)(react@19.0.0)
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -28612,7 +28615,7 @@ packages:
       - babel-plugin-macros
     dev: false
 
-  /next@15.2.4(@playwright/test@1.37.0)(react-dom@19.0.0)(react@19.0.0):
+  /next@15.2.4(@opentelemetry/api@1.9.0)(@playwright/test@1.37.0)(react-dom@19.0.0)(react@19.0.0):
     resolution: {integrity: sha512-VwL+LAaPSxEkd3lU2xWbgEOtrM8oedmyhBqaVNmgKB+GvZlCy9rgaEc+y2on0wv+l0oSFqLtYD6dcC1eAedUaQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
@@ -28634,6 +28637,7 @@ packages:
         optional: true
     dependencies:
       '@next/env': 15.2.4
+      '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.37.0
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.15

--- a/references/d3-chat/package.json
+++ b/references/d3-chat/package.json
@@ -27,6 +27,7 @@
     "@trigger.dev/python": "workspace:*",
     "@trigger.dev/react-hooks": "workspace:*",
     "@trigger.dev/sdk": "workspace:*",
+    "@opentelemetry/exporter-logs-otlp-http": "0.52.1",
     "@vercel/postgres": "^0.10.0",
     "ai": "4.2.5",
     "class-variance-authority": "^0.7.1",

--- a/references/d3-chat/package.json
+++ b/references/d3-chat/package.json
@@ -28,6 +28,7 @@
     "@trigger.dev/react-hooks": "workspace:*",
     "@trigger.dev/sdk": "workspace:*",
     "@opentelemetry/exporter-logs-otlp-http": "0.52.1",
+    "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
     "@vercel/postgres": "^0.10.0",
     "ai": "4.2.5",
     "class-variance-authority": "^0.7.1",

--- a/references/d3-chat/src/trigger/chat.ts
+++ b/references/d3-chat/src/trigger/chat.ts
@@ -227,6 +227,8 @@ export const interruptibleChat = schemaTask({
     prompt: z.string().describe("The prompt to chat with the AI"),
   }),
   run: async ({ prompt }, { signal }) => {
+    logger.info("interruptible-chat: starting", { prompt });
+
     const chunks: TextStreamPart<{}>[] = [];
 
     // 👇 This is a global onCancel hook, but it's inside of the run function

--- a/references/d3-chat/trigger.config.ts
+++ b/references/d3-chat/trigger.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "@trigger.dev/sdk";
 import { pythonExtension } from "@trigger.dev/python/extension";
 import { installPlaywrightChromium } from "./src/extensions/playwright";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 
 export default defineConfig({
   project: "proj_cdmymsrobxmcgjqzhdkq",
@@ -10,6 +11,15 @@ export default defineConfig({
     logExporters: [
       new OTLPLogExporter({
         url: "https://api.axiom.co/v1/logs",
+        headers: {
+          Authorization: `Bearer ${process.env.AXIOM_TOKEN}`,
+          "X-Axiom-Dataset": "d3-chat-tester",
+        },
+      }),
+    ],
+    exporters: [
+      new OTLPTraceExporter({
+        url: "https://api.axiom.co/v1/traces",
         headers: {
           Authorization: `Bearer ${process.env.AXIOM_TOKEN}`,
           "X-Axiom-Dataset": "d3-chat-tester",

--- a/references/d3-chat/trigger.config.ts
+++ b/references/d3-chat/trigger.config.ts
@@ -1,10 +1,22 @@
 import { defineConfig } from "@trigger.dev/sdk";
 import { pythonExtension } from "@trigger.dev/python/extension";
 import { installPlaywrightChromium } from "./src/extensions/playwright";
+import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
 
 export default defineConfig({
   project: "proj_cdmymsrobxmcgjqzhdkq",
   dirs: ["./src/trigger"],
+  telemetry: {
+    logExporters: [
+      new OTLPLogExporter({
+        url: "https://api.axiom.co/v1/logs",
+        headers: {
+          Authorization: `Bearer ${process.env.AXIOM_TOKEN}`,
+          "X-Axiom-Dataset": "d3-chat-tester",
+        },
+      }),
+    ],
+  },
   maxDuration: 3600,
   build: {
     extensions: [


### PR DESCRIPTION
This PR adds support for 3rd party log exporters (alongside the existing 3rd party trace exporters). This also fixes an issue where 3rd party trace exporters were not being registered in deployed tasks, and we've also fixed traceID generation in case 3rd parties expected the traceIDs to be in the exact format of the otel spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for external log exporters, enabling logs to be sent to external monitoring systems.
  - Introduced configuration options for external trace exporters and log exporters in telemetry settings.
  - Added the ability to disable console log interception via configuration.

- **Bug Fixes**
  - Resolved issues with missing external trace exporters in deployed tasks.

- **Chores**
  - Updated dependencies to include OpenTelemetry log and trace exporters.
  - Enhanced logging in chat tasks for improved traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->