### PR TITLE
Fix excessive framework noise in error stack traces

### DIFF
--- a/.changeset/dry-taxis-wash.md
+++ b/.changeset/dry-taxis-wash.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Improve user-facing error readability by filtering framework noise from stack traces

--- a/packages/core/src/v3/errors.ts
+++ b/packages/core/src/v3/errors.ts
@@ -227,7 +227,9 @@ export function createJsonErrorObject(error: TaskRunError): SerializedError {
       return {
         name: enhancedError.name,
         message: enhancedError.message,
-        stackTrace: enhancedError.stackTrace,
+        stackTrace: correctErrorStackTrace(enhancedError.stackTrace, undefined, {
+          removeFirstLine: false,
+        }),
       };
     }
     case "STRING_ERROR": {
@@ -400,6 +402,7 @@ const LINES_TO_IGNORE = [
   /ZodIpc/,
   /startActiveSpan/,
   /processTicksAndRejections/,
+  /AsyncLocalStorage/,
 ];
 
 function correctStackTraceLine(line: string, projectDir?: string, isDev?: boolean) {

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -1,0 +1,48 @@
+import { createJsonErrorObject } from "../src/v3/errors.js";
+import type { TaskRunError } from "../src/v3/schemas/common.js";
+
+describe("createJsonErrorObject", () => {
+  it("should filter internal framework noise from error stack traces", () => {
+    const taskRunError: TaskRunError = {
+      type: "BUILT_IN_ERROR",
+      name: "Error",
+      message: "Network error occurred",
+      stackTrace: `Error: Network error occurred
+    at fetchData (file:///src/trigger/utils/helper.ts:4:9)
+    at processResponse (file:///src/trigger/utils/helper.ts:9:10)
+    at parseResult (file:///src/trigger/utils/helper.ts:14:10)
+    at callAPI (file:///src/trigger/services/api.ts:6:10)
+    at localHelper (file:///src/trigger/example.ts:7:10)
+    at run (file:///src/trigger/example.ts:17:12)
+    at _tracer.startActiveSpan.attributes (file:///.npm/_npx/f51a09bd0abf5f10/node_modules/@trigger.dev/core/src/v3/workers/taskExecutor.ts:445:38)
+    at file:///.npm/_npx/f51a09bd0abf5f10/node_modules/@trigger.dev/core/src/v3/tracer.ts:137:24
+    at AsyncLocalStorage.run (node:async_hooks:346:14)
+    at AsyncLocalStorageContextManager.with (file:///.npm/_npx/f51a09bd0abf5f10/node_modules/@opentelemetry/context-async-hooks/src/AsyncLocalStorageContextManager.ts:40:36)`,
+    };
+
+    const jsonError = createJsonErrorObject(taskRunError);
+
+    // Should preserve user stack traces
+    expect(jsonError.stackTrace).toContain(
+      "at fetchData (file:///src/trigger/utils/helper.ts:4:9)"
+    );
+    expect(jsonError.stackTrace).toContain(
+      "at processResponse (file:///src/trigger/utils/helper.ts:9:10)"
+    );
+    expect(jsonError.stackTrace).toContain(
+      "at parseResult (file:///src/trigger/utils/helper.ts:14:10)"
+    );
+    expect(jsonError.stackTrace).toContain("at callAPI (file:///src/trigger/services/api.ts:6:10)");
+    expect(jsonError.stackTrace).toContain("at localHelper (file:///src/trigger/example.ts:7:10)");
+    expect(jsonError.stackTrace).toContain("at run (file:///src/trigger/example.ts:17:12)");
+
+    // Should filter framework noise
+    expect(jsonError.stackTrace).not.toContain("_tracer.startActiveSpan.attributes");
+    expect(jsonError.stackTrace).not.toContain("taskExecutor.ts");
+    expect(jsonError.stackTrace).not.toContain("tracer.ts");
+    expect(jsonError.stackTrace).not.toContain("AsyncLocalStorage.run");
+    expect(jsonError.stackTrace).not.toContain("AsyncLocalStorageContextManager");
+    expect(jsonError.stackTrace).not.toContain("node_modules/@trigger.dev/core");
+    expect(jsonError.stackTrace).not.toContain(".npm/_npx");
+  });
+});


### PR DESCRIPTION
## Problem

Users reported excessive framework noise in Slack error alerts, making debugging difficult. Issue #2097 shows stack traces cluttered with trigger.dev internals like:

- `_RunTimelineMetricsAPI.measureMetric`
- `ConsoleInterceptor.intercept` 
- `taskExecutor.ts` internal calls

---

## Solution

Applied existing correctErrorStackTrace filtering to `BUILT_IN_ERROR` case in createJsonErrorObject - it was the only error type returning raw stack traces without filtering.

**Changes:**
- Wrap `enhancedError.stackTrace` with correctErrorStackTrace() for filtering stack traces
- Add `AsyncLocalStorage` pattern to `LINES_TO_IGNORE` to remove OpenTelemetry noise

---

## Impact

Cleaner error experiences across all user-facing error contexts using **createJsonErrorObject**:
- ✅ **Slack alerts**  (primary issue resolved)  
- ✅ **Email notifications**
- ✅ **API responses** 
- ✅ **Run streams**

Closes #2097

---

## ✅ Checklist
- ✅ I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- ✅ The PR title follows the convention.
- ✅ I ran and tested the code works

---

## Testing

- **Manual**: Verified Slack alerts now show clean stack traces with only user code
- **Unit**: Added test for framework noise filtering in stack traces

---

## Changelog

 Improve user-facing error readability by filtering framework noise from stack traces

---

## Screenshots

N/A

