### PR TITLE
feat: show gh username and avatar for deployments triggered by the github app integration

### DIFF
--- a/apps/webapp/app/presenters/v3/BranchesPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/BranchesPresenter.server.ts
@@ -1,6 +1,6 @@
 import { GitMeta } from "@trigger.dev/core/v3";
 import { type z } from "zod";
-import { Prisma, type PrismaClient, prisma } from "~/db.server";
+import { type Prisma, type PrismaClient, prisma } from "~/db.server";
 import { type Project } from "~/models/project.server";
 import { type User } from "~/models/user.server";
 import { type BranchesOptions } from "~/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.branches/route";
@@ -38,6 +38,13 @@ export type GitMetaLinks = {
   commitMessage: string;
   /** The commit author */
   commitAuthor: string;
+
+  /** The git provider, e.g., `github` */
+  provider?: string;
+
+  source?: "trigger_github_app" | "github_actions" | "local";
+  ghUsername?: string;
+  ghUserAvatarUrl?: string;
 };
 
 export class BranchesPresenter {
@@ -239,5 +246,9 @@ export function processGitMetadata(data: Prisma.JsonValue): GitMetaLinks | null 
     isDirty: parsed.data.dirty ?? false,
     commitMessage: parsed.data.commitMessage ?? "",
     commitAuthor: parsed.data.commitAuthorName ?? "",
+    provider: parsed.data.provider,
+    source: parsed.data.source,
+    ghUsername: parsed.data.ghUsername,
+    ghUserAvatarUrl: parsed.data.ghUserAvatarUrl,
   };
 }

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments/route.tsx
@@ -245,21 +245,20 @@ export default function Page() {
                               )}
                             </TableCell>
                             <TableCell to={path} isSelected={isSelected}>
-                              {deployment.deployedBy ? (
-                                <div className="flex items-center gap-1">
-                                  <UserAvatar
-                                    avatarUrl={deployment.deployedBy.avatarUrl}
-                                    name={
-                                      deployment.deployedBy.name ??
-                                      deployment.deployedBy.displayName
-                                    }
-                                    className="h-4 w-4"
-                                  />
-                                  <Paragraph variant="extra-small">
-                                    {deployment.deployedBy.name ??
-                                      deployment.deployedBy.displayName}
-                                  </Paragraph>
-                                </div>
+                              {deployment.git?.source === "trigger_github_app" ? (
+                                <UserTag
+                                  name={deployment.git.ghUsername ?? "GitHub Integration"}
+                                  avatarUrl={deployment.git.ghUserAvatarUrl}
+                                />
+                              ) : deployment.deployedBy ? (
+                                <UserTag
+                                  name={
+                                    deployment.deployedBy.name ??
+                                    deployment.deployedBy.displayName ??
+                                    ""
+                                  }
+                                  avatarUrl={deployment.deployedBy.avatarUrl ?? undefined}
+                                />
                               ) : (
                                 "–"
                               )}
@@ -315,6 +314,15 @@ export default function Page() {
         </ResizablePanelGroup>
       </PageBody>
     </PageContainer>
+  );
+}
+
+function UserTag({ name, avatarUrl }: { name: string; avatarUrl?: string }) {
+  return (
+    <div className="flex items-center gap-1">
+      <UserAvatar avatarUrl={avatarUrl} name={name} className="h-4 w-4" />
+      <Paragraph variant="extra-small">{name}</Paragraph>
+    </div>
   );
 }
 


### PR DESCRIPTION
Small change that shows the github user in the deployments page in cases
where it was triggered by the github app integration.

These deployments are not triggered using a PAT, so we cannot associate
them with a Trigger user ID.

