### PR TITLE
Queues dashboard update (burst concurrency)

### DIFF
--- a/apps/webapp/app/components/metrics/BigNumber.tsx
+++ b/apps/webapp/app/components/metrics/BigNumber.tsx
@@ -14,7 +14,7 @@ interface BigNumberProps {
   valueClassName?: string;
   defaultValue?: number;
   accessory?: ReactNode;
-  suffix?: string;
+  suffix?: ReactNode;
   suffixClassName?: string;
   compactThreshold?: number;
 }

--- a/apps/webapp/app/components/primitives/Buttons.tsx
+++ b/apps/webapp/app/components/primitives/Buttons.tsx
@@ -163,6 +163,8 @@ const allVariants = {
   variant: variant,
 };
 
+export type ButtonVariant = keyof typeof variant;
+
 export type ButtonContentPropsType = {
   children?: React.ReactNode;
   LeadingIcon?: RenderIcon;
@@ -173,7 +175,7 @@ export type ButtonContentPropsType = {
   textAlignLeft?: boolean;
   className?: string;
   shortcut?: ShortcutDefinition;
-  variant: keyof typeof variant;
+  variant: ButtonVariant;
   shortcutPosition?: "before-trailing-icon" | "after-trailing-icon";
   tooltip?: ReactNode;
   iconSpacing?: string;

--- a/apps/webapp/app/components/runs/v3/RunFilters.tsx
+++ b/apps/webapp/app/components/runs/v3/RunFilters.tsx
@@ -1286,8 +1286,10 @@ function VersionsDropdown({
           {filtered.length > 0
             ? filtered.map((version) => (
                 <SelectItem key={version.version} value={version.version}>
-                  {version.version}{" "}
-                  {version.isCurrent ? <Badge variant="extra-small">current</Badge> : null}
+                  <span className="flex items-center gap-2">
+                    <span className="grow truncate">{version.version}</span>
+                    {version.isCurrent ? <Badge variant="extra-small">Current</Badge> : null}
+                  </span>
                 </SelectItem>
               ))
             : null}

--- a/apps/webapp/app/presenters/v3/EnvironmentQueuePresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/EnvironmentQueuePresenter.server.ts
@@ -7,6 +7,7 @@ export type Environment = {
   running: number;
   queued: number;
   concurrencyLimit: number;
+  burstFactor: number;
 };
 
 export class EnvironmentQueuePresenter extends BasePresenter {
@@ -26,6 +27,7 @@ export class EnvironmentQueuePresenter extends BasePresenter {
       running,
       queued,
       concurrencyLimit: environment.maximumConcurrencyLimit,
+      burstFactor: environment.concurrencyLimitBurstFactor.toNumber(),
     };
   }
 }

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -282,11 +282,14 @@ export default function Page() {
               animate
               valueClassName={limitClassName}
               suffix={
-                limitStatus === "burst"
-                  ? `Including ${environment.running - environment.concurrencyLimit} burst runs`
-                  : limitStatus === "limit"
-                  ? "At concurrency limit"
-                  : undefined
+                limitStatus === "burst" ? (
+                  <span className={cn(limitClassName, "flex items-center gap-1")}>
+                    Including {environment.running - environment.concurrencyLimit} burst runs{" "}
+                    <BurstFactorTooltip environment={environment} />
+                  </span>
+                ) : limitStatus === "limit" ? (
+                  "At concurrency limit"
+                ) : undefined
               }
               compactThreshold={1000000}
             />
@@ -299,10 +302,7 @@ export default function Page() {
                 environment.burstFactor > 1 ? (
                   <span className={cn(limitClassName, "flex items-center gap-1")}>
                     Burst limit {environment.burstFactor * environment.concurrencyLimit}{" "}
-                    <InfoIconTooltip
-                      content={`You can burst up to ${environment.burstFactor}x your concurrency limit. For a single queue you can't go above your normal limit (${environment.concurrencyLimit}), but you can burst when running across multiple queues/tasks.`}
-                      contentClassName="max-w-xs"
-                    />
+                    <BurstFactorTooltip environment={environment} />
                   </span>
                 ) : undefined
               }
@@ -781,5 +781,22 @@ export function QueueFilters() {
         onChange={(e) => handleSearchChange(e.target.value)}
       />
     </div>
+  );
+}
+
+function BurstFactorTooltip({
+  environment,
+}: {
+  environment: { burstFactor: number; concurrencyLimit: number };
+}) {
+  return (
+    <InfoIconTooltip
+      content={`Your single queue concurrency limit is capped at ${
+        environment.concurrencyLimit
+      }, but you can burst up to ${
+        environment.burstFactor * environment.concurrencyLimit
+      } when across multiple queues/tasks.`}
+      contentClassName="max-w-xs"
+    />
   );
 }


### PR DESCRIPTION
- Clearly show how burst concurrency works on the Queues page
- Added links to “View runs” for the queued, running in env
- Added links to individual queues for all, queued and running
- Fixed an ugly version filter “current” badge