### PR TITLE
Docs: Fixed code example in reduce spend docs page

### DIFF
--- a/docs/how-to-reduce-your-spend.mdx
+++ b/docs/how-to-reduce-your-spend.mdx
@@ -104,12 +104,10 @@ Sometimes it's more efficient to do more work in a single task than split across
 export const processItems = task({
   id: "process-items",
   run: async (payload: { items: string[] }) => {
-    // Process all items in one run
-    for (const item of payload.items) {
-      // Do async work in parallel
-      // This works very well for API calls
-      await processItem(item);
-    }
+    // Process all items in parallel
+    const promises = payload.items.map(item => processItem(item));
+    // This works very well for API calls
+    await Promise.all(promises);
   },
 });
 ```


### PR DESCRIPTION
Changed the code example so it actually shows work done in parallel, not sequential 