### PR TITLE
fix: legacyDevProcessCwdBehaviour defaults to true

### DIFF
--- a/.changeset/afraid-waves-divide.md
+++ b/.changeset/afraid-waves-divide.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Make the default of legacyDevProcessCwdBehaviour true instead of false (prevents breaking prismaExtension)

--- a/packages/cli-v3/src/dev/devSupervisor.ts
+++ b/packages/cli-v3/src/dev/devSupervisor.ts
@@ -358,10 +358,12 @@ class DevSupervisor implements WorkerRuntime {
           config: this.options.config,
         });
 
-        const cwd =
-          this.options.config.legacyDevProcessCwdBehaviour === true
-            ? undefined
-            : worker.build.outputPath;
+        const legacyDevProcessCwdBehaviour =
+          typeof this.options.config.legacyDevProcessCwdBehaviour === "boolean"
+            ? this.options.config.legacyDevProcessCwdBehaviour
+            : true;
+
+        const cwd = legacyDevProcessCwdBehaviour === true ? undefined : worker.build.outputPath;
 
         //new run
         runController = new DevRunController({

--- a/packages/core/src/v3/config.ts
+++ b/packages/core/src/v3/config.ts
@@ -280,10 +280,10 @@ export type TriggerConfig = {
   processKeepAlive?: ProcessKeepAlive;
 
   /**
-   * @default false
+   * @default true
    * @description If set to true when running the dev CLI, the current working directory will be set to where the command is run from.
    *
-   * The new default (when this flag isn't passed) is to set the current working directory to the build directory.
+   * Setting this to `false` will set the current working directory to the build directory.
    * This more closely matches the behavior of the CLI when running in production and is highly recommended.
    *
    * This impacts the value of process.cwd() in your task code.


### PR DESCRIPTION
This fixes an issue with prisma not being able to locate the native 
add-on binary