### PR TITLE
feat: enable overriding run options when replaying

### DIFF
--- a/apps/webapp/app/components/code/JSONEditor.tsx
+++ b/apps/webapp/app/components/code/JSONEditor.tsx
@@ -125,13 +125,13 @@ export function JSONEditor(opts: JSONEditorProps) {
     }
   }, [defaultValue, view]);
 
-  const clear = useCallback(() => {
+  const clear = () => {
     if (view === undefined) return;
     view.dispatch({
       changes: { from: 0, to: view.state.doc.length, insert: undefined },
     });
     onChange?.("");
-  }, [view]);
+  };
 
   const copy = useCallback(() => {
     if (view === undefined) return;

--- a/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
+++ b/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
@@ -1,19 +1,46 @@
+import { conform, useForm } from "@conform-to/react";
+import { parse } from "@conform-to/zod";
 import { DialogClose } from "@radix-ui/react-dialog";
-import { Form, useNavigation, useSubmit } from "@remix-run/react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Form,
+  useActionData,
+  useFetcher,
+  useNavigation,
+  useParams,
+  useSubmit,
+} from "@remix-run/react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { type UseDataFunctionReturn, useTypedFetcher } from "remix-typedjson";
+import { TaskIcon } from "~/assets/icons/TaskIcon";
 import { JSONEditor } from "~/components/code/JSONEditor";
 import { EnvironmentCombo } from "~/components/environments/EnvironmentLabel";
 import { Button } from "~/components/primitives/Buttons";
 import { DialogContent, DialogHeader } from "~/components/primitives/Dialog";
-import { Header3 } from "~/components/primitives/Headers";
+import { DurationPicker } from "~/components/primitives/DurationPicker";
+import { Fieldset } from "~/components/primitives/Fieldset";
+import { FormError } from "~/components/primitives/FormError";
+import { Hint } from "~/components/primitives/Hint";
+import { Input } from "~/components/primitives/Input";
 import { InputGroup } from "~/components/primitives/InputGroup";
 import { Label } from "~/components/primitives/Label";
 import { Paragraph } from "~/components/primitives/Paragraph";
+import { type loader as queuesLoader } from "~/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "~/components/primitives/Resizable";
 import { Select, SelectItem } from "~/components/primitives/Select";
 import { Spinner, SpinnerWhite } from "~/components/primitives/Spinner";
 import { TabButton, TabContainer } from "~/components/primitives/Tabs";
+import { TextLink } from "~/components/primitives/TextLink";
 import { type loader } from "~/routes/resources.taskruns.$runParam.replay";
+import { docsPath } from "~/utils/pathBuilder";
+import { ReplayTaskData } from "~/v3/replayTask";
+import { RectangleStackIcon } from "@heroicons/react/20/solid";
+import { Badge } from "~/components/primitives/Badge";
+import { RunTagInput } from "./RunTagInput";
+import { MachinePresetName } from "@trigger.dev/core/v3";
 
 type ReplayRunDialogProps = {
   runFriendlyId: string;
@@ -22,7 +49,10 @@ type ReplayRunDialogProps = {
 
 export function ReplayRunDialog({ runFriendlyId, failedRedirect }: ReplayRunDialogProps) {
   return (
-    <DialogContent key={`replay`} className="h-full md:max-h-[85vh] md:max-w-3xl lg:max-w-5xl">
+    <DialogContent
+      key={`replay`}
+      className="flex h-[85vh] max-h-[85vh] flex-col overflow-hidden px-0 md:max-w-3xl lg:max-w-5xl"
+    >
       <ReplayContent runFriendlyId={runFriendlyId} failedRedirect={failedRedirect} />
     </DialogContent>
   );
@@ -31,23 +61,44 @@ export function ReplayRunDialog({ runFriendlyId, failedRedirect }: ReplayRunDial
 function ReplayContent({ runFriendlyId, failedRedirect }: ReplayRunDialogProps) {
   const fetcher = useTypedFetcher<typeof loader>();
   const isLoading = fetcher.state === "loading";
+  const queueFetcher = useTypedFetcher<typeof queuesLoader>();
 
   useEffect(() => {
     fetcher.load(`/resources/taskruns/${runFriendlyId}/replay`);
   }, [runFriendlyId]);
 
+  const params = useParams();
+  useEffect(() => {
+    if (params.organizationSlug && params.projectParam && params.envParam) {
+      const searchParams = new URLSearchParams();
+      searchParams.set("type", "custom");
+      searchParams.set("per_page", "100");
+
+      queueFetcher.load(
+        `/resources/orgs/${params.organizationSlug}/projects/${params.projectParam}/env/${
+          params.envParam
+        }/queues?${searchParams.toString()}`
+      );
+    }
+  }, [params.organizationSlug, params.projectParam, params.envParam]);
+
+  const customQueues = useMemo(() => {
+    return queueFetcher.data?.queues ?? [];
+  }, [queueFetcher.data?.queues]);
+
   return (
-    <div className="flex h-full flex-col">
-      <DialogHeader>Replay this run</DialogHeader>
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <DialogHeader className="px-3">Replay this run</DialogHeader>
       {isLoading ? (
         <div className="grid place-items-center p-6">
           <Spinner />
         </div>
       ) : fetcher.data ? (
         <ReplayForm
-          {...fetcher.data}
+          replayData={fetcher.data}
           failedRedirect={failedRedirect}
           runFriendlyId={runFriendlyId}
+          customQueues={customQueues}
         />
       ) : (
         <>Failed to get run data</>
@@ -56,22 +107,31 @@ function ReplayContent({ runFriendlyId, failedRedirect }: ReplayRunDialogProps) 
   );
 }
 
+const startingJson = "{\n\n}";
+const machinePresets = Object.values(MachinePresetName.enum);
+
 function ReplayForm({
-  payload,
-  payloadType,
-  environment,
-  environments,
   failedRedirect,
   runFriendlyId,
-}: UseDataFunctionReturn<typeof loader> & { failedRedirect: string; runFriendlyId: string }) {
+  replayData,
+  customQueues,
+}: {
+  failedRedirect: string;
+  runFriendlyId: string;
+  replayData: UseDataFunctionReturn<typeof loader>;
+  customQueues: UseDataFunctionReturn<typeof queuesLoader>["queues"];
+}) {
   const navigation = useNavigation();
   const submit = useSubmit();
-  const currentJson = useRef<string>(payload);
+  const currentPayloadJson = useRef<string>(replayData.payload ?? startingJson);
+  const currentMetadataJson = useRef<string>(replayData.metadata ?? startingJson);
   const formAction = `/resources/taskruns/${runFriendlyId}/replay`;
+
   const isSubmitting = navigation.formAction === formAction;
 
   const editablePayload =
-    payloadType === "application/json" || payloadType === "application/super+json";
+    replayData.payloadType === "application/json" ||
+    replayData.payloadType === "application/super+json";
 
   const submitForm = useCallback(
     (e: React.FormEvent<HTMLFormElement>) => {
@@ -82,7 +142,7 @@ function ReplayForm({
       };
 
       if (editablePayload) {
-        data.payload = currentJson.current;
+        data.payload = currentPayloadJson.current;
       }
 
       submit(data, {
@@ -91,17 +151,67 @@ function ReplayForm({
       });
       e.preventDefault();
     },
-    [currentJson]
+    [currentPayloadJson]
   );
 
   const [tab, setTab] = useState<"payload" | "metadata">("payload");
+
+  const { defaultTaskQueue } = replayData;
+
+  const queues =
+    defaultTaskQueue && !customQueues.some((q) => q.id === defaultTaskQueue.id)
+      ? [defaultTaskQueue, ...customQueues]
+      : customQueues;
+
+  const queueItems = queues.map((q) => ({
+    value: q.type === "task" ? `task/${q.name}` : q.name,
+    label: q.name,
+    type: q.type,
+    paused: q.paused,
+  }));
+
+  const lastSubmission = useActionData();
+  const [
+    form,
+    {
+      environment,
+      payload,
+      metadata,
+      delaySeconds,
+      ttlSeconds,
+      idempotencyKey,
+      idempotencyKeyTTLSeconds,
+      queue,
+      concurrencyKey,
+      maxAttempts,
+      maxDurationSeconds,
+      tags,
+      version,
+      machine,
+    },
+  ] = useForm({
+    id: "replay-task",
+    lastSubmission: lastSubmission as any,
+    onSubmit(event, { formData }) {
+      event.preventDefault();
+      if (editablePayload) {
+        formData.set(payload.name, currentPayloadJson.current);
+      }
+      formData.set(metadata.name, currentMetadataJson.current);
+
+      submit(formData, { method: "POST", action: formAction });
+    },
+    onValidate({ formData }) {
+      return parse(formData, { schema: ReplayTaskData });
+    },
+  });
 
   return (
     <Form
       action={formAction}
       method="post"
       onSubmit={(e) => submitForm(e)}
-      className="flex grow flex-col gap-3"
+      className="flex flex-1 flex-col overflow-hidden px-3"
     >
       <input type="hidden" name="failedRedirect" value={failedRedirect} />
 
@@ -109,46 +219,262 @@ function ReplayForm({
         Replaying will create a new run using the same or modified payload, executing against the
         latest version in your selected environment.
       </Paragraph>
-      <div className="grow">
-        <div className="mb-3 h-full min-h-40 overflow-y-auto rounded-sm border border-grid-dimmed bg-charcoal-900 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600">
-          <JSONEditor
-            autoFocus
-            defaultValue={currentJson.current}
-            readOnly={false}
-            basicSetup
-            onChange={(v) => {
-              currentJson.current = v;
-            }}
-            height="100%"
-            min-height="100%"
-            max-height="100%"
-            additionalActions={
-              <TabContainer className="flex grow items-baseline justify-between self-end border-none">
-                <div className="flex gap-5">
-                  <TabButton
-                    isActive={!tab || tab === "payload"}
-                    layoutId="replay-editor"
-                    onClick={() => {
-                      setTab("payload");
-                    }}
+      <ResizablePanelGroup
+        orientation="horizontal"
+        className="-mx-3 mt-3 w-auto flex-1 border-b border-t border-grid-dimmed"
+      >
+        <ResizablePanel id="payload" min="300px">
+          <div className="rounded-smbg-charcoal-900 mb-3 h-full min-h-40 overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600">
+            <JSONEditor
+              autoFocus
+              defaultValue={currentPayloadJson.current}
+              readOnly={false}
+              basicSetup
+              onChange={(v) => {
+                currentPayloadJson.current = v;
+              }}
+              height="100%"
+              min-height="100%"
+              max-height="100%"
+              additionalActions={
+                <TabContainer className="flex grow items-baseline justify-between self-end border-none">
+                  <div className="flex gap-5">
+                    <TabButton
+                      isActive={!tab || tab === "payload"}
+                      layoutId="replay-editor"
+                      onClick={() => {
+                        setTab("payload");
+                      }}
+                    >
+                      Payload
+                    </TabButton>
+                    <TabButton
+                      isActive={tab === "metadata"}
+                      layoutId="replay-editor"
+                      onClick={() => {
+                        setTab("metadata");
+                      }}
+                    >
+                      Metadata
+                    </TabButton>
+                  </div>
+                </TabContainer>
+              }
+            />
+          </div>
+        </ResizablePanel>
+        <ResizableHandle />
+        <ResizablePanel id="test-task-options" min="300px" default="300px" max="360px">
+          <div className="h-full overflow-y-scroll scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600">
+            <Fieldset className="px-3 py-3">
+              <Hint>
+                Options enable you to control the execution behavior of your task.{" "}
+                <TextLink to={docsPath("triggering#options")}>Read the docs.</TextLink>
+              </Hint>
+              <InputGroup>
+                <Label variant="small">Delay</Label>
+                <DurationPicker name={delaySeconds.name} id={delaySeconds.id} />
+                <Hint>Delays run by a specific duration.</Hint>
+                <FormError id={delaySeconds.errorId}>{delaySeconds.error}</FormError>
+              </InputGroup>
+              <InputGroup>
+                <Label variant="small">TTL</Label>
+                <DurationPicker
+                  name={ttlSeconds.name}
+                  id={ttlSeconds.id}
+                  defaultValueSeconds={replayData.ttlSeconds}
+                />
+                <Hint>Expires the run if it hasn't started within the TTL.</Hint>
+                <FormError id={ttlSeconds.errorId}>{ttlSeconds.error}</FormError>
+              </InputGroup>
+              <InputGroup>
+                <Label htmlFor={queue.id} variant="small">
+                  Queue
+                </Label>
+                {replayData.allowArbitraryQueues ? (
+                  <Input
+                    {...conform.input(queue, { type: "text" })}
+                    variant="small"
+                    defaultValue={replayData.queue}
+                  />
+                ) : (
+                  <Select
+                    name={queue.name}
+                    id={queue.id}
+                    placeholder="Select queue"
+                    heading="Filter queues"
+                    variant="tertiary/small"
+                    dropdownIcon
+                    items={queueItems}
+                    filter={{ keys: ["label"] }}
+                    defaultValue={replayData.queue}
                   >
-                    Payload
-                  </TabButton>
-                  <TabButton
-                    isActive={tab === "metadata"}
-                    layoutId="replay-editor"
-                    onClick={() => {
-                      setTab("metadata");
-                    }}
-                  >
-                    Metadata
-                  </TabButton>
-                </div>
-              </TabContainer>
-            }
-          />
-        </div>
-      </div>
+                    {(matches) =>
+                      matches.map((queueItem) => (
+                        <SelectItem
+                          key={queueItem.value}
+                          value={queueItem.value}
+                          className="max-w-[var(--popover-anchor-width)]"
+                          icon={
+                            queueItem.type === "task" ? (
+                              <TaskIcon className="size-4 shrink-0 text-blue-500" />
+                            ) : (
+                              <RectangleStackIcon className="size-4 shrink-0 text-purple-500" />
+                            )
+                          }
+                        >
+                          <div className="flex w-full min-w-0 items-center justify-between">
+                            <span className="truncate">{queueItem.label}</span>
+                            {queueItem.paused && (
+                              <Badge variant="extra-small" className="ml-1 text-warning">
+                                Paused
+                              </Badge>
+                            )}
+                          </div>
+                        </SelectItem>
+                      ))
+                    }
+                  </Select>
+                )}
+                <Hint>Assign run to a specific queue.</Hint>
+                <FormError id={queue.errorId}>{queue.error}</FormError>
+              </InputGroup>
+              <InputGroup>
+                <Label htmlFor={tags.id} variant="small">
+                  Tags
+                </Label>
+                <RunTagInput
+                  name={tags.name}
+                  id={tags.id}
+                  variant="small"
+                  defaultTags={replayData.runTags}
+                />
+                <Hint>Add tags to easily filter runs.</Hint>
+                <FormError id={tags.errorId}>{tags.error}</FormError>
+              </InputGroup>
+              <InputGroup>
+                <Label htmlFor={maxAttempts.id} variant="small">
+                  Max attempts
+                </Label>
+                <Input
+                  {...conform.input(maxAttempts, { type: "number" })}
+                  className="[&::-webkit-inner-spin-button]:appearance-none"
+                  variant="small"
+                  min={1}
+                  defaultValue={replayData.maxAttempts ?? undefined}
+                  onKeyDown={(e) => {
+                    // only allow entering integers > 1
+                    if (["-", "+", ".", "e", "E"].includes(e.key)) {
+                      e.preventDefault();
+                    }
+                  }}
+                  onBlur={(e) => {
+                    const value = parseInt(e.target.value);
+                    if (value < 1 && e.target.value !== "") {
+                      e.target.value = "1";
+                    }
+                  }}
+                />
+                <Hint>Retries failed runs up to the specified number of attempts.</Hint>
+                <FormError id={maxAttempts.errorId}>{maxAttempts.error}</FormError>
+              </InputGroup>
+              <InputGroup>
+                <Label variant="small">Max duration</Label>
+                <DurationPicker
+                  name={maxDurationSeconds.name}
+                  id={maxDurationSeconds.id}
+                  defaultValueSeconds={replayData.maxDurationSeconds ?? undefined}
+                />
+                <Hint>Overrides the maximum compute time limit for the run.</Hint>
+                <FormError id={maxDurationSeconds.errorId}>{maxDurationSeconds.error}</FormError>
+              </InputGroup>
+              <InputGroup>
+                <Label htmlFor={idempotencyKey.id} variant="small">
+                  Idempotency key
+                </Label>
+                <Input {...conform.input(idempotencyKey, { type: "text" })} variant="small" />
+                <FormError id={idempotencyKey.errorId}>{idempotencyKey.error}</FormError>
+                <Hint>
+                  Specify an idempotency key to ensure that a task is only triggered once with the
+                  same key.
+                </Hint>
+              </InputGroup>
+              <InputGroup>
+                <Label variant="small">Idempotency key TTL</Label>
+                <DurationPicker
+                  name={idempotencyKeyTTLSeconds.name}
+                  id={idempotencyKeyTTLSeconds.id}
+                />
+                <Hint>Keys expire after 30 days by default.</Hint>
+                <FormError id={idempotencyKeyTTLSeconds.errorId}>
+                  {idempotencyKeyTTLSeconds.error}
+                </FormError>
+              </InputGroup>
+              <InputGroup>
+                <Label htmlFor={concurrencyKey.id} variant="small">
+                  Concurrency key
+                </Label>
+                <Input
+                  {...conform.input(concurrencyKey, { type: "text" })}
+                  variant="small"
+                  defaultValue={replayData.concurrencyKey ?? undefined}
+                />
+                <Hint>
+                  Limits concurrency by creating a separate queue for each value of the key.
+                </Hint>
+                <FormError id={concurrencyKey.errorId}>{concurrencyKey.error}</FormError>
+              </InputGroup>
+              <InputGroup>
+                <Label htmlFor={machine.id} variant="small">
+                  Machine
+                </Label>
+                <Select
+                  {...conform.select(machine)}
+                  variant="tertiary/small"
+                  placeholder="Select machine type"
+                  dropdownIcon
+                  items={machinePresets}
+                  defaultValue={replayData.machinePreset ?? undefined}
+                >
+                  {machinePresets.map((machine) => (
+                    <SelectItem key={machine} value={machine}>
+                      {machine}
+                    </SelectItem>
+                  ))}
+                </Select>
+                <Hint>Overrides the machine preset.</Hint>
+                <FormError id={machine.errorId}>{machine.error}</FormError>
+              </InputGroup>
+              <InputGroup>
+                <Label htmlFor={version.id} variant="small">
+                  Version
+                </Label>
+                <Select
+                  {...conform.select(version)}
+                  defaultValue="latest"
+                  variant="tertiary/small"
+                  placeholder="Select version"
+                  dropdownIcon
+                  disabled={replayData.disableVersionSelection}
+                >
+                  {replayData.latestVersions.map((version, i) => (
+                    <SelectItem key={version} value={i === 0 ? "latest" : version}>
+                      {version} {i === 0 && "(latest)"}
+                    </SelectItem>
+                  ))}
+                </Select>
+                {replayData.disableVersionSelection ? (
+                  <Hint>Only the latest version is available in the development environment.</Hint>
+                ) : (
+                  <Hint>Runs task on a specific version.</Hint>
+                )}
+                <FormError id={version.errorId}>{version.error}</FormError>
+              </InputGroup>
+              <FormError>{form.error}</FormError>
+            </Fieldset>
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
 
       <div className="flex items-center justify-between gap-2 border-t border-grid-dimmed pt-3.5">
         <DialogClose asChild>
@@ -161,8 +487,8 @@ function ReplayForm({
               id="environment"
               name="environment"
               placeholder="Select an environment"
-              defaultValue={environment.id}
-              items={environments}
+              defaultValue={replayData.environment.id}
+              items={replayData.environments}
               dropdownIcon
               variant="tertiary/medium"
               className="w-fit pl-1"
@@ -173,7 +499,7 @@ function ReplayForm({
                 ],
               }}
               text={(value) => {
-                const env = environments.find((env) => env.id === value)!;
+                const env = replayData.environments.find((env) => env.id === value)!;
                 return (
                   <div className="flex items-center pl-1 pr-2">
                     <EnvironmentCombo environment={env} />

--- a/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
+++ b/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
@@ -123,8 +123,23 @@ function ReplayForm({
 }) {
   const navigation = useNavigation();
   const submit = useSubmit();
+
+  const [defaultPayloadJson, setDefaultPayloadJson] = useState<string>(
+    replayData.payload ?? startingJson
+  );
+  const setPayload = useCallback((code: string) => {
+    setDefaultPayloadJson(code);
+  }, []);
   const currentPayloadJson = useRef<string>(replayData.payload ?? startingJson);
+
+  const [defaultMetadataJson, setDefaultMetadataJson] = useState<string>(
+    replayData.metadata ?? startingJson
+  );
+  const setMetadata = useCallback((code: string) => {
+    setDefaultMetadataJson(code);
+  }, []);
   const currentMetadataJson = useRef<string>(replayData.metadata ?? startingJson);
+
   const formAction = `/resources/taskruns/${runFriendlyId}/replay`;
 
   const isSubmitting = navigation.formAction === formAction;
@@ -227,11 +242,17 @@ function ReplayForm({
           <div className="rounded-smbg-charcoal-900 mb-3 h-full min-h-40 overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600">
             <JSONEditor
               autoFocus
-              defaultValue={currentPayloadJson.current}
+              defaultValue={!tab || tab === "payload" ? defaultPayloadJson : defaultMetadataJson}
               readOnly={false}
               basicSetup
               onChange={(v) => {
-                currentPayloadJson.current = v;
+                if (!tab || tab === "payload") {
+                  currentPayloadJson.current = v;
+                  setDefaultPayloadJson(v);
+                } else {
+                  currentMetadataJson.current = v;
+                  setDefaultMetadataJson(v);
+                }
               }}
               height="100%"
               min-height="100%"

--- a/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
+++ b/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
@@ -1,6 +1,6 @@
 import { DialogClose } from "@radix-ui/react-dialog";
 import { Form, useNavigation, useSubmit } from "@remix-run/react";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { type UseDataFunctionReturn, useTypedFetcher } from "remix-typedjson";
 import { JSONEditor } from "~/components/code/JSONEditor";
 import { EnvironmentCombo } from "~/components/environments/EnvironmentLabel";
@@ -12,6 +12,7 @@ import { Label } from "~/components/primitives/Label";
 import { Paragraph } from "~/components/primitives/Paragraph";
 import { Select, SelectItem } from "~/components/primitives/Select";
 import { Spinner, SpinnerWhite } from "~/components/primitives/Spinner";
+import { TabButton, TabContainer } from "~/components/primitives/Tabs";
 import { type loader } from "~/routes/resources.taskruns.$runParam.replay";
 
 type ReplayRunDialogProps = {
@@ -21,7 +22,7 @@ type ReplayRunDialogProps = {
 
 export function ReplayRunDialog({ runFriendlyId, failedRedirect }: ReplayRunDialogProps) {
   return (
-    <DialogContent key={`replay`} className="md:max-w-xl">
+    <DialogContent key={`replay`} className="h-full md:max-h-[85vh] md:max-w-3xl lg:max-w-5xl">
       <ReplayContent runFriendlyId={runFriendlyId} failedRedirect={failedRedirect} />
     </DialogContent>
   );
@@ -36,7 +37,7 @@ function ReplayContent({ runFriendlyId, failedRedirect }: ReplayRunDialogProps) 
   }, [runFriendlyId]);
 
   return (
-    <>
+    <div className="flex h-full flex-col">
       <DialogHeader>Replay this run</DialogHeader>
       {isLoading ? (
         <div className="grid place-items-center p-6">
@@ -51,7 +52,7 @@ function ReplayContent({ runFriendlyId, failedRedirect }: ReplayRunDialogProps) 
       ) : (
         <>Failed to get run data</>
       )}
-    </>
+    </div>
   );
 }
 
@@ -93,82 +94,112 @@ function ReplayForm({
     [currentJson]
   );
 
+  const [tab, setTab] = useState<"payload" | "metadata">("payload");
+
   return (
-    <Form action={formAction} method="post" onSubmit={(e) => submitForm(e)} className="pt-2">
-      {editablePayload ? (
-        <>
-          <Paragraph className="mb-3">
-            Replaying will create a new run using the same or modified payload, executing against
-            the latest version in your selected environment.
-          </Paragraph>
-          <Header3 spacing>Payload</Header3>
-          <div className="mb-3 max-h-[70vh] min-h-40 overflow-y-auto rounded-sm border border-grid-dimmed bg-charcoal-900 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600">
-            <JSONEditor
-              autoFocus
-              defaultValue={currentJson.current}
-              readOnly={false}
-              basicSetup
-              onChange={(v) => {
-                currentJson.current = v;
-              }}
-              showClearButton={false}
-              showCopyButton={false}
-              height="100%"
-              min-height="100%"
-              max-height="100%"
-            />
-          </div>
-        </>
-      ) : null}
-      <InputGroup>
-        <Label>Environment</Label>
-        <Select
-          id="environment"
-          name="environment"
-          placeholder="Select an environment"
-          defaultValue={environment.id}
-          items={environments}
-          dropdownIcon
-          variant="tertiary/medium"
-          className="w-fit pl-1"
-          filter={{
-            keys: [
-              (item) => item.type.replace(/\//g, " ").replace(/_/g, " "),
-              (item) => item.branchName?.replace(/\//g, " ").replace(/_/g, " ") ?? "",
-            ],
-          }}
-          text={(value) => {
-            const env = environments.find((env) => env.id === value)!;
-            return (
-              <div className="flex items-center pl-1 pr-2">
-                <EnvironmentCombo environment={env} />
-              </div>
-            );
-          }}
-        >
-          {(matches) =>
-            matches.map((env) => (
-              <SelectItem key={env.id} value={env.id}>
-                <EnvironmentCombo environment={env} />
-              </SelectItem>
-            ))
-          }
-        </Select>
-      </InputGroup>
+    <Form
+      action={formAction}
+      method="post"
+      onSubmit={(e) => submitForm(e)}
+      className="flex grow flex-col gap-3"
+    >
       <input type="hidden" name="failedRedirect" value={failedRedirect} />
-      <div className="mt-3 flex items-center justify-between gap-2 border-t border-grid-dimmed pt-3.5">
+
+      <Paragraph className="pt-6">
+        Replaying will create a new run using the same or modified payload, executing against the
+        latest version in your selected environment.
+      </Paragraph>
+      <div className="grow">
+        <div className="mb-3 h-full min-h-40 overflow-y-auto rounded-sm border border-grid-dimmed bg-charcoal-900 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600">
+          <JSONEditor
+            autoFocus
+            defaultValue={currentJson.current}
+            readOnly={false}
+            basicSetup
+            onChange={(v) => {
+              currentJson.current = v;
+            }}
+            height="100%"
+            min-height="100%"
+            max-height="100%"
+            additionalActions={
+              <TabContainer className="flex grow items-baseline justify-between self-end border-none">
+                <div className="flex gap-5">
+                  <TabButton
+                    isActive={!tab || tab === "payload"}
+                    layoutId="replay-editor"
+                    onClick={() => {
+                      setTab("payload");
+                    }}
+                  >
+                    Payload
+                  </TabButton>
+                  <TabButton
+                    isActive={tab === "metadata"}
+                    layoutId="replay-editor"
+                    onClick={() => {
+                      setTab("metadata");
+                    }}
+                  >
+                    Metadata
+                  </TabButton>
+                </div>
+              </TabContainer>
+            }
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-2 border-t border-grid-dimmed pt-3.5">
         <DialogClose asChild>
           <Button variant="tertiary/medium">Cancel</Button>
         </DialogClose>
-        <Button
-          type="submit"
-          variant="primary/medium"
-          LeadingIcon={isSubmitting ? SpinnerWhite : undefined}
-          disabled={isSubmitting}
-          shortcut={{ modifiers: ["mod"], key: "enter", enabledOnInputElements: true }}
-        >
-          {isSubmitting ? "Replaying..." : "Replay run"}
-        </Button>
+        <div className="flex items-center gap-3">
+          <InputGroup className="flex flex-row items-center">
+            <Label>Replay this run in</Label>
+            <Select
+              id="environment"
+              name="environment"
+              placeholder="Select an environment"
+              defaultValue={environment.id}
+              items={environments}
+              dropdownIcon
+              variant="tertiary/medium"
+              className="w-fit pl-1"
+              filter={{
+                keys: [
+                  (item) => item.type.replace(/\//g, " ").replace(/_/g, " "),
+                  (item) => item.branchName?.replace(/\//g, " ").replace(/_/g, " ") ?? "",
+                ],
+              }}
+              text={(value) => {
+                const env = environments.find((env) => env.id === value)!;
+                return (
+                  <div className="flex items-center pl-1 pr-2">
+                    <EnvironmentCombo environment={env} />
+                  </div>
+                );
+              }}
+            >
+              {(matches) =>
+                matches.map((env) => (
+                  <SelectItem key={env.id} value={env.id}>
+                    <EnvironmentCombo environment={env} />
+                  </SelectItem>
+                ))
+              }
+            </Select>
+          </InputGroup>
+          <Button
+            type="submit"
+            variant="primary/medium"
+            LeadingIcon={isSubmitting ? SpinnerWhite : undefined}
+            disabled={isSubmitting}
+            shortcut={{ modifiers: ["mod"], key: "enter", enabledOnInputElements: true }}
+          >
+            {isSubmitting ? "Replaying..." : "Replay run"}
+          </Button>
+        </div>
       </div>
     </Form>
   );

--- a/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
+++ b/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
@@ -272,20 +272,50 @@ function ReplayForm({
                 <TextLink to={docsPath("triggering#options")}>Read the docs.</TextLink>
               </Hint>
               <InputGroup>
-                <Label variant="small">Delay</Label>
-                <DurationPicker name={delaySeconds.name} id={delaySeconds.id} />
-                <Hint>Delays run by a specific duration.</Hint>
-                <FormError id={delaySeconds.errorId}>{delaySeconds.error}</FormError>
+                <Label htmlFor={machine.id} variant="small">
+                  Machine
+                </Label>
+                <Select
+                  {...conform.select(machine)}
+                  variant="tertiary/small"
+                  placeholder="Select machine type"
+                  dropdownIcon
+                  items={machinePresets}
+                  defaultValue={replayData.machinePreset ?? undefined}
+                >
+                  {machinePresets.map((machine) => (
+                    <SelectItem key={machine} value={machine}>
+                      {machine}
+                    </SelectItem>
+                  ))}
+                </Select>
+                <Hint>Overrides the machine preset.</Hint>
+                <FormError id={machine.errorId}>{machine.error}</FormError>
               </InputGroup>
               <InputGroup>
-                <Label variant="small">TTL</Label>
-                <DurationPicker
-                  name={ttlSeconds.name}
-                  id={ttlSeconds.id}
-                  defaultValueSeconds={replayData.ttlSeconds}
-                />
-                <Hint>Expires the run if it hasn't started within the TTL.</Hint>
-                <FormError id={ttlSeconds.errorId}>{ttlSeconds.error}</FormError>
+                <Label htmlFor={version.id} variant="small">
+                  Version
+                </Label>
+                <Select
+                  {...conform.select(version)}
+                  defaultValue="latest"
+                  variant="tertiary/small"
+                  placeholder="Select version"
+                  dropdownIcon
+                  disabled={replayData.disableVersionSelection}
+                >
+                  {replayData.latestVersions.map((version, i) => (
+                    <SelectItem key={version} value={i === 0 ? "latest" : version}>
+                      {version} {i === 0 && "(latest)"}
+                    </SelectItem>
+                  ))}
+                </Select>
+                {replayData.disableVersionSelection ? (
+                  <Hint>Only the latest version is available in the development environment.</Hint>
+                ) : (
+                  <Hint>Runs task on a specific version.</Hint>
+                )}
+                <FormError id={version.errorId}>{version.error}</FormError>
               </InputGroup>
               <InputGroup>
                 <Label htmlFor={queue.id} variant="small">
@@ -425,50 +455,20 @@ function ReplayForm({
                 <FormError id={concurrencyKey.errorId}>{concurrencyKey.error}</FormError>
               </InputGroup>
               <InputGroup>
-                <Label htmlFor={machine.id} variant="small">
-                  Machine
-                </Label>
-                <Select
-                  {...conform.select(machine)}
-                  variant="tertiary/small"
-                  placeholder="Select machine type"
-                  dropdownIcon
-                  items={machinePresets}
-                  defaultValue={replayData.machinePreset ?? undefined}
-                >
-                  {machinePresets.map((machine) => (
-                    <SelectItem key={machine} value={machine}>
-                      {machine}
-                    </SelectItem>
-                  ))}
-                </Select>
-                <Hint>Overrides the machine preset.</Hint>
-                <FormError id={machine.errorId}>{machine.error}</FormError>
+                <Label variant="small">Delay</Label>
+                <DurationPicker name={delaySeconds.name} id={delaySeconds.id} />
+                <Hint>Delays run by a specific duration.</Hint>
+                <FormError id={delaySeconds.errorId}>{delaySeconds.error}</FormError>
               </InputGroup>
               <InputGroup>
-                <Label htmlFor={version.id} variant="small">
-                  Version
-                </Label>
-                <Select
-                  {...conform.select(version)}
-                  defaultValue="latest"
-                  variant="tertiary/small"
-                  placeholder="Select version"
-                  dropdownIcon
-                  disabled={replayData.disableVersionSelection}
-                >
-                  {replayData.latestVersions.map((version, i) => (
-                    <SelectItem key={version} value={i === 0 ? "latest" : version}>
-                      {version} {i === 0 && "(latest)"}
-                    </SelectItem>
-                  ))}
-                </Select>
-                {replayData.disableVersionSelection ? (
-                  <Hint>Only the latest version is available in the development environment.</Hint>
-                ) : (
-                  <Hint>Runs task on a specific version.</Hint>
-                )}
-                <FormError id={version.errorId}>{version.error}</FormError>
+                <Label variant="small">TTL</Label>
+                <DurationPicker
+                  name={ttlSeconds.name}
+                  id={ttlSeconds.id}
+                  defaultValueSeconds={replayData.ttlSeconds}
+                />
+                <Hint>Expires the run if it hasn't started within the TTL.</Hint>
+                <FormError id={ttlSeconds.errorId}>{ttlSeconds.error}</FormError>
               </InputGroup>
               <FormError>{form.error}</FormError>
             </Fieldset>

--- a/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
+++ b/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
@@ -237,6 +237,7 @@ function ReplayForm({
         <ResizablePanel id="payload" min="300px">
           <div className="rounded-smbg-charcoal-900 mb-3 h-full min-h-40 overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600">
             <JSONEditor
+              className="h-full"
               autoFocus
               defaultValue={tab === "payload" ? defaultPayloadJson : defaultMetadataJson}
               readOnly={false}

--- a/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
+++ b/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
@@ -503,7 +503,7 @@ function ReplayForm({
           <Button variant="tertiary/medium">Cancel</Button>
         </DialogClose>
         <div className="flex items-center gap-3">
-          <InputGroup className="flex flex-row items-center">
+          <InputGroup className="flex flex-row items-center gap-3">
             <Label>Replay this run in</Label>
             <Select
               {...conform.select(environment)}
@@ -514,7 +514,7 @@ function ReplayForm({
               value={environmentIdOverride}
               setValue={setEnvironmentIdOverride}
               variant="tertiary/medium"
-              className="w-fit pl-1"
+              className="min-w-44"
               filter={{
                 keys: [
                   (item) => item.type.replace(/\//g, " ").replace(/_/g, " "),

--- a/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
+++ b/apps/webapp/app/components/runs/v3/ReplayRunDialog.tsx
@@ -210,8 +210,8 @@ function ReplayForm({
       <input type="hidden" name="failedRedirect" value={failedRedirect} />
 
       <Paragraph className="pt-6">
-        Replaying will create a new run using the same or modified payload, executing against the
-        latest version in your selected environment.
+        Replaying will create a new run in the selected environment. You can modify the payload,
+        metadata and run options.
       </Paragraph>
       <ResizablePanelGroup
         orientation="horizontal"

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.test.tasks.$taskParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.test.tasks.$taskParam/route.tsx
@@ -941,7 +941,7 @@ function ScheduledTaskForm({
           />
         </div>
       </div>
-      <div className="grow overflow-y-scroll p-3">
+      <div className="grow overflow-y-scroll p-3 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600">
         <Fieldset>
           <InputGroup>
             <Label htmlFor={timestamp.id} variant="small">

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.test.tasks.$taskParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.test.tasks.$taskParam/route.tsx
@@ -447,7 +447,7 @@ function StandardTaskForm({
               setConcurrencyKeyValue(template.concurrencyKey ?? "");
               setMaxAttemptsValue(template.maxAttempts ?? undefined);
               setMaxDurationValue(template.maxDurationSeconds ?? 0);
-              setMachineValue(template.machinePreset ?? "");
+              setMachineValue(template.machinePreset ?? undefined);
               setTagsValue(template.tags ?? []);
               setQueueValue(template.queue ?? undefined);
             }}
@@ -527,21 +527,55 @@ function StandardTaskForm({
                 <TextLink to={docsPath("triggering#options")}>Read the docs.</TextLink>
               </Hint>
               <InputGroup>
-                <Label variant="small">Delay</Label>
-                <DurationPicker name={delaySeconds.name} id={delaySeconds.id} />
-                <Hint>Delays run by a specific duration.</Hint>
-                <FormError id={delaySeconds.errorId}>{delaySeconds.error}</FormError>
+                <Label htmlFor={machine.id} variant="small">
+                  Machine
+                </Label>
+                <Select
+                  {...conform.select(machine)}
+                  variant="tertiary/small"
+                  placeholder="Select machine type"
+                  dropdownIcon
+                  items={machinePresets}
+                  defaultValue={undefined}
+                  value={machineValue}
+                  setValue={(e) => {
+                    if (Array.isArray(e)) return;
+                    setMachineValue(e);
+                  }}
+                >
+                  {machinePresets.map((machine) => (
+                    <SelectItem key={machine} value={machine}>
+                      {machine}
+                    </SelectItem>
+                  ))}
+                </Select>
+                <Hint>Overrides the machine preset.</Hint>
+                <FormError id={machine.errorId}>{machine.error}</FormError>
               </InputGroup>
               <InputGroup>
-                <Label variant="small">TTL</Label>
-                <DurationPicker
-                  name={ttlSeconds.name}
-                  id={ttlSeconds.id}
-                  value={ttlValue}
-                  onChange={setTtlValue}
-                />
-                <Hint>Expires the run if it hasn't started within the TTL.</Hint>
-                <FormError id={ttlSeconds.errorId}>{ttlSeconds.error}</FormError>
+                <Label htmlFor={version.id} variant="small">
+                  Version
+                </Label>
+                <Select
+                  {...conform.select(version)}
+                  defaultValue="latest"
+                  variant="tertiary/small"
+                  placeholder="Select version"
+                  dropdownIcon
+                  disabled={disableVersionSelection}
+                >
+                  {versions.map((version, i) => (
+                    <SelectItem key={version} value={i === 0 ? "latest" : version}>
+                      {version} {i === 0 && "(latest)"}
+                    </SelectItem>
+                  ))}
+                </Select>
+                {disableVersionSelection ? (
+                  <Hint>Only the latest version is available in the development environment.</Hint>
+                ) : (
+                  <Hint>Runs task on a specific version.</Hint>
+                )}
+                <FormError id={version.errorId}>{version.error}</FormError>
               </InputGroup>
               <InputGroup>
                 <Label htmlFor={queue.id} variant="small">
@@ -689,55 +723,21 @@ function StandardTaskForm({
                 <FormError id={concurrencyKey.errorId}>{concurrencyKey.error}</FormError>
               </InputGroup>
               <InputGroup>
-                <Label htmlFor={machine.id} variant="small">
-                  Machine
-                </Label>
-                <Select
-                  {...conform.select(machine)}
-                  variant="tertiary/small"
-                  placeholder="Select machine type"
-                  dropdownIcon
-                  items={machinePresets}
-                  defaultValue={undefined}
-                  value={machineValue}
-                  setValue={(e) => {
-                    if (Array.isArray(e)) return;
-                    setMachineValue(e);
-                  }}
-                >
-                  {machinePresets.map((machine) => (
-                    <SelectItem key={machine} value={machine}>
-                      {machine}
-                    </SelectItem>
-                  ))}
-                </Select>
-                <Hint>Overrides the machine preset.</Hint>
-                <FormError id={machine.errorId}>{machine.error}</FormError>
+                <Label variant="small">Delay</Label>
+                <DurationPicker name={delaySeconds.name} id={delaySeconds.id} />
+                <Hint>Delays run by a specific duration.</Hint>
+                <FormError id={delaySeconds.errorId}>{delaySeconds.error}</FormError>
               </InputGroup>
               <InputGroup>
-                <Label htmlFor={version.id} variant="small">
-                  Version
-                </Label>
-                <Select
-                  {...conform.select(version)}
-                  defaultValue="latest"
-                  variant="tertiary/small"
-                  placeholder="Select version"
-                  dropdownIcon
-                  disabled={disableVersionSelection}
-                >
-                  {versions.map((version, i) => (
-                    <SelectItem key={version} value={i === 0 ? "latest" : version}>
-                      {version} {i === 0 && "(latest)"}
-                    </SelectItem>
-                  ))}
-                </Select>
-                {disableVersionSelection ? (
-                  <Hint>Only the latest version is available in the development environment.</Hint>
-                ) : (
-                  <Hint>Runs task on a specific version.</Hint>
-                )}
-                <FormError id={version.errorId}>{version.error}</FormError>
+                <Label variant="small">TTL</Label>
+                <DurationPicker
+                  name={ttlSeconds.name}
+                  id={ttlSeconds.id}
+                  value={ttlValue}
+                  onChange={setTtlValue}
+                />
+                <Hint>Expires the run if it hasn't started within the TTL.</Hint>
+                <FormError id={ttlSeconds.errorId}>{ttlSeconds.error}</FormError>
               </InputGroup>
               <FormError>{form.error}</FormError>
             </Fieldset>
@@ -912,7 +912,7 @@ function ScheduledTaskForm({
               setConcurrencyKeyValue(template.concurrencyKey ?? "");
               setMaxAttemptsValue(template.maxAttempts ?? undefined);
               setMaxDurationValue(template.maxDurationSeconds ?? 0);
-              setMachineValue(template.machinePreset ?? "");
+              setMachineValue(template.machinePreset ?? undefined);
               setTagsValue(template.tags ?? []);
               setQueueValue(template.queue ?? undefined);
 
@@ -936,7 +936,7 @@ function ScheduledTaskForm({
               setMaxDurationValue(run.maxDurationInSeconds);
               setTagsValue(run.runTags ?? []);
               setQueueValue(run.queue);
-              setMachineValue(run.machinePreset);
+              setMachineValue(run.machinePreset ?? undefined);
             }}
           />
         </div>
@@ -1041,17 +1041,55 @@ function ScheduledTaskForm({
             <TextLink to={docsPath("triggering#options")}>Read the docs.</TextLink>
           </Hint>
           <InputGroup>
-            <Label htmlFor={ttlSeconds.id} variant="small">
-              TTL
+            <Label htmlFor={machine.id} variant="small">
+              Machine
             </Label>
-            <DurationPicker
-              name={ttlSeconds.name}
-              id={ttlSeconds.id}
-              value={ttlValue}
-              onChange={setTtlValue}
-            />
-            <Hint>Expires the run if it hasn't started within the TTL.</Hint>
-            <FormError id={ttlSeconds.errorId}>{ttlSeconds.error}</FormError>
+            <Select
+              {...conform.select(machine)}
+              variant="tertiary/small"
+              placeholder="Select machine type"
+              dropdownIcon
+              items={machinePresets}
+              defaultValue={undefined}
+              value={machineValue}
+              setValue={(e) => {
+                if (Array.isArray(e)) return;
+                setMachineValue(e);
+              }}
+            >
+              {machinePresets.map((machine) => (
+                <SelectItem key={machine} value={machine}>
+                  {machine}
+                </SelectItem>
+              ))}
+            </Select>
+            <Hint>Overrides the machine preset.</Hint>
+            <FormError id={machine.errorId}>{machine.error}</FormError>
+          </InputGroup>
+          <InputGroup>
+            <Label htmlFor={version.id} variant="small">
+              Version
+            </Label>
+            <Select
+              {...conform.select(version)}
+              defaultValue="latest"
+              variant="tertiary/small"
+              placeholder="Select version"
+              dropdownIcon
+              disabled={disableVersionSelection}
+            >
+              {versions.map((version, i) => (
+                <SelectItem key={version} value={i === 0 ? "latest" : version}>
+                  {version} {i === 0 && "(latest)"}
+                </SelectItem>
+              ))}
+            </Select>
+            {disableVersionSelection ? (
+              <Hint>Only the latest version is available in the development environment.</Hint>
+            ) : (
+              <Hint>Runs task on a specific version.</Hint>
+            )}
+            <FormError id={version.errorId}>{version.error}</FormError>
           </InputGroup>
           <InputGroup>
             <Label htmlFor={queue.id} variant="small">
@@ -1198,55 +1236,17 @@ function ScheduledTaskForm({
             <FormError id={concurrencyKey.errorId}>{concurrencyKey.error}</FormError>
           </InputGroup>
           <InputGroup>
-            <Label htmlFor={machine.id} variant="small">
-              Machine
+            <Label htmlFor={ttlSeconds.id} variant="small">
+              TTL
             </Label>
-            <Select
-              {...conform.select(machine)}
-              variant="tertiary/small"
-              placeholder="Select machine type"
-              dropdownIcon
-              items={machinePresets}
-              defaultValue={undefined}
-              value={machineValue}
-              setValue={(e) => {
-                if (Array.isArray(e)) return;
-                setMachineValue(e);
-              }}
-            >
-              {machinePresets.map((machine) => (
-                <SelectItem key={machine} value={machine}>
-                  {machine}
-                </SelectItem>
-              ))}
-            </Select>
-            <Hint>Overrides the machine preset.</Hint>
-            <FormError id={machine.errorId}>{machine.error}</FormError>
-          </InputGroup>
-          <InputGroup>
-            <Label htmlFor={version.id} variant="small">
-              Version
-            </Label>
-            <Select
-              {...conform.select(version)}
-              defaultValue="latest"
-              variant="tertiary/small"
-              placeholder="Select version"
-              dropdownIcon
-              disabled={disableVersionSelection}
-            >
-              {versions.map((version, i) => (
-                <SelectItem key={version} value={i === 0 ? "latest" : version}>
-                  {version} {i === 0 && "(latest)"}
-                </SelectItem>
-              ))}
-            </Select>
-            {disableVersionSelection ? (
-              <Hint>Only the latest version is available in the development environment.</Hint>
-            ) : (
-              <Hint>Runs task on a specific version.</Hint>
-            )}
-            <FormError id={version.errorId}>{version.error}</FormError>
+            <DurationPicker
+              name={ttlSeconds.name}
+              id={ttlSeconds.id}
+              value={ttlValue}
+              onChange={setTtlValue}
+            />
+            <Hint>Expires the run if it hasn't started within the TTL.</Hint>
+            <FormError id={ttlSeconds.errorId}>{ttlSeconds.error}</FormError>
           </InputGroup>
         </Fieldset>
       </div>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.test.tasks.$taskParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.test.tasks.$taskParam/route.tsx
@@ -481,10 +481,10 @@ function StandardTaskForm({
                 onChange={(v) => {
                   if (!tab || tab === "payload") {
                     currentPayloadJson.current = v;
-                    setDefaultPayloadJson(v);
+                    setPayload(v);
                   } else {
                     currentMetadataJson.current = v;
-                    setDefaultMetadataJson(v);
+                    setMetadata(v);
                   }
                 }}
                 height="100%"

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.test.tasks.$taskParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.test.tasks.$taskParam/route.tsx
@@ -357,7 +357,7 @@ function StandardTaskForm({
   const currentPayloadJson = useRef<string>(defaultPayloadJson);
 
   const [defaultMetadataJson, setDefaultMetadataJson] = useState<string>(
-    lastRun?.seedMetadata ?? "{}"
+    lastRun?.seedMetadata ?? startingJson
   );
   const setMetadata = useCallback((code: string) => {
     setDefaultMetadataJson(code);

--- a/apps/webapp/app/v3/replayTask.ts
+++ b/apps/webapp/app/v3/replayTask.ts
@@ -1,13 +1,47 @@
 import { z } from "zod";
 import { RunOptionsData } from "./testTask";
 
-export const ReplayTaskData = z
+export const ReplayRunData = z
   .object({
     environment: z.string().optional(),
-    payload: z.string().optional(),
-    metadata: z.string().optional(),
+    payload: z
+      .string()
+      .optional()
+      .transform((val, ctx) => {
+        if (!val) {
+          return {};
+        }
+
+        try {
+          return JSON.parse(val);
+        } catch {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Payload must be a valid JSON string",
+          });
+          return z.NEVER;
+        }
+      }),
+    metadata: z
+      .string()
+      .optional()
+      .transform((val, ctx) => {
+        if (!val) {
+          return {};
+        }
+
+        try {
+          return JSON.parse(val);
+        } catch {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Metadata must be a valid JSON string",
+          });
+          return z.NEVER;
+        }
+      }),
     failedRedirect: z.string(),
   })
   .and(RunOptionsData);
 
-export type ReplayTaskData = z.infer<typeof ReplayTaskData>;
+export type ReplayRunData = z.infer<typeof ReplayRunData>;

--- a/apps/webapp/app/v3/replayTask.ts
+++ b/apps/webapp/app/v3/replayTask.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import { RunOptionsData } from "./testTask";
+
+export const ReplayTaskData = z
+  .object({
+    environment: z.string().optional(),
+    payload: z.string().optional(),
+    metadata: z.string().optional(),
+    failedRedirect: z.string(),
+  })
+  .and(RunOptionsData);
+
+export type ReplayTaskData = z.infer<typeof ReplayTaskData>;

--- a/apps/webapp/app/v3/testTask.ts
+++ b/apps/webapp/app/v3/testTask.ts
@@ -48,6 +48,8 @@ export const RunOptionsData = z.object({
   version: z.string().optional(),
 });
 
+export type RunOptionsData = z.infer<typeof RunOptionsData>;
+
 export const TestTaskData = z
   .discriminatedUnion("triggerSource", [
     z.object({

--- a/apps/webapp/app/v3/testTask.ts
+++ b/apps/webapp/app/v3/testTask.ts
@@ -1,6 +1,53 @@
 import { z } from "zod";
 import { MachinePresetName } from "@trigger.dev/core/v3/schemas";
 
+export const RunOptionsData = z.object({
+  delaySeconds: z
+    .number()
+    .min(0)
+    .optional()
+    .transform((val) => (val === 0 ? undefined : val)),
+  ttlSeconds: z
+    .number()
+    .min(0)
+    .optional()
+    .transform((val) => (val === 0 ? undefined : val)),
+  idempotencyKey: z.string().optional(),
+  idempotencyKeyTTLSeconds: z
+    .number()
+    .min(0)
+    .optional()
+    .transform((val) => (val === 0 ? undefined : val)),
+  queue: z.string().optional(),
+  concurrencyKey: z.string().optional(),
+  maxAttempts: z.number().min(1).optional(),
+  machine: MachinePresetName.optional(),
+  maxDurationSeconds: z
+    .number()
+    .min(0)
+    .optional()
+    .transform((val) => (val === 0 ? undefined : val)),
+  tags: z
+    .string()
+    .optional()
+    .transform((val) => {
+      if (!val || val.trim() === "") {
+        return undefined;
+      }
+      return val
+        .split(",")
+        .map((tag) => tag.trim())
+        .filter((tag) => tag.length > 0);
+    })
+    .refine((tags) => !tags || tags.length <= 10, {
+      message: "Maximum 10 tags allowed",
+    })
+    .refine((tags) => !tags || tags.every((tag) => tag.length <= 128), {
+      message: "Each tag must be at most 128 characters long",
+    }),
+  version: z.string().optional(),
+});
+
 export const TestTaskData = z
   .discriminatedUnion("triggerSource", [
     z.object({
@@ -53,54 +100,11 @@ export const TestTaskData = z
       externalId: z.preprocess((val) => (val === "" ? undefined : val), z.string().optional()),
     }),
   ])
+  .and(RunOptionsData)
   .and(
     z.object({
       taskIdentifier: z.string(),
       environmentId: z.string(),
-      delaySeconds: z
-        .number()
-        .min(0)
-        .optional()
-        .transform((val) => (val === 0 ? undefined : val)),
-      ttlSeconds: z
-        .number()
-        .min(0)
-        .optional()
-        .transform((val) => (val === 0 ? undefined : val)),
-      idempotencyKey: z.string().optional(),
-      idempotencyKeyTTLSeconds: z
-        .number()
-        .min(0)
-        .optional()
-        .transform((val) => (val === 0 ? undefined : val)),
-      queue: z.string().optional(),
-      concurrencyKey: z.string().optional(),
-      maxAttempts: z.number().min(1).optional(),
-      machine: MachinePresetName.optional(),
-      maxDurationSeconds: z
-        .number()
-        .min(0)
-        .optional()
-        .transform((val) => (val === 0 ? undefined : val)),
-      tags: z
-        .string()
-        .optional()
-        .transform((val) => {
-          if (!val || val.trim() === "") {
-            return undefined;
-          }
-          return val
-            .split(",")
-            .map((tag) => tag.trim())
-            .filter((tag) => tag.length > 0);
-        })
-        .refine((tags) => !tags || tags.length <= 10, {
-          message: "Maximum 10 tags allowed",
-        })
-        .refine((tags) => !tags || tags.every((tag) => tag.length <= 128), {
-          message: "Each tag must be at most 128 characters long",
-        }),
-      version: z.string().optional(),
     })
   );
 


### PR DESCRIPTION
Changes in this PR:

- Added run options and metadata to the replay run modal.
- Rearranged the layout a bit.
- Fixed an issue with the clear button in the json editor component.

<img width="1607" height="1045" alt="image" src="https://github.com/user-attachments/assets/c59c4fad-fbf4-43c4-bb53-bf126aaaa88e" />
