### PR TITLE
fix(cli): show a useful error message when config file is missing

### DIFF
--- a/.changeset/warm-eagles-itch.md
+++ b/.changeset/warm-eagles-itch.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Fixed misleading error message in the CLI when config file is missing ("maxDuration" is now required). A useful error message is now shown, including a hint about the `--config` flag.

--- a/packages/cli-v3/src/config.ts
+++ b/packages/cli-v3/src/config.ts
@@ -167,7 +167,7 @@ async function resolveConfig(
   const missingConfigFile = !result.configFile || result.configFile === "trigger.config";
 
   if (missingConfigFile) {
-    const err = new OutroCommandError(
+    throw new OutroCommandError(
       [
         "Couldn't find your trigger.config.ts file.",
         "",
@@ -176,8 +176,6 @@ async function resolveConfig(
         "Alternatively, you can initialize a new project using `npx trigger.dev@latest init`.",
       ].join("\n")
     );
-    err.stack = undefined;
-    throw err;
   }
 
   const config =


### PR DESCRIPTION
Adds a useful message when the `trigger.config.ts` file isn't detected by
`loadConfig()` in various cli commands. Previously this would fail with
a misleading validation message, e.g., when users would run a command from the
wrong directory.

This will get rid of the dreaded `Error: The "maxDuration" trigger.config option is now required, and must be at least 5 seconds.` error reports which in almost all cases was actually a failure to detect the config file.
