### PR TITLE
Fixes incorrect icon colors

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam._index/route.tsx
@@ -372,12 +372,13 @@ export default function Page() {
                                         icon={RunsIcon}
                                         to={path}
                                         title="View runs"
-                                        leadingIconClassName="text-teal-500"
+                                        leadingIconClassName="text-runs"
                                       />
                                       <PopoverMenuItem
                                         icon={BeakerIcon}
                                         to={testPath}
                                         title="Test task"
+                                        leadingIconClassName="text-tests"
                                       />
                                     </>
                                   }


### PR DESCRIPTION
For some reason, the icon colors on the Task page dropdown menu didn't match the main side menu colors:

Before:
<img width="352" height="184" alt="CleanShot 2025-08-02 at 15 55 49@2x" src="https://github.com/user-attachments/assets/206e1b66-1875-4d07-b4f2-a95102ad4347" />

After: 
<img width="346" height="192" alt="CleanShot 2025-08-02 at 16 04 24@2x" src="https://github.com/user-attachments/assets/e740b8bf-5cdd-4003-807d-df430ceed172" />
