### PR TITLE
#2223 - carrot

### DIFF
--- a/packages/react-hooks/src/hooks/useRealtime.ts
+++ b/packages/react-hooks/src/hooks/useRealtime.ts
@@ -78,17 +78,19 @@ export function useRealtimeRun<TTask extends AnyTask>(
   const idKey = options?.id ?? hookId;
 
   // Store the streams state in SWR, using the idKey as the key to share states.
-  const { data: run, mutate: mutateRun } = useSWR<RealtimeRun<TTask>>([idKey, "run"], null);
+  const { data: run, mutate: mutateRun } = useSWR<RealtimeRun<TTask>>([idKey, "run"], null, { fetcher: () => undefined as any });
 
   const { data: error = undefined, mutate: setError } = useSWR<undefined | Error>(
     [idKey, "error"],
-    null
+    null,
+    { fetcher: () => undefined as any }
   );
 
   // Add state to track when the subscription is complete
   const { data: isComplete = false, mutate: setIsComplete } = useSWR<boolean>(
     [idKey, "complete"],
-    null
+    null,
+    { fetcher: () => undefined as any }
   );
 
   // Abort controller to cancel the current API call.
@@ -228,6 +230,7 @@ export function useRealtimeRunWithStreams<
     [idKey, "streams"],
     null,
     {
+      fetcher: () => undefined as any,
       fallbackData: initialStreamsFallback,
     }
   );
@@ -239,17 +242,19 @@ export function useRealtimeRunWithStreams<
   }, [streams]);
 
   // Store the streams state in SWR, using the idKey as the key to share states.
-  const { data: run, mutate: mutateRun } = useSWR<RealtimeRun<TTask>>([idKey, "run"], null);
+  const { data: run, mutate: mutateRun } = useSWR<RealtimeRun<TTask>>([idKey, "run"], null, { fetcher: () => undefined as any });
 
   // Add state to track when the subscription is complete
   const { data: isComplete = false, mutate: setIsComplete } = useSWR<boolean>(
     [idKey, "complete"],
-    null
+    null,
+    { fetcher: () => undefined as any }
   );
 
   const { data: error = undefined, mutate: setError } = useSWR<undefined | Error>(
     [idKey, "error"],
-    null
+    null,
+    { fetcher: () => undefined as any }
   );
 
   // Abort controller to cancel the current API call.
@@ -402,6 +407,7 @@ export function useRealtimeRunsWithTag<TTask extends AnyTask>(
 
   // Store the streams state in SWR, using the idKey as the key to share states.
   const { data: runs, mutate: mutateRuns } = useSWR<RealtimeRun<TTask>[]>([idKey, "run"], null, {
+    fetcher: () => undefined as any,
     fallbackData: [],
   });
 
@@ -413,7 +419,8 @@ export function useRealtimeRunsWithTag<TTask extends AnyTask>(
 
   const { data: error = undefined, mutate: setError } = useSWR<undefined | Error>(
     [idKey, "error"],
-    null
+    null,
+    { fetcher: () => undefined as any }
   );
 
   // Abort controller to cancel the current API call.
@@ -500,6 +507,7 @@ export function useRealtimeBatch<TTask extends AnyTask>(
 
   // Store the streams state in SWR, using the idKey as the key to share states.
   const { data: runs, mutate: mutateRuns } = useSWR<RealtimeRun<TTask>[]>([idKey, "run"], null, {
+    fetcher: () => undefined as any,
     fallbackData: [],
   });
 
@@ -511,7 +519,8 @@ export function useRealtimeBatch<TTask extends AnyTask>(
 
   const { data: error = undefined, mutate: setError } = useSWR<undefined | Error>(
     [idKey, "error"],
-    null
+    null,
+    { fetcher: () => undefined as any }
   );
 
   // Abort controller to cancel the current API call.


### PR DESCRIPTION

Problem recap
SWR lets applications supply a global `fetcher` via `<SWRConfig value={{ fetcher }}>`.  
Our realtime hooks (`useRealtime*`) were calling `useSWR(key, null)` which:

1. puts the hook into “controlled-by-mutate” mode (no local fetcher), **but**
2. still falls back to the global `fetcher` when one exists.

If an app wrapped in an `SWRConfig` defines a global fetcher, every realtime-subscription hook triggered an unexpected HTTP request before the first `mutate`, causing race-conditions and 404/500 noise.

Root-cause analysis (considered sources)  
1. Calls that omit/disable the fetcher (`null`) still inherit the global fetcher.  
2. Re-exports in `trigger-swr.ts` share the same SWR context as the host app.  
3. We store subscription state in SWR cache; an unwanted revalidation overwrites our manual `mutate`s.  
4. Caching key collisions could make the problem appear intermittent.  
5. Strict-mode double mounting in React 18 doubled the ghost requests.  
6. Dev-tools pre-fetch (not the culprit – happens after mount).  
7. Suspense middleware (not enabled here).

Most-likely issues: (1) & (2).

Fix strategy
Give every internal realtime call its own inert fetcher so the global one is never consulted.

Code changes (all in `packages/react-hooks/src/hooks/useRealtime.ts`)
• For every `useSWR`/`useSWRMutation` that is meant to be “write-only”:
  – keep the `null` second argument (still disables local revalidation)  
  – add a third-argument config `{ fetcher: () => undefined as any }`  
  – when a config object already existed (`fallbackData`), extend it.

This guarantees:

• Type-safe: the dummy fetcher satisfies `BareFetcher<T>` while returning nothing.  
• Behaviour-safe: the function is never executed (because revalidation is disabled) but it blocks inheritance of the global fetcher.

All lints now pass.

Next steps / validation
1. In a demo app wrap everything in  
   ```jsx
   <SWRConfig value={{ fetcher: url => fetch(url).then(r => r.json()) }}>
   ```  
   then mount any `useRealtime*` hook.  
   → You should see zero outbound requests until the first `mutate` we perform internally.
2. Watch your network-tab / logs to confirm.

If you still notice stray requests, enable logging in SWR by adding  
```js
onSuccess: (...args) => console.log('realtime SWR success', args),
onError:   (...args) => console.log('realtime SWR error', args),
```  
inside the config we just added to verify that our dummy fetcher is never executed.

That should permanently decouple the Trigger.dev realtime hooks from any global SWR fetcher the host application defines.