### PR TITLE
engine v2: Fix selectTopEnvs missing queues

### DIFF
--- a/internal-packages/run-engine/src/run-queue/fairQueueSelectionStrategy.ts
+++ b/internal-packages/run-engine/src/run-queue/fairQueueSelectionStrategy.ts
@@ -448,7 +448,7 @@ export class FairQueueSelectionStrategy implements RunQueueSelectionStrategy {
     // Group queues by env
     const queuesByEnv = queues.reduce(
       (acc, queue) => {
-        if (!acc[`${queue.org}:${queue.project}:${queue.env}`]) {
+        if (!acc[queue.env]) {
           acc[queue.env] = [];
         }
         acc[queue.env].push(queue);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved queue grouping logic to group by environment only, rather than by organization and project, ensuring more accurate environment-based queue selection.

- **Tests**
  - Added a new test to verify that queues are correctly grouped by environment, even when they originate from different organizations or projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->