### PR TITLE
docs(kubernetes): use v4 helm chart instead of beta

### DIFF
--- a/docs/self-hosting/kubernetes.mdx
+++ b/docs/self-hosting/kubernetes.mdx
@@ -61,7 +61,7 @@ webapp:
 ```bash
 helm upgrade -n trigger --install trigger \
   oci://ghcr.io/triggerdotdev/charts/trigger \
-  --version "~4.0.0-beta" \
+  --version "~4.0.0" \
   --create-namespace
 ```
 
@@ -107,11 +107,11 @@ The following commands will display the default values:
 ```bash
 # Specific version
 helm show values oci://ghcr.io/triggerdotdev/charts/trigger \
-  --version "4.0.0-beta.5"
+  --version "4.0.5"
 
-# Latest v4 beta
+# Latest v4
 helm show values oci://ghcr.io/triggerdotdev/charts/trigger \
-  --version "~4.0.0-beta"
+  --version "~4.0.0"
 ```
 
 ### Custom values
@@ -171,7 +171,7 @@ Deploy with your custom values:
 ```bash
 helm upgrade -n trigger --install trigger \
   oci://ghcr.io/triggerdotdev/charts/trigger \
-  --version "~4.0.0-beta" \
+  --version "~4.0.0" \
   --create-namespace \
   -f values-custom.yaml
 ```
@@ -489,14 +489,14 @@ You can lock versions in two ways:
 # Pin to a specific version for production
 helm upgrade -n trigger --install trigger \
   oci://ghcr.io/triggerdotdev/charts/trigger \
-  --version "4.0.0-beta.5"
+  --version "4.0.5"
 
 # The app version will be different from the chart version
 # This is the version of the Trigger.dev webapp and supervisor
 # ..and should always match your Trigger.dev CLI version
 helm show chart \
   oci://ghcr.io/triggerdotdev/charts/trigger \
-  --version "4.0.0-beta.5" | grep appVersion
+  --version "4.0.5" | grep appVersion
 ```
 
 **Specific image tags:**


### PR DESCRIPTION


## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

_[Describe the steps you took to test this change]_

I've executed the commands on my own Kubernetes cluster and it works.

---

## Changelog

_[Short description of what has changed]_

Updated the documentation to use the latest helm chart (v4) instead of beta.

---

## Screenshots

_[Screenshots]_

<img width="847" height="385" alt="Screenshot 2025-11-12 at 14 26 30" src="https://github.com/user-attachments/assets/e9361e7e-0f30-42ec-9106-d4271b74eaaf" />


💯
