### PR TITLE
chore: remove v2 models from schema

### DIFF
--- a/apps/webapp/app/database-types.ts
+++ b/apps/webapp/app/database-types.ts
@@ -7,7 +7,6 @@ import type {
   BatchTaskRunItemStatus as BatchTaskRunItemStatusType,
   TaskRunAttemptStatus as TaskRunAttemptStatusType,
   TaskRunStatus as TaskRunStatusType,
-  JobRunStatus as JobRunStatusType,
   RuntimeEnvironmentType as RuntimeEnvironmentTypeType,
 } from "@trigger.dev/database";
 
@@ -45,24 +44,6 @@ export const TaskRunStatus = {
   EXPIRED: "EXPIRED",
   TIMED_OUT: "TIMED_OUT",
 } as const satisfies Record<TaskRunStatusType, TaskRunStatusType>;
-
-export const JobRunStatus = {
-  PENDING: "PENDING",
-  QUEUED: "QUEUED",
-  WAITING_ON_CONNECTIONS: "WAITING_ON_CONNECTIONS",
-  PREPROCESSING: "PREPROCESSING",
-  STARTED: "STARTED",
-  EXECUTING: "EXECUTING",
-  WAITING_TO_CONTINUE: "WAITING_TO_CONTINUE",
-  WAITING_TO_EXECUTE: "WAITING_TO_EXECUTE",
-  SUCCESS: "SUCCESS",
-  FAILURE: "FAILURE",
-  TIMED_OUT: "TIMED_OUT",
-  ABORTED: "ABORTED",
-  CANCELED: "CANCELED",
-  UNRESOLVED_AUTH: "UNRESOLVED_AUTH",
-  INVALID_PAYLOAD: "INVALID_PAYLOAD",
-} as const satisfies Record<JobRunStatusType, JobRunStatusType>;
 
 export const RuntimeEnvironmentType = {
   PRODUCTION: "PRODUCTION",

--- a/apps/webapp/app/services/platform.v3.server.ts
+++ b/apps/webapp/app/services/platform.v3.server.ts
@@ -193,15 +193,6 @@ export async function getCurrentPlan(orgId: string) {
     firstDayOfNextMonth.setUTCMonth(firstDayOfNextMonth.getUTCMonth() + 1);
     firstDayOfNextMonth.setUTCHours(0, 0, 0, 0);
 
-    const currentRunCount = await $replica.jobRun.count({
-      where: {
-        organizationId: orgId,
-        createdAt: {
-          gte: firstDayOfMonth,
-        },
-      },
-    });
-
     if (!result.success) {
       logger.error("Error getting current plan", { orgId, error: result.error });
       return undefined;
@@ -212,11 +203,6 @@ export async function getCurrentPlan(orgId: string) {
     const periodRemainingDuration = periodEnd.getTime() - new Date().getTime();
 
     const usage = {
-      currentRunCount,
-      runCountCap: result.subscription?.plan.runs?.freeAllowance,
-      exceededRunCount: result.subscription?.plan.runs?.freeAllowance
-        ? currentRunCount > result.subscription?.plan.runs?.freeAllowance
-        : false,
       periodStart,
       periodEnd,
       periodRemainingDuration,

--- a/apps/webapp/app/services/telemetry.server.ts
+++ b/apps/webapp/app/services/telemetry.server.ts
@@ -1,4 +1,3 @@
-import { Job } from "@trigger.dev/database";
 import { PostHog } from "posthog-node";
 import { env } from "~/env.server";
 import { MatchedOrganization } from "~/hooks/useOrganizations";
@@ -145,7 +144,6 @@ class Telemetry {
         },
       });
     },
-    deletedJob: ({ job }: { job: Job }) => {},
   };
 
   #capture(event: CaptureEvent) {

--- a/internal-packages/database/prisma/migrations/20250526092407_remove_v2_tables_round_1/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250526092407_remove_v2_tables_round_1/migration.sql
@@ -1,0 +1,103 @@
+/*
+  Warnings:
+
+  - You are about to drop the `JobCounter` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `WebhookDeliveryCounter` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `ApiIntegrationVote` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `ConnectionAttempt` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `DeferredScheduledEventService` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `DynamicTriggerRegistration` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `EndpointIndex` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `EventExample` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `HttpSourceRequestDelivery` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `JobAlias` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `JobIntegration` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `JobRunAutoYieldExecution` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `JobRunStatusRecord` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `JobRunSubscription` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `KeyValueItem` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `MissingConnection` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `TaskAttempt` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `TriggerSourceOption` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `WebhookRequestDelivery` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `_JobRunToMissingConnection` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+
+-- DropTable
+DROP TABLE IF EXISTS "JobCounter";
+
+-- DropTable
+DROP TABLE IF EXISTS "WebhookDeliveryCounter";
+
+-- DropTable
+DROP TABLE IF EXISTS "ApiIntegrationVote";
+
+-- DropTable
+DROP TABLE IF EXISTS "ConnectionAttempt";
+
+-- DropTable
+DROP TABLE IF EXISTS "DeferredScheduledEventService";
+
+-- DropTable
+DROP TABLE IF EXISTS "DynamicTriggerRegistration";
+
+-- DropTable
+DROP TABLE IF EXISTS "EndpointIndex";
+
+-- DropTable
+DROP TABLE IF EXISTS "EventExample";
+
+-- DropTable
+DROP TABLE IF EXISTS "HttpSourceRequestDelivery";
+
+-- DropTable
+DROP TABLE IF EXISTS "JobAlias";
+
+-- DropTable
+DROP TABLE IF EXISTS "JobIntegration";
+
+-- DropTable
+DROP TABLE IF EXISTS "JobRunAutoYieldExecution";
+
+-- DropTable
+DROP TABLE IF EXISTS "JobRunStatusRecord";
+
+-- DropTable
+DROP TABLE IF EXISTS "JobRunSubscription";
+
+-- DropTable
+DROP TABLE IF EXISTS "KeyValueItem";
+
+-- DropTable
+DROP TABLE IF EXISTS "MissingConnection";
+
+-- DropTable
+DROP TABLE IF EXISTS "TaskAttempt";
+
+-- DropTable
+DROP TABLE IF EXISTS "TriggerSourceOption";
+
+-- DropTable
+DROP TABLE IF EXISTS "WebhookRequestDelivery";
+
+-- DropTable
+DROP TABLE IF EXISTS "_JobRunToMissingConnection";
+
+-- DropEnum
+DROP TYPE IF EXISTS "EndpointIndexSource";
+
+-- DropEnum
+DROP TYPE IF EXISTS "EndpointIndexStatus";
+
+-- DropEnum
+DROP TYPE IF EXISTS "JobRunSubscriptionEvents";
+
+-- DropEnum
+DROP TYPE IF EXISTS "JobRunSubscriptionRecipientMethod";
+
+-- DropEnum
+DROP TYPE IF EXISTS "JobRunSubscriptionStatus";
+
+-- DropEnum
+DROP TYPE IF EXISTS "TaskAttemptStatus";

--- a/internal-packages/database/prisma/migrations/20250526092407_remove_v2_tables_round_1/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250526092407_remove_v2_tables_round_1/migration.sql
@@ -70,7 +70,7 @@ DROP TABLE IF EXISTS "JobRunSubscription";
 DROP TABLE IF EXISTS "KeyValueItem";
 
 -- DropTable
-DROP TABLE IF EXISTS "MissingConnection";
+DROP TABLE IF EXISTS "MissingConnection" CASCADE;
 
 -- DropTable
 DROP TABLE IF EXISTS "TaskAttempt";

--- a/internal-packages/database/prisma/migrations/20250526093738_remove_v2_round_2/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250526093738_remove_v2_round_2/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - You are about to drop the `JobRunExecution` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `ScheduleSource` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `WebhookEnvironment` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE IF EXISTS "JobRunExecution" CASCADE;
+
+-- DropTable
+DROP TABLE IF EXISTS "ScheduleSource" CASCADE;
+
+-- DropTable
+DROP TABLE IF EXISTS "WebhookEnvironment" CASCADE;

--- a/internal-packages/database/prisma/migrations/20250526094044_remove_v2_trigger_http_endpoint_environment/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250526094044_remove_v2_trigger_http_endpoint_environment/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `httpEndpointEnvironmentId` on the `EventRecord` table. All the data in the column will be lost.
+  - You are about to drop the `TriggerHttpEndpointEnvironment` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "EventRecord" DROP COLUMN IF EXISTS "httpEndpointEnvironmentId" CASCADE;
+
+-- DropTable
+DROP TABLE IF EXISTS "TriggerHttpEndpointEnvironment" CASCADE;

--- a/internal-packages/database/prisma/migrations/20250526094442_remove_v2_round_3/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250526094442_remove_v2_round_3/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Task` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Webhook` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE IF EXISTS "Task" CASCADE;
+
+-- DropTable
+DROP TABLE IF EXISTS "Webhook" CASCADE;

--- a/internal-packages/database/prisma/migrations/20250526094729_remove_v2_round_4/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250526094729_remove_v2_round_4/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - You are about to drop the `RunConnection` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `TriggerSource` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+
+-- DropTable
+DROP TABLE IF EXISTS "RunConnection" CASCADE;
+
+-- DropTable
+DROP TABLE IF EXISTS "TriggerSource" CASCADE;

--- a/internal-packages/database/prisma/migrations/20250526095040_remove_v2_round_5/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250526095040_remove_v2_round_5/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the `IntegrationConnection` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE IF EXISTS "IntegrationConnection" CASCADE;

--- a/internal-packages/database/prisma/migrations/20250526095444_remove_v2_round_6/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250526095444_remove_v2_round_6/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - You are about to drop the `DynamicTrigger` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `EventDispatcher` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `EventRecord` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `JobRun` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `_DynamicTriggerToJob` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE IF EXISTS "DynamicTrigger" CASCADE;
+
+-- DropTable
+DROP TABLE IF EXISTS "EventDispatcher" CASCADE;
+
+-- DropTable
+DROP TABLE IF EXISTS "EventRecord" CASCADE;
+
+-- DropTable
+DROP TABLE IF EXISTS "JobRun" CASCADE;
+
+-- DropTable
+DROP TABLE IF EXISTS "_DynamicTriggerToJob" CASCADE;

--- a/internal-packages/database/prisma/migrations/20250526095826_remove_v2_round_7/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250526095826_remove_v2_round_7/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - You are about to drop the `JobVersion` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `TriggerHttpEndpoint` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE IF EXISTS "JobVersion" CASCADE;
+
+-- DropTable
+DROP TABLE IF EXISTS "TriggerHttpEndpoint" CASCADE;

--- a/internal-packages/database/prisma/migrations/20250526100059_remove_v2_round_8/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250526100059_remove_v2_round_8/migration.sql
@@ -1,0 +1,20 @@
+/*
+  Warnings:
+
+  - You are about to drop the `ConcurrencyLimitGroup` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Endpoint` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Job` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `JobQueue` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE IF EXISTS "ConcurrencyLimitGroup" CASCADE;
+
+-- DropTable
+DROP TABLE IF EXISTS "Endpoint" CASCADE;
+
+-- DropTable
+DROP TABLE IF EXISTS "Job" CASCADE;
+
+-- DropTable
+DROP TABLE IF EXISTS "JobQueue" CASCADE;

--- a/internal-packages/database/prisma/migrations/20250526100402_remove_v2_round_9/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250526100402_remove_v2_round_9/migration.sql
@@ -1,0 +1,20 @@
+/*
+  Warnings:
+
+  - You are about to drop the `ExternalAccount` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Integration` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `IntegrationAuthMethod` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `IntegrationDefinition` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE IF EXISTS "ExternalAccount" CASCADE;
+
+-- DropTable
+DROP TABLE IF EXISTS "Integration" CASCADE;
+
+-- DropTable
+DROP TABLE IF EXISTS "IntegrationAuthMethod" CASCADE;
+
+-- DropTable
+DROP TABLE IF EXISTS "IntegrationDefinition" CASCADE;

--- a/internal-packages/database/prisma/migrations/20250526100607_remove_v2_round_10/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250526100607_remove_v2_round_10/migration.sql
@@ -1,0 +1,38 @@
+-- DropEnum
+DROP TYPE IF EXISTS "ConnectionType";
+
+-- DropEnum
+DROP TYPE IF EXISTS "DynamicTriggerType";
+
+-- DropEnum
+DROP TYPE IF EXISTS "IntegrationAuthSource";
+
+-- DropEnum
+DROP TYPE IF EXISTS "IntegrationSetupStatus";
+
+-- DropEnum
+DROP TYPE IF EXISTS "JobRunExecutionReason";
+
+-- DropEnum
+DROP TYPE IF EXISTS "JobRunExecutionStatus";
+
+-- DropEnum
+DROP TYPE IF EXISTS "JobRunStatus";
+
+-- DropEnum
+DROP TYPE IF EXISTS "JobStartPosition";
+
+-- DropEnum
+DROP TYPE IF EXISTS "JobVersionStatus";
+
+-- DropEnum
+DROP TYPE IF EXISTS "PayloadType";
+
+-- DropEnum
+DROP TYPE IF EXISTS "TaskChildExecutionMode";
+
+-- DropEnum
+DROP TYPE IF EXISTS "TaskStatus";
+
+-- DropEnum
+DROP TYPE IF EXISTS "TriggerChannel";

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -149,100 +149,10 @@ model Organization {
   projects                 Project[]
   members                  OrgMember[]
   invites                  OrgMemberInvite[]
-  externalAccounts         ExternalAccount[]
-  integrations             Integration[]
   organizationIntegrations OrganizationIntegration[]
   workerGroups             WorkerInstanceGroup[]
   workerInstances          WorkerInstance[]
   executionSnapshots       TaskRunExecutionSnapshot[]
-}
-
-model ExternalAccount {
-  id         String @id @default(cuid())
-  identifier String
-  metadata   Json?
-
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  organizationId String
-
-  environment   RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  environmentId String
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@unique([environmentId, identifier])
-}
-
-// This is a "global" table that store all the integration methods for all the integrations across all orgs
-model IntegrationAuthMethod {
-  id  String @id @default(cuid())
-  key String
-
-  name        String
-  description String
-  type        String
-
-  client Json?
-  config Json?
-  scopes Json?
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  integrations Integration[]
-
-  definition   IntegrationDefinition @relation(fields: [definitionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  definitionId String
-
-  help Json?
-
-  @@unique([definitionId, key])
-}
-
-model IntegrationDefinition {
-  id           String  @id
-  name         String
-  instructions String?
-  description  String?
-  icon         String?
-  packageName  String  @default("")
-
-  authMethods IntegrationAuthMethod[]
-  Integration Integration[]
-}
-
-model Integration {
-  id String @id @default(cuid())
-
-  slug String
-
-  title       String?
-  description String?
-
-  setupStatus IntegrationSetupStatus @default(COMPLETE)
-  authSource  IntegrationAuthSource  @default(HOSTED)
-
-  definition   IntegrationDefinition @relation(fields: [definitionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  definitionId String
-
-  authMethod   IntegrationAuthMethod? @relation(fields: [authMethodId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  authMethodId String?
-
-  connectionType ConnectionType @default(DEVELOPER)
-
-  scopes String[]
-
-  customClientReference   SecretReference? @relation(fields: [customClientReferenceId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  customClientReferenceId String?
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  organizationId String
-
-  @@unique([organizationId, slug])
 }
 
 enum IntegrationAuthSource {
@@ -349,7 +259,6 @@ model RuntimeEnvironment {
 
   tunnelId String?
 
-  ExternalAccount            ExternalAccount[]
   backgroundWorkers          BackgroundWorker[]
   backgroundWorkerTasks      BackgroundWorkerTask[]
   taskRuns                   TaskRun[]
@@ -509,7 +418,6 @@ model SecretReference {
   key      String              @unique
   provider SecretStoreProvider @default(DATABASE)
 
-  integrations              Integration[]
   environmentVariableValues EnvironmentVariableValue[]
 
   createdAt               DateTime                  @default(now())

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -157,7 +157,6 @@ model Organization {
   invites                  OrgMemberInvite[]
   externalAccounts         ExternalAccount[]
   integrations             Integration[]
-  sources                  TriggerSource[]
   organizationIntegrations OrganizationIntegration[]
   workerGroups             WorkerInstanceGroup[]
   workerInstances          WorkerInstance[]
@@ -181,7 +180,6 @@ model ExternalAccount {
   connections     IntegrationConnection[]
   events          EventRecord[]
   runs            JobRun[]
-  triggerSources  TriggerSource[]
   EventDispatcher EventDispatcher[]
 
   @@unique([environmentId, identifier])
@@ -255,9 +253,7 @@ model Integration {
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   organizationId String
 
-  connections   IntegrationConnection[]
-  sources       TriggerSource[]
-  RunConnection RunConnection[]
+  connections IntegrationConnection[]
 
   @@unique([organizationId, slug])
 }
@@ -299,8 +295,6 @@ model IntegrationConnection {
 
   /// If enabled is false, OAuth refreshing will not be attempted
   enabled Boolean @default(true)
-
-  runConnections RunConnection[]
 }
 
 enum ConnectionType {
@@ -401,7 +395,6 @@ model RuntimeEnvironment {
   events                     EventRecord[]
   jobRuns                    JobRun[]
   JobQueue                   JobQueue[]
-  sources                    TriggerSource[]
   eventDispatchers           EventDispatcher[]
   ExternalAccount            ExternalAccount[]
   concurrencyLimitGroups     ConcurrencyLimitGroup[]
@@ -473,7 +466,6 @@ model Project {
   jobVersion             JobVersion[]
   events                 EventRecord[]
   runs                   JobRun[]
-  sources                TriggerSource[]
   httpEndpoints          TriggerHttpEndpoint[]
   backgroundWorkers      BackgroundWorker[]
   backgroundWorkerTasks  BackgroundWorkerTask[]
@@ -532,7 +524,6 @@ model Endpoint {
   jobVersions     JobVersion[]
   jobRuns         JobRun[]
   dynamictriggers DynamicTrigger[]
-  sources         TriggerSource[]
 
   @@unique([environmentId, slug])
 }
@@ -600,7 +591,6 @@ model JobVersion {
 
   runs            JobRun[]
   dynamicTriggers DynamicTrigger[]
-  triggerSources  TriggerSource[]
 
   status JobVersionStatus @default(ACTIVE)
 
@@ -648,27 +638,6 @@ model JobQueue {
   @@unique([environmentId, name])
 }
 
-model RunConnection {
-  id  String @id @default(cuid())
-  key String
-
-  authSource IntegrationAuthSource @default(HOSTED)
-
-  run   JobRun @relation(fields: [runId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  runId String
-
-  connection   IntegrationConnection? @relation(fields: [connectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  connectionId String?
-
-  integration   Integration @relation(fields: [integrationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  integrationId String
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@unique([runId, key])
-}
-
 model DynamicTrigger {
   id   String             @id @default(cuid())
   type DynamicTriggerType @default(EVENT)
@@ -677,8 +646,7 @@ model DynamicTrigger {
   endpoint   Endpoint @relation(fields: [endpointId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   endpointId String
 
-  jobs    Job[]
-  sources TriggerSource[]
+  jobs Job[]
 
   sourceRegistrationJob   JobVersion? @relation(fields: [sourceRegistrationJobId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   sourceRegistrationJobId String?
@@ -824,8 +792,6 @@ model JobRun {
 
   forceYieldImmediately Boolean @default(false)
 
-  runConnections RunConnection[]
-
   @@index([jobId, createdAt(sort: Desc)], map: "idx_jobrun_jobId_createdAt")
   @@index([organizationId, createdAt], map: "idx_jobrun_organizationId_createdAt")
   @@index([versionId], map: "idx_jobrun_versionId")
@@ -883,7 +849,6 @@ model SecretReference {
 
   connections               IntegrationConnection[]
   integrations              Integration[]
-  triggerSources            TriggerSource[]
   httpEndpoints             TriggerHttpEndpoint[]
   environmentVariableValues EnvironmentVariableValue[]
 
@@ -906,58 +871,6 @@ model SecretStore {
   updatedAt DateTime @updatedAt
 
   @@index([key(ops: raw("text_pattern_ops"))], type: BTree)
-}
-
-model TriggerSource {
-  id String @id @default(cuid())
-
-  key    String
-  params Json?
-
-  channel     TriggerChannel @default(HTTP)
-  channelData Json?
-
-  version String @default("1")
-
-  metadata Json?
-
-  secretReference   SecretReference @relation(fields: [secretReferenceId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  secretReferenceId String
-
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  organizationId String
-
-  environment   RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  environmentId String
-
-  endpoint   Endpoint @relation(fields: [endpointId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  endpointId String
-
-  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  projectId String
-
-  integration   Integration @relation(fields: [integrationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  integrationId String
-
-  dynamicTrigger   DynamicTrigger? @relation(fields: [dynamicTriggerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  dynamicTriggerId String?
-
-  externalAccount   ExternalAccount? @relation(fields: [externalAccountId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  externalAccountId String?
-
-  sourceRegistrationJob   JobVersion? @relation(fields: [sourceRegistrationJobId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  sourceRegistrationJobId String?
-
-  dynamicSourceId       String?
-  dynamicSourceMetadata Json?
-
-  active      Boolean @default(false)
-  interactive Boolean @default(false)
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@unique([key, environmentId])
 }
 
 enum TriggerChannel {

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -405,7 +405,6 @@ model RuntimeEnvironment {
   sources                    TriggerSource[]
   eventDispatchers           EventDispatcher[]
   ExternalAccount            ExternalAccount[]
-  httpEndpointEnvironments   TriggerHttpEndpointEnvironment[]
   concurrencyLimitGroups     ConcurrencyLimitGroup[]
   backgroundWorkers          BackgroundWorker[]
   backgroundWorkerTasks      BackgroundWorkerTask[]
@@ -532,11 +531,10 @@ model Endpoint {
   beforeCompleteTaskThreshold Int @default(750)
   afterCompleteTaskThreshold  Int @default(750)
 
-  jobVersions              JobVersion[]
-  jobRuns                  JobRun[]
-  dynamictriggers          DynamicTrigger[]
-  sources                  TriggerSource[]
-  httpEndpointEnvironments TriggerHttpEndpointEnvironment[]
+  jobVersions     JobVersion[]
+  jobRuns         JobRun[]
+  dynamictriggers DynamicTrigger[]
+  sources         TriggerSource[]
 
   @@unique([environmentId, slug])
 }
@@ -753,9 +751,6 @@ model EventRecord {
 
   httpEndpoint   TriggerHttpEndpoint? @relation(fields: [httpEndpointId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   httpEndpointId String?
-
-  httpEndpointEnvironment   TriggerHttpEndpointEnvironment? @relation(fields: [httpEndpointEnvironmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  httpEndpointEnvironmentId String?
 
   deliverAt   DateTime  @default(now())
   deliveredAt DateTime?
@@ -1065,41 +1060,9 @@ model TriggerHttpEndpoint {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  httpEndpointEnvironments TriggerHttpEndpointEnvironment[]
-
   eventRecords EventRecord[]
 
   @@unique([key, projectId])
-}
-
-model TriggerHttpEndpointEnvironment {
-  id String @id @default(cuid())
-
-  active Boolean @default(false)
-
-  /// If this is set, requests will be tested against the filter and we'll call the user's server immediately
-  immediateResponseFilter Json?
-
-  skipTriggeringRuns Boolean @default(false)
-
-  source String
-
-  environment   RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  environmentId String
-
-  endpoint   Endpoint @relation(fields: [endpointId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  endpointId String
-
-  httpEndpoint   TriggerHttpEndpoint @relation(fields: [httpEndpointId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  httpEndpointId String
-
-  eventRecords EventRecord[]
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@unique([environmentId, httpEndpointId])
-  @@unique([endpointId, httpEndpointId])
 }
 
 model DataMigration {

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -46,9 +46,6 @@ model User {
   orgMemberships OrgMember[]
   sentInvites    OrgMemberInvite[]
 
-  /// @deprecated
-  apiVotes ApiIntegrationVote[]
-
   invitationCode       InvitationCode?       @relation(fields: [invitationCodeId], references: [id])
   invitationCodeId     String?
   personalAccessTokens PersonalAccessToken[]
@@ -181,13 +178,12 @@ model ExternalAccount {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  connections        IntegrationConnection[]
-  events             EventRecord[]
-  runs               JobRun[]
-  schedules          ScheduleSource[]
-  triggerSources     TriggerSource[]
-  missingConnections MissingConnection[]
-  EventDispatcher    EventDispatcher[]
+  connections     IntegrationConnection[]
+  events          EventRecord[]
+  runs            JobRun[]
+  schedules       ScheduleSource[]
+  triggerSources  TriggerSource[]
+  EventDispatcher EventDispatcher[]
 
   @@unique([environmentId, identifier])
 }
@@ -260,13 +256,10 @@ model Integration {
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   organizationId String
 
-  attempts           ConnectionAttempt[]
-  connections        IntegrationConnection[]
-  jobIntegrations    JobIntegration[]
-  sources            TriggerSource[]
-  webhooks           Webhook[]
-  missingConnections MissingConnection[]
-  RunConnection      RunConnection[]
+  connections   IntegrationConnection[]
+  sources       TriggerSource[]
+  webhooks      Webhook[]
+  RunConnection RunConnection[]
 
   @@unique([organizationId, slug])
 }
@@ -315,20 +308,6 @@ model IntegrationConnection {
 enum ConnectionType {
   EXTERNAL
   DEVELOPER
-}
-
-model ConnectionAttempt {
-  id String @id @default(cuid())
-
-  securityCode String?
-
-  redirectTo String @default("/")
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
-
-  integration   Integration @relation(fields: [integrationId], references: [id])
-  integrationId String
 }
 
 model OrgMember {
@@ -417,26 +396,20 @@ model RuntimeEnvironment {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  /// @deprecated (v2)
-  tunnelId                 String?
-  endpoints                Endpoint[]
-  jobVersions              JobVersion[]
-  events                   EventRecord[]
-  jobRuns                  JobRun[]
-  requestDeliveries        HttpSourceRequestDelivery[]
-  jobAliases               JobAlias[]
-  JobQueue                 JobQueue[]
-  sources                  TriggerSource[]
-  eventDispatchers         EventDispatcher[]
-  scheduleSources          ScheduleSource[]
-  ExternalAccount          ExternalAccount[]
-  httpEndpointEnvironments TriggerHttpEndpointEnvironment[]
-  concurrencyLimitGroups   ConcurrencyLimitGroup[]
-  keyValueItems            KeyValueItem[]
-  webhookEnvironments      WebhookEnvironment[]
-  webhookRequestDeliveries WebhookRequestDelivery[]
+  tunnelId String?
 
-  /// v3
+  endpoints                  Endpoint[]
+  jobVersions                JobVersion[]
+  events                     EventRecord[]
+  jobRuns                    JobRun[]
+  JobQueue                   JobQueue[]
+  sources                    TriggerSource[]
+  eventDispatchers           EventDispatcher[]
+  scheduleSources            ScheduleSource[]
+  ExternalAccount            ExternalAccount[]
+  httpEndpointEnvironments   TriggerHttpEndpointEnvironment[]
+  concurrencyLimitGroups     ConcurrencyLimitGroup[]
+  webhookEnvironments        WebhookEnvironment[]
   backgroundWorkers          BackgroundWorker[]
   backgroundWorkerTasks      BackgroundWorkerTask[]
   taskRuns                   TaskRun[]
@@ -564,48 +537,12 @@ model Endpoint {
 
   jobVersions              JobVersion[]
   jobRuns                  JobRun[]
-  httpRequestDeliveries    HttpSourceRequestDelivery[]
-  webhookRequestDeliveries WebhookRequestDelivery[]
   dynamictriggers          DynamicTrigger[]
   sources                  TriggerSource[]
-  indexings                EndpointIndex[]
   httpEndpointEnvironments TriggerHttpEndpointEnvironment[]
   webhookEnvironments      WebhookEnvironment[]
 
   @@unique([environmentId, slug])
-}
-
-model EndpointIndex {
-  id String @id @default(cuid())
-
-  endpoint   Endpoint @relation(fields: [endpointId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  endpointId String
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  source     EndpointIndexSource @default(MANUAL)
-  sourceData Json?
-  reason     String?
-  status     EndpointIndexStatus @default(PENDING)
-
-  data  Json?
-  stats Json?
-  error Json?
-}
-
-enum EndpointIndexSource {
-  MANUAL
-  API
-  INTERNAL
-  HOOK
-}
-
-enum EndpointIndexStatus {
-  PENDING
-  STARTED
-  SUCCESS
-  FAILURE
 }
 
 model Job {
@@ -622,8 +559,6 @@ model Job {
 
   versions        JobVersion[]
   runs            JobRun[]
-  integrations    JobIntegration[]
-  aliases         JobAlias[]
   dynamicTriggers DynamicTrigger[]
 
   createdAt DateTime @default(now())
@@ -672,9 +607,6 @@ model JobVersion {
   updatedAt DateTime @updatedAt
 
   runs            JobRun[]
-  integrations    JobIntegration[]
-  aliases         JobAlias[]
-  examples        EventExample[]
   dynamicTriggers DynamicTrigger[]
   triggerSources  TriggerSource[]
 
@@ -686,24 +618,6 @@ model JobVersion {
 enum JobVersionStatus {
   ACTIVE
   DISABLED
-}
-
-model EventExample {
-  id String @id @default(cuid())
-
-  slug String
-  name String
-  icon String?
-
-  payload Json?
-
-  jobVersion   JobVersion @relation(fields: [jobVersionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  jobVersionId String
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@unique([slug, jobVersionId])
 }
 
 model ConcurrencyLimitGroup {
@@ -742,42 +656,6 @@ model JobQueue {
   @@unique([environmentId, name])
 }
 
-model JobAlias {
-  id    String @id @default(cuid())
-  name  String @default("latest")
-  value String
-
-  version   JobVersion @relation(fields: [versionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  versionId String
-
-  job   Job    @relation(fields: [jobId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  jobId String
-
-  environment   RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  environmentId String
-
-  @@unique([jobId, environmentId, name])
-}
-
-model JobIntegration {
-  id  String @id @default(cuid())
-  key String
-
-  version   JobVersion @relation(fields: [versionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  versionId String
-
-  job   Job    @relation(fields: [jobId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  jobId String
-
-  integration   Integration @relation(fields: [integrationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  integrationId String
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@unique([versionId, key])
-}
-
 model RunConnection {
   id  String @id @default(cuid())
   key String
@@ -812,7 +690,6 @@ model DynamicTrigger {
   jobs            Job[]
   sources         TriggerSource[]
   scheduleSources ScheduleSource[]
-  registrations   DynamicTriggerRegistration[]
 
   sourceRegistrationJob   JobVersion? @relation(fields: [sourceRegistrationJobId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   sourceRegistrationJobId String?
@@ -844,7 +721,6 @@ model EventDispatcher {
   environment   RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   environmentId String
 
-  registrations   DynamicTriggerRegistration[]
   scheduleSources ScheduleSource[]
 
   externalAccount   ExternalAccount? @relation(fields: [externalAccountId], references: [id], onDelete: Cascade, onUpdate: Cascade)
@@ -964,13 +840,9 @@ model JobRun {
 
   forceYieldImmediately Boolean @default(false)
 
-  tasks              Task[]
-  runConnections     RunConnection[]
-  missingConnections MissingConnection[]
-  executions         JobRunExecution[]
-  statuses           JobRunStatusRecord[]
-  autoYieldExecution JobRunAutoYieldExecution[]
-  subscriptions      JobRunSubscription[]
+  tasks          Task[]
+  runConnections RunConnection[]
+  executions     JobRunExecution[]
 
   @@index([jobId, createdAt(sort: Desc)], map: "idx_jobrun_jobId_createdAt")
   @@index([organizationId, createdAt], map: "idx_jobrun_organizationId_createdAt")
@@ -994,60 +866,6 @@ enum JobRunStatus {
   CANCELED
   UNRESOLVED_AUTH
   INVALID_PAYLOAD
-}
-
-model JobCounter {
-  jobId      String @id
-  lastNumber Int    @default(0)
-}
-
-model JobRunAutoYieldExecution {
-  id String @id @default(cuid())
-
-  run   JobRun @relation(fields: [runId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  runId String
-
-  timeRemaining Int
-  timeElapsed   Int
-  limit         Int
-  location      String
-
-  createdAt DateTime @default(now())
-}
-
-model JobRunSubscription {
-  id String @id @default(cuid())
-
-  run   JobRun @relation(fields: [runId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  runId String
-
-  recipient       String
-  recipientMethod JobRunSubscriptionRecipientMethod @default(WEBHOOK)
-
-  event  JobRunSubscriptionEvents
-  status JobRunSubscriptionStatus @default(ACTIVE)
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  deliveredAt DateTime?
-
-  @@unique([runId, recipient, event])
-}
-
-enum JobRunSubscriptionRecipientMethod {
-  WEBHOOK
-  ENDPOINT
-}
-
-enum JobRunSubscriptionStatus {
-  ACTIVE
-  INACTIVE
-}
-
-enum JobRunSubscriptionEvents {
-  SUCCESS
-  FAILURE
 }
 
 model JobRunExecution {
@@ -1132,7 +950,6 @@ model Task {
   children           Task[]                 @relation("TaskParent")
   childExecutionMode TaskChildExecutionMode @default(SEQUENTIAL)
   executions         JobRunExecution[]
-  attempts           TaskAttempt[]
 
   @@unique([runId, idempotencyKey])
   @@index([parentId], map: "idx_task_parentId")
@@ -1150,52 +967,6 @@ enum TaskStatus {
 enum TaskChildExecutionMode {
   SEQUENTIAL
   PARALLEL
-}
-
-model TaskAttempt {
-  id String @id @default(cuid())
-
-  number Int
-
-  task   Task   @relation(fields: [taskId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  taskId String
-
-  status TaskAttemptStatus @default(PENDING)
-
-  error String?
-
-  runAt DateTime?
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@unique([taskId, number])
-}
-
-enum TaskAttemptStatus {
-  PENDING
-  STARTED
-  COMPLETED
-  ERRORED
-}
-
-model JobRunStatusRecord {
-  id  String @id @default(cuid())
-  key String
-
-  run   JobRun @relation(fields: [runId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  runId String
-
-  label String
-  state String?
-  data  Json?
-
-  history Json?
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@unique([runId, key])
 }
 
 model SecretReference {
@@ -1241,8 +1012,6 @@ model TriggerSource {
 
   version String @default("1")
 
-  options TriggerSourceOption[]
-
   metadata Json?
 
   secretReference   SecretReference @relation(fields: [secretReferenceId], references: [id], onDelete: Cascade, onUpdate: Cascade)
@@ -1281,9 +1050,6 @@ model TriggerSource {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  httpDeliveries HttpSourceRequestDelivery[]
-  registrations  DynamicTriggerRegistration[]
-
   @@unique([key, environmentId])
 }
 
@@ -1291,22 +1057,6 @@ enum TriggerChannel {
   HTTP
   SQS
   SMTP
-}
-
-model TriggerSourceOption {
-  id    String @id @default(cuid())
-  name  String
-  value String
-
-  source   TriggerSource @relation(fields: [sourceId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  sourceId String
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  registered Boolean @default(false)
-
-  @@unique([name, value, sourceId])
 }
 
 model Webhook {
@@ -1318,7 +1068,6 @@ model Webhook {
   params Json?
 
   webhookEnvironments WebhookEnvironment[]
-  requestDeliveries   WebhookRequestDelivery[]
 
   httpEndpoint   TriggerHttpEndpoint @relation(fields: [httpEndpointId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   httpEndpointId String              @unique
@@ -1343,8 +1092,6 @@ model WebhookEnvironment {
   config        Json?
   desiredConfig Json?
 
-  requestDeliveries WebhookRequestDelivery[]
-
   endpoint   Endpoint @relation(fields: [endpointId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   endpointId String
 
@@ -1358,85 +1105,6 @@ model WebhookEnvironment {
   updatedAt DateTime @updatedAt
 
   @@unique([environmentId, webhookId])
-}
-
-model WebhookRequestDelivery {
-  id     String @id @default(cuid())
-  number Int
-
-  url     String
-  method  String
-  headers Json
-
-  body Bytes?
-
-  verified Boolean @default(false)
-  error    String?
-
-  webhook   Webhook @relation(fields: [webhookId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  webhookId String
-
-  environment   RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  environmentId String
-
-  webhookEnvironment   WebhookEnvironment @relation(fields: [webhookEnvironmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  webhookEnvironmentId String
-
-  endpoint   Endpoint @relation(fields: [endpointId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  endpointId String
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  deliveredAt DateTime?
-}
-
-model WebhookDeliveryCounter {
-  webhookId  String @id
-  lastNumber Int    @default(0)
-}
-
-model DynamicTriggerRegistration {
-  id String @id @default(cuid())
-
-  key String
-
-  dynamicTrigger   DynamicTrigger @relation(fields: [dynamicTriggerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  dynamicTriggerId String
-
-  eventDispatcher   EventDispatcher @relation(fields: [eventDispatcherId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  eventDispatcherId String
-
-  source   TriggerSource @relation(fields: [sourceId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  sourceId String
-
-  metadata Json?
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@unique([key, dynamicTriggerId])
-}
-
-model HttpSourceRequestDelivery {
-  id      String @id @default(cuid())
-  url     String
-  method  String
-  headers Json
-  body    Bytes?
-
-  source   TriggerSource @relation(fields: [sourceId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  sourceId String
-
-  endpoint   Endpoint @relation(fields: [endpointId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  endpointId String
-
-  environment   RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  environmentId String
-
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
-  deliveredAt DateTime?
 }
 
 model ScheduleSource {
@@ -1466,9 +1134,8 @@ model ScheduleSource {
   dynamicTrigger   DynamicTrigger? @relation(fields: [dynamicTriggerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   dynamicTriggerId String?
 
-  externalAccount   ExternalAccount?               @relation(fields: [externalAccountId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  externalAccount   ExternalAccount? @relation(fields: [externalAccountId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   externalAccountId String?
-  deferredEvent     DeferredScheduledEventService?
 
   @@unique([key, environmentId])
 }
@@ -1530,60 +1197,6 @@ model TriggerHttpEndpointEnvironment {
   @@unique([endpointId, httpEndpointId])
 }
 
-model KeyValueItem {
-  id String @id @default(cuid())
-
-  key   String
-  value Bytes
-
-  environment   RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  environmentId String
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@unique([environmentId, key])
-  @@index([key], type: Hash)
-}
-
-model MissingConnection {
-  id String @id @default(cuid())
-
-  resolved Boolean @default(false)
-
-  runs JobRun[]
-
-  integration   Integration @relation(fields: [integrationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  integrationId String
-
-  connectionType ConnectionType @default(DEVELOPER)
-
-  externalAccount   ExternalAccount? @relation(fields: [externalAccountId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  externalAccountId String?
-
-  accountIdentifier String?
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@unique([integrationId, connectionType, externalAccountId])
-  @@unique([integrationId, connectionType, accountIdentifier])
-}
-
-model ApiIntegrationVote {
-  id String @id @default(cuid())
-
-  apiIdentifier String
-
-  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  userId String
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@unique([apiIdentifier, userId])
-}
-
 model DataMigration {
   id   String @id @default(cuid())
   name String @unique
@@ -1591,19 +1204,6 @@ model DataMigration {
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
   completedAt DateTime?
-}
-
-model DeferredScheduledEventService {
-  id String @id @default(cuid())
-
-  scheduleSource   ScheduleSource @relation(fields: [scheduleSourceId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  scheduleSourceId String         @unique
-
-  runAt         DateTime
-  lastTimestamp DateTime?
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
 }
 
 // ====================================================

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -155,22 +155,6 @@ model Organization {
   executionSnapshots       TaskRunExecutionSnapshot[]
 }
 
-enum IntegrationAuthSource {
-  HOSTED
-  LOCAL
-  RESOLVER
-}
-
-enum IntegrationSetupStatus {
-  MISSING_FIELDS
-  COMPLETE
-}
-
-enum ConnectionType {
-  EXTERNAL
-  DEVELOPER
-}
-
 model OrgMember {
   id String @id @default(cuid())
 
@@ -349,70 +333,6 @@ enum ProjectVersion {
   V3
 }
 
-enum JobVersionStatus {
-  ACTIVE
-  DISABLED
-}
-
-enum DynamicTriggerType {
-  EVENT
-  SCHEDULE
-}
-
-enum JobStartPosition {
-  INITIAL
-  LATEST
-}
-
-enum PayloadType {
-  JSON
-  REQUEST
-}
-
-enum JobRunStatus {
-  PENDING
-  QUEUED
-  WAITING_ON_CONNECTIONS
-  PREPROCESSING
-  STARTED
-  EXECUTING
-  WAITING_TO_CONTINUE
-  WAITING_TO_EXECUTE
-  SUCCESS
-  FAILURE
-  TIMED_OUT
-  ABORTED
-  CANCELED
-  UNRESOLVED_AUTH
-  INVALID_PAYLOAD
-}
-
-enum JobRunExecutionReason {
-  PREPROCESS
-  EXECUTE_JOB
-}
-
-enum JobRunExecutionStatus {
-  PENDING
-  STARTED
-  SUCCESS
-  FAILURE
-}
-
-enum TaskStatus {
-  PENDING
-  WAITING
-  RUNNING
-  COMPLETED
-  ERRORED
-  CANCELED
-}
-
-enum TaskChildExecutionMode {
-  SEQUENTIAL
-  PARALLEL
-}
-
 model SecretReference {
   id       String              @id @default(cuid())
   key      String              @unique
@@ -439,12 +359,6 @@ model SecretStore {
   updatedAt DateTime @updatedAt
 
   @@index([key(ops: raw("text_pattern_ops"))], type: BTree)
-}
-
-enum TriggerChannel {
-  HTTP
-  SQS
-  SMTP
 }
 
 model DataMigration {

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -142,8 +142,6 @@ model Organization {
   hasRequestedV3 Boolean @default(false)
 
   environments RuntimeEnvironment[]
-  endpoints    Endpoint[]
-  jobs         Job[]
 
   apiRateLimiterConfig      Json?
   realtimeRateLimiterConfig Json?
@@ -351,10 +349,7 @@ model RuntimeEnvironment {
 
   tunnelId String?
 
-  endpoints                  Endpoint[]
-  JobQueue                   JobQueue[]
   ExternalAccount            ExternalAccount[]
-  concurrencyLimitGroups     ConcurrencyLimitGroup[]
   backgroundWorkers          BackgroundWorker[]
   backgroundWorkerTasks      BackgroundWorkerTask[]
   taskRuns                   TaskRun[]
@@ -418,8 +413,6 @@ model Project {
   defaultWorkerGroupId String?
 
   environments           RuntimeEnvironment[]
-  endpoints              Endpoint[]
-  jobs                   Job[]
   backgroundWorkers      BackgroundWorker[]
   backgroundWorkerTasks  BackgroundWorkerTask[]
   taskRuns               TaskRun[]
@@ -447,90 +440,9 @@ enum ProjectVersion {
   V3
 }
 
-model Endpoint {
-  id   String  @id @default(cuid())
-  slug String
-  url  String?
-
-  environment   RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  environmentId String
-
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  organizationId String
-
-  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  projectId String
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  indexingHookIdentifier String?
-  version                String  @default("unknown")
-  sdkVersion             String  @default("unknown")
-
-  runChunkExecutionLimit      Int @default(60000)
-  startTaskThreshold          Int @default(750)
-  beforeExecuteTaskThreshold  Int @default(1500)
-  beforeCompleteTaskThreshold Int @default(750)
-  afterCompleteTaskThreshold  Int @default(750)
-
-  @@unique([environmentId, slug])
-}
-
-model Job {
-  id       String  @id @default(cuid())
-  slug     String
-  title    String
-  internal Boolean @default(false)
-
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  organizationId String
-
-  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  projectId String
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
-
-  deletedAt DateTime?
-
-  @@unique([projectId, slug])
-}
-
 enum JobVersionStatus {
   ACTIVE
   DISABLED
-}
-
-model ConcurrencyLimitGroup {
-  id   String @id @default(cuid())
-  name String
-
-  concurrencyLimit Int
-
-  environment   RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  environmentId String
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@unique([environmentId, name])
-}
-
-model JobQueue {
-  id   String @id @default(cuid())
-  name String
-
-  environment   RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  environmentId String
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  jobCount Int @default(0)
-  maxJobs  Int @default(100)
-
-  @@unique([environmentId, name])
 }
 
 enum DynamicTriggerType {

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -144,7 +144,6 @@ model Organization {
   environments RuntimeEnvironment[]
   endpoints    Endpoint[]
   jobs         Job[]
-  jobVersions  JobVersion[]
 
   apiRateLimiterConfig      Json?
   realtimeRateLimiterConfig Json?
@@ -353,7 +352,6 @@ model RuntimeEnvironment {
   tunnelId String?
 
   endpoints                  Endpoint[]
-  jobVersions                JobVersion[]
   JobQueue                   JobQueue[]
   ExternalAccount            ExternalAccount[]
   concurrencyLimitGroups     ConcurrencyLimitGroup[]
@@ -422,8 +420,6 @@ model Project {
   environments           RuntimeEnvironment[]
   endpoints              Endpoint[]
   jobs                   Job[]
-  jobVersion             JobVersion[]
-  httpEndpoints          TriggerHttpEndpoint[]
   backgroundWorkers      BackgroundWorker[]
   backgroundWorkerTasks  BackgroundWorkerTask[]
   taskRuns               TaskRun[]
@@ -478,8 +474,6 @@ model Endpoint {
   beforeCompleteTaskThreshold Int @default(750)
   afterCompleteTaskThreshold  Int @default(750)
 
-  jobVersions JobVersion[]
-
   @@unique([environmentId, slug])
 }
 
@@ -495,56 +489,12 @@ model Job {
   project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   projectId String
 
-  versions JobVersion[]
-
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
   deletedAt DateTime?
 
   @@unique([projectId, slug])
-}
-
-model JobVersion {
-  id                 String @id @default(cuid())
-  version            String
-  eventSpecification Json
-
-  properties  Json?
-  triggerLink String?
-  triggerHelp Json?
-
-  job   Job    @relation(fields: [jobId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  jobId String
-
-  endpoint   Endpoint @relation(fields: [endpointId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  endpointId String
-
-  environment   RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  environmentId String
-
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  organizationId String
-
-  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  projectId String
-
-  queue   JobQueue? @relation(fields: [queueId], references: [id])
-  queueId String?
-
-  startPosition  JobStartPosition @default(INITIAL)
-  preprocessRuns Boolean          @default(false)
-
-  concurrencyLimit        Int?
-  concurrencyLimitGroup   ConcurrencyLimitGroup? @relation(fields: [concurrencyLimitGroupId], references: [id])
-  concurrencyLimitGroupId String?
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  status JobVersionStatus @default(ACTIVE)
-
-  @@unique([jobId, version, environmentId])
 }
 
 enum JobVersionStatus {
@@ -564,8 +514,6 @@ model ConcurrencyLimitGroup {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  jobVersion JobVersion[]
-
   @@unique([environmentId, name])
 }
 
@@ -581,8 +529,6 @@ model JobQueue {
 
   jobCount Int @default(0)
   maxJobs  Int @default(100)
-
-  jobVersion JobVersion[]
 
   @@unique([environmentId, name])
 }
@@ -652,7 +598,6 @@ model SecretReference {
   provider SecretStoreProvider @default(DATABASE)
 
   integrations              Integration[]
-  httpEndpoints             TriggerHttpEndpoint[]
   environmentVariableValues EnvironmentVariableValue[]
 
   createdAt               DateTime                  @default(now())
@@ -680,27 +625,6 @@ enum TriggerChannel {
   HTTP
   SQS
   SMTP
-}
-
-model TriggerHttpEndpoint {
-  id String @id @default(cuid())
-
-  key String
-
-  title      String?
-  icon       String?
-  properties Json?
-
-  secretReference   SecretReference @relation(fields: [secretReferenceId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  secretReferenceId String
-
-  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  projectId String
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@unique([key, projectId])
 }
 
 model DataMigration {

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -257,7 +257,6 @@ model Integration {
 
   connections   IntegrationConnection[]
   sources       TriggerSource[]
-  webhooks      Webhook[]
   RunConnection RunConnection[]
 
   @@unique([organizationId, slug])
@@ -476,7 +475,6 @@ model Project {
   runs                   JobRun[]
   sources                TriggerSource[]
   httpEndpoints          TriggerHttpEndpoint[]
-  webhooks               Webhook[]
   backgroundWorkers      BackgroundWorker[]
   backgroundWorkerTasks  BackgroundWorkerTask[]
   taskRuns               TaskRun[]
@@ -668,8 +666,6 @@ model RunConnection {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  tasks Task[]
-
   @@unique([runId, key])
 }
 
@@ -828,7 +824,6 @@ model JobRun {
 
   forceYieldImmediately Boolean @default(false)
 
-  tasks          Task[]
   runConnections RunConnection[]
 
   @@index([jobId, createdAt(sort: Desc)], map: "idx_jobrun_jobId_createdAt")
@@ -865,52 +860,6 @@ enum JobRunExecutionStatus {
   STARTED
   SUCCESS
   FAILURE
-}
-
-model Task {
-  id             String  @id
-  idempotencyKey String
-  displayKey     String?
-  name           String
-  icon           String?
-
-  status     TaskStatus @default(PENDING)
-  delayUntil DateTime?
-  noop       Boolean    @default(false)
-
-  description       String?
-  properties        Json?
-  outputProperties  Json?
-  params            Json?
-  output            Json?
-  outputIsUndefined Boolean @default(false)
-  context           Json?
-  error             String?
-  redact            Json?
-  style             Json?
-  operation         String?
-  callbackUrl       String?
-
-  startedAt   DateTime?
-  completedAt DateTime?
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  run   JobRun @relation(fields: [runId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  runId String
-
-  parent   Task?   @relation("TaskParent", fields: [parentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  parentId String?
-
-  runConnection   RunConnection? @relation(fields: [runConnectionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  runConnectionId String?
-
-  children           Task[]                 @relation("TaskParent")
-  childExecutionMode TaskChildExecutionMode @default(SEQUENTIAL)
-
-  @@unique([runId, idempotencyKey])
-  @@index([parentId], map: "idx_task_parentId")
 }
 
 enum TaskStatus {
@@ -1017,29 +966,6 @@ enum TriggerChannel {
   SMTP
 }
 
-model Webhook {
-  id String @id @default(cuid())
-
-  active Boolean @default(false)
-
-  key    String
-  params Json?
-
-  httpEndpoint   TriggerHttpEndpoint @relation(fields: [httpEndpointId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  httpEndpointId String              @unique
-
-  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  projectId String
-
-  integration   Integration @relation(fields: [integrationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  integrationId String
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@unique([key, projectId])
-}
-
 model TriggerHttpEndpoint {
   id String @id @default(cuid())
 
@@ -1048,8 +974,6 @@ model TriggerHttpEndpoint {
   title      String?
   icon       String?
   properties Json?
-
-  webhook Webhook?
 
   secretReference   SecretReference @relation(fields: [secretReferenceId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   secretReferenceId String

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -181,7 +181,6 @@ model ExternalAccount {
   connections     IntegrationConnection[]
   events          EventRecord[]
   runs            JobRun[]
-  schedules       ScheduleSource[]
   triggerSources  TriggerSource[]
   EventDispatcher EventDispatcher[]
 
@@ -405,11 +404,9 @@ model RuntimeEnvironment {
   JobQueue                   JobQueue[]
   sources                    TriggerSource[]
   eventDispatchers           EventDispatcher[]
-  scheduleSources            ScheduleSource[]
   ExternalAccount            ExternalAccount[]
   httpEndpointEnvironments   TriggerHttpEndpointEnvironment[]
   concurrencyLimitGroups     ConcurrencyLimitGroup[]
-  webhookEnvironments        WebhookEnvironment[]
   backgroundWorkers          BackgroundWorker[]
   backgroundWorkerTasks      BackgroundWorkerTask[]
   taskRuns                   TaskRun[]
@@ -540,7 +537,6 @@ model Endpoint {
   dynamictriggers          DynamicTrigger[]
   sources                  TriggerSource[]
   httpEndpointEnvironments TriggerHttpEndpointEnvironment[]
-  webhookEnvironments      WebhookEnvironment[]
 
   @@unique([environmentId, slug])
 }
@@ -687,9 +683,8 @@ model DynamicTrigger {
   endpoint   Endpoint @relation(fields: [endpointId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   endpointId String
 
-  jobs            Job[]
-  sources         TriggerSource[]
-  scheduleSources ScheduleSource[]
+  jobs    Job[]
+  sources TriggerSource[]
 
   sourceRegistrationJob   JobVersion? @relation(fields: [sourceRegistrationJobId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   sourceRegistrationJobId String?
@@ -720,8 +715,6 @@ model EventDispatcher {
 
   environment   RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   environmentId String
-
-  scheduleSources ScheduleSource[]
 
   externalAccount   ExternalAccount? @relation(fields: [externalAccountId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   externalAccountId String?
@@ -842,7 +835,6 @@ model JobRun {
 
   tasks          Task[]
   runConnections RunConnection[]
-  executions     JobRunExecution[]
 
   @@index([jobId, createdAt(sort: Desc)], map: "idx_jobrun_jobId_createdAt")
   @@index([organizationId, createdAt], map: "idx_jobrun_organizationId_createdAt")
@@ -866,34 +858,6 @@ enum JobRunStatus {
   CANCELED
   UNRESOLVED_AUTH
   INVALID_PAYLOAD
-}
-
-model JobRunExecution {
-  id String @id @default(cuid())
-
-  run   JobRun @relation(fields: [runId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  runId String
-
-  retryCount     Int @default(0)
-  retryLimit     Int @default(0)
-  retryDelayInMs Int @default(0)
-
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
-  startedAt   DateTime?
-  completedAt DateTime?
-
-  error String?
-
-  reason JobRunExecutionReason @default(EXECUTE_JOB)
-  status JobRunExecutionStatus @default(PENDING)
-
-  resumeTask   Task?   @relation(fields: [resumeTaskId], references: [id], onDelete: SetNull, onUpdate: Cascade)
-  resumeTaskId String?
-
-  graphileJobId String?
-
-  isRetry Boolean @default(false)
 }
 
 enum JobRunExecutionReason {
@@ -949,7 +913,6 @@ model Task {
 
   children           Task[]                 @relation("TaskParent")
   childExecutionMode TaskChildExecutionMode @default(SEQUENTIAL)
-  executions         JobRunExecution[]
 
   @@unique([runId, idempotencyKey])
   @@index([parentId], map: "idx_task_parentId")
@@ -1067,8 +1030,6 @@ model Webhook {
   key    String
   params Json?
 
-  webhookEnvironments WebhookEnvironment[]
-
   httpEndpoint   TriggerHttpEndpoint @relation(fields: [httpEndpointId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   httpEndpointId String              @unique
 
@@ -1082,62 +1043,6 @@ model Webhook {
   updatedAt DateTime @updatedAt
 
   @@unique([key, projectId])
-}
-
-model WebhookEnvironment {
-  id String @id @default(cuid())
-
-  active Boolean @default(false)
-
-  config        Json?
-  desiredConfig Json?
-
-  endpoint   Endpoint @relation(fields: [endpointId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  endpointId String
-
-  environment   RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  environmentId String
-
-  webhook   Webhook @relation(fields: [webhookId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  webhookId String
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@unique([environmentId, webhookId])
-}
-
-model ScheduleSource {
-  id String @id @default(cuid())
-
-  key      String
-  schedule Json
-
-  environment   RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  environmentId String
-
-  dispatcher   EventDispatcher @relation(fields: [dispatcherId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  dispatcherId String
-
-  lastEventTimestamp DateTime?
-  nextEventTimestamp DateTime?
-
-  workerJobId String?
-
-  active Boolean @default(false)
-
-  metadata Json?
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  dynamicTrigger   DynamicTrigger? @relation(fields: [dynamicTriggerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  dynamicTriggerId String?
-
-  externalAccount   ExternalAccount? @relation(fields: [externalAccountId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  externalAccountId String?
-
-  @@unique([key, environmentId])
 }
 
 model TriggerHttpEndpoint {

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -528,7 +528,8 @@ model TaskRun {
   lockedQueueId String?
 
   /// The main queue that this run is part of
-  workerQueue          String  @default("main") @map("masterQueue")
+  workerQueue String @default("main") @map("masterQueue")
+
   /// @deprecated
   secondaryMasterQueue String?
 

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -145,8 +145,6 @@ model Organization {
   endpoints    Endpoint[]
   jobs         Job[]
   jobVersions  JobVersion[]
-  events       EventRecord[]
-  jobRuns      JobRun[]
 
   apiRateLimiterConfig      Json?
   realtimeRateLimiterConfig Json?
@@ -175,10 +173,6 @@ model ExternalAccount {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-
-  events          EventRecord[]
-  runs            JobRun[]
-  EventDispatcher EventDispatcher[]
 
   @@unique([environmentId, identifier])
 }
@@ -360,10 +354,7 @@ model RuntimeEnvironment {
 
   endpoints                  Endpoint[]
   jobVersions                JobVersion[]
-  events                     EventRecord[]
-  jobRuns                    JobRun[]
   JobQueue                   JobQueue[]
-  eventDispatchers           EventDispatcher[]
   ExternalAccount            ExternalAccount[]
   concurrencyLimitGroups     ConcurrencyLimitGroup[]
   backgroundWorkers          BackgroundWorker[]
@@ -432,8 +423,6 @@ model Project {
   endpoints              Endpoint[]
   jobs                   Job[]
   jobVersion             JobVersion[]
-  events                 EventRecord[]
-  runs                   JobRun[]
   httpEndpoints          TriggerHttpEndpoint[]
   backgroundWorkers      BackgroundWorker[]
   backgroundWorkerTasks  BackgroundWorkerTask[]
@@ -489,9 +478,7 @@ model Endpoint {
   beforeCompleteTaskThreshold Int @default(750)
   afterCompleteTaskThreshold  Int @default(750)
 
-  jobVersions     JobVersion[]
-  jobRuns         JobRun[]
-  dynamictriggers DynamicTrigger[]
+  jobVersions JobVersion[]
 
   @@unique([environmentId, slug])
 }
@@ -508,9 +495,7 @@ model Job {
   project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   projectId String
 
-  versions        JobVersion[]
-  runs            JobRun[]
-  dynamicTriggers DynamicTrigger[]
+  versions JobVersion[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
@@ -557,9 +542,6 @@ model JobVersion {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  runs            JobRun[]
-  dynamicTriggers DynamicTrigger[]
-
   status JobVersionStatus @default(ACTIVE)
 
   @@unique([jobId, version, environmentId])
@@ -600,26 +582,9 @@ model JobQueue {
   jobCount Int @default(0)
   maxJobs  Int @default(100)
 
-  runs       JobRun[]
   jobVersion JobVersion[]
 
   @@unique([environmentId, name])
-}
-
-model DynamicTrigger {
-  id   String             @id @default(cuid())
-  type DynamicTriggerType @default(EVENT)
-  slug String
-
-  endpoint   Endpoint @relation(fields: [endpointId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  endpointId String
-
-  jobs Job[]
-
-  sourceRegistrationJob   JobVersion? @relation(fields: [sourceRegistrationJobId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  sourceRegistrationJobId String?
-
-  @@unique([endpointId, slug, type])
 }
 
 enum DynamicTriggerType {
@@ -627,143 +592,14 @@ enum DynamicTriggerType {
   SCHEDULE
 }
 
-model EventDispatcher {
-  id            String   @id @default(cuid())
-  event         String[]
-  source        String
-  payloadFilter Json?
-  contextFilter Json?
-  manual        Boolean  @default(false)
-
-  dispatchableId String
-  dispatchable   Json
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  enabled Boolean @default(true)
-
-  environment   RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  environmentId String
-
-  externalAccount   ExternalAccount? @relation(fields: [externalAccountId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  externalAccountId String?
-
-  @@unique([dispatchableId, environmentId])
-}
-
 enum JobStartPosition {
   INITIAL
   LATEST
 }
 
-model EventRecord {
-  id            String      @id @default(cuid())
-  eventId       String
-  name          String
-  timestamp     DateTime    @default(now())
-  payload       Json
-  payloadType   PayloadType @default(JSON)
-  context       Json?
-  sourceContext Json?
-
-  source String @default("trigger.dev")
-
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  organizationId String
-
-  environment   RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  environmentId String
-
-  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  projectId String
-
-  externalAccount   ExternalAccount? @relation(fields: [externalAccountId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  externalAccountId String?
-
-  httpEndpoint   TriggerHttpEndpoint? @relation(fields: [httpEndpointId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  httpEndpointId String?
-
-  deliverAt   DateTime  @default(now())
-  deliveredAt DateTime?
-
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
-  cancelledAt DateTime?
-
-  isTest   Boolean  @default(false)
-  internal Boolean  @default(false)
-  runs     JobRun[]
-
-  @@unique([eventId, environmentId])
-}
-
 enum PayloadType {
   JSON
   REQUEST
-}
-
-model JobRun {
-  id       String  @id @default(cuid())
-  number   Int?
-  internal Boolean @default(false)
-
-  job   Job    @relation(fields: [jobId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  jobId String
-
-  version   JobVersion @relation(fields: [versionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  versionId String
-
-  event   EventRecord @relation(fields: [eventId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  eventId String
-
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  organizationId String
-
-  endpoint   Endpoint @relation(fields: [endpointId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  endpointId String
-
-  environment   RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  environmentId String
-
-  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  projectId String
-
-  queue   JobQueue? @relation(fields: [queueId], references: [id])
-  queueId String?
-
-  externalAccount   ExternalAccount? @relation(fields: [externalAccountId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  externalAccountId String?
-
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
-  queuedAt    DateTime?
-  startedAt   DateTime?
-  completedAt DateTime?
-
-  properties Json?
-
-  status JobRunStatus @default(PENDING)
-  output Json?
-
-  timedOutAt     DateTime?
-  timedOutReason String?
-
-  executionCount        Int @default(0)
-  executionFailureCount Int @default(0)
-  executionDuration     Int @default(0)
-
-  isTest     Boolean @default(false)
-  preprocess Boolean @default(false)
-
-  yieldedExecutions String[]
-
-  forceYieldImmediately Boolean @default(false)
-
-  @@index([jobId, createdAt(sort: Desc)], map: "idx_jobrun_jobId_createdAt")
-  @@index([organizationId, createdAt], map: "idx_jobrun_organizationId_createdAt")
-  @@index([versionId], map: "idx_jobrun_versionId")
-  @@index([eventId], map: "JobRun_eventId_idx")
 }
 
 enum JobRunStatus {
@@ -863,8 +699,6 @@ model TriggerHttpEndpoint {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-
-  eventRecords EventRecord[]
 
   @@unique([key, projectId])
 }

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -142,7 +142,6 @@ model Organization {
   hasRequestedV3 Boolean @default(false)
 
   environments RuntimeEnvironment[]
-  connections  IntegrationConnection[]
   endpoints    Endpoint[]
   jobs         Job[]
   jobVersions  JobVersion[]
@@ -177,7 +176,6 @@ model ExternalAccount {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  connections     IntegrationConnection[]
   events          EventRecord[]
   runs            JobRun[]
   EventDispatcher EventDispatcher[]
@@ -253,8 +251,6 @@ model Integration {
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   organizationId String
 
-  connections IntegrationConnection[]
-
   @@unique([organizationId, slug])
 }
 
@@ -267,34 +263,6 @@ enum IntegrationAuthSource {
 enum IntegrationSetupStatus {
   MISSING_FIELDS
   COMPLETE
-}
-
-model IntegrationConnection {
-  id String @id @default(cuid())
-
-  connectionType ConnectionType @default(DEVELOPER)
-
-  expiresAt DateTime?
-  metadata  Json
-  scopes    String[]
-
-  dataReference   SecretReference @relation(fields: [dataReferenceId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  dataReferenceId String
-
-  integration   Integration @relation(fields: [integrationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  integrationId String
-
-  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  organizationId String
-
-  externalAccount   ExternalAccount? @relation(fields: [externalAccountId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  externalAccountId String?
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  /// If enabled is false, OAuth refreshing will not be attempted
-  enabled Boolean @default(true)
 }
 
 enum ConnectionType {
@@ -847,7 +815,6 @@ model SecretReference {
   key      String              @unique
   provider SecretStoreProvider @default(DATABASE)
 
-  connections               IntegrationConnection[]
   integrations              Integration[]
   httpEndpoints             TriggerHttpEndpoint[]
   environmentVariableValues EnvironmentVariableValue[]


### PR DESCRIPTION
Removed v2 models from the schema in a safe way (migrations can be run manually on the database before actually applying the migrations during deploy). Takes the schema down from 22,268 tokens (93378 characters) to 14,317 tokens (59810 characters), a savings of 35.7%