### PR TITLE
docs: update Firecrawl example

### DIFF
--- a/docs/guides/examples/firecrawl-url-crawl.mdx
+++ b/docs/guides/examples/firecrawl-url-crawl.mdx
@@ -20,11 +20,11 @@ Here are two examples of how to use Firecrawl with Trigger.dev:
 This task crawls a website and returns the `crawlResult` object. You can set the `limit` parameter to control the number of URLs that are crawled.
 
 ```ts trigger/firecrawl-url-crawl.ts
-import FirecrawlApp from "@mendable/firecrawl-js";
+import Firecrawl from "@mendable/firecrawl-js";
 import { task } from "@trigger.dev/sdk";
 
 // Initialize the Firecrawl client with your API key
-const firecrawlClient = new FirecrawlApp({
+const firecrawlClient = new Firecrawl({
   apiKey: process.env.FIRECRAWL_API_KEY, // Get this from your Firecrawl dashboard
 });
 
@@ -34,15 +34,15 @@ export const firecrawlCrawl = task({
     const { url } = payload;
 
     // Crawl: scrapes all the URLs of a web page and return content in LLM-ready format
-    const crawlResult = await firecrawlClient.crawlUrl(url, {
+    const crawlResult = await firecrawlClient.crawl(url, {
       limit: 100, // Limit the number of URLs to crawl
       scrapeOptions: {
         formats: ["markdown", "html"],
       },
     });
 
-    if (!crawlResult.success) {
-      throw new Error(`Failed to crawl: ${crawlResult.error}`);
+    if (crawlResult.status === "failed") {
+      throw new Error(`Failed to crawl: ${url}`);
     }
 
     return {
@@ -65,11 +65,11 @@ You can test your task by triggering it from the Trigger.dev dashboard.
 This task scrapes a single URL and returns the `scrapeResult` object.
 
 ```ts trigger/firecrawl-url-scrape.ts
-import FirecrawlApp, { ScrapeResponse } from "@mendable/firecrawl-js";
+import Firecrawl from "@mendable/firecrawl-js";
 import { task } from "@trigger.dev/sdk";
 
 // Initialize the Firecrawl client with your API key
-const firecrawlClient = new FirecrawlApp({
+const firecrawlClient = new Firecrawl({
   apiKey: process.env.FIRECRAWL_API_KEY, // Get this from your Firecrawl dashboard
 });
 
@@ -79,13 +79,9 @@ export const firecrawlScrape = task({
     const { url } = payload;
 
     // Scrape: scrapes a URL and get its content in LLM-ready format (markdown, structured data via LLM Extract, screenshot, html)
-    const scrapeResult = (await firecrawlClient.scrapeUrl(url, {
+    const scrapeResult = await firecrawlClient.scrape(url, {
       formats: ["markdown", "html"],
-    })) as ScrapeResponse;
-
-    if (!scrapeResult.success) {
-      throw new Error(`Failed to scrape: ${scrapeResult.error}`);
-    }
+    });
 
     return {
       data: scrapeResult,


### PR DESCRIPTION
The current example doesn't work anymore. `FirecrawlApp` is now `FirecrawlAppV1`, and `ScrapeResponse` isn't exposed. So I updated the example to use the updated SDK, trying to keep this new example as close to the original as I could.

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

I tested the updated workflows on `cloud.trigger.dev`.

---

## Changelog

Update the Firecrawl example to use the updated Firecrawl SDK.

---

## Screenshots

<img width="1232" height="715" alt="Screenshot 2025-11-05 at 03 08 57" src="https://github.com/user-attachments/assets/d89a4401-db0d-42fe-baed-99af789c0194" />

<img width="1228" height="627" alt="Screenshot 2025-11-05 at 03 09 25" src="https://github.com/user-attachments/assets/fe53fd74-c085-4bd6-8442-7df06d12f5a8" />

💯
