### PR TITLE
Preview branches blank state: improved messaging

### DIFF
--- a/apps/webapp/app/components/BlankStatePanels.tsx
+++ b/apps/webapp/app/components/BlankStatePanels.tsx
@@ -477,6 +477,10 @@ export function BranchesNoBranchableEnvironment() {
         Preview branches in Trigger.dev create isolated environments for testing new features before
         production.
       </Paragraph>
+      <Paragraph variant="small">
+        You must be on <V4Badge inline /> to access preview branches. Read our{" "}
+        <TextLink to={docsPath("upgrade-to-v4")}>upgrade to v4 guide</TextLink> to learn more.
+      </Paragraph>
     </InfoPanel>
   );
 }


### PR DESCRIPTION
Better messaging so people know they need to be on v4 in order to get v4.

<img width="1182" height="638" alt="CleanShot 2025-08-02 at 18 36 22@2x" src="https://github.com/user-attachments/assets/f43dc3a4-dc6a-437a-8aad-fdd3f7ebc836" />
