### PR TITLE
perf: cancel readonly ClickHouse queries on client close

### DIFF
--- a/internal-packages/clickhouse/src/client/client.ts
+++ b/internal-packages/clickhouse/src/client/client.ts
@@ -62,6 +62,7 @@ export class ClickhouseClient implements ClickhouseReader, ClickhouseWriter {
         ...config.clickhouseSettings,
         output_format_json_quote_64bit_integers: 0,
         output_format_json_quote_64bit_floats: 0,
+        cancel_http_readonly_queries_on_client_close: 1,
       },
       log: {
         level: convertLogLevelToClickhouseLogLevel(config.logLevel),


### PR DESCRIPTION
This PR enables the `cancel_http_readonly_queries_on_client_close`
setting explicitly on the client side. Helps reduce the load on the database
by canceling queries where the client has already disconnected.
