### PR TITLE
docs: format Sequin embedding example

### DIFF
--- a/docs/guides/frameworks/sequin.mdx
+++ b/docs/guides/frameworks/sequin.mdx
@@ -39,54 +39,52 @@ Start by creating a new Trigger.dev task that takes in a Sequin change event as 
   In your `src/trigger/tasks` directory, create a new file called `create-embedding-for-post.ts` and add the following code:
 
   <CodeGroup>
-  ```ts trigger/create-embedding-for-post.ts
-  import { task } from "@trigger.dev/sdk";
-  import { OpenAI } from "openai";
-  import { upsertEmbedding } from "../util";
+```ts trigger/create-embedding-for-post.ts
+import { task } from "@trigger.dev/sdk";
+import { OpenAI } from "openai";
+import { upsertEmbedding } from "../util";
 
 const openai = new OpenAI({
-apiKey: process.env.OPENAI_API_KEY,
+  apiKey: process.env.OPENAI_API_KEY,
 });
 
 export const createEmbeddingForPost = task({
-id: "create-embedding-for-post",
-run: async (payload: {
-record: {
-id: number;
-title: string;
-body: string;
-author: string;
-createdAt: string;
-embedding: string | null;
-},
-metadata: {
-table_schema: string,
-table_name: string,
-consumer: {
-id: string;
-name: string;
-};
-};
-}) => {
-// Create an embedding using the title and body of payload.record
-const content = `${payload.record.title}\n\n${payload.record.body}`;
-const embedding = (await openai.embeddings.create({
-model: "text-embedding-ada-002",
-input: content,
-})).data[0].embedding;
-
-      // Upsert the embedding in the database. See utils.ts for the implementation -> ->
-      await upsertEmbedding(embedding, payload.record.id);
-
-      // Return the updated record
-      return {
-        ...payload.record,
-        embedding: JSON.stringify(embedding),
+  id: "create-embedding-for-post",
+  run: async (payload: {
+    record: {
+      id: number;
+      title: string;
+      body: string;
+      author: string;
+      createdAt: string;
+      embedding: string | null;
+    },
+    metadata: {
+      table_schema: string,
+      table_name: string,
+      consumer: {
+        id: string;
+        name: string;
       };
-    }
+    };
+  }) => {
+    // Create an embedding using the title and body of payload.record
+    const content = `${payload.record.title}\n\n${payload.record.body}`;
+    const embedding = (await openai.embeddings.create({
+      model: "text-embedding-ada-002",
+      input: content,
+    })).data[0].embedding;
 
+    // Upsert the embedding in the database. See utils.ts for the implementation -> ->
+    await upsertEmbedding(embedding, payload.record.id);
+
+    // Return the updated record
+    return {
+      ...payload.record,
+      embedding: JSON.stringify(embedding),
+    };
+  }
 });
-
 ````
 
 ```ts utils.ts


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

I spun up the documentation locally, formatted the code, and tested the changed docs with FireFox and Google Chrome.

---

## Changelog

Fix the format on the `create-embedding-for-post.ts` example in the Sequin guide.

---

## Screenshots

_[Before & After]_
<img width="1017" height="1283" alt="Screenshot 2025-11-06 at 11 13 03" src="https://github.com/user-attachments/assets/7f2aa535-e66d-4a31-8a4f-4a73fbee35fc" />
<img width="998" height="1251" alt="Screenshot 2025-11-06 at 11 13 37" src="https://github.com/user-attachments/assets/bddc2f23-4794-45e0-a59f-84ae9434a433" />


💯
