### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,8 @@
 name: "E2E"
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/triggerdotdev/trigger.dev/security/code-scanning/1](https://github.com/triggerdotdev/trigger.dev/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the permissions required. Based on the workflow's operations, the minimal required permission is likely `contents: read`, as the workflow primarily reads repository contents and does not perform write operations. This change ensures that the `GITHUB_TOKEN` is restricted to read-only access, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflow permissions for improved configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->