### PR TITLE
Fixes conflicting shortcut keys

### DIFF
--- a/apps/webapp/app/components/Shortcuts.tsx
+++ b/apps/webapp/app/components/Shortcuts.tsx
@@ -123,7 +123,7 @@ function ShortcutContent() {
               <ShortcutKey shortcut={{ key: "d" }} variant="medium/bright" />
             </Shortcut>
             <Shortcut name="Context">
-              <ShortcutKey shortcut={{ key: "c" }} variant="medium/bright" />
+              <ShortcutKey shortcut={{ key: "x" }} variant="medium/bright" />
             </Shortcut>
             <Shortcut name="Metadata">
               <ShortcutKey shortcut={{ key: "m" }} variant="medium/bright" />

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -381,7 +381,7 @@ function RunBody({
             onClick={() => {
               replace({ tab: "context" });
             }}
-            shortcut={{ key: "c" }}
+            shortcut={{ key: "x" }}
           >
             Context
           </TabButton>


### PR DESCRIPTION
### Bug
We accidentally shipped the shortcut for "Cancel run" button as "C" which conflicts with toggling to the "Context" tab on the run page.

### Fixes
- The Context tab shortcut is now "X"
- The shortcut help panel is also update to match

<img width="964" height="820" alt="CleanShot 2025-08-19 at 15 25 30@2x" src="https://github.com/user-attachments/assets/70c0d4ba-e5b4-4b63-9a2b-2e5405711af3" />
