### PR TITLE
Runtime agnostic SDK configuration via env vars

### DIFF
--- a/.changeset/flat-pianos-live.md
+++ b/.changeset/flat-pianos-live.md
@@ -1,0 +1,6 @@
+---
+"trigger.dev": patch
+"@trigger.dev/core": patch
+---
+
+Runtime agnostic SDK config via env vars

--- a/packages/core/src/v3/utils/getEnv.ts
+++ b/packages/core/src/v3/utils/getEnv.ts
@@ -1,10 +1,15 @@
-export function getEnvVar(name: string, defaultValue?: string): string | undefined {
-  // This could run in a non-Node.js environment (Bun, Deno, CF Worker, etc.), so don't just assume process.env is a thing
-  if (typeof process !== "undefined" && typeof process.env === "object" && process.env !== null) {
-    return process.env[name] ?? defaultValue;
-  }
+import { env } from "std-env";
 
-  return defaultValue;
+/**
+ * Get an environment variable with optional default value. Runtime agnostic.
+ *
+ * @param name The name of the environment variable.
+ * @param defaultValue The default value to return if the environment variable is not set.
+ * @returns The value of the environment variable, or the default value if the environment variable is not set.
+ *
+ */
+export function getEnvVar(name: string, defaultValue?: string): string | undefined {
+  return env[name] ?? defaultValue;
 }
 
 export function getNumberEnvVar(name: string, defaultValue?: number): number | undefined {


### PR DESCRIPTION
Less of this:
```ts
import { configure } from "@trigger.dev/sdk/v3";

configure({
  secretKey: "tr_dev_…", // nasty, don't do this
});
```

More of that:
```
TRIGGER_SECRET_KEY="tr_dev_…"
```