### PR TITLE
Fix metrics format

### DIFF
--- a/apps/webapp/app/routes/metrics.ts
+++ b/apps/webapp/app/routes/metrics.ts
@@ -13,7 +13,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     }
   }
 
-  const prismaMetrics = await prisma.$metrics.prometheus();
+  // We need to remove empty lines from the prisma metrics, grafana doesn't like them
+  const prismaMetrics = (await prisma.$metrics.prometheus()).replace(/^\s*[\r\n]/gm, "");
   const coreMetrics = await metricsRegister.metrics();
 
   // Order matters, core metrics end with `# EOF`, prisma metrics don't

--- a/apps/webapp/app/routes/metrics.ts
+++ b/apps/webapp/app/routes/metrics.ts
@@ -16,7 +16,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const prismaMetrics = await prisma.$metrics.prometheus();
   const coreMetrics = await metricsRegister.metrics();
 
-  return new Response(coreMetrics + prismaMetrics, {
+  // Order matters, core metrics end with `# EOF`, prisma metrics don't
+  const metrics = prismaMetrics + coreMetrics;
+
+  return new Response(metrics, {
     headers: {
       "Content-Type": metricsRegister.contentType,
     },


### PR DESCRIPTION
Grafana requires:
- `# EOF` marker at the end
- No empty lines