### PR TITLE
fix: calculating next schedule should always just be from now

### DIFF
--- a/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
@@ -1,13 +1,12 @@
-import { Prisma, type RuntimeEnvironmentType, type ScheduleType } from "@trigger.dev/database";
+import { type RuntimeEnvironmentType, type ScheduleType } from "@trigger.dev/database";
 import { type ScheduleListFilters } from "~/components/runs/v3/ScheduleFilters";
-import { sqlDatabaseSchema } from "~/db.server";
 import { displayableEnvironment } from "~/models/runtimeEnvironment.server";
 import { getLimit } from "~/services/platform.v3.server";
-import { CheckScheduleService } from "~/v3/services/checkSchedule.server";
-import { calculateNextScheduledTimestamp } from "~/v3/utils/calculateNextSchedule.server";
-import { BasePresenter } from "./basePresenter.server";
 import { findCurrentWorkerFromEnvironment } from "~/v3/models/workerDeployment.server";
 import { ServiceValidationError } from "~/v3/services/baseService.server";
+import { CheckScheduleService } from "~/v3/services/checkSchedule.server";
+import { calculateNextScheduledTimestampFromNow } from "~/v3/utils/calculateNextSchedule.server";
+import { BasePresenter } from "./basePresenter.server";
 
 type ScheduleListOptions = {
   projectId: string;
@@ -258,7 +257,10 @@ export class ScheduleListPresenter extends BasePresenter {
         active: schedule.active,
         externalId: schedule.externalId,
         lastRun: schedule.lastRunTriggeredAt ?? undefined,
-        nextRun: calculateNextScheduledTimestamp(schedule.generatorExpression, schedule.timezone),
+        nextRun: calculateNextScheduledTimestampFromNow(
+          schedule.generatorExpression,
+          schedule.timezone
+        ),
         environments: schedule.instances.map((instance) => {
           const environment = project.environments.find((env) => env.id === instance.environmentId);
           if (!environment) {

--- a/apps/webapp/app/v3/services/registerNextTaskScheduleInstance.server.ts
+++ b/apps/webapp/app/v3/services/registerNextTaskScheduleInstance.server.ts
@@ -1,5 +1,5 @@
 import { startActiveSpan } from "../tracer.server";
-import { calculateNextScheduledTimestamp } from "../utils/calculateNextSchedule.server";
+import { calculateNextScheduledTimestampFromNow } from "../utils/calculateNextSchedule.server";
 import { BaseService } from "./baseService.server";
 import { TriggerScheduledTaskService } from "./triggerScheduledTask.server";
 
@@ -33,10 +33,9 @@ export class RegisterNextTaskScheduleInstanceService extends BaseService {
           instance.lastScheduledTimestamp?.toISOString() ?? new Date().toISOString()
         );
 
-        return calculateNextScheduledTimestamp(
+        return calculateNextScheduledTimestampFromNow(
           instance.taskSchedule.generatorExpression,
-          instance.taskSchedule.timezone,
-          instance.lastScheduledTimestamp ?? new Date()
+          instance.taskSchedule.timezone
         );
       }
     );

--- a/apps/webapp/app/v3/services/upsertTaskSchedule.server.ts
+++ b/apps/webapp/app/v3/services/upsertTaskSchedule.server.ts
@@ -4,7 +4,7 @@ import { nanoid } from "nanoid";
 import { $transaction } from "~/db.server";
 import { generateFriendlyId } from "../friendlyIdentifiers";
 import { type UpsertSchedule } from "../schedules";
-import { calculateNextScheduledTimestamp } from "../utils/calculateNextSchedule.server";
+import { calculateNextScheduledTimestampFromNow } from "../utils/calculateNextSchedule.server";
 import { BaseService, ServiceValidationError } from "./baseService.server";
 import { CheckScheduleService } from "./checkSchedule.server";
 import { RegisterNextTaskScheduleInstanceService } from "./registerNextTaskScheduleInstance.server";
@@ -262,7 +262,7 @@ export class UpsertTaskScheduleService extends BaseService {
       cron: taskSchedule.generatorExpression,
       cronDescription: taskSchedule.generatorDescription,
       timezone: taskSchedule.timezone,
-      nextRun: calculateNextScheduledTimestamp(
+      nextRun: calculateNextScheduledTimestampFromNow(
         taskSchedule.generatorExpression,
         taskSchedule.timezone
       ),

--- a/apps/webapp/app/v3/utils/calculateNextSchedule.server.ts
+++ b/apps/webapp/app/v3/utils/calculateNextSchedule.server.ts
@@ -1,40 +1,15 @@
 import { parseExpression } from "cron-parser";
 
+export function calculateNextScheduledTimestampFromNow(schedule: string, timezone: string | null) {
+  return calculateNextScheduledTimestamp(schedule, timezone, new Date());
+}
+
 export function calculateNextScheduledTimestamp(
   schedule: string,
   timezone: string | null,
-  lastScheduledTimestamp: Date = new Date()
+  currentDate: Date = new Date()
 ) {
-  const now = Date.now();
-
-  let nextStep = calculateNextStep(schedule, timezone, lastScheduledTimestamp);
-
-  // If the next step is still in the past, we might need to skip ahead
-  if (nextStep.getTime() <= now) {
-    // Calculate a second step to determine the interval
-    const secondStep = calculateNextStep(schedule, timezone, nextStep);
-    const interval = secondStep.getTime() - nextStep.getTime();
-
-    // If we have a consistent interval and it would take many iterations,
-    // skip ahead mathematically instead of iterating
-    if (interval > 0) {
-      const stepsNeeded = Math.floor((now - nextStep.getTime()) / interval);
-
-      // Only skip ahead if it would save us more than a few iterations
-      if (stepsNeeded > 10) {
-        // Skip ahead by calculating how many intervals to add
-        const skipAheadTime = nextStep.getTime() + stepsNeeded * interval;
-        nextStep = calculateNextStep(schedule, timezone, new Date(skipAheadTime));
-      }
-    }
-
-    // Use the normal iteration for the remaining steps (should be <= 10 now)
-    while (nextStep.getTime() <= now) {
-      nextStep = calculateNextStep(schedule, timezone, nextStep);
-    }
-  }
-
-  return nextStep;
+  return calculateNextStep(schedule, timezone, currentDate);
 }
 
 function calculateNextStep(schedule: string, timezone: string | null, currentDate: Date) {


### PR DESCRIPTION
As they always follow a deterministic step (instead of an interval from an non-deterministic starting point) and previous timestamps don't matter