### PR TITLE
fix(docs): tooltip color contrast accessibility

### DIFF
--- a/.changeset/tough-feet-accept.md
+++ b/.changeset/tough-feet-accept.md
@@ -1,5 +1,0 @@
----
-"trigger.dev": patch
----
-
-Fix tooltip color contrast accessibility on docs


### PR DESCRIPTION
Closes #2633 

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

1. Start the docs locally with `pnpm run dev --filter docs`
2. In the docs, go to /manual-setup. 
3. Hover the *Copy* or any other action icon on any code block.

---

## Changelog

Added a new global style.css file.
Included a CSS selector that improves text visibility by adjusting the tooltip’s text color for better contrast.

---

## Screenshots

### Before:
<img width="1190" height="278" alt="image" src="https://github.com/user-attachments/assets/5ad310d2-9ba1-4a3a-ae1a-56433ad94892" />

### After
<img width="1190" height="278" alt="image" src="https://github.com/user-attachments/assets/48836969-961a-4885-936a-c2e086369871" />
