### PR TITLE
fix(helm): allow electric db url var to be set from secret

### DIFF
--- a/hosting/docker/webapp/docker-compose.yml
+++ b/hosting/docker/webapp/docker-compose.yml
@@ -120,7 +120,7 @@ services:
       start_period: 10s
 
   electric:
-    image: electricsql/electric:${ELECTRIC_IMAGE_TAG:-1.0.13}
+    image: electricsql/electric:${ELECTRIC_IMAGE_TAG:-1.0.24}
     restart: ${RESTART_POLICY:-unless-stopped}
     logging: *logging-config
     depends_on:

--- a/hosting/k8s/helm/Chart.yaml
+++ b/hosting/k8s/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: trigger
 description: The official Trigger.dev Helm chart
 type: application
-version: 4.0.0-beta.17
-appVersion: v4.0.0-v4-beta.22
+version: 4.0.0-beta.18
+appVersion: v4.0.0-v4-beta.23
 home: https://trigger.dev
 sources:
   - https://github.com/triggerdotdev/trigger.dev

--- a/hosting/k8s/helm/templates/electric.yaml
+++ b/hosting/k8s/helm/templates/electric.yaml
@@ -37,8 +37,16 @@ spec:
               containerPort: {{ .Values.electric.service.targetPort }}
               protocol: TCP
           env:
+            {{- if include "trigger-v4.postgres.useSecretUrl" . }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "trigger-v4.postgres.external.secretName" . }}
+                  key: {{ include "trigger-v4.postgres.external.databaseUrlKey" . }}
+            {{- else }}
             - name: DATABASE_URL
               value: {{ include "trigger-v4.postgres.connectionString" . | quote }}
+            {{- end }}
             - name: ELECTRIC_INSECURE
               value: {{ .Values.electric.config.insecure | quote }}
             - name: ELECTRIC_USAGE_REPORTING

--- a/hosting/k8s/helm/values.yaml
+++ b/hosting/k8s/helm/values.yaml
@@ -440,7 +440,7 @@ electric:
   image:
     registry: docker.io
     repository: electricsql/electric
-    tag: "1.0.13"
+    tag: "1.0.24"
     pullPolicy: IfNotPresent
   config:
     insecure: true


### PR DESCRIPTION
Previously, the postgres `DATABASE_URL` on the electric service could not be set from a secret. This also updates electric to the latest patch release.

Fixes #2281 