### PR TITLE
Docs: Fixes incorrect concurrency pricing on the limits page

### DIFF
--- a/docs/limits.mdx
+++ b/docs/limits.mdx
@@ -13,7 +13,7 @@ import RateLimitHitUseBatchTrigger from "/snippets/rate-limit-hit-use-batchtrigg
 | Hobby        | 25 concurrent runs   |
 | Pro          | 100+ concurrent runs |
 
-Additional bundles above the Pro tier are available for $10/month per 100 concurrent runs. Contact us via [email](https://trigger.dev/contact) or [Discord](https://trigger.dev/discord) to request more.
+Additional bundles above the Pro tier are available for $50/month per 50 concurrent runs. Contact us via [email](https://trigger.dev/contact) or [Discord](https://trigger.dev/discord) to request more.
 
 ## Rate limits
 
@@ -69,7 +69,7 @@ Additional bundles above the Pro tier are available for $10/month per preview br
 | Hobby        | 50 concurrent connections   |
 | Pro          | 500+ concurrent connections |
 
-Additional bundles are available for $10/month per 100 realtime connections. Contact us via [email](https://trigger.dev/contact) or [Discord](https://trigger.dev/discord) to request more.
+Additional bundles are available for $10/month per 100 concurrent connections. Contact us via [email](https://trigger.dev/contact) or [Discord](https://trigger.dev/discord) to request more.
 
 ## Task payloads and outputs
 


### PR DESCRIPTION
Updates the concurrency pricing to the correct $50 for bundles of 50.