### PR TITLE
fix(run-engine): carryover batchId after PENDING_EXECUTING stalls

### DIFF
--- a/internal-packages/run-engine/src/engine/index.ts
+++ b/internal-packages/run-engine/src/engine/index.ts
@@ -1454,6 +1454,7 @@ export class RunEngine {
             projectId: latestSnapshot.projectId,
             checkpointId: latestSnapshot.checkpointId ?? undefined,
             completedWaitpoints: latestSnapshot.completedWaitpoints,
+            batchId: latestSnapshot.batchId ?? undefined,
             error: {
               type: "INTERNAL_ERROR",
               code: "TASK_RUN_DEQUEUED_MAX_RETRIES",

--- a/internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
@@ -1140,6 +1140,7 @@ export class RunAttemptSystem {
     runnerId,
     checkpointId,
     completedWaitpoints,
+    batchId,
     tx,
   }: {
     run: TaskRun;
@@ -1159,6 +1160,7 @@ export class RunAttemptSystem {
       id: string;
       index?: number;
     }[];
+    batchId?: string;
   }): Promise<{ wasRequeued: boolean } & ExecutionResult> {
     const prisma = tx ?? this.$.prisma;
 
@@ -1207,6 +1209,7 @@ export class RunAttemptSystem {
         runnerId,
         checkpointId,
         completedWaitpoints,
+        batchId,
       });
 
       return {


### PR DESCRIPTION
This fixes batch resumes after stalling. Existing runs that are stuck here and are already EXECUTING again will have to be replayed.