### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-webapp.yml
+++ b/.github/workflows/publish-webapp.yml
@@ -1,5 +1,9 @@
 name: "🐳 Publish Webapp"
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/triggerdotdev/trigger.dev/security/code-scanning/2](https://github.com/triggerdotdev/trigger.dev/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, the following permissions are needed:
- `contents: read` for checking out the repository.
- `packages: write` for logging into the GitHub Container Registry and pushing Docker images.

The `permissions` block will be added at the top level of the workflow, ensuring that all jobs inherit these permissions unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions to enhance security by restricting access to repository contents and packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->