### PR TITLE
chore(helm): increase default clickhouse resources

### DIFF
--- a/hosting/k8s/helm/Chart.yaml
+++ b/hosting/k8s/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: trigger
 description: The official Trigger.dev Helm chart
 type: application
-version: 4.0.4
+version: 4.0.5
 appVersion: v4.0.4
 home: https://trigger.dev
 sources:

--- a/hosting/k8s/helm/README.md
+++ b/hosting/k8s/helm/README.md
@@ -656,14 +656,16 @@ helm upgrade --install trigger . \
           cpu: 250m
           memory: 512Mi
   
+  # ClickHouse can be very resource intensive, so we recommend setting limits and requests accordingly
+  # Note: not doing this can cause OOM crashes which will cause issues across many different features
   clickhouse:
     resources:
       limits:
-        cpu: 1000m
-        memory: 2Gi
+        cpu: 4000m
+        memory: 16Gi
       requests:
-        cpu: 500m
-        memory: 1Gi
+        cpu: 2000m
+        memory: 8Gi
   
   supervisor:
     resources:

--- a/hosting/k8s/helm/values-production-example.yaml
+++ b/hosting/k8s/helm/values-production-example.yaml
@@ -78,13 +78,15 @@ clickhouse:
     enabled: true
     size: 100Gi
     storageClass: "fast-ssd"
+  # ClickHouse can be very resource intensive, so we recommend setting limits and requests accordingly
+  # Note: not doing this can cause OOM crashes which will cause issues across many different
   resources:
     limits:
-      cpu: 1000m
-      memory: 2Gi
+      cpu: 4000m
+      memory: 16Gi
     requests:
-      cpu: 500m
-      memory: 1Gi
+      cpu: 2000m
+      memory: 8Gi
 
 # Production S3-compatible object storage
 s3:

--- a/hosting/k8s/helm/values.yaml
+++ b/hosting/k8s/helm/values.yaml
@@ -110,8 +110,7 @@ webapp:
     defaultOrgExecutionConcurrencyLimit: 300
 
   # Resources
-  resources:
-    {}
+  resources: {}
     # Example resource configuration:
     # limits:
     #   cpu: 1000m
@@ -125,8 +124,7 @@ webapp:
     postgres: true # Set to false to disable DATABASE_HOST env var (overrides postgres.external.connectivityCheck)
 
   # Extra environment variables for webapp
-  extraEnvVars:
-    []
+  extraEnvVars: []
     # - name: CUSTOM_VAR
     #   value: "custom-value"
     # - name: SECRET_VAR
@@ -140,8 +138,7 @@ webapp:
     #   value: "/etc/ssl/certs/postgres-ca.crt"
 
   # Extra volumes for the webapp pod
-  extraVolumes:
-    []
+  extraVolumes: []
     # - name: config-volume
     #   configMap:
     #     name: my-config
@@ -158,8 +155,7 @@ webapp:
     #         path: postgres-ca.crt
 
   # Extra volume mounts for the webapp container
-  extraVolumeMounts:
-    []
+  extraVolumeMounts: []
     # - name: config-volume
     #   mountPath: /etc/config
     #   readOnly: true
@@ -248,8 +244,7 @@ webapp:
         paths:
           - path: /
             pathType: Prefix
-    tls:
-      []
+    tls: []
       # - secretName: trigger-tls
       #   hosts:
       #     - trigger.local
@@ -322,8 +317,7 @@ supervisor:
     role:
       name: ""
   # Extra environment variables for Supervisor
-  extraEnvVars:
-    []
+  extraEnvVars: []
     # - name: CUSTOM_VAR
     #   value: "custom-value"
 
@@ -520,8 +514,7 @@ electric:
     url: "" # For example: "http://electric:3000"
 
   # Extra environment variables for Electric
-  extraEnvVars:
-    []
+  extraEnvVars: []
     # - name: CUSTOM_VAR
     #   value: "custom-value"
 
@@ -553,6 +546,12 @@ clickhouse:
   persistence:
     enabled: true
     size: 10Gi
+
+  ## ClickHouse resource requests and limits
+  ## ref: http://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+  ## @param resourcesPreset Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production).
+  ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+  resourcesPreset: "xlarge"
   resources: {}
 
   # External ClickHouse connection (when deploy: false)
@@ -736,8 +735,7 @@ registry:
     successThreshold: 1
 
   # Extra environment variables for Registry
-  extraEnvVars:
-    []
+  extraEnvVars: []
     # - name: CUSTOM_VAR
     #   value: "custom-value"
 
@@ -763,8 +761,7 @@ registry:
         paths:
           - path: /
             pathType: Prefix
-    tls:
-      []
+    tls: []
       # - secretName: registry-tls
       #   hosts:
       #     - registry.local
@@ -786,8 +783,7 @@ telemetry:
 
 # Extra Kubernetes manifests
 # This allows you to add additional Kubernetes resources that will be deployed with the chart
-extraManifests:
-  []
+extraManifests: []
   # - apiVersion: v1
   #   kind: ConfigMap
   #   metadata:


### PR DESCRIPTION
Many self-hosters ran into issues with the defaults and prod resource examples. This should help, but at the same time it's important to keep an eye on resource usage of self-hosted deployments for reliable operation.