### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: 🦋 Changesets Release
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/triggerdotdev/trigger.dev/security/code-scanning/3](https://github.com/triggerdotdev/trigger.dev/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the minimum permissions required for the workflow to function correctly. Based on the workflow's steps:
- The `contents: read` permission is required for actions like checking out the repository.
- The `contents: write` permission is needed for creating GitHub releases in the `changesets/action@v1` step.
- Additional permissions like `packages: write` might be required for publishing to npm, but this is handled via the `NPM_TOKEN` secret, so it does not require explicit permissions.

The `permissions` block will be added at the workflow level to apply to all jobs, ensuring consistency and simplicity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions release workflow configuration to set explicit permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->