### PR TITLE
Adds 200 and 500 % billing alert options

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.settings.billing-alerts/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.settings.billing-alerts/route.tsx
@@ -181,7 +181,7 @@ export default function Page() {
   const fieldValues = useRef<string[]>(alerts.emails);
   const emailFields = useFieldList(form.ref, { ...emails, defaultValue: alerts.emails });
 
-  const checkboxLevels = [0.75, 0.9, 1.0];
+  const checkboxLevels = [0.75, 0.9, 1.0, 2.0, 5.0];
 
   useEffect(() => {
     if (alerts.emails.length > 0) {


### PR DESCRIPTION
Includes 200% and 500% options in the billing alerts (checked by default) to help prevent surprise bills

<img width="1164" height="1146" alt="CleanShot 2025-09-28 at 17 10 50@2x" src="https://github.com/user-attachments/assets/e3ec20d9-d0d9-4db3-8e42-c88b9bbe2fc6" />
