### PR TITLE
fix: use higher entropy invite tokens

### DIFF
--- a/apps/webapp/app/models/member.server.ts
+++ b/apps/webapp/app/models/member.server.ts
@@ -99,7 +99,7 @@ export async function inviteMembers({
     throw new Error("User does not have access to this organization");
   }
 
-  const invites = emails.map(
+  const invites = [...new Set(emails)].map(
     (email) =>
       ({
         email,
@@ -112,7 +112,6 @@ export async function inviteMembers({
 
   await prisma.orgMemberInvite.createMany({
     data: invites,
-    skipDuplicates: true,
   });
 
   return await prisma.orgMemberInvite.findMany({


### PR DESCRIPTION
We currently use CUIDs for invite tokens, which are generated using
a pattern and are not cryptographically secure. This PR switches to
a higher entropy string generated with `nanoid`.

Will remove the default value in the prisma schema in a separate PR.
