### PR TITLE
Allow alerts to be created if ALERT_SMTP_HOST is defined

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.alerts.new/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.alerts.new/route.tsx
@@ -158,7 +158,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const option = url.searchParams.get("option");
 
   const emailAlertsEnabled =
-    env.ALERT_FROM_EMAIL !== undefined && env.ALERT_RESEND_API_KEY !== undefined;
+    env.ALERT_FROM_EMAIL !== undefined && (env.ALERT_RESEND_API_KEY !== undefined || env.ALERT_SMTP_HOST !== undefined);
 
   return typedjson({
     ...results,


### PR DESCRIPTION
The previous behavior only allowed email alerts in self-hosting if ALERT_RESEND_API_KEY was defined.  This commit updates the environment check to also use ALERT_SMTP_HOST for alert email configuration.  The ALERT_SMTP_HOST is already used in the SMPT client, so no other changes are necessary.

Closes #2618

## ✅ Checklist

- ✅ I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- ✅ The PR title follows the convention.
- [ ] I ran and tested the code works

---

## Testing

None

---

## Changelog

I modified the assignment of `emailAlertsEnabled` to also check `ALERT_SMTP_HOST` in addition to `ALERT_RESEND_API_KEY` when determining if alerts are enabled.

---

## Screenshots

None

