### PR TITLE
Run repository test fix

### DIFF
--- a/apps/webapp/test/runsRepository.test.ts
+++ b/apps/webapp/test/runsRepository.test.ts
@@ -1,3 +1,11 @@
+import { describe, expect, vi } from "vitest";
+
+// Mock the db prisma client
+vi.mock("~/db.server", () => ({
+  prisma: {},
+  $replica: {},
+}));
+
 import { containerTest } from "@internal/testcontainers";
 import { setTimeout } from "node:timers/promises";
 import { RunsRepository } from "~/services/runsRepository/runsRepository.server";


### PR DESCRIPTION
The normal database needs to be mocked because an import somewhere is 
using it which causes issues with the test container dbs and hanging at 
the end. 

Strategy copied from the trigger test file.