### PR TITLE
feat: installing status for deployments

### DIFF
--- a/.changeset/kind-kids-teach.md
+++ b/.changeset/kind-kids-teach.md
@@ -1,0 +1,6 @@
+---
+"trigger.dev": patch
+"@trigger.dev/core": patch
+---
+
+Added INSTALLING status to the deployment status enum.

--- a/apps/webapp/app/components/runs/v3/DeploymentStatus.tsx
+++ b/apps/webapp/app/components/runs/v3/DeploymentStatus.tsx
@@ -53,6 +53,7 @@ export function DeploymentStatusIcon({
       return (
         <RectangleStackIcon className={cn(deploymentStatusClassNameColor(status), className)} />
       );
+    case "INSTALLING":
     case "BUILDING":
     case "DEPLOYING":
       return <Spinner className={cn(deploymentStatusClassNameColor(status), className)} />;
@@ -78,6 +79,7 @@ export function deploymentStatusClassNameColor(status: WorkerDeploymentStatus): 
   switch (status) {
     case "PENDING":
       return "text-charcoal-500";
+    case "INSTALLING":
     case "BUILDING":
     case "DEPLOYING":
       return "text-pending";
@@ -98,6 +100,8 @@ export function deploymentStatusTitle(status: WorkerDeploymentStatus, isBuilt: b
   switch (status) {
     case "PENDING":
       return "Queued…";
+    case "INSTALLING":
+      return "Installing…";
     case "BUILDING":
       return "Building…";
     case "DEPLOYING":
@@ -127,6 +131,7 @@ export function deploymentStatusTitle(status: WorkerDeploymentStatus, isBuilt: b
 // PENDING and CANCELED are not used so are ommited from the UI
 export const deploymentStatuses: WorkerDeploymentStatus[] = [
   "PENDING",
+  "INSTALLING",
   "BUILDING",
   "DEPLOYING",
   "DEPLOYED",
@@ -138,6 +143,8 @@ export function deploymentStatusDescription(status: WorkerDeploymentStatus): str
   switch (status) {
     case "PENDING":
       return "The deployment is queued and waiting to be processed.";
+    case "INSTALLING":
+      return "The project dependencies are being installed.";
     case "BUILDING":
       return "The code is being built and prepared for deployment.";
     case "DEPLOYING":

--- a/internal-packages/database/prisma/migrations/20250923182708_add_installing_status_to_deployments/migration.sql
+++ b/internal-packages/database/prisma/migrations/20250923182708_add_installing_status_to_deployments/migration.sql
@@ -1,0 +1,3 @@
+ALTER TYPE "public"."WorkerDeploymentStatus" ADD VALUE 'INSTALLING';
+
+ALTER TABLE "public"."WorkerDeployment" ADD COLUMN     "installedAt" TIMESTAMP(3);

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -1764,9 +1764,10 @@ model WorkerDeployment {
   triggeredBy   User?   @relation(fields: [triggeredById], references: [id], onDelete: SetNull, onUpdate: Cascade)
   triggeredById String?
 
-  startedAt  DateTime?
-  builtAt    DateTime?
-  deployedAt DateTime?
+  startedAt   DateTime?
+  installedAt DateTime?
+  builtAt     DateTime?
+  deployedAt  DateTime?
 
   failedAt  DateTime?
   errorData Json?
@@ -1787,6 +1788,7 @@ model WorkerDeployment {
 
 enum WorkerDeploymentStatus {
   PENDING
+  INSTALLING
   /// This is the status when the image is being built
   BUILDING
   /// This is the status when the image is built and we are waiting for the indexing to finish

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -676,6 +676,7 @@ async function failDeploy(
 
     switch (serverDeployment.status) {
       case "PENDING":
+      case "INSTALLING":
       case "DEPLOYING":
       case "BUILDING": {
         await doOutputLogs();

--- a/packages/core/src/v3/schemas/api.ts
+++ b/packages/core/src/v3/schemas/api.ts
@@ -377,13 +377,13 @@ export const FinalizeDeploymentRequestBody = z.object({
 
 export type FinalizeDeploymentRequestBody = z.infer<typeof FinalizeDeploymentRequestBody>;
 
-export const StartDeploymentRequestBody = z.object({
+export const ProgressDeploymentRequestBody = z.object({
   contentHash: z.string().optional(),
   gitMeta: GitMeta.optional(),
   runtime: z.string().optional(),
 });
 
-export type StartDeploymentRequestBody = z.infer<typeof StartDeploymentRequestBody>;
+export type ProgressDeploymentRequestBody = z.infer<typeof ProgressDeploymentRequestBody>;
 
 export const ExternalBuildData = z.object({
   buildId: z.string(),

--- a/packages/core/src/v3/schemas/api.ts
+++ b/packages/core/src/v3/schemas/api.ts
@@ -465,6 +465,7 @@ export const GetDeploymentResponseBody = z.object({
   id: z.string(),
   status: z.enum([
     "PENDING",
+    "INSTALLING",
     "BUILDING",
     "DEPLOYING",
     "DEPLOYED",


### PR DESCRIPTION
This PR adds a new status if the deployment lifecycle: `INSTALLING`. This is
relevant only for deployments triggered by the build server, with locally
triggered deployments the install stage is done on the client side.

Now we have a `/progress` endpoint which allows progressing from `PENDING` to
`INSTALLING` and then to `BUILDING`, which can be further extended in the future
if we have new statuses. The short-lived Depot build token is only created before
moving to the `BUILDING` status to avoid expiration issues.

The `/start` endpoint is superseded by the newer `/progress` endpoint. Removing
it won't cause trouble as it is not yet used in the SDK or documented in the
API docs.

