### PR TITLE
Prevents long project menu titles pushing the admin buttons out of bo…

### DIFF
--- a/apps/webapp/app/components/navigation/SideMenu.tsx
+++ b/apps/webapp/app/components/navigation/SideMenu.tsx
@@ -143,16 +143,18 @@ export function SideMenu({
     >
       <div
         className={cn(
-          "flex items-center justify-between overflow-hidden border-b px-1 py-1 transition duration-300",
+          "flex items-center overflow-hidden border-b px-1 py-1 transition duration-300",
           showHeaderDivider ? "border-grid-bright" : "border-transparent"
         )}
       >
-        <ProjectSelector
-          organizations={organizations}
-          organization={organization}
-          project={project}
-          user={user}
-        />
+        <div className="min-w-0 flex-1">
+          <ProjectSelector
+            organizations={organizations}
+            organization={organization}
+            project={project}
+            user={user}
+          />
+        </div>
         {isAdmin && !user.isImpersonating ? (
           <TooltipProvider disableHoverableContent={true}>
             <Tooltip>


### PR DESCRIPTION
This fixes long project titles pushing the admin buttons out of the Main menu container. 

### Non-truncated titles
<img width="464" height="84" alt="CleanShot 2025-08-01 at 14 16 22@2x" src="https://github.com/user-attachments/assets/60f79178-69a3-4c96-84ca-62664153f522" />

<img width="458" height="92" alt="CleanShot 2025-08-01 at 14 12 36@2x" src="https://github.com/user-attachments/assets/0d3ebf55-cb02-4c77-a60f-0e35381d6fa2" />

### Truncated titles
<img width="468" height="88" alt="CleanShot 2025-08-01 at 14 16 00@2x" src="https://github.com/user-attachments/assets/fbbede0b-540b-49c2-a4d0-bf862a492f65" />

<img width="470" height="88" alt="CleanShot 2025-08-01 at 14 15 15@2x" src="https://github.com/user-attachments/assets/9ac4fa31-dc20-44d8-a487-78608952ba02" />
