### PR TITLE
Sync env vars (parent env vars)

### DIFF
--- a/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
@@ -69,6 +69,7 @@ export class ScheduleListPresenter extends BasePresenter {
             type: true,
             slug: true,
             branchName: true,
+            archivedAt: true,
             orgMember: {
               select: {
                 user: {

--- a/apps/webapp/app/routes/api.v1.projects.$projectRef.envvars.$slug.import.ts
+++ b/apps/webapp/app/routes/api.v1.projects.$projectRef.envvars.$slug.import.ts
@@ -60,7 +60,7 @@ export async function action({ params, request }: ActionFunctionArgs) {
     let childFailure = !result.success ? result : undefined;
     let parentFailure = !parentResult.success ? parentResult : undefined;
 
-    if (result.success && parentResult.success) {
+    if (result.success || parentResult.success) {
       return json({ success: true });
     } else {
       return json(

--- a/apps/webapp/app/routes/api.v1.projects.$projectRef.envvars.$slug.import.ts
+++ b/apps/webapp/app/routes/api.v1.projects.$projectRef.envvars.$slug.import.ts
@@ -47,6 +47,32 @@ export async function action({ params, request }: ActionFunctionArgs) {
     })),
   });
 
+  if (environment.parentEnvironmentId && body.parentVariables) {
+    const parentResult = await repository.create(environment.project.id, {
+      override: typeof body.override === "boolean" ? body.override : false,
+      environmentIds: [environment.parentEnvironmentId],
+      variables: Object.entries(body.parentVariables).map(([key, value]) => ({
+        key,
+        value,
+      })),
+    });
+
+    let childFailure = !result.success ? result : undefined;
+    let parentFailure = !parentResult.success ? parentResult : undefined;
+
+    if (result.success && parentResult.success) {
+      return json({ success: true });
+    } else {
+      return json(
+        {
+          error: childFailure?.error || parentFailure?.error || "Unknown error",
+          variableErrors: childFailure?.variableErrors || parentFailure?.variableErrors,
+        },
+        { status: 400 }
+      );
+    }
+  }
+
   if (result.success) {
     return json({ success: true });
   } else {

--- a/apps/webapp/app/v3/services/checkSchedule.server.ts
+++ b/apps/webapp/app/v3/services/checkSchedule.server.ts
@@ -108,9 +108,11 @@ export class CheckScheduleService extends BaseService {
     environments,
   }: {
     prisma: PrismaClientOrTransaction;
-    environments: { id: string; type: RuntimeEnvironmentType }[];
+    environments: { id: string; type: RuntimeEnvironmentType; archivedAt: Date | null }[];
   }) {
-    const deployedEnvironments = environments.filter((env) => env.type !== "DEVELOPMENT");
+    const deployedEnvironments = environments.filter(
+      (env) => env.type !== "DEVELOPMENT" && !env.archivedAt
+    );
     const schedulesCount = await prisma.taskScheduleInstance.count({
       where: {
         environmentId: {

--- a/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
@@ -146,6 +146,11 @@ export class CreateBackgroundWorkerService extends BaseService {
           backgroundWorker,
           environment,
         });
+
+        if (schedulesError instanceof ServiceValidationError) {
+          throw schedulesError;
+        }
+
         throw new ServiceValidationError("Error syncing declarative schedules");
       }
 

--- a/apps/webapp/app/v3/services/createDeploymentBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createDeploymentBackgroundWorker.server.ts
@@ -114,7 +114,10 @@ export class CreateDeploymentBackgroundWorkerService extends BaseService {
           error: schedulesError,
         });
 
-        const serviceError = new ServiceValidationError("Error syncing declarative schedules");
+        const serviceError =
+          schedulesError instanceof ServiceValidationError
+            ? schedulesError
+            : new ServiceValidationError("Error syncing declarative schedules");
 
         await this.#failBackgroundWorkerDeployment(deployment, serviceError);
 

--- a/packages/build/src/extensions/core/syncEnvVars.ts
+++ b/packages/build/src/extensions/core/syncEnvVars.ts
@@ -114,12 +114,6 @@ export function syncEnvVars(fn: SyncEnvVarsFunction, options?: SyncEnvVarsOption
         $spinner.stop(`Found ${numberOfEnvVars} env vars to sync`);
       }
 
-      context.logger.debug("syncEnvVars", {
-        env,
-        parentEnv,
-        numberOfEnvVars,
-      });
-
       context.addLayer({
         id: "sync-env-vars",
         deploy: {

--- a/packages/build/src/extensions/core/syncEnvVars.ts
+++ b/packages/build/src/extensions/core/syncEnvVars.ts
@@ -1,6 +1,8 @@
 import { BuildContext, BuildExtension } from "@trigger.dev/core/v3/build";
 
-export type SyncEnvVarsBody = Record<string, string> | Array<{ name: string; value: string }>;
+export type SyncEnvVarsBody =
+  | Record<string, string>
+  | Array<{ name: string; value: string; isParentEnv?: boolean }>;
 
 export type SyncEnvVarsResult =
   | SyncEnvVarsBody
@@ -96,24 +98,11 @@ export function syncEnvVars(fn: SyncEnvVarsFunction, options?: SyncEnvVarsOption
         return;
       }
 
-      const env = Object.entries(result).reduce(
-        (acc, [key, value]) => {
-          if (UNSYNCABLE_ENV_VARS.includes(key)) {
-            return acc;
-          }
+      const env = stripUnsyncableEnvVars(result.env);
+      const parentEnv = result.parentEnv ? stripUnsyncableEnvVars(result.parentEnv) : undefined;
 
-          // Strip out any TRIGGER_ prefix env vars
-          if (UNSYNCABLE_ENV_VARS_PREFIXES.some((prefix) => key.startsWith(prefix))) {
-            return acc;
-          }
-
-          acc[key] = value;
-          return acc;
-        },
-        {} as Record<string, string>
-      );
-
-      const numberOfEnvVars = Object.keys(env).length;
+      const numberOfEnvVars =
+        Object.keys(env).length + (parentEnv ? Object.keys(parentEnv).length : 0);
 
       if (numberOfEnvVars === 0) {
         $spinner.stop("No env vars detected");
@@ -125,15 +114,41 @@ export function syncEnvVars(fn: SyncEnvVarsFunction, options?: SyncEnvVarsOption
         $spinner.stop(`Found ${numberOfEnvVars} env vars to sync`);
       }
 
+      context.logger.debug("syncEnvVars", {
+        env,
+        parentEnv,
+        numberOfEnvVars,
+      });
+
       context.addLayer({
         id: "sync-env-vars",
         deploy: {
           env,
+          parentEnv,
           override: options?.override ?? true,
         },
       });
     },
   };
+}
+
+function stripUnsyncableEnvVars(env: Record<string, string>): Record<string, string> {
+  return Object.entries(env).reduce(
+    (acc, [key, value]) => {
+      if (UNSYNCABLE_ENV_VARS.includes(key)) {
+        return acc;
+      }
+
+      // Strip out any TRIGGER_ prefix env vars
+      if (UNSYNCABLE_ENV_VARS_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+        return acc;
+      }
+
+      acc[key] = value;
+      return acc;
+    },
+    {} as Record<string, string>
+  );
 }
 
 async function callSyncEnvVarsFn(
@@ -142,9 +157,11 @@ async function callSyncEnvVarsFn(
   environment: string,
   branch: string | undefined,
   context: BuildContext
-): Promise<Record<string, string> | undefined> {
+): Promise<{ env: Record<string, string>; parentEnv?: Record<string, string> } | undefined> {
   if (syncEnvVarsFn && typeof syncEnvVarsFn === "function") {
-    let resolvedEnvVars: Record<string, string> = {};
+    let resolvedEnvVars: { env: Record<string, string>; parentEnv?: Record<string, string> } = {
+      env: {},
+    };
     let result;
 
     try {
@@ -172,11 +189,18 @@ async function callSyncEnvVarsFn(
           typeof item.name === "string" &&
           typeof item.value === "string"
         ) {
-          resolvedEnvVars[item.name] = item.value;
+          if (item.isParentEnv) {
+            if (!resolvedEnvVars.parentEnv) {
+              resolvedEnvVars.parentEnv = {};
+            }
+            resolvedEnvVars.parentEnv[item.name] = item.value;
+          } else {
+            resolvedEnvVars.env[item.name] = item.value;
+          }
         }
       }
     } else if (result) {
-      resolvedEnvVars = result;
+      resolvedEnvVars.env = result;
     }
 
     return resolvedEnvVars;

--- a/packages/cli-v3/src/build/extensions.ts
+++ b/packages/cli-v3/src/build/extensions.ts
@@ -143,6 +143,7 @@ function applyLayerToManifest(layer: BuildLayer, manifest: BuildManifest): Build
     $manifest.deploy.env ??= {};
     $manifest.deploy.sync ??= {};
     $manifest.deploy.sync.env ??= {};
+    $manifest.deploy.sync.parentEnv ??= {};
 
     for (const [key, value] of Object.entries(layer.deploy.env)) {
       if (!value) {
@@ -154,6 +155,26 @@ function applyLayerToManifest(layer: BuildLayer, manifest: BuildManifest): Build
 
         if (existingValue !== value) {
           $manifest.deploy.sync.env[key] = value;
+        }
+      }
+    }
+  }
+
+  if (layer.deploy?.parentEnv) {
+    $manifest.deploy.env ??= {};
+    $manifest.deploy.sync ??= {};
+    $manifest.deploy.sync.parentEnv ??= {};
+
+    for (const [key, value] of Object.entries(layer.deploy.parentEnv)) {
+      if (!value) {
+        continue;
+      }
+
+      if (layer.deploy.override || $manifest.deploy.env[key] === undefined) {
+        const existingValue = $manifest.deploy.env[key];
+
+        if (existingValue !== value) {
+          $manifest.deploy.sync.parentEnv[key] = value;
         }
       }
     }

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -632,8 +632,6 @@ export async function syncEnvVarsWithServer(
     override: true,
   });
 
-  logger.debug("syncEnvVarsWithServer", uploadResult);
-
   return uploadResult.success;
 }
 

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -351,12 +351,17 @@ async function _deployCommand(dir: string, options: DeployCommandOptions) {
     }
   }
 
-  if (
+  const hasVarsToSync =
     buildManifest.deploy.sync &&
-    buildManifest.deploy.sync.env &&
-    Object.keys(buildManifest.deploy.sync.env).length > 0
-  ) {
-    const numberOfEnvVars = Object.keys(buildManifest.deploy.sync.env).length;
+    ((buildManifest.deploy.sync.env && Object.keys(buildManifest.deploy.sync.env).length > 0) ||
+      (buildManifest.deploy.sync.parentEnv &&
+        Object.keys(buildManifest.deploy.sync.parentEnv).length > 0));
+
+  if (hasVarsToSync) {
+    const childVars = buildManifest.deploy.sync?.env ?? {};
+    const parentVars = buildManifest.deploy.sync?.parentEnv ?? {};
+
+    const numberOfEnvVars = Object.keys(childVars).length + Object.keys(parentVars).length;
     const vars = numberOfEnvVars === 1 ? "var" : "vars";
 
     if (!options.skipSyncEnvVars) {
@@ -366,7 +371,8 @@ async function _deployCommand(dir: string, options: DeployCommandOptions) {
         projectClient.client,
         resolvedConfig.project,
         options.env,
-        buildManifest.deploy.sync.env
+        childVars,
+        parentVars
       );
 
       if (!success) {
@@ -495,21 +501,28 @@ async function _deployCommand(dir: string, options: DeployCommandOptions) {
       $spinner
     );
 
-    throw new SkipLoggingError("Failed to get deployment with worker");
+    throw new SkipLoggingError(getDeploymentResponse.error);
   }
 
   const deploymentWithWorker = getDeploymentResponse.data;
 
   if (!deploymentWithWorker.worker) {
+    const errorData = deploymentWithWorker.errorData
+      ? prepareDeploymentError(deploymentWithWorker.errorData)
+      : undefined;
+
     await failDeploy(
       projectClient.client,
       deployment,
-      { name: "DeploymentError", message: "Failed to get deployment with worker" },
+      {
+        name: "DeploymentError",
+        message: errorData?.message ?? "Failed to get deployment with worker",
+      },
       buildResult.logs,
       $spinner
     );
 
-    throw new SkipLoggingError("Failed to get deployment with worker");
+    throw new SkipLoggingError(errorData?.message ?? "Failed to get deployment with worker");
   }
 
   const imageReference = options.selfHosted
@@ -610,12 +623,16 @@ export async function syncEnvVarsWithServer(
   apiClient: CliApiClient,
   projectRef: string,
   environmentSlug: string,
-  envVars: Record<string, string>
+  envVars: Record<string, string>,
+  parentEnvVars?: Record<string, string>
 ) {
   const uploadResult = await apiClient.importEnvVars(projectRef, environmentSlug, {
     variables: envVars,
+    parentVariables: parentEnvVars,
     override: true,
   });
+
+  logger.debug("syncEnvVarsWithServer", uploadResult);
 
   return uploadResult.success;
 }
@@ -629,6 +646,8 @@ async function failDeploy(
   warnings?: string[],
   errors?: string[]
 ) {
+  logger.debug("failDeploy", { error, logs, warnings, errors });
+
   $spinner.stop(`Failed to deploy project`);
 
   const doOutputLogs = async (prefix: string = "Error") => {
@@ -688,7 +707,7 @@ async function failDeploy(
           : undefined;
 
         if (errorData) {
-          prettyError(errorData.name, errorData.stack, errorData.stderr);
+          prettyError(errorData.message, errorData.stack, errorData.stderr);
 
           if (logs.trim() !== "") {
             const logPath = await saveLogs(deployment.shortCode, logs);

--- a/packages/cli-v3/src/commands/workers/build.ts
+++ b/packages/cli-v3/src/commands/workers/build.ts
@@ -281,7 +281,8 @@ async function _workerBuildCommand(dir: string, options: WorkersBuildCommandOpti
         projectClient.client,
         resolvedConfig.project,
         options.env,
-        buildManifest.deploy.sync.env
+        buildManifest.deploy.sync.env,
+        buildManifest.deploy.sync.parentEnv
       );
 
       if (!success) {
@@ -456,10 +457,12 @@ export async function syncEnvVarsWithServer(
   apiClient: CliApiClient,
   projectRef: string,
   environmentSlug: string,
-  envVars: Record<string, string>
+  envVars: Record<string, string>,
+  parentEnvVars?: Record<string, string>
 ) {
   const uploadResult = await apiClient.importEnvVars(projectRef, environmentSlug, {
     variables: envVars,
+    parentVariables: parentEnvVars,
     override: true,
   });
 

--- a/packages/core/src/v3/build/extensions.ts
+++ b/packages/core/src/v3/build/extensions.ts
@@ -62,6 +62,7 @@ export interface BuildLayer {
   };
   deploy?: {
     env?: Record<string, string | undefined>;
+    parentEnv?: Record<string, string | undefined>;
     override?: boolean;
   };
   dependencies?: Record<string, string>;

--- a/packages/core/src/v3/schemas/api.ts
+++ b/packages/core/src/v3/schemas/api.ts
@@ -805,6 +805,7 @@ export type UpdateEnvironmentVariableRequestBody = z.infer<
 
 export const ImportEnvironmentVariablesRequestBody = z.object({
   variables: z.record(z.string()),
+  parentVariables: z.record(z.string()).optional(),
   override: z.boolean().optional(),
 });
 

--- a/packages/core/src/v3/schemas/build.ts
+++ b/packages/core/src/v3/schemas/build.ts
@@ -52,6 +52,7 @@ export const BuildManifest = z.object({
     sync: z
       .object({
         env: z.record(z.string()).optional(),
+        parentEnv: z.record(z.string()).optional(),
       })
       .optional(),
   }),

--- a/references/hello-world/trigger.config.ts
+++ b/references/hello-world/trigger.config.ts
@@ -24,7 +24,8 @@ export default defineConfig({
         console.log(ctx.branch);
         return [
           { name: "SYNC_ENV", value: ctx.environment },
-          { name: "BRANCH", value: ctx.branch ?? "–" },
+          { name: "BRANCH", value: ctx.branch ?? "NO_BRANCH" },
+          { name: "BRANCH", value: "PARENT", isParentEnv: true },
           { name: "SECRET_KEY", value: "secret-value" },
           { name: "ANOTHER_SECRET", value: "another-secret-value" },
         ];


### PR DESCRIPTION
syncEnvVars (and syncVercelEnvVars) would only sync the environment, not the parent environment's variables.

This is relevant for syncing preview env vars, where you want to set the "Preview" env vars AND the override for the specific environment (if there is an override).