### PR TITLE
helm: increase default postgres resource preset

### DIFF
--- a/hosting/k8s/helm/Chart.yaml
+++ b/hosting/k8s/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trigger
 description: The official Trigger.dev Helm chart
 type: application
-version: 4.0.0-beta.11
+version: 4.0.0-beta.12
 appVersion: trigger-helm-rc.1
 home: https://trigger.dev
 sources:

--- a/hosting/k8s/helm/values.yaml
+++ b/hosting/k8s/helm/values.yaml
@@ -658,7 +658,6 @@ persistence:
     storageClass: ""
     retain: true # Prevents deletion on uninstall
 
-
 # Telemetry configuration
 telemetry:
   enabled: true

--- a/hosting/k8s/helm/values.yaml
+++ b/hosting/k8s/helm/values.yaml
@@ -335,6 +335,7 @@ postgres:
     persistence:
       enabled: true
       size: 10Gi
+    resourcesPreset: "small"
     resources: {}
     configuration: |
       listen_addresses = '*'


### PR DESCRIPTION
The prior `nano` preset sets a very low memory limit causing OOM errors even while testing.