### PR TITLE
chore(supervisor): remove deprecated snapshot route

### DIFF
--- a/apps/supervisor/src/workloadServer/index.ts
+++ b/apps/supervisor/src/workloadServer/index.ts
@@ -16,7 +16,6 @@ import {
   type WorkloadRunAttemptCompleteResponseBody,
   WorkloadRunAttemptStartRequestBody,
   type WorkloadRunAttemptStartResponseBody,
-  type WorkloadRunLatestSnapshotResponseBody,
   WorkloadRunSnapshotsSinceResponseBody,
   type WorkloadServerToClientEvents,
   type WorkloadSuspendRunResponseBody,
@@ -322,28 +321,6 @@ export class WorkloadServer extends EventEmitter<WorkloadServerEvents> {
           },
         }
       )
-      .route("/api/v1/workload-actions/runs/:runFriendlyId/snapshots/latest", "GET", {
-        paramsSchema: WorkloadActionParams.pick({ runFriendlyId: true }),
-        handler: async ({ req, reply, params }) => {
-          const latestSnapshotResponse = await this.workerClient.getLatestSnapshot(
-            params.runFriendlyId,
-            this.runnerIdFromRequest(req)
-          );
-
-          if (!latestSnapshotResponse.success) {
-            this.logger.error("Failed to get latest snapshot", {
-              runId: params.runFriendlyId,
-              error: latestSnapshotResponse.error,
-            });
-            reply.empty(500);
-            return;
-          }
-
-          reply.json({
-            execution: latestSnapshotResponse.data.execution,
-          } satisfies WorkloadRunLatestSnapshotResponseBody);
-        },
-      })
       .route(
         "/api/v1/workload-actions/runs/:runFriendlyId/snapshots/since/:snapshotFriendlyId",
         "GET",

--- a/packages/core/src/v3/runEngineWorker/workload/http.ts
+++ b/packages/core/src/v3/runEngineWorker/workload/http.ts
@@ -5,7 +5,6 @@ import {
   WorkloadRunAttemptCompleteRequestBody,
   WorkloadRunAttemptCompleteResponseBody,
   WorkloadRunAttemptStartResponseBody,
-  WorkloadRunLatestSnapshotResponseBody,
   WorkloadDequeueFromVersionResponseBody,
   WorkloadRunAttemptStartRequestBody,
   WorkloadSuspendRunResponseBody,
@@ -126,19 +125,6 @@ export class WorkloadHttpClient {
           ...this.defaultHeaders(),
         },
         body: JSON.stringify(body),
-      }
-    );
-  }
-
-  async getRunExecutionData(runId: string) {
-    return wrapZodFetch(
-      WorkloadRunLatestSnapshotResponseBody,
-      `${this.apiUrl}/api/v1/workload-actions/runs/${runId}/snapshots/latest`,
-      {
-        method: "GET",
-        headers: {
-          ...this.defaultHeaders(),
-        },
       }
     );
   }


### PR DESCRIPTION
This was used only briefly by one of our first beta version and we replaced it with `getSnapshotsSince`