### PR TITLE
fix(webapp): disable gh-triggered preview deployments if the preview env is disabled

### DIFF
--- a/apps/webapp/app/services/projectSettings.server.ts
+++ b/apps/webapp/app/services/projectSettings.server.ts
@@ -4,7 +4,7 @@ import { DeleteProjectService } from "~/services/deleteProject.server";
 import { BranchTrackingConfigSchema, type BranchTrackingConfig } from "~/v3/github";
 import { checkGitHubBranchExists } from "~/services/gitHub.server";
 import { errAsync, fromPromise, okAsync, ResultAsync } from "neverthrow";
-import { BuildSettings } from "~/v3/buildSettings";
+import { type BuildSettings } from "~/v3/buildSettings";
 
 export class ProjectSettingsService {
   #prismaClient: PrismaClient;
@@ -82,7 +82,7 @@ export class ProjectSettingsService {
         (error) => ({ type: "other" as const, cause: error })
       );
 
-    const createConnectedRepo = (defaultBranch: string) =>
+    const createConnectedRepo = (defaultBranch: string, previewDeploymentsEnabled: boolean) =>
       fromPromise(
         this.#prismaClient.connectedGithubRepository.create({
           data: {
@@ -92,21 +92,23 @@ export class ProjectSettingsService {
               prod: { branch: defaultBranch },
               staging: {},
             } satisfies BranchTrackingConfig,
-            previewDeploymentsEnabled: true,
+            previewDeploymentsEnabled,
           },
         }),
         (error) => ({ type: "other" as const, cause: error })
       );
 
-    return ResultAsync.combine([getRepository(), findExistingConnection()]).andThen(
-      ([repository, existingConnection]) => {
-        if (existingConnection) {
-          return errAsync({ type: "project_already_has_connected_repository" as const });
-        }
-
-        return createConnectedRepo(repository.defaultBranch);
+    return ResultAsync.combine([
+      getRepository(),
+      findExistingConnection(),
+      this.isPreviewEnvironmentEnabled(projectId),
+    ]).andThen(([repository, existingConnection, previewEnvironmentEnabled]) => {
+      if (existingConnection) {
+        return errAsync({ type: "project_already_has_connected_repository" as const });
       }
-    );
+
+      return createConnectedRepo(repository.defaultBranch, previewEnvironmentEnabled);
+    });
   }
 
   disconnectGitHubRepo(projectId: string) {
@@ -208,7 +210,11 @@ export class ProjectSettingsService {
       return okAsync(stagingBranch);
     };
 
-    const updateConnectedRepo = () =>
+    const updateConnectedRepo = (data: {
+      productionBranch: string | undefined;
+      stagingBranch: string | undefined;
+      previewDeploymentsEnabled: boolean | undefined;
+    }) =>
       fromPromise(
         this.#prismaClient.connectedGithubRepository.update({
           where: {
@@ -216,10 +222,10 @@ export class ProjectSettingsService {
           },
           data: {
             branchTracking: {
-              prod: productionBranch ? { branch: productionBranch } : {},
-              staging: stagingBranch ? { branch: stagingBranch } : {},
+              prod: data.productionBranch ? { branch: data.productionBranch } : {},
+              staging: data.stagingBranch ? { branch: data.stagingBranch } : {},
             } satisfies BranchTrackingConfig,
-            previewDeploymentsEnabled: previewDeploymentsEnabled,
+            previewDeploymentsEnabled: data.previewDeploymentsEnabled,
           },
         }),
         (error) => ({ type: "other" as const, cause: error })
@@ -240,8 +246,14 @@ export class ProjectSettingsService {
             fullRepoName: connectedRepo.repository.fullName,
             oldStagingBranch: connectedRepo.branchTracking?.staging?.branch,
           }),
+          this.isPreviewEnvironmentEnabled(projectId),
         ]);
       })
+      .map(([productionBranch, stagingBranch, previewEnvironmentEnabled]) => ({
+        productionBranch,
+        stagingBranch,
+        previewDeploymentsEnabled: previewDeploymentsEnabled && previewEnvironmentEnabled,
+      }))
       .andThen(updateConnectedRepo);
   }
 
@@ -295,5 +307,23 @@ export class ProjectSettingsService {
         organizationId: project.organizationId,
       });
     });
+  }
+
+  private isPreviewEnvironmentEnabled(projectId: string) {
+    return fromPromise(
+      this.#prismaClient.runtimeEnvironment.findFirst({
+        select: {
+          id: true,
+        },
+        where: {
+          projectId: projectId,
+          slug: "preview",
+        },
+      }),
+      (error) => ({
+        type: "other" as const,
+        cause: error,
+      })
+    ).map((previewEnvironment) => previewEnvironment !== null);
   }
 }

--- a/apps/webapp/app/services/projectSettingsPresenter.server.ts
+++ b/apps/webapp/app/services/projectSettingsPresenter.server.ts
@@ -136,7 +136,7 @@ export class ProjectSettingsPresenter {
 
     const isPreviewEnvironmentEnabled = (projectId: string) =>
       fromPromise(
-        prisma.runtimeEnvironment.findFirst({
+        this.#prismaClient.runtimeEnvironment.findFirst({
           select: {
             id: true,
           },

--- a/apps/webapp/app/services/projectSettingsPresenter.server.ts
+++ b/apps/webapp/app/services/projectSettingsPresenter.server.ts
@@ -3,7 +3,7 @@ import { prisma } from "~/db.server";
 import { BranchTrackingConfigSchema } from "~/v3/github";
 import { env } from "~/env.server";
 import { findProjectBySlug } from "~/models/project.server";
-import { err, fromPromise, ok, okAsync } from "neverthrow";
+import { err, fromPromise, ok, ResultAsync } from "neverthrow";
 import { BuildSettingsSchema } from "~/v3/buildSettings";
 
 export class ProjectSettingsPresenter {
@@ -20,33 +20,31 @@ export class ProjectSettingsPresenter {
       fromPromise(findProjectBySlug(organizationSlug, projectSlug, userId), (error) => ({
         type: "other" as const,
         cause: error,
-      })).andThen((project) => {
-        if (!project) {
-          return err({ type: "project_not_found" as const });
-        }
-        return ok(project);
-      });
+      }))
+        .andThen((project) => {
+          if (!project) {
+            return err({ type: "project_not_found" as const });
+          }
+          return ok(project);
+        })
+        .map((project) => {
+          const buildSettingsOrFailure = BuildSettingsSchema.safeParse(project.buildSettings);
+          const buildSettings = buildSettingsOrFailure.success
+            ? buildSettingsOrFailure.data
+            : undefined;
+          return { ...project, buildSettings };
+        });
 
     if (!githubAppEnabled) {
-      return getProject().andThen((project) => {
-        if (!project) {
-          return err({ type: "project_not_found" as const });
-        }
-
-        const buildSettingsOrFailure = BuildSettingsSchema.safeParse(project.buildSettings);
-        const buildSettings = buildSettingsOrFailure.success
-          ? buildSettingsOrFailure.data
-          : undefined;
-
-        return ok({
-          gitHubApp: {
-            enabled: false,
-            connectedRepository: undefined,
-            installations: undefined,
-          },
-          buildSettings,
-        });
-      });
+      return getProject().map(({ buildSettings }) => ({
+        gitHubApp: {
+          enabled: false,
+          connectedRepository: undefined,
+          installations: undefined,
+          isPreviewEnvironmentEnabled: undefined,
+        },
+        buildSettings,
+      }));
     }
 
     const findConnectedGithubRepository = (projectId: string) =>
@@ -136,37 +134,39 @@ export class ProjectSettingsPresenter {
         })
       );
 
+    const isPreviewEnvironmentEnabled = (projectId: string) =>
+      fromPromise(
+        prisma.runtimeEnvironment.findFirst({
+          select: {
+            id: true,
+          },
+          where: {
+            projectId: projectId,
+            slug: "preview",
+          },
+        }),
+        (error) => ({
+          type: "other" as const,
+          cause: error,
+        })
+      ).map((previewEnvironment) => previewEnvironment !== null);
+
     return getProject().andThen((project) =>
-      findConnectedGithubRepository(project.id).andThen((connectedGithubRepository) => {
-        const buildSettingsOrFailure = BuildSettingsSchema.safeParse(project.buildSettings);
-        const buildSettings = buildSettingsOrFailure.success
-          ? buildSettingsOrFailure.data
-          : undefined;
-
-        if (connectedGithubRepository) {
-          return okAsync({
-            gitHubApp: {
-              enabled: true,
-              connectedRepository: connectedGithubRepository,
-              // skip loading installations if there is a connected repository
-              // a project can have only a single connected repository
-              installations: undefined,
-            },
-            buildSettings,
-          });
-        }
-
-        return listGithubAppInstallations(project.organizationId).map((githubAppInstallations) => {
-          return {
-            gitHubApp: {
-              enabled: true,
-              connectedRepository: undefined,
-              installations: githubAppInstallations,
-            },
-            buildSettings,
-          };
-        });
-      })
+      ResultAsync.combine([
+        isPreviewEnvironmentEnabled(project.id),
+        findConnectedGithubRepository(project.id),
+        listGithubAppInstallations(project.organizationId),
+      ]).map(
+        ([isPreviewEnvironmentEnabled, connectedGithubRepository, githubAppInstallations]) => ({
+          gitHubApp: {
+            enabled: true,
+            connectedRepository: connectedGithubRepository,
+            installations: githubAppInstallations,
+            isPreviewEnvironmentEnabled,
+          },
+          buildSettings: project.buildSettings,
+        })
+      )
     );
   }
 }


### PR DESCRIPTION
The build server already handles this case gracefully, but doesn't hurt showing an early hint when preview deployments are disabled.