### PR TITLE
feat: separate deployment initialize and start steps

### DIFF
--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -312,6 +312,10 @@ const EnvironmentSchema = z
       .number()
       .int()
       .default(60 * 1000 * 8), // 8 minutes
+    DEPLOY_QUEUE_TIMEOUT_MS: z.coerce
+      .number()
+      .int()
+      .default(60 * 1000 * 15), // 15 minutes
 
     OBJECT_STORE_BASE_URL: z.string().optional(),
     OBJECT_STORE_ACCESS_KEY_ID: z.string().optional(),

--- a/apps/webapp/app/presenters/v3/DeploymentPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/DeploymentPresenter.server.ts
@@ -102,6 +102,7 @@ export class DeploymentPresenter {
         builtAt: true,
         deployedAt: true,
         createdAt: true,
+        startedAt: true,
         git: true,
         promotions: {
           select: {
@@ -145,6 +146,7 @@ export class DeploymentPresenter {
         version: deployment.version,
         status: deployment.status,
         createdAt: deployment.createdAt,
+        startedAt: deployment.startedAt,
         builtAt: deployment.builtAt,
         deployedAt: deployment.deployedAt,
         tasks: deployment.worker?.tasks,

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments.$deploymentParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments.$deploymentParam/route.tsx
@@ -32,6 +32,7 @@ import { requireUserId } from "~/services/session.server";
 import { cn } from "~/utils/cn";
 import { v3DeploymentParams, v3DeploymentsPath, v3RunsPath } from "~/utils/pathBuilder";
 import { capitalizeWord } from "~/utils/string";
+import { UserTag } from "../_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments/route";
 
 export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const userId = await requireUserId(request);
@@ -232,17 +233,16 @@ export default function Page() {
               <Property.Item>
                 <Property.Label>Deployed by</Property.Label>
                 <Property.Value>
-                  {deployment.deployedBy ? (
-                    <div className="flex items-center gap-1">
-                      <UserAvatar
-                        avatarUrl={deployment.deployedBy.avatarUrl}
-                        name={deployment.deployedBy.name ?? deployment.deployedBy.displayName}
-                        className="h-4 w-4"
-                      />
-                      <Paragraph variant="small">
-                        {deployment.deployedBy.name ?? deployment.deployedBy.displayName}
-                      </Paragraph>
-                    </div>
+                  {deployment.git?.source === "trigger_github_app" ? (
+                    <UserTag
+                      name={deployment.git.ghUsername ?? "GitHub Integration"}
+                      avatarUrl={deployment.git.ghUserAvatarUrl}
+                    />
+                  ) : deployment.deployedBy ? (
+                    <UserTag
+                      name={deployment.deployedBy.name ?? deployment.deployedBy.displayName ?? ""}
+                      avatarUrl={deployment.deployedBy.avatarUrl ?? undefined}
+                    />
                   ) : (
                     "–"
                   )}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments.$deploymentParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments.$deploymentParam/route.tsx
@@ -187,7 +187,13 @@ export default function Page() {
               <Property.Item>
                 <Property.Label>Started at</Property.Label>
                 <Property.Value>
-                  <DateTimeAccurate date={deployment.createdAt} /> UTC
+                  {deployment.startedAt ? (
+                    <>
+                      <DateTimeAccurate date={deployment.startedAt} /> UTC
+                    </>
+                  ) : (
+                    "–"
+                  )}
                 </Property.Value>
               </Property.Item>
               <Property.Item>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments/route.tsx
@@ -358,7 +358,7 @@ export default function Page() {
   );
 }
 
-function UserTag({ name, avatarUrl }: { name: string; avatarUrl?: string }) {
+export function UserTag({ name, avatarUrl }: { name: string; avatarUrl?: string }) {
   return (
     <div className="flex items-center gap-1">
       <UserAvatar avatarUrl={avatarUrl} name={name} className="h-4 w-4" />

--- a/apps/webapp/app/routes/api.v1.deployments.$deploymentId.start.ts
+++ b/apps/webapp/app/routes/api.v1.deployments.$deploymentId.start.ts
@@ -1,0 +1,64 @@
+import { type ActionFunctionArgs, json } from "@remix-run/server-runtime";
+import { StartDeploymentRequestBody } from "@trigger.dev/core/v3";
+import { z } from "zod";
+import { authenticateRequest } from "~/services/apiAuth.server";
+import { logger } from "~/services/logger.server";
+import { DeploymentService } from "~/v3/services/deployment.server";
+
+const ParamsSchema = z.object({
+  deploymentId: z.string(),
+});
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  if (request.method.toUpperCase() !== "POST") {
+    return json({ error: "Method Not Allowed" }, { status: 405 });
+  }
+
+  const parsedParams = ParamsSchema.safeParse(params);
+
+  if (!parsedParams.success) {
+    return json({ error: "Invalid params" }, { status: 400 });
+  }
+
+  const authenticationResult = await authenticateRequest(request, {
+    apiKey: true,
+    organizationAccessToken: false,
+    personalAccessToken: false,
+  });
+
+  if (!authenticationResult || !authenticationResult.result.ok) {
+    logger.info("Invalid or missing api key", { url: request.url });
+    return json({ error: "Invalid or Missing API key" }, { status: 401 });
+  }
+
+  const { environment: authenticatedEnv } = authenticationResult.result;
+  const { deploymentId } = parsedParams.data;
+
+  const rawBody = await request.json();
+  const body = StartDeploymentRequestBody.safeParse(rawBody);
+
+  if (!body.success) {
+    return json({ error: "Invalid request body", issues: body.error.issues }, { status: 400 });
+  }
+
+  const deploymentService = new DeploymentService();
+
+  const result = await deploymentService.startDeployment(authenticatedEnv, deploymentId, body.data);
+  return result.match(
+    () => {
+      return json(null, { status: 204 });
+    },
+    (error) => {
+      switch (error.type) {
+        case "deployment_not_found":
+          return json({ error: "Deployment not found" }, { status: 404 });
+        case "deployment_not_pending":
+          return json({ error: "Deployment is not pending" }, { status: 409 });
+        case "other":
+        default:
+          error.type satisfies "other";
+          return json({ error: "Internal server error" }, { status: 500 });
+      }
+    }
+  );
+}

--- a/apps/webapp/app/routes/api.v1.deployments.$deploymentId.start.ts
+++ b/apps/webapp/app/routes/api.v1.deployments.$deploymentId.start.ts
@@ -50,6 +50,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
     },
     (error) => {
       switch (error.type) {
+        case "failed_to_extend_deployment_timeout":
+          return json(null, { status: 204 }); // ignore these errors for now
         case "deployment_not_found":
           return json({ error: "Deployment not found" }, { status: 404 });
         case "deployment_not_pending":

--- a/apps/webapp/app/routes/api.v1.deployments.ts
+++ b/apps/webapp/app/routes/api.v1.deployments.ts
@@ -1,8 +1,8 @@
-import { ActionFunctionArgs, json } from "@remix-run/server-runtime";
+import { type ActionFunctionArgs, json } from "@remix-run/server-runtime";
 import {
   ApiDeploymentListSearchParams,
   InitializeDeploymentRequestBody,
-  InitializeDeploymentResponseBody,
+  type InitializeDeploymentResponseBody,
 } from "@trigger.dev/core/v3";
 import { $replica } from "~/db.server";
 import { authenticateApiRequest } from "~/services/apiAuth.server";

--- a/apps/webapp/app/v3/services/deployment.server.ts
+++ b/apps/webapp/app/v3/services/deployment.server.ts
@@ -1,0 +1,63 @@
+import { type AuthenticatedEnvironment } from "~/services/apiAuth.server";
+import { BaseService } from "./baseService.server";
+import { errAsync, fromPromise, okAsync } from "neverthrow";
+import { type WorkerDeployment } from "@trigger.dev/database";
+import { type GitMeta } from "@trigger.dev/core/v3";
+
+export class DeploymentService extends BaseService {
+  public async startDeployment(
+    authenticatedEnv: AuthenticatedEnvironment,
+    friendlyId: string,
+    updates: Partial<Pick<WorkerDeployment, "contentHash" | "runtime"> & { git: GitMeta }>
+  ) {
+    const getDeployment = () =>
+      fromPromise(
+        this._prisma.workerDeployment.findFirst({
+          where: {
+            friendlyId,
+            environmentId: authenticatedEnv.id,
+          },
+          select: {
+            status: true,
+            id: true,
+          },
+        }),
+        (error) => ({
+          type: "other" as const,
+          cause: error,
+        })
+      ).andThen((deployment) => {
+        if (!deployment) {
+          return errAsync({ type: "deployment_not_found" as const });
+        }
+        return okAsync(deployment);
+      });
+
+    const validateDeployment = (deployment: Pick<WorkerDeployment, "id" | "status">) => {
+      if (deployment.status !== "PENDING") {
+        return errAsync({ type: "deployment_not_pending" as const });
+      }
+
+      return okAsync(deployment);
+    };
+
+    const updateDeployment = (deployment: Pick<WorkerDeployment, "id">) =>
+      fromPromise(
+        this._prisma.workerDeployment.updateMany({
+          where: { id: deployment.id, status: "PENDING" }, // status could've changed in the meantime, we're not locking the row
+          data: { ...updates, status: "BUILDING" },
+        }),
+        (error) => ({
+          type: "other" as const,
+          cause: error,
+        })
+      ).andThen((result) => {
+        if (result.count === 0) {
+          return errAsync({ type: "deployment_not_pending" as const });
+        }
+        return okAsync(undefined);
+      });
+
+    return getDeployment().andThen(validateDeployment).andThen(updateDeployment);
+  }
+}

--- a/apps/webapp/app/v3/services/initializeDeployment.server.ts
+++ b/apps/webapp/app/v3/services/initializeDeployment.server.ts
@@ -138,7 +138,11 @@ export class InitializeDeploymentService extends BaseService {
         deployment.id,
         deployment.status,
         "Building timed out",
-        new Date(Date.now() + env.DEPLOY_TIMEOUT_MS)
+        new Date(
+          Date.now() + deployment.status === "PENDING"
+            ? env.DEPLOY_QUEUE_TIMEOUT_MS
+            : env.DEPLOY_TIMEOUT_MS
+        )
       );
 
       return {

--- a/apps/webapp/app/v3/services/initializeDeployment.server.ts
+++ b/apps/webapp/app/v3/services/initializeDeployment.server.ts
@@ -131,6 +131,7 @@ export class InitializeDeploymentService extends BaseService {
           imagePlatform: env.DEPLOY_IMAGE_PLATFORM,
           git: payload.gitMeta ?? undefined,
           runtime: payload.runtime ?? undefined,
+          startedAt: initialStatus === "BUILDING" ? new Date() : undefined,
         },
       });
 

--- a/internal-packages/database/prisma/migrations/20250918122438_add_started_at_to_deployment_schema/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250918122438_add_started_at_to_deployment_schema/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."WorkerDeployment" ADD COLUMN     "startedAt" TIMESTAMP(3);

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -1764,6 +1764,7 @@ model WorkerDeployment {
   triggeredBy   User?   @relation(fields: [triggeredById], references: [id], onDelete: SetNull, onUpdate: Cascade)
   triggeredById String?
 
+  startedAt  DateTime?
   builtAt    DateTime?
   deployedAt DateTime?
 

--- a/packages/core/src/v3/schemas/api.ts
+++ b/packages/core/src/v3/schemas/api.ts
@@ -419,6 +419,7 @@ export const InitializeDeploymentRequestBody = z.object({
   gitMeta: GitMeta.optional(),
   type: z.enum(["MANAGED", "UNMANAGED", "V1"]).optional(),
   runtime: z.string().optional(),
+  initialStatus: z.enum(["PENDING", "BUILDING"]).optional(),
 });
 
 export type InitializeDeploymentRequestBody = z.infer<typeof InitializeDeploymentRequestBody>;

--- a/packages/core/src/v3/schemas/api.ts
+++ b/packages/core/src/v3/schemas/api.ts
@@ -377,6 +377,14 @@ export const FinalizeDeploymentRequestBody = z.object({
 
 export type FinalizeDeploymentRequestBody = z.infer<typeof FinalizeDeploymentRequestBody>;
 
+export const StartDeploymentRequestBody = z.object({
+  contentHash: z.string().optional(),
+  gitMeta: GitMeta.optional(),
+  runtime: z.string().optional(),
+});
+
+export type StartDeploymentRequestBody = z.infer<typeof StartDeploymentRequestBody>;
+
 export const ExternalBuildData = z.object({
   buildId: z.string(),
   buildToken: z.string(),


### PR DESCRIPTION
Changes in this PR:

- Enabled setting the initial status on deployment creation
- Exposed endpoint to start deployments

This enables showing queued (pending) deployments before they are started.
Relevant for limiting build concurrency.
