### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ jobs:
   release:
     name: 🦋 Changesets Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
     if: github.repository == 'triggerdotdev/trigger.dev'
     outputs:
       published: ${{ steps.changesets.outputs.published }}
@@ -93,6 +97,8 @@ jobs:
   publish:
     needs: release
     uses: ./.github/workflows/publish.yml
+    permissions:
+      contents: read
     secrets: inherit
     # if: needs.release.outputs.published == 'true'
     # disable automatic publishing for now


### PR DESCRIPTION
Potential fix for [https://github.com/triggerdotdev/trigger.dev/security/code-scanning/6](https://github.com/triggerdotdev/trigger.dev/security/code-scanning/6)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the minimal permissions required for the `release` and `publish` jobs. Based on the workflow's actions:
- The `release` job requires `contents: read` for repository access and `contents: write` for publishing changes.
- The `publish` job does not perform any actions requiring elevated permissions, so it can be limited to `contents: read`.

The `permissions` block will be added at the job level to ensure each job has only the permissions it needs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
