### PR TITLE
docs: update triggering.mdx fixing wrongly stated argument position for options

### DIFF
--- a/docs/triggering.mdx
+++ b/docs/triggering.mdx
@@ -117,7 +117,7 @@ export async function POST(request: Request) {
 }
 ```
 
-You can pass in options to the `batchTrigger` function using the second argument:
+You can pass in options to the `batchTrigger` function using the third argument:
 
 ```ts Your backend
 import { tasks } from "@trigger.dev/sdk/v3";

--- a/docs/triggering.mdx
+++ b/docs/triggering.mdx
@@ -66,7 +66,7 @@ export async function POST(request: Request) {
 }
 ```
 
-You can pass in options to the task using the second argument:
+You can pass in options to the task using the third argument:
 
 ```ts Your backend
 import { tasks } from "@trigger.dev/sdk/v3";


### PR DESCRIPTION
## Changelog

Update the docs triggering.mdx - text indicating options argument position:
- Options object is a third argument instead of stated second argument (`trigger` function)
- Options object is a third argument instead of stated second argument (`batchTrigger` function)
