### PR TITLE
fix(docker): apply max old space size env var to webapp

### DIFF
--- a/hosting/docker/webapp/docker-compose.yml
+++ b/hosting/docker/webapp/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       OBJECT_STORE_ACCESS_KEY_ID: ${OBJECT_STORE_ACCESS_KEY_ID}
       OBJECT_STORE_SECRET_ACCESS_KEY: ${OBJECT_STORE_SECRET_ACCESS_KEY}
       GRACEFUL_SHUTDOWN_TIMEOUT: 1000
+      NODE_MAX_OLD_SPACE_SIZE: ${NODE_MAX_OLD_SPACE_SIZE}
       # Bootstrap - this will automatically set up a worker group for you
       # This will NOT work for split deployments
       TRIGGER_BOOTSTRAP_ENABLED: 1


### PR DESCRIPTION
Previously, setting `NODE_MAX_OLD_SPACE_SIZE` in you `.env` would have no effect