### PR TITLE
Feat: Can override machine request and limit independently for kubernetes

### DIFF
--- a/apps/kubernetes-provider/src/index.ts
+++ b/apps/kubernetes-provider/src/index.ts
@@ -545,8 +545,8 @@ class KubernetesTaskOperations implements TaskOperations {
 
   #getResourceRequestsForMachine(preset: MachinePreset): ResourceQuantities {
     return {
-      cpu: `${preset.cpu * 0.75}`,
-      memory: `${preset.memory}G`,
+      cpu: `${preset.cpuRequest ?? preset.cpu * 0.75}`,
+      memory: `${preset.memoryRequest ?? preset.memory}G`,
     };
   }
 

--- a/apps/supervisor/src/workloadManager/kubernetes.ts
+++ b/apps/supervisor/src/workloadManager/kubernetes.ts
@@ -296,8 +296,8 @@ export class KubernetesWorkloadManager implements WorkloadManager {
 
   #getResourceRequestsForMachine(preset: MachinePreset): ResourceQuantities {
     return {
-      cpu: `${preset.cpu * 0.75}`,
-      memory: `${preset.memory}G`,
+      cpu: `${preset.cpuRequest ?? preset.cpu * 0.75}`,
+      memory: `${preset.memoryRequest ?? preset.memory}G`,
     };
   }
 

--- a/apps/webapp/app/services/platform.v3.server.ts
+++ b/apps/webapp/app/services/platform.v3.server.ts
@@ -80,7 +80,9 @@ type Machines = typeof machinesFromPlatform;
 
 const MachineOverrideValues = z.object({
   cpu: z.number(),
+  cpuRequest: z.number().optional(), // Only used for k8s fallback to cpu
   memory: z.number(),
+  memoryRequest: z.number().optional(), // Only used for k8s fallback to memory
 });
 type MachineOverrideValues = z.infer<typeof MachineOverrideValues>;
 

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -41,7 +41,6 @@ While [limits](#limits) are generally configurable when self-hosting, some featu
 | Community support | ✅    | ✅          | Access to our Discord community         |
 | ARM support       | ✅    | ✅          | ARM-based deployments                   |
 
-
 ## Limits
 
 Most of the [limits](/limits) are configurable when self-hosting, with some hardcoded exceptions. You can configure them via environment variables on the [webapp](/self-hosting/env/webapp) container.
@@ -88,6 +87,18 @@ All fields are optional. Partial overrides are supported:
   "defaultMachine": "small-2x",
   "machines": {
     "small-1x": { "memory": 2 }
+  }
+}
+```
+
+You can also set cpu/memory requests for each machine type. This is used in k8s environments to set the minimum resources required for each machine type.
+We do not recommend setting these values to zero, as it can cause the k8s scheduler to schedule an infinite number of pods in parallel and cause the pods to get killed due to resource exhaustion.
+
+```json
+{
+  "defaultMachine": "small-2x",
+  "machines": {
+    "small-1x": { "cpu": 0.5, "memory": 0.5, "cpuRequest": 0.25, "memoryRequest": 0.25 }
   }
 }
 ```

--- a/packages/core/src/v3/schemas/common.ts
+++ b/packages/core/src/v3/schemas/common.ts
@@ -118,8 +118,10 @@ export const MachinePreset = z.object({
   name: MachinePresetName,
   /** unit: vCPU */
   cpu: z.number(),
+  cpuRequest: z.number().optional(), // Only used for k8s fallback to cpu
   /** unit: GB */
   memory: z.number(),
+  memoryRequest: z.number().optional(), // Only used for k8s fallback to memory
   centsPerMs: z.number(),
 });
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

I deployed a built version of the webapp, supervisor into a public registry and tried it in my cluster.

Webapp: `public.ecr.aws/n5q7l0s4/trigger-supervisor:latest`
Supervisor: `public.ecr.aws/n5q7l0s4/trigger-webapp:latest`

---

## Changelog

You can now add memory/cpu request specification to the machine override which allows you ton control request and limit independently for kubernetes.


💯
