### PR TITLE
Fix for broken retrieve runs docs page

### DIFF
--- a/docs/v3-openapi.yaml
+++ b/docs/v3-openapi.yaml
@@ -570,7 +570,7 @@ paths:
 
             const handle = await runs.reschedule("run_1234", { delay: new Date("2024-06-29T20:45:56.340Z") });
 
-  "/api/runs/{runId}":
+  "/api/v3/runs/{runId}":
     parameters:
       - $ref: "#/components/parameters/runId"
     get:


### PR DESCRIPTION
The API path was accidentally edited as part of a /v3 purge