### PR TITLE
#1926 - apple 2nd try (use this one)

### DIFF
--- a/docs/config/extensions/prismaExtension.mdx
+++ b/docs/config/extensions/prismaExtension.mdx
@@ -155,3 +155,53 @@ prismaExtension({
   migrate: false,
 }),
 ```
+
+### Example Usage (Prisma 6.6.0+)
+
+```ts
+import { defineConfig } from "@trigger.dev/sdk/v3";
+import { prismaExtension } from "@trigger.dev/build/extensions/prisma";
+
+export default defineConfig({
+  project: "<project ref>",
+  build: {
+    extensions: [
+      prismaExtension({
+        schema: "prisma/schema.prisma",
+        output: "prisma/generated/client", // required for Prisma 6.6.0+
+        version: "6.6.0", // optional
+      }),
+    ],
+  },
+});
+```
+
+### Using `prisma.config.ts`
+
+If you have a `prisma.config.ts` file, you can specify `schema` and `output` there instead of in the extension options:
+
+```ts
+// prisma.config.ts
+export default {
+  schema: "prisma/schema.prisma",
+  output: "prisma/generated/client",
+};
+```
+
+The extension will use these values automatically if not provided in the extension options.
+
+### Migrations
+
+The `migrations` directory must be alongside your `schema.prisma` file. The extension will copy migrations from this location during the build process if `migrate: true` is set.
+
+### Migration Guide: Upgrading to Prisma 6.6.0+
+
+1. Move your `schema.prisma` file into a dedicated directory (e.g., `prisma/schema/`).
+2. Place your `migrations` directory alongside `schema.prisma`.
+3. Specify the `schema` and `output` options in your `prismaExtension` call or in `prisma.config.ts`.
+4. Update any code that previously expected the client in `node_modules` to use the new output path.
+5. If you use multiple schemas, repeat the above for each schema.
+
+### Error Handling
+
+If required paths are missing or misconfigured, the extension will throw clear errors to help you fix your setup.


### PR DESCRIPTION
special PR for eric

Here’s a technical recap of what was changed in the Prisma extension to support Prisma 6.6.0+:

---

## Technical Recap: Prisma Extension Updates for Prisma 6.6.0+

### 1. **Explicit Schema and Output Path Handling**
- The extension now requires an explicit `schema` and `output` path for the Prisma client, matching Prisma 6.6.0+ requirements.
- These can be provided either in the extension options or in a `prisma.config.ts` file.

### 2. **Support for `prisma.config.ts`**
- The extension detects and parses a `prisma.config.ts` file if it exists in the project.
- If present, it uses the `schema` and `output` values from this config file unless they are overridden in the extension options.

### 3. **Removed Directory Inference**
- The extension no longer infers the schema directory by checking if the parent folder is named `schema`.
- All directory and file paths must now be explicitly provided.

### 4. **Migrations Directory Handling**
- The extension expects the `migrations` directory to be located alongside the `schema.prisma` file.
- During the build, it copies the migrations from this location if migrations are enabled.

### 5. **Prisma Client Output**
- The Prisma client is no longer assumed to be generated in `node_modules`.
- The extension uses the explicit `output` path for the generated client, as required by Prisma 6.6.0+.

### 6. **Error Handling**
- The extension throws clear errors if required paths (schema or output) are missing or misconfigured, making misconfigurations easier to debug.

### 7. **Refactored Build Logic**
- All build steps (copying schema, migrations, generating client) now use the explicit paths.
- The extension is compatible with both legacy and new Prisma setups, but is optimized for 6.6.0+.

---

**Summary:**  
The extension was refactored to require explicit configuration for schema and client output, support `prisma.config.ts`, remove all directory inference, and ensure compatibility with Prisma 6.6.0+’s new requirements for client generation and schema location. All build logic now uses these explicit paths, and error handling is improved for easier troubleshooting.