### PR TITLE
Fix syncing parent env vars for non-preview deployments

### DIFF
--- a/.changeset/witty-cherries-tan.md
+++ b/.changeset/witty-cherries-tan.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Fix `syncEnvVars` for non-preview deployments

--- a/apps/webapp/app/routes/api.v1.projects.$projectRef.envvars.$slug.import.ts
+++ b/apps/webapp/app/routes/api.v1.projects.$projectRef.envvars.$slug.import.ts
@@ -47,6 +47,7 @@ export async function action({ params, request }: ActionFunctionArgs) {
     })),
   });
 
+  // Only sync parent variables if this is a branch environment
   if (environment.parentEnvironmentId && body.parentVariables) {
     const parentResult = await repository.create(environment.project.id, {
       override: typeof body.override === "boolean" ? body.override : false,


### PR DESCRIPTION
If there are only parent env vars to sync and this isn't a preview deployment, we shouldn't try to sync at all.