### PR TITLE
Improve email whitelisting and extend to GitHub auth

### DIFF
--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -379,7 +379,7 @@ const EnvironmentSchema = z.object({
   MAX_SEQUENTIAL_INDEX_FAILURE_COUNT: z.coerce.number().default(96),
 
   LOOPS_API_KEY: z.string().optional(),
-  MARQS_DISABLE_REBALANCING: z.coerce.boolean().default(false),
+  MARQS_DISABLE_REBALANCING: BoolEnv.default(false),
   MARQS_VISIBILITY_TIMEOUT_MS: z.coerce
     .number()
     .int()
@@ -457,7 +457,7 @@ const EnvironmentSchema = z.object({
     .number()
     .int()
     .default(60_000 * 10),
-  RUN_ENGINE_DEBUG_WORKER_NOTIFICATIONS: z.coerce.boolean().default(false),
+  RUN_ENGINE_DEBUG_WORKER_NOTIFICATIONS: BoolEnv.default(false),
   RUN_ENGINE_PARENT_QUEUE_LIMIT: z.coerce.number().int().default(1000),
   RUN_ENGINE_CONCURRENCY_LIMIT_BIAS: z.coerce.number().default(0.75),
   RUN_ENGINE_AVAILABLE_CAPACITY_BIAS: z.coerce.number().default(0.3),

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { SecretStoreOptionsSchema } from "./services/secrets/secretStoreOptionsSchema.server";
 import { isValidDatabaseUrl } from "./utils/db";
 import { isValidRegex } from "./utils/regex";
+import { BoolEnv } from "./utils/boolEnv";
 
 const EnvironmentSchema = z.object({
   NODE_ENV: z.union([z.literal("development"), z.literal("production"), z.literal("test")]),
@@ -50,7 +51,7 @@ const EnvironmentSchema = z.object({
   RESEND_API_KEY: z.string().optional(),
   SMTP_HOST: z.string().optional(),
   SMTP_PORT: z.coerce.number().optional(),
-  SMTP_SECURE: z.coerce.boolean().optional(),
+  SMTP_SECURE: BoolEnv.optional(),
   SMTP_USER: z.string().optional(),
   SMTP_PASSWORD: z.string().optional(),
 
@@ -338,7 +339,7 @@ const EnvironmentSchema = z.object({
   ALERT_RESEND_API_KEY: z.string().optional(),
   ALERT_SMTP_HOST: z.string().optional(),
   ALERT_SMTP_PORT: z.coerce.number().optional(),
-  ALERT_SMTP_SECURE: z.coerce.boolean().optional(),
+  ALERT_SMTP_SECURE: BoolEnv.optional(),
   ALERT_SMTP_USER: z.string().optional(),
   ALERT_SMTP_PASSWORD: z.string().optional(),
   ALERT_RATE_LIMITER_EMISSION_INTERVAL: z.coerce.number().int().default(2_500),

--- a/apps/webapp/app/models/user.server.ts
+++ b/apps/webapp/app/models/user.server.ts
@@ -7,7 +7,7 @@ import {
   getDashboardPreferences,
 } from "~/services/dashboardPreferences.server";
 export type { User } from "@trigger.dev/database";
-
+import { assertEmailAllowed } from "~/utils/email";
 type FindOrCreateMagicLink = {
   authenticationMethod: "MAGIC_LINK";
   email: string;
@@ -41,9 +41,7 @@ export async function findOrCreateUser(input: FindOrCreateUser): Promise<LoggedI
 export async function findOrCreateMagicLinkUser({
   email,
 }: FindOrCreateMagicLink): Promise<LoggedInUser> {
-  if (env.WHITELISTED_EMAILS && !new RegExp(env.WHITELISTED_EMAILS).test(email)) {
-    throw new Error("This email is unauthorized");
-  }
+  assertEmailAllowed(email);
 
   const existingUser = await prisma.user.findFirst({
     where: {
@@ -79,9 +77,7 @@ export async function findOrCreateGithubUser({
   authenticationProfile,
   authenticationExtraParams,
 }: FindOrCreateGithub): Promise<LoggedInUser> {
-  if (env.WHITELISTED_EMAILS && !new RegExp(env.WHITELISTED_EMAILS).test(email)) {
-    throw new Error("This email is unauthorized");
-  }
+  assertEmailAllowed(email);
 
   const name = authenticationProfile._json.name;
   let avatarUrl: string | undefined = undefined;

--- a/apps/webapp/app/services/email.server.ts
+++ b/apps/webapp/app/services/email.server.ts
@@ -3,11 +3,11 @@ import { EmailClient, MailTransportOptions } from "emails";
 import type { SendEmailOptions } from "remix-auth-email-link";
 import { redirect } from "remix-typedjson";
 import { env } from "~/env.server";
-import type { User } from "~/models/user.server";
 import type { AuthUser } from "./authUser";
 import { workerQueue } from "./worker.server";
 import { logger } from "./logger.server";
 import { singleton } from "~/utils/singleton";
+import { assertEmailAllowed } from "~/utils/email";
 
 const client = singleton(
   "email-client",
@@ -66,6 +66,8 @@ function buildTransportOptions(alerts?: boolean): MailTransportOptions {
 }
 
 export async function sendMagicLinkEmail(options: SendEmailOptions<AuthUser>): Promise<void> {
+  assertEmailAllowed(options.emailAddress);
+
   // Auto redirect when in development mode
   if (env.NODE_ENV === "development") {
     throw redirect(options.magicLink);

--- a/apps/webapp/app/utils/boolEnv.ts
+++ b/apps/webapp/app/utils/boolEnv.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const BoolEnv = z.preprocess((val) => {
+  if (typeof val !== "string") {
+    return val;
+  }
+
+  return ["true", "1"].includes(val.toLowerCase().trim());
+}, z.boolean());

--- a/apps/webapp/app/utils/email.ts
+++ b/apps/webapp/app/utils/email.ts
@@ -1,0 +1,13 @@
+import { env } from "~/env.server";
+
+export function assertEmailAllowed(email: string) {
+  if (!env.WHITELISTED_EMAILS) {
+    return;
+  }
+
+  const regexp = new RegExp(env.WHITELISTED_EMAILS);
+
+  if (!regexp.test(email)) {
+    throw new Error("This email is unauthorized");
+  }
+}


### PR DESCRIPTION
No magic link emails will be sent out to non-whitelisted emails. GitHub auth is now also covered and errors will be displayed.

Also includes a fix for boolean env vars. The following env vars always evaluated to true if any value was set:
- MARQS_DISABLE_REBALANCING
- RUN_ENGINE_DEBUG_WORKER_NOTIFICATIONS
- SMTP_SECURE
- ALERT_SMTP_SECURE

Thanks @Kritik-J for the prior work on this! And sorry it took us so long to get this in :face_with_peeking_eye: 

Fixes #833 