### PR TITLE
fix(docker): support the latest docker version

### DIFF
--- a/apps/supervisor/src/env.ts
+++ b/apps/supervisor/src/env.ts
@@ -57,7 +57,7 @@ const Env = z.object({
   RESOURCE_MONITOR_OVERRIDE_MEMORY_TOTAL_GB: z.coerce.number().optional(),
 
   // Docker settings
-  DOCKER_API_VERSION: z.string().default("v1.41"),
+  DOCKER_API_VERSION: z.string().optional(),
   DOCKER_PLATFORM: z.string().optional(), // e.g. linux/amd64, linux/arm64
   DOCKER_STRIP_IMAGE_DIGEST: BoolEnv.default(true),
   DOCKER_REGISTRY_USERNAME: z.string().optional(),


### PR DESCRIPTION
The API version we locked to is now deprecated. Support was removed from the latest docker release. Not passing a version to dockerode means that docker-modem will make versionless requests instead - the docker daemon will use its default version to handle them.