### PR TITLE
Improve schedule engine performance

### DIFF
--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -618,6 +618,9 @@ const EnvironmentSchema = z.object({
   LEGACY_RUN_ENGINE_WORKER_IMMEDIATE_POLL_INTERVAL: z.coerce.number().int().default(50),
   LEGACY_RUN_ENGINE_WORKER_CONCURRENCY_LIMIT: z.coerce.number().int().default(100),
   LEGACY_RUN_ENGINE_WORKER_SHUTDOWN_TIMEOUT_MS: z.coerce.number().int().default(60_000),
+  LEGACY_RUN_ENGINE_WORKER_LOG_LEVEL: z
+    .enum(["log", "error", "warn", "info", "debug"])
+    .default("info"),
 
   LEGACY_RUN_ENGINE_WORKER_REDIS_HOST: z
     .string()
@@ -661,6 +664,7 @@ const EnvironmentSchema = z.object({
   COMMON_WORKER_IMMEDIATE_POLL_INTERVAL: z.coerce.number().int().default(50),
   COMMON_WORKER_CONCURRENCY_LIMIT: z.coerce.number().int().default(100),
   COMMON_WORKER_SHUTDOWN_TIMEOUT_MS: z.coerce.number().int().default(60_000),
+  COMMON_WORKER_LOG_LEVEL: z.enum(["log", "error", "warn", "info", "debug"]).default("info"),
 
   COMMON_WORKER_REDIS_HOST: z
     .string()
@@ -699,6 +703,7 @@ const EnvironmentSchema = z.object({
   ALERTS_WORKER_IMMEDIATE_POLL_INTERVAL: z.coerce.number().int().default(100),
   ALERTS_WORKER_CONCURRENCY_LIMIT: z.coerce.number().int().default(100),
   ALERTS_WORKER_SHUTDOWN_TIMEOUT_MS: z.coerce.number().int().default(60_000),
+  ALERTS_WORKER_LOG_LEVEL: z.enum(["log", "error", "warn", "info", "debug"]).default("info"),
 
   ALERTS_WORKER_REDIS_HOST: z
     .string()
@@ -732,8 +737,8 @@ const EnvironmentSchema = z.object({
 
   SCHEDULE_ENGINE_LOG_LEVEL: z.enum(["log", "error", "warn", "info", "debug"]).default("info"),
   SCHEDULE_WORKER_ENABLED: z.string().default(process.env.WORKER_ENABLED ?? "true"),
-  SCHEDULE_WORKER_CONCURRENCY_WORKERS: z.coerce.number().int().default(1),
-  SCHEDULE_WORKER_CONCURRENCY_TASKS_PER_WORKER: z.coerce.number().int().default(1),
+  SCHEDULE_WORKER_CONCURRENCY_WORKERS: z.coerce.number().int().default(2),
+  SCHEDULE_WORKER_CONCURRENCY_TASKS_PER_WORKER: z.coerce.number().int().default(10),
   SCHEDULE_WORKER_POLL_INTERVAL: z.coerce.number().int().default(1000),
   SCHEDULE_WORKER_IMMEDIATE_POLL_INTERVAL: z.coerce.number().int().default(50),
   SCHEDULE_WORKER_CONCURRENCY_LIMIT: z.coerce.number().int().default(50),

--- a/apps/webapp/app/v3/alertsWorker.server.ts
+++ b/apps/webapp/app/v3/alertsWorker.server.ts
@@ -61,7 +61,7 @@ function initializeWorker() {
     pollIntervalMs: env.ALERTS_WORKER_POLL_INTERVAL,
     immediatePollIntervalMs: env.ALERTS_WORKER_IMMEDIATE_POLL_INTERVAL,
     shutdownTimeoutMs: env.ALERTS_WORKER_SHUTDOWN_TIMEOUT_MS,
-    logger: new Logger("AlertsWorker", "debug"),
+    logger: new Logger("AlertsWorker", env.ALERTS_WORKER_LOG_LEVEL),
     jobs: {
       "v3.deliverAlert": async ({ payload }) => {
         const service = new DeliverAlertService();

--- a/apps/webapp/app/v3/commonWorker.server.ts
+++ b/apps/webapp/app/v3/commonWorker.server.ts
@@ -196,7 +196,7 @@ function initializeWorker() {
     pollIntervalMs: env.COMMON_WORKER_POLL_INTERVAL,
     immediatePollIntervalMs: env.COMMON_WORKER_IMMEDIATE_POLL_INTERVAL,
     shutdownTimeoutMs: env.COMMON_WORKER_SHUTDOWN_TIMEOUT_MS,
-    logger: new Logger("CommonWorker", "debug"),
+    logger: new Logger("CommonWorker", env.COMMON_WORKER_LOG_LEVEL),
     jobs: {
       scheduleEmail: async ({ payload }) => {
         await sendEmail(payload);

--- a/apps/webapp/app/v3/legacyRunEngineWorker.server.ts
+++ b/apps/webapp/app/v3/legacyRunEngineWorker.server.ts
@@ -68,7 +68,7 @@ function initializeWorker() {
     pollIntervalMs: env.LEGACY_RUN_ENGINE_WORKER_POLL_INTERVAL,
     immediatePollIntervalMs: env.LEGACY_RUN_ENGINE_WORKER_IMMEDIATE_POLL_INTERVAL,
     shutdownTimeoutMs: env.LEGACY_RUN_ENGINE_WORKER_SHUTDOWN_TIMEOUT_MS,
-    logger: new Logger("LegacyRunEngineWorker", "debug"),
+    logger: new Logger("LegacyRunEngineWorker", env.LEGACY_RUN_ENGINE_WORKER_LOG_LEVEL),
     jobs: {
       runHeartbeat: async ({ payload }) => {
         const service = new TaskRunHeartbeatFailedService();

--- a/apps/webapp/app/v3/scheduleEngine.server.ts
+++ b/apps/webapp/app/v3/scheduleEngine.server.ts
@@ -61,6 +61,8 @@ function createScheduleEngine() {
     },
     worker: {
       concurrency: env.SCHEDULE_WORKER_CONCURRENCY_LIMIT,
+      workers: env.SCHEDULE_WORKER_CONCURRENCY_WORKERS,
+      tasksPerWorker: env.SCHEDULE_WORKER_CONCURRENCY_TASKS_PER_WORKER,
       pollIntervalMs: env.SCHEDULE_WORKER_POLL_INTERVAL,
       shutdownTimeoutMs: env.SCHEDULE_WORKER_SHUTDOWN_TIMEOUT_MS,
       disabled: env.SCHEDULE_WORKER_ENABLED === "0",

--- a/internal-packages/run-engine/src/engine/index.ts
+++ b/internal-packages/run-engine/src/engine/index.ts
@@ -152,7 +152,7 @@ export class RunEngine {
       pollIntervalMs: options.worker.pollIntervalMs,
       immediatePollIntervalMs: options.worker.immediatePollIntervalMs,
       shutdownTimeoutMs: options.worker.shutdownTimeoutMs,
-      logger: new Logger("RunEngineWorker", "debug"),
+      logger: new Logger("RunEngineWorker", options.logLevel ?? "info"),
       jobs: {
         finishWaitpoint: async ({ payload }) => {
           await this.waitpointSystem.completeWaitpoint({

--- a/internal-packages/schedule-engine/src/engine/index.ts
+++ b/internal-packages/schedule-engine/src/engine/index.ts
@@ -92,6 +92,8 @@ export class ScheduleEngine {
       catalog: scheduleWorkerCatalog,
       concurrency: {
         limit: options.worker.concurrency,
+        workers: options.worker.workers,
+        tasksPerWorker: options.worker.tasksPerWorker,
       },
       pollIntervalMs: options.worker.pollIntervalMs,
       shutdownTimeoutMs: options.worker.shutdownTimeoutMs,
@@ -590,7 +592,8 @@ export class ScheduleEngine {
 
       const distributedExecutionTime = calculateDistributedExecutionTime(
         exactScheduleTime,
-        this.distributionWindowSeconds
+        this.distributionWindowSeconds,
+        instanceId
       );
 
       const distributionOffsetMs = exactScheduleTime.getTime() - distributedExecutionTime.getTime();

--- a/internal-packages/schedule-engine/src/engine/types.ts
+++ b/internal-packages/schedule-engine/src/engine/types.ts
@@ -35,6 +35,8 @@ export interface ScheduleEngineOptions {
   redis: RedisOptions;
   worker: {
     concurrency: number;
+    workers?: number;
+    tasksPerWorker?: number;
     pollIntervalMs?: number;
     shutdownTimeoutMs?: number;
     disabled?: boolean;

--- a/packages/redis-worker/src/worker.ts
+++ b/packages/redis-worker/src/worker.ts
@@ -452,7 +452,7 @@ class Worker<TCatalog extends WorkerCatalog> {
           continue;
         }
 
-        this.logger.info("Dequeued items", {
+        this.logger.debug("Dequeued items", {
           workerId,
           itemCount: items.length,
           concurrencyOptions: this.concurrency,


### PR DESCRIPTION
Fixed the calculation for distributing schedules across the "calculation window" timeframe to include the schedule instanceId in the random seed and not just the schedule time, which was causing all schedules to be "distributed" into the exact same timestamp (not good).

Also fixed an issue where the schedule engine `workers` and `tasksPerWorker` options were not being passed down to the internal RedisWorker, causing the defaults of `1` and `10` to be used. 

I also added some additional logging into RedisWorker and also spaced-out the starting times of each run worker loop.