### PR TITLE
Fix run replication payloads/outputs trying to send invalid types like BigInt to clickhouse

### DIFF
--- a/apps/webapp/app/services/runsReplicationService.server.ts
+++ b/apps/webapp/app/services/runsReplicationService.server.ts
@@ -10,7 +10,7 @@ import {
 import { recordSpanError, startSpan, trace, type Tracer } from "@internal/tracing";
 import { Logger, LogLevel } from "@trigger.dev/core/logger";
 import { tryCatch } from "@trigger.dev/core/utils";
-import { parsePacket } from "@trigger.dev/core/v3/utils/ioSerialization";
+import { parsePacketAsJson } from "@trigger.dev/core/v3/utils/ioSerialization";
 import { TaskRun } from "@trigger.dev/database";
 import { nanoid } from "nanoid";
 import EventEmitter from "node:events";
@@ -636,7 +636,7 @@ export class RunsReplicationService {
       dataType,
     };
 
-    const [parseError, parsedData] = await tryCatch(parsePacket(packet));
+    const [parseError, parsedData] = await tryCatch(parsePacketAsJson(packet));
 
     if (parseError) {
       this.logger.error("Error parsing packet", {

--- a/packages/core/src/v3/utils/ioSerialization.ts
+++ b/packages/core/src/v3/utils/ioSerialization.ts
@@ -41,6 +41,36 @@ export async function parsePacket(value: IOPacket, options?: ParsePacketOptions)
   }
 }
 
+export async function parsePacketAsJson(
+  value: IOPacket,
+  options?: ParsePacketOptions
+): Promise<any> {
+  if (!value.data) {
+    return undefined;
+  }
+
+  switch (value.dataType) {
+    case "application/json":
+      return JSON.parse(value.data, makeSafeReviver(options));
+    case "application/super+json":
+      const { parse, serialize } = await loadSuperJSON();
+
+      const superJsonResult = parse(value.data);
+
+      const { json } = serialize(superJsonResult);
+
+      return json;
+    case "text/plain":
+      return value.data;
+    case "application/store":
+      throw new Error(
+        `Cannot parse an application/store packet (${value.data}). Needs to be imported first.`
+      );
+    default:
+      return value.data;
+  }
+}
+
 export async function conditionallyImportAndParsePacket(
   value: IOPacket,
   client?: ApiClient


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for parsing and replicating payloads encoded with superjson, enabling correct handling of complex data types such as BigInt, Date, and Map.
- **Tests**
  - Introduced a new integration test to verify replication and deserialization of superjson-encoded payloads, ensuring data integrity for complex types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->