### PR TITLE
feat(supervisor): add k8 worker pod priority class support

### DIFF
--- a/apps/supervisor/src/env.ts
+++ b/apps/supervisor/src/env.ts
@@ -81,6 +81,7 @@ const Env = z.object({
   KUBERNETES_FORCE_ENABLED: BoolEnv.default(false),
   KUBERNETES_NAMESPACE: z.string().default("default"),
   KUBERNETES_WORKER_NODETYPE_LABEL: z.string().default("v4-worker"),
+  KUBERNETES_WORKER_PRIORITY_CLASS_NAME: z.string().optional(),
   KUBERNETES_IMAGE_PULL_SECRETS: z.string().optional(), // csv
   KUBERNETES_EPHEMERAL_STORAGE_SIZE_LIMIT: z.string().default("10Gi"),
   KUBERNETES_EPHEMERAL_STORAGE_SIZE_REQUEST: z.string().default("2Gi"),
@@ -91,7 +92,6 @@ const Env = z.object({
   KUBERNETES_MEMORY_REQUEST_RATIO: z.coerce.number().min(0).max(1).default(1), // Ratio of memory limit, so 1 = 100% of memory limit
   KUBERNETES_MEMORY_OVERHEAD_GB: z.coerce.number().min(0).optional(), // Optional memory overhead to add to the limit in GB
   KUBERNETES_SCHEDULER_NAME: z.string().optional(), // Custom scheduler name for pods
-  KUBERNETES_POD_PRIORITY_CLASS_NAME: z.string().optional(), // Priority class name for task run pods
 
   // Placement tags settings
   PLACEMENT_TAGS_ENABLED: BoolEnv.default(false),

--- a/apps/supervisor/src/env.ts
+++ b/apps/supervisor/src/env.ts
@@ -91,6 +91,7 @@ const Env = z.object({
   KUBERNETES_MEMORY_REQUEST_RATIO: z.coerce.number().min(0).max(1).default(1), // Ratio of memory limit, so 1 = 100% of memory limit
   KUBERNETES_MEMORY_OVERHEAD_GB: z.coerce.number().min(0).optional(), // Optional memory overhead to add to the limit in GB
   KUBERNETES_SCHEDULER_NAME: z.string().optional(), // Custom scheduler name for pods
+  KUBERNETES_POD_PRIORITY_CLASS_NAME: z.string().optional(), // Priority class name for task run pods
 
   // Placement tags settings
   PLACEMENT_TAGS_ENABLED: BoolEnv.default(false),

--- a/apps/supervisor/src/workloadManager/kubernetes.ts
+++ b/apps/supervisor/src/workloadManager/kubernetes.ts
@@ -286,9 +286,9 @@ export class KubernetesWorkloadManager implements WorkloadManager {
             },
           }
         : {}),
-      ...(env.KUBERNETES_POD_PRIORITY_CLASS_NAME
+      ...(env.KUBERNETES_WORKER_PRIORITY_CLASS_NAME
         ? {
-            priorityClassName: env.KUBERNETES_POD_PRIORITY_CLASS_NAME,
+            priorityClassName: env.KUBERNETES_WORKER_PRIORITY_CLASS_NAME,
           }
         : {}),
     };

--- a/apps/supervisor/src/workloadManager/kubernetes.ts
+++ b/apps/supervisor/src/workloadManager/kubernetes.ts
@@ -286,6 +286,11 @@ export class KubernetesWorkloadManager implements WorkloadManager {
             },
           }
         : {}),
+      ...(env.KUBERNETES_POD_PRIORITY_CLASS_NAME
+        ? {
+            priorityClassName: env.KUBERNETES_POD_PRIORITY_CLASS_NAME,
+          }
+        : {}),
     };
   }
 


### PR DESCRIPTION
Add KUBERNETES_WORKER_PRIORITY_CLASS_NAME environment variable to allow configuring a priority class for task run pods in Kubernetes environments.

This addresses pod preemption issues in resource-constrained clusters, particularly in GKE Autopilot where low-priority pods can be preempted by system pods during scale-up operations.

Closes #2630

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Added example configuration and tested assignment of priority class on our worker pods in our GKE Autopilot production cluster.

```yaml
supervisor:
  extraEnvVars:
    - name: KUBERNETES_WORKER_PRIORITY_CLASS_NAME
      value: "trigger-task-runs"

extraManifests:
  - apiVersion: scheduling.k8s.io/v1
    kind: PriorityClass
    metadata:
      name: trigger-task-runs
    value: 100000
    globalDefault: false
 ```

## Changelog

- **Added**: `KUBERNETES_WORKER_PRIORITY_CLASS_NAME` environment variable to `apps/supervisor/src/env.ts`
- **Added**: Support for `priorityClassName` in Kubernetes pod spec (`apps/supervisor/src/workloadManager/kubernetes.ts`)
- **Enhancement**: Worker pods can now be configured with priority classes to prevent preemption in resource-constrained environments
- **Compatibility**: Fully backward compatible - optional configuration with no breaking changes

---

## Screenshots

N/A - Infrastructure/backend change. Configuration can be verified via:

```bash
# Verify priority class is applied to new worker pods
kubectl get pods -n trigger -l app=task-run \
  -o custom-columns=NAME:.metadata.name,PRIORITY:.spec.priority,PRIORITY_CLASS:.spec.priorityClassName
```

Expected output after configuration:
```bash
NAME                               PRIORITY   PRIORITY_CLASS
runner-cmh4xxxxx                   100000     trigger-task-runs
```