### PR TITLE
Prevent socket hangup error by removing the aggressive clickhouse keep alive ttl env var default

### DIFF
--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -770,7 +770,7 @@ const EnvironmentSchema = z.object({
   RUN_REPLICATION_LEADER_LOCK_RETRY_INTERVAL_MS: z.coerce.number().int().default(500),
   RUN_REPLICATION_WAIT_FOR_ASYNC_INSERT: z.string().default("0"),
   RUN_REPLICATION_KEEP_ALIVE_ENABLED: z.string().default("1"),
-  RUN_REPLICATION_KEEP_ALIVE_IDLE_SOCKET_TTL_MS: z.coerce.number().int().default(9_000),
+  RUN_REPLICATION_KEEP_ALIVE_IDLE_SOCKET_TTL_MS: z.coerce.number().int().optional(),
   RUN_REPLICATION_MAX_OPEN_CONNECTIONS: z.coerce.number().int().default(10),
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated environment variable handling so that `RUN_REPLICATION_KEEP_ALIVE_IDLE_SOCKET_TTL_MS` is now optional and no longer defaults to 9000 if not set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->