### PR TITLE
Docs: Adds 2 references to the node.js versions we use for v3 and v4

### DIFF
--- a/docs/config/config-file.mdx
+++ b/docs/config/config-file.mdx
@@ -6,6 +6,7 @@ description: "This file is used to configure your project and how it's built."
 
 import ScrapingWarning from "/snippets/web-scraping-warning.mdx";
 import BundlePackages from "/snippets/bundle-packages.mdx";
+import NodeVersions from "/snippets/node-versions.mdx";
 
 The `trigger.config.ts` file is used to configure your Trigger.dev project. It is a TypeScript file at the root of your project that exports a default configuration object. Here's an example:
 
@@ -244,6 +245,10 @@ export default defineConfig({
 ```
 
 See our [Bun guide](/guides/frameworks/bun) for more information.
+
+### Node.js versions
+
+<NodeVersions />
 
 ## Default machine
 

--- a/docs/snippets/node-versions.mdx
+++ b/docs/snippets/node-versions.mdx
@@ -1,16 +1,4 @@
-Trigger.dev runs your tasks on specific Node.js versions depending on the version you're using:
+Trigger.dev runs your tasks on specific Node.js versions:
 
 - **v3**: Uses Node.js `21.7.3`
-- **v4**: Uses Node.js `21.7.3` by default, or Node.js `22.12.0` if you set `runtime: "node-22"` in your `trigger.config.ts` 
-
-In v4, you can specify `runtime: "node-22"` to use Node.js 22 like this:
-
-```ts trigger.config.ts
-import { defineConfig } from "@trigger.dev/sdk/v3";
-
-export default defineConfig({
-  project: "<project ref>",
-  // Your other config settings...
-  runtime: "node-22", // Uses Node.js 22.12.0
-});
-```
+- **v4**: Uses Node.js `21.7.3` 

--- a/docs/snippets/node-versions.mdx
+++ b/docs/snippets/node-versions.mdx
@@ -1,0 +1,16 @@
+Trigger.dev runs your tasks on specific Node.js versions depending on the version you're using:
+
+- **v3**: Uses Node.js `21.7.3`
+- **v4**: Uses Node.js `21.7.3` by default, or Node.js `22.12.0` if you set `runtime: "node-22"` in your `trigger.config.ts` 
+
+In v4, you can specify `runtime: "node-22"` to use Node.js 22 like this:
+
+```ts trigger.config.ts
+import { defineConfig } from "@trigger.dev/sdk/v3";
+
+export default defineConfig({
+  project: "<project ref>",
+  // Your other config settings...
+  runtime: "node-22", // Uses Node.js 22.12.0
+});
+```

--- a/docs/upgrade-to-v4.mdx
+++ b/docs/upgrade-to-v4.mdx
@@ -9,7 +9,7 @@ import NodeVersions from "/snippets/node-versions.mdx";
 
 [Read our blog post](https://trigger.dev/blog/v4-beta-launch) for an overview of the new features.
 
-### Node.js 22 support
+### Node.js support
 
 <NodeVersions />
 

--- a/docs/upgrade-to-v4.mdx
+++ b/docs/upgrade-to-v4.mdx
@@ -3,9 +3,15 @@ title: "Upgrading to v4"
 description: "What's new in v4, how to upgrade, and breaking changes."
 ---
 
+import NodeVersions from "/snippets/node-versions.mdx";
+
 ## What's new in v4?
 
 [Read our blog post](https://trigger.dev/blog/v4-beta-launch) for an overview of the new features.
+
+### Node.js 22 support
+
+<NodeVersions />
 
 ### Wait tokens
 


### PR DESCRIPTION
Adds a snippet to show which node.js versions we use in v3 and v4. Snippet has been added to: 

- config-file.mdx
- upgrade-to-v4.mdx
