### PR TITLE
Expose esbuild `keepNames` and `minify` options (experimental)

### DIFF
--- a/.changeset/gold-insects-invite.md
+++ b/.changeset/gold-insects-invite.md
@@ -1,0 +1,6 @@
+---
+"trigger.dev": patch
+"@trigger.dev/core": patch
+---
+
+Expose esbuild `keepNames` option (experimental)

--- a/.changeset/wild-mirrors-return.md
+++ b/.changeset/wild-mirrors-return.md
@@ -1,0 +1,6 @@
+---
+"trigger.dev": patch
+"@trigger.dev/core": patch
+---
+
+Expose esbuild `minify` option (experimental)

--- a/packages/cli-v3/src/build/bundle.ts
+++ b/packages/cli-v3/src/build/bundle.ts
@@ -177,6 +177,7 @@ async function createBuildOptions(
   const conditions = [...customConditions, "trigger.dev", "module", "node"];
 
   const keepNames = options.resolvedConfig.build?.experimental_keepNames ?? false;
+  const minify = options.resolvedConfig.build?.experimental_minify ?? false;
 
   const $buildPlugins = await buildPlugins(options.target, options.resolvedConfig);
 
@@ -187,7 +188,7 @@ async function createBuildOptions(
     bundle: true,
     metafile: true,
     write: false,
-    minify: false,
+    minify,
     splitting: true,
     charset: "utf8",
     platform: "node",

--- a/packages/cli-v3/src/build/bundle.ts
+++ b/packages/cli-v3/src/build/bundle.ts
@@ -174,8 +174,9 @@ async function createBuildOptions(
   options: BundleOptions & { entryPoints: string[]; buildResultPlugin?: esbuild.Plugin }
 ): Promise<esbuild.BuildOptions & { metafile: true }> {
   const customConditions = options.resolvedConfig.build?.conditions ?? [];
-
   const conditions = [...customConditions, "trigger.dev", "module", "node"];
+
+  const keepNames = options.resolvedConfig.build?.experimental_keepNames ?? false;
 
   const $buildPlugins = await buildPlugins(options.target, options.resolvedConfig);
 
@@ -193,6 +194,7 @@ async function createBuildOptions(
     sourcemap: true,
     sourcesContent: options.target === "dev",
     conditions,
+    keepNames,
     format: "esm",
     target: ["node20", "es2022"],
     loader: {

--- a/packages/core/src/v3/config.ts
+++ b/packages/core/src/v3/config.ts
@@ -196,6 +196,21 @@ export type TriggerConfig = {
      */
     experimental_keepNames?: boolean;
 
+    /**
+     * **WARNING: This is an experimental feature and might be removed in a future version.**
+     *
+     * "Minification is not safe for 100% of all JavaScript code" - esbuild docs
+     *
+     * Minify the generated code to help decrease bundle size. This may break stuff.
+     *
+     * @link https://esbuild.github.io/api/#minify
+     *
+     * @default false
+     *
+     * @deprecated (experimental)
+     */
+    experimental_minify?: boolean;
+
     jsx?: {
       /**
        * @default "React.createElement"

--- a/packages/core/src/v3/config.ts
+++ b/packages/core/src/v3/config.ts
@@ -183,6 +183,19 @@ export type TriggerConfig = {
      */
     experimental_autoDetectExternal?: boolean;
 
+    /**
+     * **WARNING: This is an experimental feature and might be removed in a future version.**
+     *
+     * Preserve the original names of functions and classes in the bundle. This can fix issues with frameworks that rely on the original names for registration and binding, for example MikroORM.
+     *
+     * @link https://esbuild.github.io/api/#keep-names
+     *
+     * @default false
+     *
+     * @deprecated (experimental)
+     */
+    experimental_keepNames?: boolean;
+
     jsx?: {
       /**
        * @default "React.createElement"

--- a/references/v3-catalog/src/trigger/binaries.ts
+++ b/references/v3-catalog/src/trigger/binaries.ts
@@ -43,13 +43,14 @@ function unzip(inputPath: string, outputPath: string) {
 
 import { createClient } from "@1password/sdk";
 
-// Creates an authenticated client.
-const client = await createClient({
-  auth: process.env.OP_SERVICE_ACCOUNT_TOKEN ?? "",
-  // Set the following to your own integration name and version.
-  integrationName: "My 1Password Integration",
-  integrationVersion: "v1.0.0",
-});
+function create1PasswordClient() {
+  return createClient({
+    auth: process.env.OP_SERVICE_ACCOUNT_TOKEN ?? "",
+    // Set the following to your own integration name and version.
+    integrationName: "My 1Password Integration",
+    integrationVersion: "v1.0.0",
+  });
+}
 
 // Fetches a secret.
 // const secret = await client.secrets.resolve("op://vault/item/field");

--- a/references/v3-catalog/trigger.config.ts
+++ b/references/v3-catalog/trigger.config.ts
@@ -32,6 +32,8 @@ export default defineConfig({
   build: {
     conditions: ["react-server"],
     experimental_autoDetectExternal: true,
+    experimental_keepNames: true,
+    experimental_minify: true,
     extensions: [
       additionalFiles({
         files: ["./wrangler/wrangler.toml"],


### PR DESCRIPTION
The `minify` option can decrease bundle sizes by up to half, if not more. It could also break a lot of stuff, hence experimental.
The `keepNames` option can fix issues in frameworks like MikroORM. Unsure about potential to break things, but best to be safe.
Both disabled by default.