### PR TITLE
fix(playwright): improve chrome installation and fix spinner duplication on narrow terminals

### DIFF
--- a/.changeset/silent-lobsters-march.md
+++ b/.changeset/silent-lobsters-march.md
@@ -1,0 +1,7 @@
+---
+"trigger.dev": patch
+"@trigger.dev/build": patch
+---
+
+- Improve playwright non-headless chrome installation
+- Prevent spinner message duplication in narrow terminals

--- a/packages/cli-v3/src/utilities/windows.ts
+++ b/packages/cli-v3/src/utilities/windows.ts
@@ -7,6 +7,67 @@ export function escapeImportPath(path: string) {
   return isWindows ? path.replaceAll("\\", "\\\\") : path;
 }
 
+// Removes ANSI escape sequences to get actual visible length
+function getVisibleLength(str: string): number {
+  return (
+    str
+      // Remove terminal hyperlinks: \u001b]8;;URL\u0007TEXT\u001b]8;;\u0007
+      .replace(/\u001b]8;;[^\u0007]*\u0007/g, "")
+      // Remove standard ANSI escape sequences (colors, cursor movement, etc.)
+      .replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "").length
+  );
+}
+
+function truncateMessage(msg: string, maxLength?: number): string {
+  const terminalWidth = maxLength ?? process.stdout.columns ?? 80;
+  const availableWidth = terminalWidth - 5; // Reserve some space for the spinner and padding
+  const visibleLength = getVisibleLength(msg);
+
+  if (visibleLength <= availableWidth) {
+    return msg;
+  }
+
+  // We need to truncate based on visible characters, but preserve ANSI sequences
+  // Simple approach: truncate character by character until we fit
+  let truncated = msg;
+  while (getVisibleLength(truncated) > availableWidth - 3) {
+    truncated = truncated.slice(0, -1);
+  }
+
+  return truncated + "...";
+}
+
+const wrappedClackSpinner = () => {
+  let currentMessage = "";
+  let isActive = false;
+
+  const handleResize = () => {
+    if (isActive && currentMessage) {
+      spinner.message(truncateMessage(currentMessage));
+    }
+  };
+
+  const spinner = clackSpinner();
+
+  return {
+    start: (msg?: string): void => {
+      currentMessage = msg ?? "";
+      isActive = true;
+      process.stdout.on("resize", handleResize);
+      spinner.start(truncateMessage(currentMessage));
+    },
+    stop: (msg?: string, code?: number): void => {
+      isActive = false;
+      process.stdout.off("resize", handleResize);
+      spinner.stop(truncateMessage(msg ?? ""), code);
+    },
+    message: (msg?: string): void => {
+      currentMessage = msg ?? "";
+      spinner.message(truncateMessage(currentMessage));
+    },
+  };
+};
+
 const ballmerSpinner = () => ({
   start: (msg?: string): void => {
     log.step(msg ?? "");
@@ -21,4 +82,4 @@ const ballmerSpinner = () => ({
 
 // This will become unecessary with the next clack release, the bug was fixed here:
 // https://github.com/natemoo-re/clack/pull/182
-export const spinner = () => (isWindows ? ballmerSpinner() : clackSpinner());
+export const spinner = () => (isWindows ? ballmerSpinner() : wrappedClackSpinner());


### PR DESCRIPTION
Fixes #2226 

- **Improved Playwright chrome installation**: Enhanced non-headless chrome installation to ensure both chrome binaries are installed even when `headless: false` is specified
- **Fixed spinner duplication**: Resolved issue where spinner messages would duplicate on narrow terminals