### PR TITLE
feat(api): defer remote build creation for pending deployments

### DIFF
--- a/apps/webapp/app/routes/api.v1.deployments.$deploymentId.start.ts
+++ b/apps/webapp/app/routes/api.v1.deployments.$deploymentId.start.ts
@@ -61,6 +61,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
             return json({ error: "Deployment not found" }, { status: 404 });
           case "deployment_not_pending":
             return json({ error: "Deployment is not pending" }, { status: 409 });
+          case "failed_to_create_remote_build":
+            return json({ error: "Failed to create remote build" }, { status: 500 });
           case "other":
           default:
             error.type satisfies "other";

--- a/apps/webapp/app/v3/remoteImageBuilder.server.ts
+++ b/apps/webapp/app/v3/remoteImageBuilder.server.ts
@@ -1,9 +1,12 @@
 import { depot } from "@depot/sdk-node";
-import { Project } from "@trigger.dev/database";
+import { type ExternalBuildData } from "@trigger.dev/core/v3";
+import { type Project } from "@trigger.dev/database";
 import { prisma } from "~/db.server";
 import { env } from "~/env.server";
 
-export async function createRemoteImageBuild(project: Project) {
+export async function createRemoteImageBuild(
+  project: Project
+): Promise<ExternalBuildData | undefined> {
   if (!remoteBuildsEnabled()) {
     return;
   }

--- a/apps/webapp/app/v3/services/initializeDeployment.server.ts
+++ b/apps/webapp/app/v3/services/initializeDeployment.server.ts
@@ -87,8 +87,12 @@ export class InitializeDeploymentService extends BaseService {
         );
       }
 
-      // Try and create a depot build and get back the external build data
-      const externalBuildData = await createRemoteImageBuild(environment.project);
+      // For the `PENDING` initial status, defer the creation of the Depot build until the deployment is started.
+      // This helps avoid Depot token expiration issues.
+      const externalBuildData =
+        payload.initialStatus === "PENDING"
+          ? undefined
+          : await createRemoteImageBuild(environment.project);
 
       const triggeredBy = payload.userId
         ? await this._prisma.user.findFirst({


### PR DESCRIPTION
Depot builds have short-lived tokens and their TTL is not exposed in the SDK. As queued deployments can stay in the queue for an arbitrary amount of time, deferring the remote build creation helps avoid expired Depot token issues.
