### PR TITLE
Show text wrapping on code blocks

### DIFF
--- a/apps/webapp/app/components/runs/v3/DeploymentError.tsx
+++ b/apps/webapp/app/components/runs/v3/DeploymentError.tsx
@@ -18,6 +18,7 @@ export function DeploymentError({ errorData }: DeploymentErrorProps) {
           showLineNumbers={false}
           code={errorData.stack}
           maxLines={20}
+          showTextWrapping
         />
       )}
       {errorData.stderr && (
@@ -28,6 +29,7 @@ export function DeploymentError({ errorData }: DeploymentErrorProps) {
             showLineNumbers={false}
             code={errorData.stderr}
             maxLines={20}
+            showTextWrapping
           />
         </>
       )}

--- a/apps/webapp/app/components/runs/v3/PacketDisplay.tsx
+++ b/apps/webapp/app/components/runs/v3/PacketDisplay.tsx
@@ -33,6 +33,7 @@ export function PacketDisplay({
           code={data}
           maxLines={20}
           showLineNumbers={false}
+          showTextWrapping
         />
       );
     }

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -753,12 +753,12 @@ function RunBody({
             </div>
           ) : tab === "context" ? (
             <div className="flex flex-col gap-4 py-3">
-              <CodeBlock code={run.context} showLineNumbers={false} />
+              <CodeBlock code={run.context} showLineNumbers={false} showTextWrapping />
             </div>
           ) : tab === "metadata" ? (
             <div className="flex flex-col gap-4 py-3">
               {run.metadata ? (
-                <CodeBlock code={run.metadata} showLineNumbers={false} />
+                <CodeBlock code={run.metadata} showLineNumbers={false} showTextWrapping />
               ) : (
                 <Callout to="https://trigger.dev/docs/runs/metadata" variant="docs">
                   No metadata set for this run. View our metadata documentation to learn more.


### PR DESCRIPTION
Adds `textWrapping` button to the CodeBlocks on the:
- Context tab on the Run page
- Error CodeBlocks on the Deployments page
<img width="864" height="400" alt="CleanShot 2025-08-02 at 15 19 43@2x" src="https://github.com/user-attachments/assets/23ea9d2b-efe7-4286-a779-b9177cbcb918" />
