### PR TITLE
feat: expose project build settings

### DIFF
--- a/apps/webapp/app/services/projectSettings.server.ts
+++ b/apps/webapp/app/services/projectSettings.server.ts
@@ -4,6 +4,7 @@ import { DeleteProjectService } from "~/services/deleteProject.server";
 import { BranchTrackingConfigSchema, type BranchTrackingConfig } from "~/v3/github";
 import { checkGitHubBranchExists } from "~/services/gitHub.server";
 import { errAsync, fromPromise, okAsync, ResultAsync } from "neverthrow";
+import { BuildSettings } from "~/v3/buildSettings";
 
 export class ProjectSettingsService {
   #prismaClient: PrismaClient;
@@ -242,6 +243,23 @@ export class ProjectSettingsService {
         ]);
       })
       .andThen(updateConnectedRepo);
+  }
+
+  updateBuildSettings(projectId: string, buildSettings: BuildSettings) {
+    return fromPromise(
+      this.#prismaClient.project.update({
+        where: {
+          id: projectId,
+        },
+        data: {
+          buildSettings: buildSettings,
+        },
+      }),
+      (error) => ({
+        type: "other" as const,
+        cause: error,
+      })
+    );
   }
 
   verifyProjectMembership(organizationSlug: string, projectSlug: string, userId: string) {

--- a/apps/webapp/app/v3/buildSettings.ts
+++ b/apps/webapp/app/v3/buildSettings.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const BuildSettingsSchema = z.object({
+  rootDirectory: z.string().optional(),
+  installCommand: z.string().optional(),
+  triggerConfigFile: z.string().optional(),
+});
+
+export type BuildSettings = z.infer<typeof BuildSettingsSchema>;

--- a/internal-packages/database/prisma/migrations/20250915141201_add_build_settings_to_project/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250915141201_add_build_settings_to_project/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."Project" ADD COLUMN     "buildSettings" JSONB;
+

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -394,6 +394,8 @@ model Project {
   executionSnapshots        TaskRunExecutionSnapshot[]
   waitpointTags             WaitpointTag[]
   connectedGithubRepository ConnectedGithubRepository?
+
+  buildSettings Json?
 }
 
 enum ProjectVersion {


### PR DESCRIPTION
This PR enables setting project build settings in the settings page:
Root directory, install command and trigger config file path.

For most cases there should be no need to set these explicitly.

<img width="2552" height="1850" alt="image" src="https://github.com/user-attachments/assets/856282e2-de98-454d-a9d6-7483b4941d53" />

