### PR TITLE
Preview branches fix: set the branch header for the SDK realtime functions

### DIFF
--- a/packages/core/src/v3/apiClient/index.ts
+++ b/packages/core/src/v3/apiClient/index.ts
@@ -1016,10 +1016,14 @@ export class ApiClient {
   }
 
   #getRealtimeHeaders() {
-    const headers: Record<string, string> = {
+    let headers: Record<string, string> = {
       Authorization: `Bearer ${this.accessToken}`,
       "trigger-version": VERSION,
     };
+
+    if (this.previewBranch) {
+      headers["x-trigger-branch"] = this.previewBranch;
+    }
 
     return headers;
   }


### PR DESCRIPTION
Without the branch header it listens to the wrong environment