### PR TITLE
chore: add deepwiki badge to main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
 [![Twitter Follow](https://img.shields.io/twitter/follow/triggerdotdev?style=social)](https://twitter.com/triggerdotdev)
 [![Discord](https://img.shields.io/discord/1066956501299777596?logo=discord&logoColor=white&color=7289da)](https://discord.gg/nkqV9xBYWy)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/triggerdotdev/trigger.dev)
 [![GitHub stars](https://img.shields.io/github/stars/triggerdotdev/trigger.dev?style=social)](https://github.com/triggerdotdev/trigger.dev)
 
 </div>


### PR DESCRIPTION
This means DeepWiki will automatically re-index our repo and keep our page fresh

<img width="663" height="241" alt="image" src="https://github.com/user-attachments/assets/e3090018-68d6-49a2-ac35-8dc2ea71b2ce" />
