### PR TITLE
docs: add ClickHouse environment variables and Docker Compose

### DIFF
--- a/docs/migrating-from-v3.mdx
+++ b/docs/migrating-from-v3.mdx
@@ -304,6 +304,24 @@ const batch = await batch.retrieve(batchHandle.batchId);
 console.log(batch.runs);
 ```
 
+### ClickHouse
+
+**V4 now uses ClickHouse by default** as the database for storing run traces and analytics data. 
+If you're using Docker Compose, you need to update your `docker-compose.yml` to add the ClickHouse service and configure the webapp to connect to it. Update your configuration according to the [docker-compose.yml file on GitHub](https://github.com/triggerdotdev/trigger.dev/blob/main/hosting/docker/webapp/docker-compose.yml).
+
+You need to configure the following environment variables:
+
+```bash
+# ClickHouse configuration
+CLICKHOUSE_URL=http://default:password@clickhouse:8123?secure=false
+CLICKHOUSE_LOG_LEVEL=info
+
+# Run replication
+RUN_REPLICATION_ENABLED=1
+RUN_REPLICATION_CLICKHOUSE_URL=http://default:password@clickhouse:8123
+RUN_REPLICATION_LOG_LEVEL=info
+```
+
 ### OpenTelemetry
 
 We are now using newer versions of the OpenTelemetry packages. This means that if you're using custom exporters you may need to update the packages:


### PR DESCRIPTION
## Description

Updates the v4 migration guide to document the ClickHouse requirement.

## Changes

- Added a new "ClickHouse" section to the breaking changes
- Documented that **v4 now uses ClickHouse by default** for storing run traces and analytics data
- Listed all required environment variables for ClickHouse configuration:
  - `CLICKHOUSE_URL`
  - `CLICKHOUSE_LOG_LEVEL`
  - `RUN_REPLICATION_ENABLED`
  - `RUN_REPLICATION_CLICKHOUSE_URL`
  - `RUN_REPLICATION_LOG_LEVEL`
- Added instructions for Docker Compose users to update their configuration
- Linked to the complete docker-compose.yml example on GitHub

## Why

Users migrating from v3 to v4 need to know that ClickHouse is now dependency and how to configure it properly, especially when self-hosting or using Docker Compose.

## ✅ Checklist

- [X] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [X] The PR title follows the convention.
- [ ] I ran and tested the code works

---

## Testing
NO

---

## Changelog
NO
---

## Screenshots
<img width="1195" height="706" alt="Screenshot 2025-10-16 at 15 18 11" src="https://github.com/user-attachments/assets/7fecff65-6640-4b36-85fb-69c8de5c6832" />

💯
