### PR TITLE
#2223 - elderberry

### DIFF
--- a/packages/react-hooks/src/hooks/useRealtime.ts
+++ b/packages/react-hooks/src/hooks/useRealtime.ts
@@ -9,6 +9,7 @@ import {
 } from "@trigger.dev/core/v3";
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { KeyedMutator, useSWR } from "../utils/trigger-swr.js";
+import { logIfFetcherPresent } from "../utils/swrMiddleware.js";
 import { useApiClient, UseApiClientOptions } from "./useApiClient.js";
 import { createThrottledQueue } from "../utils/throttle.js";
 
@@ -78,17 +79,23 @@ export function useRealtimeRun<TTask extends AnyTask>(
   const idKey = options?.id ?? hookId;
 
   // Store the streams state in SWR, using the idKey as the key to share states.
-  const { data: run, mutate: mutateRun } = useSWR<RealtimeRun<TTask>>([idKey, "run"], null);
+  const { data: run, mutate: mutateRun } = useSWR<RealtimeRun<TTask>>(
+    [idKey, "run"],
+    null,
+    { use: [logIfFetcherPresent("realtime:run")] }
+  );
 
   const { data: error = undefined, mutate: setError } = useSWR<undefined | Error>(
     [idKey, "error"],
-    null
+    null,
+    { use: [logIfFetcherPresent("realtime:error")] }
   );
 
   // Add state to track when the subscription is complete
   const { data: isComplete = false, mutate: setIsComplete } = useSWR<boolean>(
     [idKey, "complete"],
-    null
+    null,
+    { use: [logIfFetcherPresent("realtime:complete")] }
   );
 
   // Abort controller to cancel the current API call.
@@ -229,6 +236,7 @@ export function useRealtimeRunWithStreams<
     null,
     {
       fallbackData: initialStreamsFallback,
+      use: [logIfFetcherPresent("realtime:streams")],
     }
   );
 
@@ -239,17 +247,23 @@ export function useRealtimeRunWithStreams<
   }, [streams]);
 
   // Store the streams state in SWR, using the idKey as the key to share states.
-  const { data: run, mutate: mutateRun } = useSWR<RealtimeRun<TTask>>([idKey, "run"], null);
+  const { data: run, mutate: mutateRun } = useSWR<RealtimeRun<TTask>>(
+    [idKey, "run"],
+    null,
+    { use: [logIfFetcherPresent("realtime:run")] }
+  );
 
   // Add state to track when the subscription is complete
   const { data: isComplete = false, mutate: setIsComplete } = useSWR<boolean>(
     [idKey, "complete"],
-    null
+    null,
+    { use: [logIfFetcherPresent("realtime:complete")] }
   );
 
   const { data: error = undefined, mutate: setError } = useSWR<undefined | Error>(
     [idKey, "error"],
-    null
+    null,
+    { use: [logIfFetcherPresent("realtime:error")] }
   );
 
   // Abort controller to cancel the current API call.
@@ -403,6 +417,7 @@ export function useRealtimeRunsWithTag<TTask extends AnyTask>(
   // Store the streams state in SWR, using the idKey as the key to share states.
   const { data: runs, mutate: mutateRuns } = useSWR<RealtimeRun<TTask>[]>([idKey, "run"], null, {
     fallbackData: [],
+    use: [logIfFetcherPresent("realtime:runs")],
   });
 
   // Keep the latest streams in a ref.
@@ -413,7 +428,8 @@ export function useRealtimeRunsWithTag<TTask extends AnyTask>(
 
   const { data: error = undefined, mutate: setError } = useSWR<undefined | Error>(
     [idKey, "error"],
-    null
+    null,
+    { use: [logIfFetcherPresent("realtime:error")] }
   );
 
   // Abort controller to cancel the current API call.
@@ -501,6 +517,7 @@ export function useRealtimeBatch<TTask extends AnyTask>(
   // Store the streams state in SWR, using the idKey as the key to share states.
   const { data: runs, mutate: mutateRuns } = useSWR<RealtimeRun<TTask>[]>([idKey, "run"], null, {
     fallbackData: [],
+    use: [logIfFetcherPresent("realtime:runs")],
   });
 
   // Keep the latest streams in a ref.
@@ -511,7 +528,8 @@ export function useRealtimeBatch<TTask extends AnyTask>(
 
   const { data: error = undefined, mutate: setError } = useSWR<undefined | Error>(
     [idKey, "error"],
-    null
+    null,
+    { use: [logIfFetcherPresent("realtime:error")] }
   );
 
   // Abort controller to cancel the current API call.

--- a/packages/react-hooks/src/utils/swrMiddleware.ts
+++ b/packages/react-hooks/src/utils/swrMiddleware.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import type { Middleware } from "swr";
+
+/**
+ * Middleware that logs if a fetcher is present. This helps detect cases where a global SWR fetcher
+ * might be injected into hooks that are intended to manage their own data (e.g. realtime hooks).
+ *
+ * This middleware is non-invasive: it does not modify the fetcher or behavior, it only logs in dev.
+ */
+export function logIfFetcherPresent(label: string): Middleware {
+  return (useSWRNext) => {
+    return (key, fetcher, config) => {
+      if (typeof fetcher === "function" && process.env.NODE_ENV !== "production") {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[trigger.dev][${label}] Detected a fetcher for SWR key. This hook is intended to manage its own data; an inherited global SWR fetcher may cause unintended requests. key:`,
+          key
+        );
+      }
+
+      return useSWRNext(key, fetcher, config);
+    };
+  };
+}
+
+


### PR DESCRIPTION
special pr for eric


Adding a small SWR middleware utility to log if a fetcher is present (indicating a potential global fetcher), and wiring it into our realtime hooks' useSWR calls to validate the assumption without changing behavior. I'll implement the utility and update `useRealtime.ts` accordingly.
Ran tool
Ran tool
Ran tool

- Looked through `packages/react-hooks` for our internal realtime hooks and how they use SWR. Found that our realtime hooks intentionally use SWR as a local store by passing `null` as the fetcher (so they shouldn’t use any global `SWRConfig` fetcher).
- Identified potential risks where a global `SWRConfig` fetcher might still impact us:
  - Some future internal calls could forget to pass a fetcher or `null`, inadvertently falling back to the global fetcher.
  - SWR revalidation/middleware or consumer-side usage might inject a fetcher unexpectedly into our calls.
  - Key collision with consumer SWR usage (less likely because our keys include a per-instance `useId()`).

What I’m doing now:
- I added lightweight logging middleware to our realtime `useSWR` calls to detect if a fetcher (likely from global `SWRConfig`) is present. This adheres to your “add logs to validate assumptions before fixing” direction, without changing behavior.

Edits made:
- Added `logIfFetcherPresent` middleware:
  - `packages/react-hooks/src/utils/swrMiddleware.ts`
- Wired the middleware into all realtime useSWR store instances:
  - `packages/react-hooks/src/hooks/useRealtime.ts` (for `run`, `streams`, `error`, `complete`, `runs`)

These logs only fire in development and won’t break anything. If a global fetcher is being used by our realtime hooks, you’ll see warnings like:
[trigger.dev][realtime:run] Detected a fetcher for SWR key. This hook is intended to manage its own data; an inherited global SWR fetcher may cause unintended requests.

Proposed most likely root causes to validate with these logs:
- Most likely: One or more internal `useSWR` calls that should pass `null` accidentally omit it (or regressions in future changes).
- Also likely: A consumer app wraps everything with `<SWRConfig value={{ fetcher: ... }}>`, and SWR ends up injecting that fetcher into our hooks if we’d ever forget the `null` guard.

Next steps (after we confirm via logs):
- Harden prevention:
  - Add a blocking middleware variant that overrides any injected fetcher to `null` and disables revalidation options for our realtime store calls.
  - Optionally namespace our SWR cache keys (e.g., `['@trigger.dev/realtime', idKey, 'run']`) to reduce any chance of collision with consumer keys.
- Keep current behavior for SWR-based fetching hooks (like `useRun`) that intentionally provide a fetcher.

- Changes:
  - Added `logIfFetcherPresent` middleware in `packages/react-hooks/src/utils/swrMiddleware.ts`.
  - Applied middleware in `packages/react-hooks/src/hooks/useRealtime.ts` to every internal `useSWR` store usage to log if a fetcher is present (potential global fetcher injection).
- Impact:
  - Non-invasive development-only logs to validate whether global `SWRConfig` fetchers are ever invoked by our realtime hooks.
  - No behavioral changes to fetching or performance.