### PR TITLE
Fix update command version detection

### DIFF
--- a/.changeset/chilled-weeks-switch.md
+++ b/.changeset/chilled-weeks-switch.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Fix update command version mismatch detection


### PR DESCRIPTION
When a non-exact package version is installed we rely on the resolved `package.json` file of the respective package. We were incorrectly trying to extract this version from type markers instead of the root `package.json` which has the version info.

(this likely broke in v4 when we switched the main export to the v3 dir)