### PR TITLE
Force-wrap long strings in the run error callout

### DIFF
--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -855,7 +855,7 @@ function RunError({ error }: { error: TaskRunError }) {
           <Header3 className="text-rose-500">{name}</Header3>
           {enhancedError.message && (
             <Callout variant="error">
-              <pre className="text-wrap font-sans text-sm font-normal text-rose-200">
+              <pre className="text-wrap font-sans text-sm font-normal text-rose-200 [word-break:break-word]">
                 {enhancedError.message}
               </pre>
             </Callout>


### PR DESCRIPTION
Long error strings were breaking out of the error callout panel on the Run details inspector:

<img width="496" height="600" alt="CleanShot 2025-08-02 at 16 53 40" src="https://github.com/user-attachments/assets/1b9cea23-610e-4e47-afbf-cb974d587465" />

<img width="638" height="596" alt="CleanShot 2025-08-02 at 16 53 53" src="https://github.com/user-attachments/assets/b9e5dc0d-ba3e-4d73-818f-7d20d5976698" />

### They now wrap:
<img width="872" height="702" alt="CleanShot 2025-08-02 at 16 49 59@2x" src="https://github.com/user-attachments/assets/0ab09f6c-2bf1-41e9-9e68-27662a6ff5a9" />
