### PR TITLE
Docs: Fixes incorrect embeded video width size

### DIFF
--- a/docs/guides/example-projects/realtime-fal-ai.mdx
+++ b/docs/guides/example-projects/realtime-fal-ai.mdx
@@ -31,7 +31,7 @@ This full stack Next.js project showcases the following:
 This video walks through the process of creating this task in a Next.js project.
 
 <iframe
-  width="100"
+  width="100%"
   height="315"
   src="https://www.youtube.com/embed/BWZqYfUaigg?si=XpqVUEIf1j4bsYZ4"
   title="Trigger.dev walkthrough"


### PR DESCRIPTION
The video width was collapsing too 100 px because the unit was missing from the width value.