### PR TITLE
Tasks page didn't include Delayed runs

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam._index/route.tsx
@@ -503,6 +503,7 @@ function TaskActivityGraph({ activity }: { activity: TaskActivity }) {
           barSize={10}
           isAnimationActive={false}
         />
+        <Bar dataKey="DELAYED" fill="#5F6570" stackId="a" strokeWidth={0} barSize={10} />
         <Bar dataKey="PENDING" fill="#5F6570" stackId="a" strokeWidth={0} barSize={10} />
         <Bar dataKey="PENDING_VERSION" fill="#F59E0B" stackId="a" strokeWidth={0} barSize={10} />
         <Bar dataKey="EXECUTING" fill="#3B82F6" stackId="a" strokeWidth={0} barSize={10} />
@@ -533,7 +534,7 @@ function TaskActivityGraph({ activity }: { activity: TaskActivity }) {
         <Bar dataKey="SYSTEM_FAILURE" fill="#F43F5E" stackId="a" strokeWidth={0} barSize={10} />
         <Bar dataKey="PAUSED" fill="#FCD34D" stackId="a" strokeWidth={0} barSize={10} />
         <Bar dataKey="CRASHED" fill="#F43F5E" stackId="a" strokeWidth={0} barSize={10} />
-        <Bar dataKey="EXPIRED" fill="#F43F5E" stackId="a" strokeWidth={0} barSize={10} />
+        <Bar dataKey="EXPIRED" fill="#5F6570" stackId="a" strokeWidth={0} barSize={10} />
         <Bar dataKey="TIMED_OUT" fill="#F43F5E" stackId="a" strokeWidth={0} barSize={10} />
       </BarChart>
     </ResponsiveContainer>

--- a/internal-packages/clickhouse/src/taskRuns.ts
+++ b/internal-packages/clickhouse/src/taskRuns.ts
@@ -178,7 +178,7 @@ export function getCurrentRunningStats(ch: ClickhouseReader, settings?: ClickHou
         organization_id = {organizationId: String}
         AND project_id = {projectId: String}
         AND environment_id = {environmentId: String}
-        AND status IN ('PENDING', 'WAITING_FOR_DEPLOY', 'WAITING_TO_RESUME', 'QUEUED', 'EXECUTING')
+        AND status IN ('PENDING', 'WAITING_FOR_DEPLOY', 'WAITING_TO_RESUME', 'QUEUED', 'EXECUTING', 'DELAYED')
         AND _is_deleted = 0
         AND created_at >= now() - INTERVAL {days: Int64} DAY
     GROUP BY


### PR DESCRIPTION
- Since we switched to using ClickHouse to show the Tasks page statistics, the Queued count didn't include Delayed runs anymore. It used to.
- The mini-graph never included Delayed runs.
 
![CleanShot 2025-06-16 at 13 57 17](https://github.com/user-attachments/assets/d948028f-fd30-44ff-ad8c-8706568ddbf0)
