### PR TITLE
Fix: webapp crash on clickhouse data corruption

### DIFF
--- a/apps/webapp/app/services/runsReplicationService.server.ts
+++ b/apps/webapp/app/services/runsReplicationService.server.ts
@@ -148,6 +148,11 @@ export class RunsReplicationService {
         }
 
         for (const item of newBatch) {
+          if (!item?.run?.id) {
+            this.logger.warn("Skipping replication event with null run", { event: item });
+            continue;
+          }
+
           const key = `${item.event}_${item.run.id}`;
           const existingItem = merged.get(key);
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

## Issue

When you delete `TaskRun` manually from the database you can get this error on the webapp due to some data corruption. You will not be able to start the webapp again until dropping the replication slot.

```bash
2025-09-02T07:04:37.301Z {"error":{"name":"TypeError","message":"Cannot read properties of null (reading 'id')","stack":"TypeError: Cannot read properties of null (reading 'id')\n    at Object.mergeBatch (/triggerdotdev/apps/webapp/build/index.js:111786:47)\n    at ConcurrentFlushScheduler.addToBatch (/triggerdotdev/apps/webapp/build/index.js:112206:62)\n    at #handleTransaction (/triggerdotdev/apps/webapp/build/index.js:111913:36)\n    at #handleData (/triggerdotdev/apps/webapp/build/index.js:111892:148)\n    at EventEmitter.<anonymous> (/triggerdotdev/apps/webapp/build/index.js:111794:23)\n    at EventEmitter.emit (node:events:518:28)\n    at Connection.<anonymous> (/triggerdotdev/apps/webapp/build/index.js:111558:23)\n    at Connection.emit (node:events:530:35)\n    at /triggerdotdev/node_modules/.pnpm/pg@8.15.6/node_modules/pg/lib/connection.js:116:12\n    at Parser.parse (/triggerdotdev/node_modules/.pnpm/pg-protocol@1.9.5/node_modules/pg-protocol/dist/parser.js:36:17)"},"origin":"unhandledRejection","timestamp":"2025-09-02T07:04:37.300Z","name":"webapp","message":"uncaughtException","level":"error"}
```

Original message: https://discord.com/channels/1066956501299777596/1287767734595092480/1412332657689366591

---

## Testing

I had the bug and I wasn't able to start the webapp. After implementing this fix everything went fine again.

---

## Changelog

Ensure that the run exists so it doesn't crash if not

💯
