### PR TITLE
feat(ecr): make assume role optional

### DIFF
--- a/apps/webapp/app/v3/services/finalizeDeploymentV2.server.ts
+++ b/apps/webapp/app/v3/services/finalizeDeploymentV2.server.ts
@@ -271,10 +271,12 @@ async function ensureLoggedIntoDockerRegistry(
   if (isEcrRegistry(registryHost)) {
     auth = await getEcrAuthToken({
       registryHost,
-      assumeRole: {
-        roleArn: env.DEPLOY_REGISTRY_ECR_ASSUME_ROLE_ARN,
-        externalId: env.DEPLOY_REGISTRY_ECR_ASSUME_ROLE_EXTERNAL_ID,
-      },
+      assumeRole: env.DEPLOY_REGISTRY_ECR_ASSUME_ROLE_ARN
+        ? {
+            roleArn: env.DEPLOY_REGISTRY_ECR_ASSUME_ROLE_ARN,
+            externalId: env.DEPLOY_REGISTRY_ECR_ASSUME_ROLE_EXTERNAL_ID,
+          }
+        : undefined,
     });
   } else if (!auth) {
     throw new Error("Authentication required for non-ECR registry");

--- a/apps/webapp/app/v3/services/initializeDeployment.server.ts
+++ b/apps/webapp/app/v3/services/initializeDeployment.server.ts
@@ -77,10 +77,12 @@ export class InitializeDeploymentService extends BaseService {
           nextVersion,
           environmentSlug: environment.slug,
           registryTags: env.DEPLOY_REGISTRY_ECR_TAGS,
-          assumeRole: {
-            roleArn: env.DEPLOY_REGISTRY_ECR_ASSUME_ROLE_ARN,
-            externalId: env.DEPLOY_REGISTRY_ECR_ASSUME_ROLE_EXTERNAL_ID,
-          },
+          assumeRole: env.DEPLOY_REGISTRY_ECR_ASSUME_ROLE_ARN
+            ? {
+                roleArn: env.DEPLOY_REGISTRY_ECR_ASSUME_ROLE_ARN,
+                externalId: env.DEPLOY_REGISTRY_ECR_ASSUME_ROLE_EXTERNAL_ID,
+              }
+            : undefined,
         })
       );
 


### PR DESCRIPTION
Fixes #2291 

When using an ECR registry without specifying a role ARN the deploy would previously fail even when valid credentials were already present.