### PR TITLE
#2250 elderberry

### DIFF
--- a/internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
@@ -181,6 +181,7 @@ export class RunAttemptSystem {
         lockedById: true,
         lockedQueueId: true,
         queue: true,
+        concurrencyKey: true,
         attemptNumber: true,
         status: true,
         ttl: true,
@@ -248,6 +249,7 @@ export class RunAttemptSystem {
     ]);
 
     return {
+      concurrencyKey: run.concurrencyKey ?? undefined,
       run: {
         id: run.friendlyId,
         tags: run.runTags,
@@ -396,6 +398,7 @@ export class RunAttemptSystem {
                   lockedById: true,
                   lockedQueueId: true,
                   queue: true,
+                  concurrencyKey: true,
                   attemptNumber: true,
                   status: true,
                   ttl: true,
@@ -533,6 +536,7 @@ export class RunAttemptSystem {
             ]);
 
           const execution: BackwardsCompatibleTaskRunExecution = {
+            concurrencyKey: updatedRun.concurrencyKey ?? undefined,
             attempt: {
               number: nextAttemptNumber,
               startedAt: latestSnapshot.updatedAt,

--- a/packages/core/src/v3/schemas/common.ts
+++ b/packages/core/src/v3/schemas/common.ts
@@ -334,6 +334,8 @@ export const TaskRunExecution = z.object({
       traceContext: z.record(z.unknown()).optional(),
     })
   ),
+  // The concurrencyKey creates a copy of the queue per unique value
+  concurrencyKey: z.string().optional(),
   ...StaticTaskRunExecutionShape,
 });
 
@@ -406,6 +408,8 @@ export const TaskRunContext = z.object({
     durationMs: true,
     costInCents: true,
   }),
+  // The concurrencyKey used for this run, if any
+  concurrencyKey: z.string().optional(),
   ...StaticTaskRunExecutionShape,
 });
 


### PR DESCRIPTION
special issue for eric

Edits made:
- packages/core/src/v3/schemas/common.ts
  - Added optional concurrencyKey to both `TaskRunExecution` and `TaskRunContext`:
    - `concurrencyKey?: string` on the top-level of both objects.

- internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
  - In `resolveTaskRunContext`:
    - Included `concurrencyKey: true` in the Prisma `select`.
    - Returned `concurrencyKey: run.concurrencyKey ?? undefined` at the top-level of the context.
  - In `startRunAttempt` (where the execution payload is built):
    - Included `concurrencyKey: true` in the Prisma `select`.
    - Added `concurrencyKey: updatedRun.concurrencyKey ?? undefined` to the top-level of the execution payload.

Why this fixes it:
- The worker process parses `TaskRunContext` directly from the execution payload. With the schema updates and engine population, `ctx.concurrencyKey` will now be available in the task’s `run` function as requested.

Notes on validation:
- There’s already a log in the managed worker that prints the received execution payload. That log will now include `concurrencyKey`, allowing you to verify it quickly.
- Lints on modified files show no errors.

- Added `ctx.concurrencyKey` support:
  - Schemas: Added `concurrencyKey?: string` to `TaskRunExecution` and `TaskRunContext` in `packages/core/src/v3/schemas/common.ts`.
  - Engine: Selected and populated `concurrencyKey` in `resolveTaskRunContext` and the execution payload in `startRunAttempt` within `internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts`.
  - You can now access it via `ctx.concurrencyKey` inside task `run`.