### PR TITLE
Idempotency ignores failed runs in v4

### DIFF
--- a/apps/webapp/app/v3/eventRepository.server.ts
+++ b/apps/webapp/app/v3/eventRepository.server.ts
@@ -1097,7 +1097,7 @@ export class EventRepository {
       tracestate: typeof tracestate === "string" ? tracestate : undefined,
       duration: options.incomplete ? 0 : duration,
       isPartial: failedWithError ? false : options.incomplete,
-      isError: !!failedWithError,
+      isError: options.isError === true || !!failedWithError,
       message: message,
       serviceName: "api server",
       serviceNamespace: "trigger.dev",

--- a/apps/webapp/app/v3/taskStatus.ts
+++ b/apps/webapp/app/v3/taskStatus.ts
@@ -128,3 +128,7 @@ export function isRestorableRunStatus(status: TaskRunStatus): boolean {
 export function isRestorableAttemptStatus(status: TaskRunAttemptStatus): boolean {
   return RESTORABLE_ATTEMPT_STATUSES.includes(status);
 }
+
+export function shouldIdempotencyKeyBeCleared(status: TaskRunStatus): boolean {
+  return isFailedRunStatus(status) || status === "EXPIRED";
+}


### PR DESCRIPTION
If you trigger a run with an idempotency key but that run fails it won’t be returned as a cached run in v4. 

It’s hard to come up with a situation where you would want the old behaviour. If you did want to cache a failure, you should return a `Result` type instead of throwing an error. Failures should only be used when something has gone wrong, not to indicate a known false case.