### PR TITLE
feat: gather deployment git meta from the build server

### DIFF
--- a/packages/core/src/v3/schemas/common.ts
+++ b/packages/core/src/v3/schemas/common.ts
@@ -235,7 +235,12 @@ export const TaskRun = z.object({
 
 export type TaskRun = z.infer<typeof TaskRun>;
 
+// newly added fields need to be optional for backwards compatibility
 export const GitMeta = z.object({
+  provider: z.string().optional(),
+  source: z.enum(["trigger_github_app", "github_actions", "local"]).optional(),
+  ghUsername: z.string().optional(),
+  ghUserAvatarUrl: z.string().optional(),
   commitAuthorName: z.string().optional(),
   commitMessage: z.string().optional(),
   commitRef: z.string().optional(),


### PR DESCRIPTION
This PR adapts the deployment command to also evaluate build server env
variables when creating the git meta. The build server will initially
only support deployments triggered by the github app, but we might add
other git providers in the future.

Sticking to the GH actions naming convention for the env variables set
by the build server in favor of consistency.
