### PR TITLE
Ensure webapp container does not fetch pnpm at runtime

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,7 +66,6 @@ RUN pnpm run build --filter=webapp...
 FROM ${NODE_IMAGE} AS runner
 RUN apt-get update && apt-get install -y openssl netcat-openbsd ca-certificates
 WORKDIR /triggerdotdev
-RUN corepack enable
 ENV NODE_ENV production
 
 COPY --from=base /usr/bin/dumb-init /usr/bin/dumb-init
@@ -93,6 +92,9 @@ ENV BUILD_APP_VERSION=${BUILD_APP_VERSION} \
     BUILD_TIMESTAMP_SECONDS=${BUILD_TIMESTAMP_SECONDS}
 
 EXPOSE 3000
+
+# Add global pnpm shims and install pnpm during build
+RUN corepack enable && corepack prepare --activate
 
 USER node
 CMD ["./scripts/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -93,8 +93,12 @@ ENV BUILD_APP_VERSION=${BUILD_APP_VERSION} \
 
 EXPOSE 3000
 
-# Add global pnpm shims and install pnpm during build
+# Add global pnpm shims and install pnpm during build (root user)
 RUN corepack enable && corepack prepare --activate
 
 USER node
+
+# Ensure pnpm is installed during build and not silently downloaded at runtime (node user)
+RUN corepack prepare --activate
+
 CMD ["./scripts/entrypoint.sh"]


### PR DESCRIPTION
This fixes an issue where only the corepack shims were present in the final stage. We now include pnpm for both node and root users by default. The correct version specified in the package.json will be used.

Fixes #2178 