### PR TITLE
fix(docs): force latest buildx version in sample gh action

### DIFF
--- a/docs/github-actions.mdx
+++ b/docs/github-actions.mdx
@@ -164,6 +164,8 @@ jobs:
       # docker setup - part 1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
 
       # docker setup - part 2
       - name: Login to DockerHub


### PR DESCRIPTION
It defaults to the latest buildx version _available in the runner_ which may not be the latest _published_ version. This would then break certain flags we use for local deploys that are unavailable in older versions.