### PR TITLE
chore(helm): migrate to bitnami legacy registry and add configurable utility images

### DIFF
--- a/docker/dev-compose.yml
+++ b/docker/dev-compose.yml
@@ -48,7 +48,7 @@ services:
       - db
 
   clickhouse:
-    image: bitnami/clickhouse:latest
+    image: bitnamilegacy/clickhouse:latest
     container_name: clickhouse-dev
     environment:
       CLICKHOUSE_ADMIN_USER: default

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - database
 
   clickhouse:
-    image: bitnami/clickhouse:latest
+    image: bitnamilegacy/clickhouse:latest
     restart: always
     container_name: clickhouse
     environment:

--- a/hosting/docker/webapp/docker-compose.yml
+++ b/hosting/docker/webapp/docker-compose.yml
@@ -139,7 +139,7 @@ services:
       start_period: 10s
 
   clickhouse:
-    image: bitnami/clickhouse:${CLICKHOUSE_IMAGE_TAG:-latest}
+    image: bitnamilegacy/clickhouse:${CLICKHOUSE_IMAGE_TAG:-latest}
     restart: ${RESTART_POLICY:-unless-stopped}
     logging: *logging-config
     ports:
@@ -183,7 +183,7 @@ services:
       start_period: 10s
 
   minio:
-    image: bitnami/minio:${MINIO_IMAGE_TAG:-latest}
+    image: bitnamilegacy/minio:${MINIO_IMAGE_TAG:-latest}
     restart: ${RESTART_POLICY:-unless-stopped}
     logging: *logging-config
     ports:

--- a/hosting/k8s/helm/Chart.yaml
+++ b/hosting/k8s/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trigger
 description: The official Trigger.dev Helm chart
 type: application
-version: 4.0.2
+version: 4.0.3
 appVersion: v4.0.4
 home: https://trigger.dev
 sources:

--- a/hosting/k8s/helm/Chart.yaml
+++ b/hosting/k8s/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trigger
 description: The official Trigger.dev Helm chart
 type: application
-version: 4.0.1
+version: 4.0.2
 appVersion: v4.0.4
 home: https://trigger.dev
 sources:

--- a/hosting/k8s/helm/templates/_helpers.tpl
+++ b/hosting/k8s/helm/templates/_helpers.tpl
@@ -96,6 +96,34 @@ Get the full image name for supervisor
 {{- end }}
 
 {{/*
+Get the full image name for webapp volumePermissions init container
+*/}}
+{{- define "trigger-v4.webapp.volumePermissions.image" -}}
+{{- $registry := .Values.global.imageRegistry | default .Values.webapp.volumePermissions.image.registry -}}
+{{- $repository := .Values.webapp.volumePermissions.image.repository -}}
+{{- $tag := .Values.webapp.volumePermissions.image.tag -}}
+{{- if $registry }}
+{{- printf "%s/%s:%s" $registry $repository $tag }}
+{{- else }}
+{{- printf "%s:%s" $repository $tag }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get the full image name for webapp tokenSyncer sidecar
+*/}}
+{{- define "trigger-v4.webapp.tokenSyncer.image" -}}
+{{- $registry := .Values.global.imageRegistry | default .Values.webapp.tokenSyncer.image.registry -}}
+{{- $repository := .Values.webapp.tokenSyncer.image.repository -}}
+{{- $tag := .Values.webapp.tokenSyncer.image.tag -}}
+{{- if $registry }}
+{{- printf "%s/%s:%s" $registry $repository $tag }}
+{{- else }}
+{{- printf "%s:%s" $repository $tag }}
+{{- end }}
+{{- end }}
+
+{{/*
 PostgreSQL hostname (deprecated - used only for legacy DATABASE_HOST env var)
 */}}
 {{- define "trigger-v4.postgres.hostname" -}}

--- a/hosting/k8s/helm/templates/webapp.yaml
+++ b/hosting/k8s/helm/templates/webapp.yaml
@@ -68,7 +68,8 @@ spec:
         {{- end }}
       initContainers:
         - name: init-shared
-          image: busybox:1.35
+          image: "{{ .Values.webapp.initImage.registry }}/{{ .Values.webapp.initImage.repository }}:{{ .Values.webapp.initImage.tag }}"
+          imagePullPolicy: {{ .Values.webapp.initImage.pullPolicy }}
           command: ['sh', '-c', 'mkdir -p /home/node/shared']
           securityContext:
             runAsUser: 1000
@@ -77,7 +78,8 @@ spec:
               mountPath: /home/node/shared
       containers:
         - name: token-syncer
-          image: bitnamilegacy/kubectl:1.28
+          image: "{{ .Values.webapp.tokenSyncerImage.registry }}/{{ .Values.webapp.tokenSyncerImage.repository }}:{{ .Values.webapp.tokenSyncerImage.tag }}"
+          imagePullPolicy: {{ .Values.webapp.tokenSyncerImage.pullPolicy }}
           securityContext:
             runAsUser: 1000
             runAsNonRoot: true

--- a/hosting/k8s/helm/templates/webapp.yaml
+++ b/hosting/k8s/helm/templates/webapp.yaml
@@ -67,9 +67,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       initContainers:
-        - name: init-shared
-          image: "{{ .Values.webapp.initImage.registry }}/{{ .Values.webapp.initImage.repository }}:{{ .Values.webapp.initImage.tag }}"
-          imagePullPolicy: {{ .Values.webapp.initImage.pullPolicy }}
+        - name: volume-permissions
+          image: {{ include "trigger-v4.webapp.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.webapp.volumePermissions.image.pullPolicy }}
           command: ['sh', '-c', 'mkdir -p /home/node/shared']
           securityContext:
             runAsUser: 1000
@@ -78,8 +78,8 @@ spec:
               mountPath: /home/node/shared
       containers:
         - name: token-syncer
-          image: "{{ .Values.webapp.tokenSyncerImage.registry }}/{{ .Values.webapp.tokenSyncerImage.repository }}:{{ .Values.webapp.tokenSyncerImage.tag }}"
-          imagePullPolicy: {{ .Values.webapp.tokenSyncerImage.pullPolicy }}
+          image: {{ include "trigger-v4.webapp.tokenSyncer.image" . }}
+          imagePullPolicy: {{ .Values.webapp.tokenSyncer.image.pullPolicy }}
           securityContext:
             runAsUser: 1000
             runAsNonRoot: true

--- a/hosting/k8s/helm/templates/webapp.yaml
+++ b/hosting/k8s/helm/templates/webapp.yaml
@@ -77,7 +77,7 @@ spec:
               mountPath: /home/node/shared
       containers:
         - name: token-syncer
-          image: bitnami/kubectl:1.28
+          image: bitnamilegacy/kubectl:1.28
           securityContext:
             runAsUser: 1000
             runAsNonRoot: true

--- a/hosting/k8s/helm/values.yaml
+++ b/hosting/k8s/helm/values.yaml
@@ -2,6 +2,9 @@ global:
   imageRegistry: ""
   imagePullSecrets: []
   storageClass: ""
+  security:
+    # Required when using bitnami legacy images
+    allowInsecureImages: true
 
 nameOverride: ""
 fullnameOverride: ""
@@ -359,6 +362,11 @@ supervisor:
 postgres:
   deploy: true
 
+  image:
+    # Use bitnami legacy repo
+    repository: bitnamilegacy/postgresql
+    # image: docker.io/bitnamilegacy/postgresql:17.5.0-debian-12-r12
+
   # Bitnami PostgreSQL chart configuration (when deploy: true)
   auth:
     enablePostgresUser: true
@@ -408,6 +416,11 @@ postgres:
 # Subchart: https://github.com/bitnami/charts/tree/main/bitnami/redis
 redis:
   deploy: true
+
+  image:
+    # Use bitnami legacy repo
+    repository: bitnamilegacy/redis
+    # image: docker.io/bitnamilegacy/redis:8.0.2-debian-12-r4
 
   # Bitnami Redis chart configuration (when deploy: true)
   auth:
@@ -499,6 +512,11 @@ electric:
 clickhouse:
   deploy: true
 
+  image:
+    # Use bitnami legacy repo
+    repository: bitnamilegacy/clickhouse
+    # image: docker.io/bitnamilegacy/clickhouse:25.6.1-debian-12-r0
+
   # TLS/Secure connection configuration
   secure: false # Set to true to use HTTPS and secure connections
 
@@ -560,6 +578,11 @@ s3:
   # Set to false to use external S3-compatible storage
   # Set to true to deploy internal MinIO (default)
   deploy: true
+
+  image:
+    # Use bitnami legacy repo
+    repository: bitnamilegacy/minio
+    # image: docker.io/bitnamilegacy/minio:2025.6.13-debian-12-r0
 
   # Bitnami MinIO chart configuration (when deploy: true)
   # MinIO provides S3-compatible storage when deployed internally

--- a/hosting/k8s/helm/values.yaml
+++ b/hosting/k8s/helm/values.yaml
@@ -48,19 +48,21 @@ webapp:
     tag: "" # Defaults to Chart.appVersion when empty
     pullPolicy: IfNotPresent
 
-  # Init container image configuration
-  initImage:
-    registry: docker.io
-    repository: busybox
-    tag: "1.35"
-    pullPolicy: IfNotPresent
+  # Init container for shared directory setup
+  volumePermissions:
+    image:
+      registry: docker.io
+      repository: busybox
+      tag: "1.35"
+      pullPolicy: IfNotPresent
 
-  # Token syncer image configuration
-  tokenSyncerImage:
-    registry: docker.io
-    repository: bitnamilegacy/kubectl
-    tag: "1.28"
-    pullPolicy: IfNotPresent
+  # Sidecar for token syncing
+  tokenSyncer:
+    image:
+      registry: docker.io
+      repository: bitnamilegacy/kubectl
+      tag: "1.28"
+      pullPolicy: IfNotPresent
 
   # Origin configuration
   appOrigin: "http://localhost:3040"

--- a/hosting/k8s/helm/values.yaml
+++ b/hosting/k8s/helm/values.yaml
@@ -48,6 +48,20 @@ webapp:
     tag: "" # Defaults to Chart.appVersion when empty
     pullPolicy: IfNotPresent
 
+  # Init container image configuration
+  initImage:
+    registry: docker.io
+    repository: busybox
+    tag: "1.35"
+    pullPolicy: IfNotPresent
+
+  # Token syncer image configuration
+  tokenSyncerImage:
+    registry: docker.io
+    repository: bitnamilegacy/kubectl
+    tag: "1.28"
+    pullPolicy: IfNotPresent
+
   # Origin configuration
   appOrigin: "http://localhost:3040"
   loginOrigin: "http://localhost:3040"


### PR DESCRIPTION
Migrates all Bitnami chart dependencies to the bitnamilegacy registry following Bitnami's repository restructuring, and adds full configurability for webapp utility container images using Bitnami-style configuration patterns. Users can now customize the busybox and kubectl images used by the webapp pod, enabling compatibility with private registries and specific image versions.

## Backwards Compatibility

The configuration structure has been changed but maintains the same default images and behavior.

## Changes Made

### Bitnami Legacy Registry Migration

- Updated all Docker Compose files to use `bitnamilegacy/` image prefix for PostgreSQL and Redis
- Updated Helm chart subchart configurations to use `bitnamilegacy/` repository
- Added commented image tags to values.yaml showing the specific versions used by each subchart
  - PostgreSQL: `bitnamilegacy/postgresql:17.5.0-debian-12-r12`
  - Redis: `bitnamilegacy/redis:8.0.2-debian-12-r4`
  - ClickHouse: `bitnamilegacy/clickhouse:25.6.1-debian-12-r0`
  - MinIO: `bitnamilegacy/minio:2025.6.13-debian-12-r0`

### Utility Image Configurability

- Cherry-picked PR #2573 and resolved conflicts with bitnamilegacy registry usage
- Restructured `values.yaml` to use `webapp.volumePermissions.image` and `webapp.tokenSyncer.image` sections following Bitnami conventions
- Renamed init container from `init-shared` to `volume-permissions` to match Bitnami standards
- Added helper templates `trigger-v4.webapp.volumePermissions.image` and `trigger-v4.webapp.tokenSyncer.image` in `_helpers.tpl`
- Updated `webapp.yaml` template to use new helper functions
- Both image configurations support global registry override via `global.imageRegistry`
- Bumped chart version to 4.0.3

### Utility Image Config

```yaml
webapp:
  volumePermissions:
    image:
      registry: docker.io
      repository: busybox
      tag: "1.35"
      pullPolicy: IfNotPresent
  tokenSyncer:
    image:
      registry: docker.io
      repository: bitnamilegacy/kubectl
      tag: "1.28"
      pullPolicy: IfNotPresent
```

## Testing

- Helm template rendering verified with correct image references
- Helm lint passes successfully
- Maintains existing functionality with new configuration structure