### PR TITLE
feat(k8s): add placement tags for flexible node selection

### DIFF
--- a/.changeset/proud-nails-grin.md
+++ b/.changeset/proud-nails-grin.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Add optional billing info to DequeuedMessage for tiered scheduling

--- a/.changeset/proud-nails-grin.md
+++ b/.changeset/proud-nails-grin.md
@@ -2,4 +2,4 @@
 "@trigger.dev/core": patch
 ---
 
-Add optional billing info to DequeuedMessage for tiered scheduling
+Add optional placement tags to dequeued messages for targeted scheduling

--- a/apps/supervisor/src/env.ts
+++ b/apps/supervisor/src/env.ts
@@ -77,11 +77,9 @@ const Env = z.object({
   KUBERNETES_EPHEMERAL_STORAGE_SIZE_LIMIT: z.string().default("10Gi"),
   KUBERNETES_EPHEMERAL_STORAGE_SIZE_REQUEST: z.string().default("2Gi"),
 
-  // Tier scheduling settings
-  ENABLE_TIER_SCHEDULING: BoolEnv.default(false),
-  TIER_LABEL_KEY: z.string().default("node.cluster.x-k8s.io/paid"),
-  TIER_LABEL_VALUE_FREE: z.string().default("false"),
-  TIER_LABEL_VALUE_PAID: z.string().default("true"),
+  // Placement tags settings
+  PLACEMENT_TAGS_ENABLED: BoolEnv.default(false),
+  PLACEMENT_TAGS_PREFIX: z.string().default("node.cluster.x-k8s.io"),
 
   // Metrics
   METRICS_ENABLED: BoolEnv.default(true),

--- a/apps/supervisor/src/env.ts
+++ b/apps/supervisor/src/env.ts
@@ -15,7 +15,7 @@ const Env = z.object({
   OTEL_EXPORTER_OTLP_ENDPOINT: z.string().url(), // set on the runners
 
   // Workload API settings (coordinator mode) - the workload API is what the run controller connects to
-  TRIGGER_WORKLOAD_API_ENABLED: BoolEnv.default("true"),
+  TRIGGER_WORKLOAD_API_ENABLED: BoolEnv.default(true),
   TRIGGER_WORKLOAD_API_PROTOCOL: z
     .string()
     .transform((s) => z.enum(["http", "https"]).parse(s.toLowerCase()))
@@ -32,7 +32,7 @@ const Env = z.object({
   RUNNER_PRETTY_LOGS: BoolEnv.default(false),
 
   // Dequeue settings (provider mode)
-  TRIGGER_DEQUEUE_ENABLED: BoolEnv.default("true"),
+  TRIGGER_DEQUEUE_ENABLED: BoolEnv.default(true),
   TRIGGER_DEQUEUE_INTERVAL_MS: z.coerce.number().int().default(250),
   TRIGGER_DEQUEUE_IDLE_INTERVAL_MS: z.coerce.number().int().default(1000),
   TRIGGER_DEQUEUE_MAX_RUN_COUNT: z.coerce.number().int().default(10),

--- a/apps/supervisor/src/env.ts
+++ b/apps/supervisor/src/env.ts
@@ -77,6 +77,12 @@ const Env = z.object({
   KUBERNETES_EPHEMERAL_STORAGE_SIZE_LIMIT: z.string().default("10Gi"),
   KUBERNETES_EPHEMERAL_STORAGE_SIZE_REQUEST: z.string().default("2Gi"),
 
+  // Tier scheduling settings
+  ENABLE_TIER_SCHEDULING: BoolEnv.default(false),
+  TIER_LABEL_KEY: z.string().default("node.cluster.x-k8s.io/paid"),
+  TIER_LABEL_VALUE_FREE: z.string().default("false"),
+  TIER_LABEL_VALUE_PAID: z.string().default("true"),
+
   // Metrics
   METRICS_ENABLED: BoolEnv.default(true),
   METRICS_COLLECT_DEFAULTS: BoolEnv.default(true),

--- a/apps/supervisor/src/envUtil.ts
+++ b/apps/supervisor/src/envUtil.ts
@@ -3,13 +3,18 @@ import { SimpleStructuredLogger } from "@trigger.dev/core/v3/utils/structuredLog
 
 const logger = new SimpleStructuredLogger("env-util");
 
-export const BoolEnv = z.preprocess((val) => {
+const baseBoolEnv = z.preprocess((val) => {
   if (typeof val !== "string") {
     return val;
   }
 
   return ["true", "1"].includes(val.toLowerCase().trim());
 }, z.boolean());
+
+// Create a type-safe version that only accepts boolean defaults
+export const BoolEnv = baseBoolEnv as Omit<typeof baseBoolEnv, "default"> & {
+  default: (value: boolean) => z.ZodDefault<typeof baseBoolEnv>;
+};
 
 export const AdditionalEnvVars = z.preprocess((val) => {
   if (typeof val !== "string") {

--- a/apps/supervisor/src/index.ts
+++ b/apps/supervisor/src/index.ts
@@ -247,7 +247,7 @@ class ManagedSupervisor {
           nextAttemptNumber: message.run.attemptNumber,
           snapshotId: message.snapshot.id,
           snapshotFriendlyId: message.snapshot.friendlyId,
-          isPaidTier: message.billing?.currentPlan.isPaying ?? false,
+          placementTags: message.placementTags,
         });
 
         // Disabled for now

--- a/apps/supervisor/src/index.ts
+++ b/apps/supervisor/src/index.ts
@@ -247,6 +247,7 @@ class ManagedSupervisor {
           nextAttemptNumber: message.run.attemptNumber,
           snapshotId: message.snapshot.id,
           snapshotFriendlyId: message.snapshot.friendlyId,
+          isPaidTier: message.billing?.currentPlan.isPaying ?? false,
         });
 
         // Disabled for now

--- a/apps/supervisor/src/workloadManager/kubernetes.ts
+++ b/apps/supervisor/src/workloadManager/kubernetes.ts
@@ -22,11 +22,9 @@ export class KubernetesWorkloadManager implements WorkloadManager {
   private readonly logger = new SimpleStructuredLogger("kubernetes-workload-provider");
   private k8s: K8sApi;
   private namespace = env.KUBERNETES_NAMESPACE;
-  private placementConfig: PlacementConfig;
 
   constructor(private opts: WorkloadManagerOptions) {
     this.k8s = createK8sApi();
-    this.placementConfig = this.placementTagsConfig;
 
     if (opts.workloadApiDomain) {
       this.logger.warn("[KubernetesWorkloadManager] ⚠️ Custom workload API domain", {
@@ -35,7 +33,7 @@ export class KubernetesWorkloadManager implements WorkloadManager {
     }
   }
 
-  private get placementTagsConfig(): PlacementConfig {
+  private get placementConfig(): PlacementConfig {
     return {
       enabled: env.PLACEMENT_TAGS_ENABLED,
       prefix: env.PLACEMENT_TAGS_PREFIX,

--- a/apps/supervisor/src/workloadManager/types.ts
+++ b/apps/supervisor/src/workloadManager/types.ts
@@ -32,4 +32,6 @@ export interface WorkloadManagerCreateOptions {
   runFriendlyId: string;
   snapshotId: string;
   snapshotFriendlyId: string;
+  // tier scheduling
+  isPaidTier?: boolean;
 }

--- a/apps/supervisor/src/workloadManager/types.ts
+++ b/apps/supervisor/src/workloadManager/types.ts
@@ -1,4 +1,4 @@
-import { type EnvironmentType, type MachinePreset } from "@trigger.dev/core/v3";
+import type { EnvironmentType, MachinePreset, PlacementTag } from "@trigger.dev/core/v3";
 
 export interface WorkloadManagerOptions {
   workloadApiProtocol: "http" | "https";
@@ -23,6 +23,7 @@ export interface WorkloadManagerCreateOptions {
   version: string;
   nextAttemptNumber?: number;
   dequeuedAt: Date;
+  placementTags?: PlacementTag[];
   // identifiers
   envId: string;
   envType: EnvironmentType;
@@ -32,6 +33,4 @@ export interface WorkloadManagerCreateOptions {
   runFriendlyId: string;
   snapshotId: string;
   snapshotFriendlyId: string;
-  // tier scheduling
-  isPaidTier?: boolean;
 }

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -761,7 +761,7 @@ const EnvironmentSchema = z.object({
     .int()
     .default(60_000 * 5), // 5 minutes
 
-  BATCH_TRIGGER_CACHED_RUNS_CHECK_ENABLED: BoolEnv.default("false"),
+  BATCH_TRIGGER_CACHED_RUNS_CHECK_ENABLED: BoolEnv.default(false),
 
   BATCH_TRIGGER_WORKER_ENABLED: z.string().default(process.env.WORKER_ENABLED ?? "true"),
   BATCH_TRIGGER_WORKER_CONCURRENCY_WORKERS: z.coerce.number().int().default(2),

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -761,6 +761,8 @@ const EnvironmentSchema = z.object({
     .int()
     .default(60_000 * 5), // 5 minutes
 
+  BATCH_TRIGGER_CACHED_RUNS_CHECK_ENABLED: BoolEnv.default("false"),
+
   BATCH_TRIGGER_WORKER_ENABLED: z.string().default(process.env.WORKER_ENABLED ?? "true"),
   BATCH_TRIGGER_WORKER_CONCURRENCY_WORKERS: z.coerce.number().int().default(2),
   BATCH_TRIGGER_WORKER_CONCURRENCY_TASKS_PER_WORKER: z.coerce.number().int().default(10),

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.select-plan.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.select-plan.tsx
@@ -42,6 +42,7 @@ import { redirectWithErrorMessage } from "~/models/message.server";
 import { logger } from "~/services/logger.server";
 import { setPlan } from "~/services/platform.v3.server";
 import { requireUser } from "~/services/session.server";
+import { engine } from "~/v3/runEngine.server";
 import { cn } from "~/utils/cn";
 import { sendToPlain } from "~/utils/plain.server";
 
@@ -152,7 +153,9 @@ export async function action({ request, params }: ActionFunctionArgs) {
     }
   }
 
-  return setPlan(organization, request, form.callerPath, payload);
+  return setPlan(organization, request, form.callerPath, payload, {
+    invalidateBillingCache: engine.invalidateBillingCache.bind(engine),
+  });
 }
 
 const pricingDefinitions = {

--- a/apps/webapp/app/runEngine/concerns/queues.server.ts
+++ b/apps/webapp/app/runEngine/concerns/queues.server.ts
@@ -177,8 +177,11 @@ export class DefaultQueueManager implements QueueManager {
     return task.queue.name ?? defaultQueueName;
   }
 
-  async validateQueueLimits(environment: AuthenticatedEnvironment): Promise<QueueValidationResult> {
-    const queueSizeGuard = await guardQueueSizeLimitsForEnv(this.engine, environment);
+  async validateQueueLimits(
+    environment: AuthenticatedEnvironment,
+    itemsToAdd?: number
+  ): Promise<QueueValidationResult> {
+    const queueSizeGuard = await guardQueueSizeLimitsForEnv(this.engine, environment, itemsToAdd);
 
     logger.debug("Queue size guard result", {
       queueSizeGuard,

--- a/apps/webapp/app/runEngine/types.ts
+++ b/apps/webapp/app/runEngine/types.ts
@@ -1,12 +1,7 @@
-import { BackgroundWorker, TaskRun } from "@trigger.dev/database";
-
-import {
-  IOPacket,
-  RunChainState,
-  TaskRunError,
-  TriggerTaskRequestBody,
-} from "@trigger.dev/core/v3";
-import { AuthenticatedEnvironment } from "~/services/apiAuth.server";
+import type { BackgroundWorker, TaskRun } from "@trigger.dev/database";
+import type { IOPacket, TaskRunError, TriggerTaskRequestBody } from "@trigger.dev/core/v3";
+import type { AuthenticatedEnvironment } from "~/services/apiAuth.server";
+import type { ReportUsagePlan } from "@trigger.dev/platform";
 
 export type TriggerTaskServiceOptions = {
   idempotencyKey?: string;
@@ -22,6 +17,7 @@ export type TriggerTaskServiceOptions = {
   skipChecks?: boolean;
   oneTimeUseToken?: string;
   overrideCreatedAt?: Date;
+  planType?: string;
 };
 
 // domain/triggerTask.ts
@@ -112,9 +108,19 @@ export type ValidationResult =
       error: Error;
     };
 
+export type EntitlementValidationResult =
+  | {
+      ok: true;
+      plan?: ReportUsagePlan;
+    }
+  | {
+      ok: false;
+      error: Error;
+    };
+
 export interface TriggerTaskValidator {
   validateTags(params: TagValidationParams): ValidationResult;
-  validateEntitlement(params: EntitlementValidationParams): Promise<ValidationResult>;
+  validateEntitlement(params: EntitlementValidationParams): Promise<EntitlementValidationResult>;
   validateMaxAttempts(params: MaxAttemptsValidationParams): ValidationResult;
   validateParentRun(params: ParentRunValidationParams): ValidationResult;
 }

--- a/apps/webapp/app/runEngine/types.ts
+++ b/apps/webapp/app/runEngine/types.ts
@@ -62,7 +62,10 @@ export interface QueueManager {
     lockedBackgroundWorker?: LockedBackgroundWorker
   ): Promise<QueueProperties>;
   getQueueName(request: TriggerTaskRequest): Promise<string>;
-  validateQueueLimits(env: AuthenticatedEnvironment): Promise<QueueValidationResult>;
+  validateQueueLimits(
+    env: AuthenticatedEnvironment,
+    itemsToAdd?: number
+  ): Promise<QueueValidationResult>;
   getWorkerQueue(
     env: AuthenticatedEnvironment,
     regionOverride?: string

--- a/apps/webapp/app/runEngine/validators/triggerTaskValidator.ts
+++ b/apps/webapp/app/runEngine/validators/triggerTaskValidator.ts
@@ -4,8 +4,9 @@ import { getEntitlement } from "~/services/platform.v3.server";
 import { MAX_ATTEMPTS, OutOfEntitlementError } from "~/v3/services/triggerTask.server";
 import { isFinalRunStatus } from "~/v3/taskStatus";
 import { EngineServiceValidationError } from "../concerns/errors";
-import {
+import type {
   EntitlementValidationParams,
+  EntitlementValidationResult,
   MaxAttemptsValidationParams,
   ParentRunValidationParams,
   TagValidationParams,
@@ -37,7 +38,9 @@ export class DefaultTriggerTaskValidator implements TriggerTaskValidator {
     return { ok: true };
   }
 
-  async validateEntitlement(params: EntitlementValidationParams): Promise<ValidationResult> {
+  async validateEntitlement(
+    params: EntitlementValidationParams
+  ): Promise<EntitlementValidationResult> {
     const { environment } = params;
 
     if (environment.type === "DEVELOPMENT") {
@@ -53,7 +56,7 @@ export class DefaultTriggerTaskValidator implements TriggerTaskValidator {
       };
     }
 
-    return { ok: true };
+    return { ok: true, plan: result?.plan };
   }
 
   validateMaxAttempts(params: MaxAttemptsValidationParams): ValidationResult {

--- a/apps/webapp/app/services/platform.v3.server.ts
+++ b/apps/webapp/app/services/platform.v3.server.ts
@@ -10,6 +10,8 @@ import {
   type MachineCode,
   type UpdateBillingAlertsRequest,
   type BillingAlertsResult,
+  type ReportUsageResult,
+  type ReportUsagePlan,
 } from "@trigger.dev/platform";
 import { createCache, DefaultStatefulContext, Namespace } from "@unkey/cache";
 import { MemoryStore } from "@unkey/cache/stores";
@@ -432,7 +434,9 @@ export async function reportComputeUsage(request: Request) {
   });
 }
 
-export async function getEntitlement(organizationId: string) {
+export async function getEntitlement(
+  organizationId: string
+): Promise<ReportUsageResult | undefined> {
   if (!client) return undefined;
 
   try {

--- a/apps/webapp/app/utils/boolEnv.ts
+++ b/apps/webapp/app/utils/boolEnv.ts
@@ -1,9 +1,14 @@
 import { z } from "zod";
 
-export const BoolEnv = z.preprocess((val) => {
+const baseBoolEnv = z.preprocess((val) => {
   if (typeof val !== "string") {
     return val;
   }
 
   return ["true", "1"].includes(val.toLowerCase().trim());
 }, z.boolean());
+
+// Create a type-safe version that only accepts boolean defaults
+export const BoolEnv = baseBoolEnv as Omit<typeof baseBoolEnv, "default"> & {
+  default: (value: boolean) => z.ZodDefault<typeof baseBoolEnv>;
+};

--- a/apps/webapp/app/v3/runEngine.server.ts
+++ b/apps/webapp/app/v3/runEngine.server.ts
@@ -110,14 +110,23 @@ function createRunEngine() {
         const plan = await getCurrentPlan(orgId);
 
         if (!plan) {
-          return { isPaying: false };
+          return {
+            isPaying: false,
+            type: "free",
+          };
         }
 
         if (!plan.v3Subscription) {
-          return { isPaying: false };
+          return {
+            isPaying: false,
+            type: "free",
+          };
         }
 
-        return { isPaying: plan.v3Subscription.isPaying };
+        return {
+          isPaying: plan.v3Subscription.isPaying,
+          type: plan.v3Subscription.plan?.type ?? "free",
+        };
       },
     },
   });

--- a/apps/webapp/app/v3/runEngine.server.ts
+++ b/apps/webapp/app/v3/runEngine.server.ts
@@ -1,7 +1,7 @@
 import { RunEngine } from "@internal/run-engine";
 import { $replica, prisma } from "~/db.server";
 import { env } from "~/env.server";
-import { defaultMachine } from "~/services/platform.v3.server";
+import { defaultMachine, getCurrentPlan } from "~/services/platform.v3.server";
 import { singleton } from "~/utils/singleton";
 import { allMachines } from "./machinePresets.server";
 import { meter, tracer } from "./tracer.server";
@@ -105,6 +105,21 @@ function createRunEngine() {
       SUSPENDED: env.RUN_ENGINE_TIMEOUT_SUSPENDED,
     },
     retryWarmStartThresholdMs: env.RUN_ENGINE_RETRY_WARM_START_THRESHOLD_MS,
+    billing: {
+      getCurrentPlan: async (orgId: string) => {
+        const plan = await getCurrentPlan(orgId);
+
+        if (!plan) {
+          return { isPaying: false };
+        }
+
+        if (!plan.v3Subscription) {
+          return { isPaying: false };
+        }
+
+        return { isPaying: plan.v3Subscription.isPaying };
+      },
+    },
   });
 
   return engine;

--- a/apps/webapp/app/v3/services/triggerTask.server.ts
+++ b/apps/webapp/app/v3/services/triggerTask.server.ts
@@ -33,6 +33,7 @@ export type TriggerTaskServiceOptions = {
   queueTimestamp?: Date;
   overrideCreatedAt?: Date;
   replayedFromTaskRunFriendlyId?: string;
+  planType?: string;
 };
 
 export class OutOfEntitlementError extends Error {

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -113,7 +113,7 @@
     "@trigger.dev/core": "workspace:*",
     "@trigger.dev/database": "workspace:*",
     "@trigger.dev/otlp-importer": "workspace:*",
-    "@trigger.dev/platform": "1.0.17",
+    "@trigger.dev/platform": "1.0.18",
     "@trigger.dev/redis-worker": "workspace:*",
     "@trigger.dev/sdk": "workspace:*",
     "@types/pg": "8.6.6",

--- a/internal-packages/cache/src/index.ts
+++ b/internal-packages/cache/src/index.ts
@@ -3,6 +3,8 @@ export {
   DefaultStatefulContext,
   Namespace,
   type Cache as UnkeyCache,
+  type CacheError,
 } from "@unkey/cache";
+export { type Result, Ok, Err } from "@unkey/error";
 export { MemoryStore } from "@unkey/cache/stores";
 export { RedisCacheStore } from "./stores/redis.js";

--- a/internal-packages/database/prisma/migrations/20250814092224_add_task_run_plan_type/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250814092224_add_task_run_plan_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "TaskRun" ADD COLUMN     "planType" TEXT;

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -707,6 +707,9 @@ model TaskRun {
   /// Run error
   error Json?
 
+  /// Organization's billing plan type (cached for fallback when billing API fails)
+  planType String?
+
   maxDurationInSeconds Int?
 
   @@unique([oneTimeUseToken])

--- a/internal-packages/run-engine/src/engine/billingCache.ts
+++ b/internal-packages/run-engine/src/engine/billingCache.ts
@@ -1,0 +1,92 @@
+import {
+  createCache,
+  DefaultStatefulContext,
+  MemoryStore,
+  Namespace,
+  Ok,
+  RedisCacheStore,
+  type UnkeyCache,
+  type CacheError,
+  type Result,
+} from "@internal/cache";
+import type { RedisOptions } from "@internal/redis";
+import type { Logger } from "@trigger.dev/core/logger";
+import type { RunEngineOptions } from "./types.js";
+
+// Cache TTLs for billing information - shorter than other caches since billing can change
+const BILLING_FRESH_TTL = 60000 * 5; // 5 minutes
+const BILLING_STALE_TTL = 60000 * 10; // 10 minutes
+
+export type BillingPlan = {
+  isPaying: boolean;
+  type: "free" | "paid" | "enterprise";
+};
+
+export type BillingCacheOptions = {
+  billingOptions?: RunEngineOptions["billing"];
+  redisOptions: RedisOptions;
+  logger: Logger;
+};
+
+export class BillingCache {
+  private readonly cache: UnkeyCache<{
+    currentPlan: BillingPlan;
+  }>;
+  private readonly logger: Logger;
+  private readonly billingOptions?: RunEngineOptions["billing"];
+
+  constructor(options: BillingCacheOptions) {
+    this.logger = options.logger;
+    this.billingOptions = options.billingOptions;
+
+    // Initialize cache
+    const ctx = new DefaultStatefulContext();
+    const memory = new MemoryStore({ persistentMap: new Map() });
+    const redisCacheStore = new RedisCacheStore({
+      name: "billing-cache",
+      connection: {
+        ...options.redisOptions,
+        keyPrefix: "engine:billing:cache:",
+      },
+      useModernCacheKeyBuilder: true,
+    });
+
+    this.cache = createCache({
+      currentPlan: new Namespace<BillingPlan>(ctx, {
+        stores: [memory, redisCacheStore],
+        fresh: BILLING_FRESH_TTL,
+        stale: BILLING_STALE_TTL,
+      }),
+    });
+  }
+
+  /**
+   * Gets the current billing plan for an organization
+   * Returns a Result that allows the caller to handle errors and missing values
+   */
+  async getCurrentPlan(orgId: string): Promise<Result<BillingPlan | undefined, CacheError>> {
+    if (!this.billingOptions?.getCurrentPlan) {
+      // Return a successful result with default free plan
+      return Ok({ isPaying: false, type: "free" });
+    }
+
+    return await this.cache.currentPlan.swr(orgId, async () => {
+      // This is safe because options can't change at runtime
+      const planResult = await this.billingOptions!.getCurrentPlan(orgId);
+      return { isPaying: planResult.isPaying, type: planResult.type };
+    });
+  }
+
+  /**
+   * Invalidates the billing cache for an organization when their plan changes
+   * Runs in background and handles all errors internally
+   */
+  invalidate(orgId: string): void {
+    this.cache.currentPlan.remove(orgId).catch((error) => {
+      this.logger.warn("Failed to invalidate billing cache", {
+        orgId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }
+}

--- a/internal-packages/run-engine/src/engine/index.ts
+++ b/internal-packages/run-engine/src/engine/index.ts
@@ -298,6 +298,7 @@ export class RunEngine {
       runAttemptSystem: this.runAttemptSystem,
       machines: this.options.machines,
       billing: this.options.billing,
+      redisOptions: this.options.cache?.redis ?? this.options.runLock.redis,
     });
   }
 
@@ -1347,5 +1348,13 @@ export class RunEngine {
         id: run.id,
         orgId: run.organizationId!,
       }));
+  }
+
+  /**
+   * Invalidates the billing cache for an organization when their plan changes
+   * Runs in background and handles all errors internally
+   */
+  invalidateBillingCache(orgId: string): void {
+    this.dequeueSystem.invalidateBillingCache(orgId);
   }
 }

--- a/internal-packages/run-engine/src/engine/index.ts
+++ b/internal-packages/run-engine/src/engine/index.ts
@@ -297,6 +297,7 @@ export class RunEngine {
       executionSnapshotSystem: this.executionSnapshotSystem,
       runAttemptSystem: this.runAttemptSystem,
       machines: this.options.machines,
+      billing: this.options.billing,
     });
   }
 

--- a/internal-packages/run-engine/src/engine/index.ts
+++ b/internal-packages/run-engine/src/engine/index.ts
@@ -307,7 +307,6 @@ export class RunEngine {
       runAttemptSystem: this.runAttemptSystem,
       machines: this.options.machines,
       billingCache: this.billingCache,
-      redisOptions: this.options.cache?.redis ?? this.options.runLock.redis,
     });
   }
 
@@ -382,7 +381,7 @@ export class RunEngine {
         const currentPlan = await this.billingCache.getCurrentPlan(environment.organization.id);
 
         if (currentPlan.err || !currentPlan.val) {
-          // If billing lookup fails, don't block the trigger - planType will be null
+          // If billing lookup fails, don't block the trigger - planType will be undefined
           this.logger.warn(
             "Failed to get billing info during trigger, proceeding without planType",
             {

--- a/internal-packages/run-engine/src/engine/systems/dequeueSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/dequeueSystem.ts
@@ -401,7 +401,7 @@ export class DequeueSystem {
                   }
                 );
 
-                isPaying = lockedTaskRun.planType !== null && lockedTaskRun.planType !== "free";
+                isPaying = (lockedTaskRun.planType ?? "free") !== "free";
               } else {
                 isPaying = billingResult.val.isPaying;
               }

--- a/internal-packages/run-engine/src/engine/systems/dequeueSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/dequeueSystem.ts
@@ -1,4 +1,3 @@
-import type { RedisOptions } from "@internal/redis";
 import type { BillingCache } from "../billingCache.js";
 import { startSpan } from "@internal/tracing";
 import { assertExhaustive } from "@trigger.dev/core";
@@ -20,7 +19,6 @@ export type DequeueSystemOptions = {
   executionSnapshotSystem: ExecutionSnapshotSystem;
   runAttemptSystem: RunAttemptSystem;
   billingCache: BillingCache;
-  redisOptions: RedisOptions;
 };
 
 export class DequeueSystem {

--- a/internal-packages/run-engine/src/engine/systems/dequeueSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/dequeueSystem.ts
@@ -1,7 +1,7 @@
 import type { BillingCache } from "../billingCache.js";
 import { startSpan } from "@internal/tracing";
 import { assertExhaustive } from "@trigger.dev/core";
-import { DequeuedMessage, RetryOptions } from "@trigger.dev/core/v3";
+import { DequeuedMessage, RetryOptions, placementTag } from "@trigger.dev/core/v3";
 import { getMaxDuration } from "@trigger.dev/core/v3/isomorphic";
 import { PrismaClientOrTransaction } from "@trigger.dev/database";
 import { getRunWithBackgroundWorkerTasks } from "../db/worker.js";
@@ -474,11 +474,7 @@ export class DequeueSystem {
                 project: {
                   id: lockedTaskRun.projectId,
                 },
-                billing: {
-                  currentPlan: {
-                    isPaying,
-                  },
-                },
+                placementTags: [placementTag("paid", isPaying ? "true" : "false")],
               } satisfies DequeuedMessage;
             }
           );

--- a/internal-packages/run-engine/src/engine/types.ts
+++ b/internal-packages/run-engine/src/engine/types.ts
@@ -5,7 +5,6 @@ import {
   MachinePreset,
   MachinePresetName,
   RetryOptions,
-  RunChainState,
   TriggerTraceContext,
 } from "@trigger.dev/core/v3";
 import { PrismaClient, PrismaReplicaClient } from "@trigger.dev/database";
@@ -14,6 +13,7 @@ import { FairQueueSelectionStrategyOptions } from "../run-queue/fairQueueSelecti
 import { MinimalAuthenticatedEnvironment } from "../shared/index.js";
 import { LockRetryConfig } from "./locking.js";
 import { workerCatalog } from "./workerCatalog.js";
+import { type BillingPlan } from "./billingCache.js";
 
 export type RunEngineOptions = {
   prisma: PrismaClient;
@@ -31,7 +31,7 @@ export type RunEngineOptions = {
     baseCostInCents: number;
   };
   billing?: {
-    getCurrentPlan: (orgId: string) => Promise<{ isPaying: boolean }>;
+    getCurrentPlan: (orgId: string) => Promise<BillingPlan>;
   };
   queue: {
     redis: RedisOptions;

--- a/internal-packages/run-engine/src/engine/types.ts
+++ b/internal-packages/run-engine/src/engine/types.ts
@@ -30,6 +30,9 @@ export type RunEngineOptions = {
     machines: Record<string, MachinePreset>;
     baseCostInCents: number;
   };
+  billing?: {
+    getCurrentPlan: (orgId: string) => Promise<{ isPaying: boolean }>;
+  };
   queue: {
     redis: RedisOptions;
     shardCount?: number;

--- a/internal-packages/run-engine/src/engine/types.ts
+++ b/internal-packages/run-engine/src/engine/types.ts
@@ -136,6 +136,7 @@ export type TriggerParams = {
   scheduleInstanceId?: string;
   createdAt?: Date;
   bulkActionId?: string;
+  planType?: string;
 };
 
 export type EngineWorker = Worker<typeof workerCatalog>;

--- a/packages/core/src/v3/schemas/runEngine.ts
+++ b/packages/core/src/v3/schemas/runEngine.ts
@@ -224,6 +224,17 @@ export const DequeueMessageCheckpoint = z.object({
 });
 export type DequeueMessageCheckpoint = z.infer<typeof DequeueMessageCheckpoint>;
 
+export const PlacementTag = z.object({
+  key: z.string(),
+  values: z.array(z.string()).optional(),
+});
+export type PlacementTag = z.infer<typeof PlacementTag>;
+
+/** Helper functions for placement tags. Accepts a single value or an array of values. */
+export function placementTag(key: string, valueOrValues: string | string[]): PlacementTag {
+  return { key, values: Array.isArray(valueOrValues) ? valueOrValues : [valueOrValues] };
+}
+
 /** This is sent to a Worker when a run is dequeued (a new run or continuing run) */
 export const DequeuedMessage = z.object({
   version: z.literal("1"),
@@ -261,12 +272,6 @@ export const DequeuedMessage = z.object({
   project: z.object({
     id: z.string(),
   }),
-  billing: z
-    .object({
-      currentPlan: z.object({
-        isPaying: z.boolean(),
-      }),
-    })
-    .optional(),
+  placementTags: z.array(PlacementTag).optional(),
 });
 export type DequeuedMessage = z.infer<typeof DequeuedMessage>;

--- a/packages/core/src/v3/schemas/runEngine.ts
+++ b/packages/core/src/v3/schemas/runEngine.ts
@@ -261,5 +261,12 @@ export const DequeuedMessage = z.object({
   project: z.object({
     id: z.string(),
   }),
+  billing: z
+    .object({
+      currentPlan: z.object({
+        isPaying: z.boolean(),
+      }),
+    })
+    .optional(),
 });
 export type DequeuedMessage = z.infer<typeof DequeuedMessage>;

--- a/packages/core/src/v3/schemas/runEngine.ts
+++ b/packages/core/src/v3/schemas/runEngine.ts
@@ -230,9 +230,9 @@ export const PlacementTag = z.object({
 });
 export type PlacementTag = z.infer<typeof PlacementTag>;
 
-/** Helper functions for placement tags. Accepts a single value or an array of values. */
-export function placementTag(key: string, valueOrValues: string | string[]): PlacementTag {
-  return { key, values: Array.isArray(valueOrValues) ? valueOrValues : [valueOrValues] };
+/** Helper functions for placement tags. In the future this will be able to support multiple values and operators. For now it's just a single value. */
+export function placementTag(key: string, value: string): PlacementTag {
+  return { key, values: [value] };
 }
 
 /** This is sent to a Worker when a run is dequeued (a new run or continuing run) */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,8 +444,8 @@ importers:
         specifier: workspace:*
         version: link:../../internal-packages/otlp-importer
       '@trigger.dev/platform':
-        specifier: 1.0.17
-        version: 1.0.17
+        specifier: 1.0.18
+        version: 1.0.18
       '@trigger.dev/redis-worker':
         specifier: workspace:*
         version: link:../../packages/redis-worker
@@ -19779,8 +19779,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@trigger.dev/platform@1.0.17:
-    resolution: {integrity: sha512-cR05nn8HnP03h/bmRN6O/EKgvQncbs3Y/7fp1QboEDWn6rJTRrWJpZVrA3ZQ32SIW1qvHuZLcB1OVaEsJk2wjA==}
+  /@trigger.dev/platform@1.0.18:
+    resolution: {integrity: sha512-7huIRYY9+QzoV9b8lIr7GGLhLSrt2mu/LX+aENO2Jch8C0SAKuztBdJk/zi9NXYhmQzkpS2ASWGukf4qOAIwXg==}
     dependencies:
       zod: 3.23.8
     dev: false


### PR DESCRIPTION
Enables runs to be scheduled on specific nodes based on configurable placement tags. The system uses k/v pairs, with billing information automatically converted to placement tags during dequeue.

## Environment Variables

### Supervisor
- `PLACEMENT_TAGS_ENABLED=false` - Enable placement tags scheduling (default: false)
- `PLACEMENT_TAGS_PREFIX=node.cluster.x-k8s.io` - Kubernetes label prefix for placement tags (default shown)
- `BATCH_TRIGGER_CACHED_RUNS_CHECK_ENABLED` - Whether to perform potentially expensive checks (default: `false`)

## Backwards Compatibility

All placement tag scheduling is disabled by default and schema changes are optional.