### PR TITLE
Potential fix for code scanning alert no. 42: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,8 @@
 name: "🧪 Unit Tests"
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
 


### PR DESCRIPTION
Potential fix for [https://github.com/triggerdotdev/trigger.dev/security/code-scanning/42](https://github.com/triggerdotdev/trigger.dev/security/code-scanning/42)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily needs to read the repository contents (e.g., for checking out the code) and does not appear to require any write permissions. Therefore, we will set `contents: read` as the permission. If additional permissions are required in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
