### PR TITLE
#2250 - carrot

### DIFF
--- a/internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
@@ -187,6 +187,7 @@ export class RunAttemptSystem {
         machinePreset: true,
         runTags: true,
         isTest: true,
+        concurrencyKey: true,
         idempotencyKey: true,
         startedAt: true,
         maxAttempts: true,
@@ -248,6 +249,7 @@ export class RunAttemptSystem {
     ]);
 
     return {
+      concurrencyKey: run.concurrencyKey ?? undefined,
       run: {
         id: run.friendlyId,
         tags: run.runTags,

--- a/packages/core/src/v3/schemas/common.ts
+++ b/packages/core/src/v3/schemas/common.ts
@@ -398,6 +398,8 @@ export const V3TaskRunExecution = z.object({
 export type V3TaskRunExecution = z.infer<typeof V3TaskRunExecution>;
 
 export const TaskRunContext = z.object({
+  /** The concurrency key used when triggering this run, if any */
+  concurrencyKey: z.string().optional(),
   attempt: TaskRunExecutionAttempt,
   run: TaskRun.omit({
     payload: true,
@@ -420,6 +422,8 @@ export const V3TaskRunExecutionEnvironment = z.object({
 export type V3TaskRunExecutionEnvironment = z.infer<typeof V3TaskRunExecutionEnvironment>;
 
 export const V3TaskRunContext = z.object({
+  /** The concurrency key used when triggering this run, if any */
+  concurrencyKey: z.string().optional(),
   attempt: V3TaskRunExecutionAttempt.omit({
     backgroundWorkerId: true,
     backgroundWorkerTaskId: true,


### PR DESCRIPTION
special pr for eric


Added `concurrencyKey` to the task-run execution context so you can now access it directly in your task’s `ctx`.

Key changes:
1. `packages/core/src/v3/schemas/common.ts`
   • Extended both `TaskRunContext` and `V3TaskRunContext` schemas with an optional `concurrencyKey` field.

2. `internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts`
   • Fetched `concurrencyKey` from the database when resolving a run’s context.
   • Included `concurrencyKey` at the top level of the context object returned by `resolveTaskRunContext`.

Now, inside a task you can do:

```ts
run: async (payload, { ctx }) => {
  console.log(ctx.concurrencyKey); // "user-123" (if provided when triggering)
}
```

No other code paths are affected; the new field is optional and won’t break existing tasks.