### PR TITLE
#2223 - dragonfruit

### DIFF
--- a/packages/react-hooks/src/hooks/useRealtime.ts
+++ b/packages/react-hooks/src/hooks/useRealtime.ts
@@ -8,7 +8,7 @@ import {
   RealtimeRunSkipColumns,
 } from "@trigger.dev/core/v3";
 import { useCallback, useEffect, useId, useRef, useState } from "react";
-import { KeyedMutator, useSWR } from "../utils/trigger-swr.js";
+import { KeyedMutator, useInternalSWR } from "../utils/trigger-swr.js";
 import { useApiClient, UseApiClientOptions } from "./useApiClient.js";
 import { createThrottledQueue } from "../utils/throttle.js";
 
@@ -78,15 +78,15 @@ export function useRealtimeRun<TTask extends AnyTask>(
   const idKey = options?.id ?? hookId;
 
   // Store the streams state in SWR, using the idKey as the key to share states.
-  const { data: run, mutate: mutateRun } = useSWR<RealtimeRun<TTask>>([idKey, "run"], null);
+  const { data: run, mutate: mutateRun } = useInternalSWR<RealtimeRun<TTask>>([idKey, "run"], null);
 
-  const { data: error = undefined, mutate: setError } = useSWR<undefined | Error>(
+  const { data: error = undefined, mutate: setError } = useInternalSWR<undefined | Error>(
     [idKey, "error"],
     null
   );
 
   // Add state to track when the subscription is complete
-  const { data: isComplete = false, mutate: setIsComplete } = useSWR<boolean>(
+  const { data: isComplete = false, mutate: setIsComplete } = useInternalSWR<boolean>(
     [idKey, "complete"],
     null
   );
@@ -224,7 +224,7 @@ export function useRealtimeRunWithStreams<
   const [initialStreamsFallback] = useState({} as StreamResults<TStreams>);
 
   // Store the streams state in SWR, using the idKey as the key to share states.
-  const { data: streams, mutate: mutateStreams } = useSWR<StreamResults<TStreams>>(
+  const { data: streams, mutate: mutateStreams } = useInternalSWR<StreamResults<TStreams>>(
     [idKey, "streams"],
     null,
     {
@@ -239,15 +239,15 @@ export function useRealtimeRunWithStreams<
   }, [streams]);
 
   // Store the streams state in SWR, using the idKey as the key to share states.
-  const { data: run, mutate: mutateRun } = useSWR<RealtimeRun<TTask>>([idKey, "run"], null);
+  const { data: run, mutate: mutateRun } = useInternalSWR<RealtimeRun<TTask>>([idKey, "run"], null);
 
   // Add state to track when the subscription is complete
-  const { data: isComplete = false, mutate: setIsComplete } = useSWR<boolean>(
+  const { data: isComplete = false, mutate: setIsComplete } = useInternalSWR<boolean>(
     [idKey, "complete"],
     null
   );
 
-  const { data: error = undefined, mutate: setError } = useSWR<undefined | Error>(
+  const { data: error = undefined, mutate: setError } = useInternalSWR<undefined | Error>(
     [idKey, "error"],
     null
   );
@@ -401,7 +401,7 @@ export function useRealtimeRunsWithTag<TTask extends AnyTask>(
   const idKey = options?.id ?? hookId;
 
   // Store the streams state in SWR, using the idKey as the key to share states.
-  const { data: runs, mutate: mutateRuns } = useSWR<RealtimeRun<TTask>[]>([idKey, "run"], null, {
+  const { data: runs, mutate: mutateRuns } = useInternalSWR<RealtimeRun<TTask>[]>([idKey, "run"], null, {
     fallbackData: [],
   });
 
@@ -411,7 +411,7 @@ export function useRealtimeRunsWithTag<TTask extends AnyTask>(
     runsRef.current = runs ?? [];
   }, [runs]);
 
-  const { data: error = undefined, mutate: setError } = useSWR<undefined | Error>(
+  const { data: error = undefined, mutate: setError } = useInternalSWR<undefined | Error>(
     [idKey, "error"],
     null
   );
@@ -499,7 +499,7 @@ export function useRealtimeBatch<TTask extends AnyTask>(
   const idKey = options?.id ?? hookId;
 
   // Store the streams state in SWR, using the idKey as the key to share states.
-  const { data: runs, mutate: mutateRuns } = useSWR<RealtimeRun<TTask>[]>([idKey, "run"], null, {
+  const { data: runs, mutate: mutateRuns } = useInternalSWR<RealtimeRun<TTask>[]>([idKey, "run"], null, {
     fallbackData: [],
   });
 
@@ -509,7 +509,7 @@ export function useRealtimeBatch<TTask extends AnyTask>(
     runsRef.current = runs ?? [];
   }, [runs]);
 
-  const { data: error = undefined, mutate: setError } = useSWR<undefined | Error>(
+  const { data: error = undefined, mutate: setError } = useInternalSWR<undefined | Error>(
     [idKey, "error"],
     null
   );

--- a/packages/react-hooks/src/utils/trigger-swr.ts
+++ b/packages/react-hooks/src/utils/trigger-swr.ts
@@ -6,6 +6,8 @@ import { ApiRequestOptions } from "@trigger.dev/core/v3";
 export * from "swr";
 // eslint-disable-next-line import/export
 export { default as useSWR, SWRConfig } from "swr";
+// Import the original useSWR separately for internal use
+import { default as useSWROriginal } from "swr";
 
 export type CommonTriggerHookOptions = {
   /**
@@ -24,3 +26,38 @@ export type CommonTriggerHookOptions = {
   /** Optional additional request configuration */
   requestOptions?: ApiRequestOptions;
 };
+
+/**
+ * Internal isolated useSWR hook that prevents global SWRConfig interference.
+ * This should only be used by internal Trigger.dev hooks for state management.
+ * 
+ * For realtime hooks, this ensures that:
+ * 1. No global fetcher will be invoked accidentally
+ * 2. Internal state management remains isolated 
+ * 3. Manual mutate() calls work as expected
+ * 
+ * @param key - SWR key for caching
+ * @param fetcher - Fetcher function (should be null for internal state management)
+ * @param config - SWR configuration options
+ * @returns SWR hook result with isolated configuration
+ */
+export function useInternalSWR<Data = any, Error = any>(
+  key: any,
+  fetcher: ((key: any) => Data | Promise<Data>) | null = null,
+  config: any = {}
+) {
+  // Always override fetcher to null and disable auto-revalidation for internal state management
+  // This prevents global SWRConfig fetchers from being invoked
+  const internalConfig = {
+    // Disable automatic revalidation for internal state management
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    revalidateIfStale: false,
+    // Override any config that might cause global interference
+    ...config,
+    // Ensure fetcher remains null even if passed in config to prevent global fetcher usage
+    fetcher: null,
+  };
+
+  return useSWROriginal(key, fetcher, internalConfig);
+}


### PR DESCRIPTION
special PR for eric



I have successfully implemented a solution to prevent global SWRConfig fetchers from interfering with Trigger.dev's internal useSWR hooks. Here's what I accomplished:

### **Problem Analysis**

I identified **5-7 potential sources** of the issue and narrowed them down to **2 most likely root causes**:

1. **Realtime hooks vulnerability**: The realtime hooks (`useRealtimeRun`, `useRealtimeRunWithStreams`, `useRealtimeRunsWithTag`, `useRealtimeBatch`) use `useSWR` with `null` as the fetcher for internal state management, but global SWRConfig could override this behavior.

2. **No isolation mechanism**: There was no explicit isolation from global SWRConfig, allowing user-defined global fetchers to potentially interfere with internal hook operations.

### **Solution Implemented**

#### **1. Created `useInternalSWR` Hook** (`packages/react-hooks/src/utils/trigger-swr.ts`)

```typescript
/**
 * Internal isolated useSWR hook that prevents global SWRConfig interference.
 * This should only be used by internal Trigger.dev hooks for state management.
 */
export function useInternalSWR<Data = any, Error = any>(
  key: any,
  fetcher: ((key: any) => Data | Promise<Data>) | null = null,
  config: any = {}
) {
  const internalConfig = {
    // Disable automatic revalidation for internal state management
    revalidateOnFocus: false,
    revalidateOnReconnect: false,
    revalidateIfStale: false,
    // Override any config that might cause global interference
    ...config,
    // Ensure fetcher remains null even if passed in config to prevent global fetcher usage
    fetcher: null,
  };

  return useSWROriginal(key, fetcher, internalConfig);
}
```

#### **2. Updated All Realtime Hooks** (`packages/react-hooks/src/hooks/useRealtime.ts`)

Replaced all `useSWR` calls with `useInternalSWR` in:
- `useRealtimeRun` (lines 81, 83-86, 89-92)
- `useRealtimeRunWithStreams` (lines 227-233, 242, 245-248, 250-253)  
- `useRealtimeRunsWithTag` (lines 404-406, 414-417)
- `useRealtimeBatch` (lines 502-504, 512-515)

### **Key Benefits**

1. **Prevents Global Fetcher Interference**: The `useInternalSWR` hook explicitly sets `fetcher: null` and disables automatic revalidation, ensuring global SWRConfig fetchers cannot be accidentally invoked.

2. **Maintains Internal State Management**: Realtime hooks continue to work as intended with manual `mutate()` calls for state updates.

3. **Backward Compatibility**: The solution doesn't break existing functionality - it only adds protection against global configuration interference.

4. **Isolated Configuration**: Internal hooks now have their own configuration that overrides global settings, ensuring predictable behavior regardless of user's global SWRConfig.

### **How It Solves the Problem**

- **Before**: `useSWR([idKey, "run"], null)` could inherit global fetcher from SWRConfig
- **After**: `useInternalSWR([idKey, "run"], null)` explicitly prevents global fetcher usage

This ensures that when users wrap their apps in `<SWRConfig value={{ fetcher: globalFetcher }}>`, the internal Trigger.dev hooks remain unaffected and continue to function correctly for realtime state management.

The solution is minimal, focused, and addresses the specific issue without over-engineering or affecting other parts of the codebase.