### PR TITLE
Make nodetype node selector label optional

### DIFF
--- a/apps/supervisor/src/workloadManager/kubernetes.ts
+++ b/apps/supervisor/src/workloadManager/kubernetes.ts
@@ -228,9 +228,13 @@ export class KubernetesWorkloadManager implements WorkloadManager {
       restartPolicy: "Never",
       automountServiceAccountToken: false,
       imagePullSecrets: this.getImagePullSecrets(),
-      nodeSelector: {
-        nodetype: env.KUBERNETES_WORKER_NODETYPE_LABEL,
-      },
+      ...(env.KUBERNETES_WORKER_NODETYPE_LABEL
+        ? {
+            nodeSelector: {
+              nodetype: env.KUBERNETES_WORKER_NODETYPE_LABEL,
+            },
+          }
+        : {}),
     };
   }
 


### PR DESCRIPTION
When `KUBERNETES_WORKER_NODETYPE_LABEL` is set to an empty string, runs will now be scheduled on _any_ node. This mostly preserves backwards compatibility, except where this has already been set to an empty string.