### PR TITLE
feat(mcp): add wait_for_run_to_complete tool so agents don't spam the get_run_details call after triggering

### DIFF
--- a/.changeset/eleven-games-relate.md
+++ b/.changeset/eleven-games-relate.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+add wait_for_run_to_complete tool so agents don't spam the get_run_details call after triggering

--- a/packages/cli-v3/src/commands/install-mcp.ts
+++ b/packages/cli-v3/src/commands/install-mcp.ts
@@ -15,7 +15,6 @@ import {
 } from "../utilities/fileSystem.js";
 import { printStandloneInitialBanner } from "../utilities/initialBanner.js";
 import { VERSION } from "../version.js";
-import { spinner } from "../utilities/windows.js";
 
 const cliVersion = VERSION as string;
 const cliTag = cliVersion.includes("v4-beta") ? "v4-beta" : "latest";
@@ -113,7 +112,7 @@ type ResolvedClients = SupportedClients | "unsupported";
 
 const InstallMcpCommandOptions = z.object({
   projectRef: z.string().optional(),
-  tag: z.string().default(cliVersion),
+  tag: z.string().default(cliTag),
   devOnly: z.boolean().optional(),
   yolo: z.boolean().default(false),
   scope: z.enum(scopes).optional(),

--- a/packages/cli-v3/src/mcp/config.ts
+++ b/packages/cli-v3/src/mcp/config.ts
@@ -56,13 +56,19 @@ export const toolsMetadata = {
     name: "trigger_task",
     title: "Trigger Task",
     description:
-      "Trigger a task in the project. Use the get_tasks tool to get a list of tasks and ask the user to select one if it's not clear which one to use.",
+      "Trigger a task in the project. Use the get_tasks tool to get a list of tasks and ask the user to select one if it's not clear which one to use. Use the wait_for_run_to_complete tool to wait for the run to complete.",
   },
   get_run_details: {
     name: "get_run_details",
     title: "Get Run Details",
     description:
       "Get the details of a run. The run ID is the ID of the run that was triggered. It starts with run_",
+  },
+  wait_for_run_to_complete: {
+    name: "wait_for_run_to_complete",
+    title: "Wait for Run to Complete",
+    description:
+      "Wait for a run to complete. The run ID is the ID of the run that was triggered. It starts with run_",
   },
   cancel_run: {
     name: "cancel_run",

--- a/packages/cli-v3/src/mcp/formatters.ts
+++ b/packages/cli-v3/src/mcp/formatters.ts
@@ -1,3 +1,4 @@
+import { AnyRunShape } from "@trigger.dev/core/v3";
 import {
   ListRunResponseItem,
   RetrieveRunResponse,
@@ -95,6 +96,34 @@ export function formatRun(run: RetrieveRunResponse): string {
   // Metadata
   if (run.metadata && Object.keys(run.metadata).length > 0) {
     lines.push(`Metadata: ${Object.keys(run.metadata).length} fields`);
+  }
+
+  return lines.join("\n");
+}
+
+export function formatRunShape(run: AnyRunShape): string {
+  const lines: string[] = [];
+
+  lines.push(`Run ${run.id}`);
+  lines.push(`Task: ${run.taskIdentifier}`);
+  lines.push(`Status: ${formatStatus(run.status)}`);
+
+  if (run.output) {
+    lines.push(`Output: ${JSON.stringify(run.output, null, 2)}`);
+  }
+
+  if (run.error) {
+    lines.push(`Error: ${run.error.name || "Error"}: ${run.error.message}`);
+  }
+
+  if (run.metadata) {
+    lines.push(`Metadata: ${JSON.stringify(run.metadata, null, 2)}`);
+  }
+
+  lines.push(`Created at: ${formatDateTime(run.createdAt)}`);
+
+  if (run.finishedAt) {
+    lines.push(`Finished at: ${formatDateTime(run.finishedAt)}`);
   }
 
   return lines.join("\n");

--- a/packages/cli-v3/src/mcp/mintlifyClient.ts
+++ b/packages/cli-v3/src/mcp/mintlifyClient.ts
@@ -1,5 +1,5 @@
 export async function performSearch(query: string, signal: AbortSignal) {
-  const body = callToolBody("Search", { query });
+  const body = callToolBody("SearchTriggerDev", { query });
 
   const response = await fetch("https://trigger.dev/docs/mcp", {
     method: "POST",

--- a/packages/cli-v3/src/mcp/tools.ts
+++ b/packages/cli-v3/src/mcp/tools.ts
@@ -8,7 +8,12 @@ import {
   listProjectsTool,
 } from "./tools/orgs.js";
 import { listPreviewBranchesTool } from "./tools/previewBranches.js";
-import { cancelRunTool, getRunDetailsTool, listRunsTool } from "./tools/runs.js";
+import {
+  cancelRunTool,
+  getRunDetailsTool,
+  listRunsTool,
+  waitForRunToCompleteTool,
+} from "./tools/runs.js";
 import { getCurrentWorker, triggerTaskTool } from "./tools/tasks.js";
 import { respondWithError } from "./utils.js";
 
@@ -23,6 +28,7 @@ export function registerTools(context: McpContext) {
     triggerTaskTool,
     listRunsTool,
     getRunDetailsTool,
+    waitForRunToCompleteTool,
     cancelRunTool,
     deployTool,
     listDeploysTool,

--- a/packages/cli-v3/src/mcp/tools/tasks.ts
+++ b/packages/cli-v3/src/mcp/tools/tasks.ts
@@ -130,7 +130,7 @@ export const triggerTaskTool = {
     const contents = [
       `Task ${input.taskId} triggered and run with ID created: ${result.id}.`,
       `View the run in the dashboard: ${taskRunUrl}`,
-      `You can also use the get_run_details tool to get the details of the run.`,
+      `Use the ${toolsMetadata.wait_for_run_to_complete.name} tool to wait for the run to complete and the ${toolsMetadata.get_run_details.name} tool to get the details of the run.`,
     ];
 
     if (input.environment === "dev") {


### PR DESCRIPTION
- Fix the search docs MCP tool
- When installing the MCP server, using the `@latest` tag instead of `@<current version>`