### PR TITLE
Explain run status on run inspector panel

### DIFF
--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -7,7 +7,6 @@ import {
 import { type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import {
   formatDurationMilliseconds,
-  MachinePresetName,
   type TaskRunError,
   taskRunErrorEnhancer,
 } from "@trigger.dev/core/v3";
@@ -46,7 +45,10 @@ import { RunTag } from "~/components/runs/v3/RunTag";
 import { SpanEvents } from "~/components/runs/v3/SpanEvents";
 import { SpanTitle } from "~/components/runs/v3/SpanTitle";
 import { TaskRunAttemptStatusCombo } from "~/components/runs/v3/TaskRunAttemptStatus";
-import { TaskRunStatusCombo, TaskRunStatusReason } from "~/components/runs/v3/TaskRunStatus";
+import {
+  descriptionForTaskRunStatus,
+  TaskRunStatusCombo,
+} from "~/components/runs/v3/TaskRunStatus";
 import { WaitpointDetailTable } from "~/components/runs/v3/WaitpointDetails";
 import { RuntimeIcon } from "~/components/RuntimeIcon";
 import { WarmStartCombo } from "~/components/WarmStarts";
@@ -403,7 +405,10 @@ function RunBody({
                 <Property.Item>
                   <Property.Label>Status</Property.Label>
                   <Property.Value>
-                    <TaskRunStatusCombo status={run.status} />
+                    <SimpleTooltip
+                      button={<TaskRunStatusCombo status={run.status} />}
+                      content={descriptionForTaskRunStatus(run.status)}
+                    />
                   </Property.Value>
                 </Property.Item>
                 <Property.Item>
@@ -767,9 +772,11 @@ function RunBody({
             </div>
           ) : (
             <div className="flex flex-col gap-4 pt-3">
-              <div className="space-y-2 border-b border-grid-bright pb-3">
-                <TaskRunStatusCombo status={run.status} className="text-sm" />
-                <TaskRunStatusReason status={run.status} statusReason={run.statusReason} />
+              <div className="border-b border-grid-bright pb-3">
+                <SimpleTooltip
+                  button={<TaskRunStatusCombo status={run.status} className="text-sm" />}
+                  content={descriptionForTaskRunStatus(run.status)}
+                />
               </div>
               <RunTimeline run={run} />
 


### PR DESCRIPTION
### You can now hover over the status in the Run Inspector to see the status description

<img width="786" height="353" alt="CleanShot 2025-08-02 at 18 19 38@2x" src="https://github.com/user-attachments/assets/2aae5da3-e8f4-43e1-a3a3-f15735e4e92f" />

### Also added to the status in the Details tab:
<img width="778" height="297" alt="CleanShot 2025-08-02 at 18 20 01@2x" src="https://github.com/user-attachments/assets/d6e55123-ee5a-4b52-afd7-b3e56e059cd7" />
