### PR TITLE
fix(ui): refresh deployments logs stream on status change

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments.$deploymentParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments.$deploymentParam/route.tsx
@@ -84,6 +84,7 @@ export default function Page() {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [isStreaming, setIsStreaming] = useState(true);
   const [streamError, setStreamError] = useState<string | null>(null);
+  const isPending = deployment.status === "PENDING";
 
   useEffect(() => {
     if (logsDisabled) return;
@@ -157,7 +158,7 @@ export default function Page() {
     return () => {
       abortController.abort();
     };
-  }, [s2Logs?.basin, s2Logs?.stream, s2Logs?.accessToken]);
+  }, [s2Logs?.basin, s2Logs?.stream, s2Logs?.accessToken, isPending]);
 
   return (
     <div className="grid h-full max-h-full grid-rows-[2.5rem_1fr] overflow-hidden bg-background-bright">


### PR DESCRIPTION
The logs stream is created after the deployment moves from `PENDING` status to `INSTALLING`.
