### PR TITLE
docs: deployments with local builds

### DIFF
--- a/docs/deployment/overview.mdx
+++ b/docs/deployment/overview.mdx
@@ -198,7 +198,7 @@ npx trigger.dev deploy --force-local-build
 
 To use local builds, you need the following tools installed on your machine:
 
-- Docker ([installation guide](https://docs.docker.com/get-docker/))
+- Docker ([installation guide](https://docs.docker.com/get-started/get-docker))
 - Docker Buildx ([installation guide](https://github.com/docker/buildx#installing))
 
 ## Environment variables


### PR DESCRIPTION
Adds a section to the deployment docs page about the option to deploy using a locally built image.
