### PR TITLE
feat(supervisor): make resource request ratios configurable

### DIFF
--- a/apps/supervisor/src/env.ts
+++ b/apps/supervisor/src/env.ts
@@ -85,6 +85,10 @@ const Env = z.object({
   KUBERNETES_EPHEMERAL_STORAGE_SIZE_LIMIT: z.string().default("10Gi"),
   KUBERNETES_EPHEMERAL_STORAGE_SIZE_REQUEST: z.string().default("2Gi"),
   KUBERNETES_STRIP_IMAGE_DIGEST: BoolEnv.default(false),
+  KUBERNETES_CPU_REQUEST_MIN_CORES: z.coerce.number().min(0).default(0),
+  KUBERNETES_CPU_REQUEST_RATIO: z.coerce.number().min(0).max(1).default(0.75), // Ratio of CPU limit, so 0.75 = 75% of CPU limit
+  KUBERNETES_MEMORY_REQUEST_MIN_GB: z.coerce.number().min(0).default(0),
+  KUBERNETES_MEMORY_REQUEST_RATIO: z.coerce.number().min(0).max(1).default(1), // Ratio of memory limit, so 1 = 100% of memory limit
 
   // Placement tags settings
   PLACEMENT_TAGS_ENABLED: BoolEnv.default(false),


### PR DESCRIPTION
Adds environment variables to configure Kubernetes resource requests with customizable CPU/memory ratios and minimum values. Defaults preserve existing behavior when not configured.

## Environment Variables

### Supervisor

- `KUBERNETES_CPU_REQUEST_MIN_CORES` - Minimum CPU cores to request (e.g. `0.5`), defaults to `0`
- `KUBERNETES_MEMORY_REQUEST_MIN_GB` - Minimum memory GB to request (e.g. `2`), defaults to `0`
- `KUBERNETES_CPU_REQUEST_RATIO` - Ratio of CPU limit to request (e.g. `0.75` for 75%), defaults to `0.75`
- `KUBERNETES_MEMORY_REQUEST_RATIO` - Ratio of memory limit to request (e.g. `1` for 100%), defaults to `1`
