### PR TITLE
Small fix: Adds `tabular-nums` to the individually selected runs number

### DIFF
--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.bulkaction.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.bulkaction.tsx
@@ -320,7 +320,7 @@ export function CreateBulkActionInspector({
                   label={simplur`${selectedItems.size} individually selected run[|s]`}
                   value={"selected"}
                   variant="button/small"
-                  className="grow"
+                  className="grow tabular-nums"
                 />
               </RadioGroup>
             </InputGroup>


### PR DESCRIPTION
This prevents the button moving when incrementing numbers and means i can record a better landing page video

<img width="330" height="157" alt="CleanShot 2025-08-19 at 16 07 12" src="https://github.com/user-attachments/assets/31fe12f8-209c-464f-94af-4d9b7db65a10" />
