### PR TITLE
helm: set default webapp container and add extraVolumes

### DIFF
--- a/hosting/k8s/helm/Chart.yaml
+++ b/hosting/k8s/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trigger
 description: The official Trigger.dev Helm chart
 type: application
-version: 4.0.0-beta.12
+version: 4.0.0-beta.13
 appVersion: trigger-helm-rc.1
 home: https://trigger.dev
 sources:

--- a/hosting/k8s/helm/Chart.yaml
+++ b/hosting/k8s/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trigger
 description: The official Trigger.dev Helm chart
 type: application
-version: 4.0.0-beta.13
+version: 4.0.0-beta.14
 appVersion: trigger-helm-rc.1
 home: https://trigger.dev
 sources:

--- a/hosting/k8s/helm/templates/webapp.yaml
+++ b/hosting/k8s/helm/templates/webapp.yaml
@@ -324,6 +324,9 @@ spec:
           volumeMounts:
             - name: shared
               mountPath: /home/node/shared
+            {{- with .Values.webapp.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: shared
           {{- if .Values.persistence.shared.enabled }}
@@ -332,6 +335,9 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- with .Values.webapp.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.webapp.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/hosting/k8s/helm/templates/webapp.yaml
+++ b/hosting/k8s/helm/templates/webapp.yaml
@@ -48,10 +48,11 @@ spec:
       {{- include "trigger-v4.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" $component) | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.webapp.podAnnotations }}
       annotations:
+        kubectl.kubernetes.io/default-container: webapp
+        {{- with .Values.webapp.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "trigger-v4.componentSelectorLabels" (dict "Chart" .Chart "Release" .Release "Values" .Values "component" $component) | nindent 8 }}
     spec:

--- a/hosting/k8s/helm/values.yaml
+++ b/hosting/k8s/helm/values.yaml
@@ -115,6 +115,26 @@ webapp:
     #       name: my-secret
     #       key: secret-key
 
+  # Extra volumes for the webapp pod
+  extraVolumes:
+    []
+    # - name: config-volume
+    #   configMap:
+    #     name: my-config
+    # - name: secret-volume
+    #   secret:
+    #     secretName: my-secret
+
+  # Extra volume mounts for the webapp container
+  extraVolumeMounts:
+    []
+    # - name: config-volume
+    #   mountPath: /etc/config
+    #   readOnly: true
+    # - name: secret-volume
+    #   mountPath: /etc/secrets
+    #   readOnly: true
+
   # ServiceMonitor for Prometheus monitoring
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
Since adding the token sync sidecar any kubectl commands would default to this instead of the webapp container. This broke most kubectl commands listed in the docs :melting_face: 

Also adds webapp.extraVolumes and webapp.extraVolumeMounts