### PR TITLE
Adds a link to the reduce spend docs page from the billing alerts page

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.settings.billing-alerts/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.settings.billing-alerts/route.tsx
@@ -205,8 +205,11 @@ export default function Page() {
               <Header2 spacing>Billing alerts</Header2>
               <Paragraph variant="small">
                 Receive an email when your compute spend crosses different thresholds. You can also
-                learn how to reduce your compute spend in the{" "}
-                <TextLink to={docsPath("how-to-reduce-your-spend")}>docs</TextLink>.
+                learn how to{" "}
+                <TextLink to={docsPath("how-to-reduce-your-spend")}>
+                  reduce your compute spend
+                </TextLink>
+                .
               </Paragraph>
             </div>
             <Form method="post" {...form.props}>


### PR DESCRIPTION
Link to the "How to reduce your spend" docs page from the billing alerts page

<img width="1254" height="1254" alt="CleanShot 2025-08-03 at 11 10 05@2x" src="https://github.com/user-attachments/assets/392f116f-2e74-47a3-aa4b-f0eaab970210" />
