### PR TITLE
Prevent circular references from breaking run logs in task outputs

### DIFF
--- a/packages/core/src/v3/utils/ioSerialization.ts
+++ b/packages/core/src/v3/utils/ioSerialization.ts
@@ -400,7 +400,15 @@ interface ReplacerOptions {
 }
 
 function makeSafeReplacer(options?: ReplacerOptions) {
+  const seen = new WeakSet<any>();
+
   return function replacer(key: string, value: any) {
+    if (typeof value === "object" && value !== null) {
+      if (seen.has(value)) {
+        return "[Circular]";
+      }
+      seen.add(value);
+    }
     // Check if the key should be filtered out
     if (options?.filteredKeys?.includes(key)) {
       return undefined;

--- a/references/hello-world/src/trigger/example.ts
+++ b/references/hello-world/src/trigger/example.ts
@@ -301,3 +301,30 @@ export const resourceMonitorTest = task({
     };
   },
 });
+
+export const circularReferenceTask = task({
+  id: "circular-reference",
+  run: async (payload: { message: string }, { ctx }) => {
+    logger.info("Hello, world from the circular reference task", { message: payload.message });
+
+    // Create an object
+    const user = {
+      name: "Alice",
+      details: {
+        age: 30,
+        email: "alice@example.com",
+      },
+    };
+
+    // Create the circular reference
+    // @ts-expect-error - This is a circular reference
+    user.details.user = user;
+
+    // Now user.details.user points back to the user object itself
+    // This creates a circular reference that standard JSON can't handle
+
+    return {
+      user,
+    };
+  },
+});


### PR DESCRIPTION
Because superjson supports circular references (as in it will deserialize back into a circular reference) it isn't safe to `JSON.stringify` the result of `superjson.deserialize` without handling circular references. This PR makes use of a WeakSet to keep track of references and will output a `[Circular]` string whenever one is encountered:

![CleanShot 2025-07-09 at 10 21 30](https://github.com/user-attachments/assets/1da645c1-40f8-43cd-b75e-209c86fb7607)