### PR TITLE
fix: use generatedCopy.text instead of full object

### DIFF
--- a/docs/guides/ai-agents/generate-translate-copy.mdx
+++ b/docs/guides/ai-agents/generate-translate-copy.mdx
@@ -80,7 +80,7 @@ export const generateAndTranslateTask = task({
         },
         {
           role: "user",
-          content: `Translate the following marketing copy to ${payload.targetLanguage}, maintaining the same tone and marketing impact:\n\n${generatedCopy}`,
+          content: `Translate the following marketing copy to ${payload.targetLanguage}, maintaining the same tone and marketing impact:\n\n${generatedCopy.text}`,
         },
       ],
       experimental_telemetry: {


### PR DESCRIPTION
Ran into a small issue when following the example at https://trigger.dev/docs/guides/ai-agents/generate-translate-copy.  
This PR includes a minor fix to address it.

## ✅ Checklist
- [ ] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
  - Just made a small fix based on usage context; not a full local install.
- [X] The PR title follows the convention.
- [ ] I ran and tested the code works
  - Didn't run the full project, but the change looks small and safe.

## Testing

Manually verified that `generatedCopy.text` is rendered correctly in the template literal.

## Changelog

Fixed a bug where the AI-generated object was being passed instead of its `.text` value.

## Screenshots

N/A
