### PR TITLE
fix(webapp): concurrency override upper bound should be env not org

### DIFF
--- a/apps/webapp/app/v3/services/concurrencySystem.server.ts
+++ b/apps/webapp/app/v3/services/concurrencySystem.server.ts
@@ -121,11 +121,7 @@ function overrideQueueConcurrencyLimit(
   overriddenBy?: User
 ) {
   const newConcurrencyLimit = Math.max(
-    Math.min(
-      concurrencyLimit,
-      environment.maximumConcurrencyLimit,
-      environment.organization.maximumConcurrencyLimit
-    ),
+    Math.min(concurrencyLimit, environment.maximumConcurrencyLimit),
     0
   );
 


### PR DESCRIPTION
We don't care about the org limit here