### PR TITLE
fix(webapp): hide outdated connected repos from deleted installations

### DIFF
--- a/apps/webapp/app/services/projectSettingsPresenter.server.ts
+++ b/apps/webapp/app/services/projectSettingsPresenter.server.ts
@@ -54,6 +54,12 @@ export class ProjectSettingsPresenter {
         this.#prismaClient.connectedGithubRepository.findFirst({
           where: {
             projectId,
+            repository: {
+              installation: {
+                deletedAt: null,
+                suspendedAt: null,
+              },
+            },
           },
           select: {
             branchTracking: true,


### PR DESCRIPTION
Fixes small issue in the settings page which would cause outdated connected
project repos to be shown.
