### PR TITLE
Make Helm webapp chart images configurable

### DIFF
--- a/hosting/k8s/helm/Chart.yaml
+++ b/hosting/k8s/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trigger
 description: The official Trigger.dev Helm chart
 type: application
-version: 4.0.1
+version: 4.0.2
 appVersion: v4.0.4
 home: https://trigger.dev
 sources:

--- a/hosting/k8s/helm/templates/webapp.yaml
+++ b/hosting/k8s/helm/templates/webapp.yaml
@@ -68,7 +68,8 @@ spec:
         {{- end }}
       initContainers:
         - name: init-shared
-          image: busybox:1.35
+          image: "{{ .Values.webapp.initImage.registry }}/{{ .Values.webapp.initImage.repository }}:{{ .Values.webapp.initImage.tag }}"
+          imagePullPolicy: {{ .Values.webapp.initImage.pullPolicy }}
           command: ['sh', '-c', 'mkdir -p /home/node/shared']
           securityContext:
             runAsUser: 1000
@@ -77,7 +78,8 @@ spec:
               mountPath: /home/node/shared
       containers:
         - name: token-syncer
-          image: bitnami/kubectl:1.28
+          image: "{{ .Values.webapp.tokenSyncerImage.registry }}/{{ .Values.webapp.tokenSyncerImage.repository }}:{{ .Values.webapp.tokenSyncerImage.tag }}"
+          imagePullPolicy: {{ .Values.webapp.tokenSyncerImage.pullPolicy }}
           securityContext:
             runAsUser: 1000
             runAsNonRoot: true

--- a/hosting/k8s/helm/values.yaml
+++ b/hosting/k8s/helm/values.yaml
@@ -45,6 +45,20 @@ webapp:
     tag: "" # Defaults to Chart.appVersion when empty
     pullPolicy: IfNotPresent
 
+  # Init container image configuration
+  initImage:
+    registry: docker.io
+    repository: busybox
+    tag: "1.35"
+    pullPolicy: IfNotPresent
+
+  # Token syncer image configuration
+  tokenSyncerImage:
+    registry: docker.io
+    repository: bitnami/kubectl
+    tag: "1.28"
+    pullPolicy: IfNotPresent
+
   # Origin configuration
   appOrigin: "http://localhost:3040"
   loginOrigin: "http://localhost:3040"


### PR DESCRIPTION
Adds configurability for init and token syncer container images through new values in the Helm chart configuration

Closes #2518 

## ✅ Checklist

- [X] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [X] The PR title follows the convention.
- [X] I ran and tested the code works

---

## Testing

**Steps to test:**

1. **Install with default values** (should work unchanged):
   ```bash
   helm install test-trigger ./hosting/k8s/helm
   ```

2. **Test image customization** by creating a custom values file:
   ```yaml
   # custom-values.yaml
   webapp:
     initImage:
       registry: docker.io
       repository: alpine  # Alternative to busybox
       tag: "3.18"
       pullPolicy: IfNotPresent
     
     tokenSyncerImage:
       registry: docker.io
       repository: bitnamilegacy/kubectl  # Migration path
       tag: "1.28"
       pullPolicy: IfNotPresent
   ```

3. **Install with custom images**:
   ```bash
   helm install test-trigger ./hosting/k8s/helm -f custom-values.yaml
   ```

4. **Verify the pods use the correct images**:
   ```bash
   kubectl describe pod -l app.kubernetes.io/name=trigger

---

## Changelog

**Added configurability for previously hardcoded container images:**

- Added `webapp.initImage` configuration for the init container (previously hardcoded to `busybox:1.35`)
- Added `webapp.tokenSyncerImage` configuration for the token syncer container (previously hardcoded to `bitnami/kubectl:1.28`)
- Maintains backward compatibility - existing deployments continue to work without changes
- Incremented Chart version from 4.0.1 to 4.0.2

**New configurable values:**
```yaml
webapp:
  # Init container image configuration
  initImage:
    registry: docker.io
    repository: busybox
    tag: "1.35"
    pullPolicy: IfNotPresent

  # Token syncer image configuration  
  tokenSyncerImage:
    registry: docker.io
    repository: bitnami/kubectl
    tag: "1.28"
    pullPolicy: IfNotPresent
```
---

## Migration from Bitnami Images

This PR addresses issue #2518 regarding Bitnami's deprecation of their public Docker catalog. Users can now easily migrate away from deprecated Bitnami images by overriding the new configuration values.

**Tested working alternatives for Bitnami migration:**

```yaml
# For token syncer (kubectl)
webapp:
  tokenSyncerImage:
    registry: docker.io
    repository: bitnamilegacy/kubectl
    tag: "1.28"

# For database dependencies (subcharts)
postgres:
  image:
    registry: docker.io
    repository: bitnamilegacy/postgresql
    tag: "16.6.0-debian-12-r2"

redis:
  image:
    registry: docker.io
    repository: bitnamilegacy/redis  
    tag: "8.2.0-debian-12-r0"

clickhouse:
  image:
    registry: docker.io
    repository: bitnamilegacy/clickhouse
    tag: "25.7.5-debian-12-r0"

s3:
  image:
    registry: docker.io
    repository: bitnamilegacy/minio
    tag: "2025.7.23-debian-12-r3"
```

**Benefits:**
- ✅ Enables migration to `bitnamilegacy` repository
- ✅ Allows switching to alternative base images (e.g., `alpine` instead of `busybox`)
- ✅ Supports private registries through `registry` configuration
- ✅ Maintains full backward compatibility
- ✅ Consistent with existing image configuration patterns in the chart

---

## Screenshot
no screenshot needed


💯 **This change provides users with the flexibility needed to address the Bitnami deprecation while maintaining the stability of existing deployments.**

