### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -3,6 +3,9 @@ name: "ʦ TypeScript"
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/triggerdotdev/trigger.dev/security/code-scanning/38](https://github.com/triggerdotdev/trigger.dev/security/code-scanning/38)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the tasks performed in this workflow. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration to specify repository read permissions for the typecheck process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->