### PR TITLE
fix(api): Fix preview branch targeting in environment variable API routes

### DIFF
--- a/apps/webapp/app/routes/api.v1.projects.$projectRef.$env.ts
+++ b/apps/webapp/app/routes/api.v1.projects.$projectRef.$env.ts
@@ -5,6 +5,7 @@ import { env as processEnv } from "~/env.server";
 import {
   authenticatedEnvironmentForAuthentication,
   authenticateRequest,
+  branchNameFromRequest,
 } from "~/services/apiAuth.server";
 
 const ParamsSchema = z.object({
@@ -32,7 +33,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   const environment = await authenticatedEnvironmentForAuthentication(
     authenticationResult,
     projectRef,
-    env
+    env,
+    branchNameFromRequest(request)
   );
 
   const result: GetProjectEnvResponse = {

--- a/apps/webapp/app/routes/api.v1.projects.$projectRef.background-workers.$envSlug.$version.ts
+++ b/apps/webapp/app/routes/api.v1.projects.$projectRef.background-workers.$envSlug.$version.ts
@@ -4,6 +4,7 @@ import { prisma } from "~/db.server";
 import {
   authenticateRequest,
   authenticatedEnvironmentForAuthentication,
+  branchNameFromRequest,
 } from "~/services/apiAuth.server";
 import zlib from "node:zlib";
 
@@ -29,7 +30,8 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const environment = await authenticatedEnvironmentForAuthentication(
     authenticationResult,
     parsedParams.data.projectRef,
-    parsedParams.data.envSlug
+    parsedParams.data.envSlug,
+    branchNameFromRequest(request)
   );
 
   // Find the background worker and tasks and files

--- a/apps/webapp/app/routes/api.v1.projects.$projectRef.envvars.$slug.$name.ts
+++ b/apps/webapp/app/routes/api.v1.projects.$projectRef.envvars.$slug.$name.ts
@@ -5,6 +5,7 @@ import { prisma } from "~/db.server";
 import {
   authenticateRequest,
   authenticatedEnvironmentForAuthentication,
+  branchNameFromRequest,
 } from "~/services/apiAuth.server";
 import { EnvironmentVariablesRepository } from "~/v3/environmentVariables/environmentVariablesRepository.server";
 
@@ -30,7 +31,8 @@ export async function action({ params, request }: ActionFunctionArgs) {
   const environment = await authenticatedEnvironmentForAuthentication(
     authenticationResult,
     parsedParams.data.projectRef,
-    parsedParams.data.slug
+    parsedParams.data.slug,
+    branchNameFromRequest(request)
   );
 
   // Find the environment variable
@@ -106,7 +108,8 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const environment = await authenticatedEnvironmentForAuthentication(
     authenticationResult,
     parsedParams.data.projectRef,
-    parsedParams.data.slug
+    parsedParams.data.slug,
+    branchNameFromRequest(request)
   );
 
   // Find the environment variable

--- a/apps/webapp/app/routes/api.v1.projects.$projectRef.envvars.$slug.ts
+++ b/apps/webapp/app/routes/api.v1.projects.$projectRef.envvars.$slug.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import {
   authenticateRequest,
   authenticatedEnvironmentForAuthentication,
+  branchNameFromRequest,
 } from "~/services/apiAuth.server";
 import { EnvironmentVariablesRepository } from "~/v3/environmentVariables/environmentVariablesRepository.server";
 
@@ -28,7 +29,8 @@ export async function action({ params, request }: ActionFunctionArgs) {
   const environment = await authenticatedEnvironmentForAuthentication(
     authenticationResult,
     parsedParams.data.projectRef,
-    parsedParams.data.slug
+    parsedParams.data.slug,
+    branchNameFromRequest(request)
   );
 
   const jsonBody = await request.json();
@@ -75,7 +77,8 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const environment = await authenticatedEnvironmentForAuthentication(
     authenticationResult,
     parsedParams.data.projectRef,
-    parsedParams.data.slug
+    parsedParams.data.slug,
+    branchNameFromRequest(request)
   );
 
   const repository = new EnvironmentVariablesRepository();

--- a/apps/webapp/app/services/apiAuth.server.ts
+++ b/apps/webapp/app/services/apiAuth.server.ts
@@ -497,7 +497,9 @@ export async function authenticatedEnvironmentForAuthentication(
         throw json({ error: "Project not found" }, { status: 404 });
       }
 
-      if (!branch) {
+      const sanitizedBranch = sanitizeBranchName(branch);
+
+      if (!sanitizedBranch) {
         const environment = await prisma.runtimeEnvironment.findFirst({
           where: {
             projectId: project.id,
@@ -526,8 +528,8 @@ export async function authenticatedEnvironmentForAuthentication(
       const environment = await prisma.runtimeEnvironment.findFirst({
         where: {
           projectId: project.id,
-          slug: slug,
-          branchName: sanitizeBranchName(branch),
+          type: "PREVIEW",
+          branchName: sanitizedBranch,
           archivedAt: null,
         },
         include: {
@@ -574,7 +576,9 @@ export async function authenticatedEnvironmentForAuthentication(
         throw json({ error: "Project not found" }, { status: 404 });
       }
 
-      if (!branch) {
+      const sanitizedBranch = sanitizeBranchName(branch);
+
+      if (!sanitizedBranch) {
         const environment = await prisma.runtimeEnvironment.findFirst({
           where: {
             projectId: project.id,
@@ -596,8 +600,8 @@ export async function authenticatedEnvironmentForAuthentication(
       const environment = await prisma.runtimeEnvironment.findFirst({
         where: {
           projectId: project.id,
-          slug: slug,
-          branchName: sanitizeBranchName(branch),
+          type: "PREVIEW",
+          branchName: sanitizedBranch,
           archivedAt: null,
         },
         include: {

--- a/apps/webapp/app/v3/gitBranch.ts
+++ b/apps/webapp/app/v3/gitBranch.ts
@@ -29,7 +29,7 @@ export function isValidGitBranchName(branch: string): boolean {
   return true;
 }
 
-export function sanitizeBranchName(ref: string): string | null {
+export function sanitizeBranchName(ref: string | undefined): string | null {
   if (!ref) return null;
   if (ref.startsWith("refs/heads/")) return ref.substring("refs/heads/".length);
   if (ref.startsWith("refs/remotes/")) return ref.substring("refs/remotes/".length);


### PR DESCRIPTION
This PR fixes the `x-trigger-branch` header support for targeting specific preview branches when managing environment variables. The header was documented but not actually being extracted or used in the environment variable API routes. Additionally, the query logic in `authenticatedEnvironmentForAuthentication` was fundamentally broken—it searched for environments with both `slug: "preview"` (parent environment property) AND a specific `branchName` (child environment property), which no environment could satisfy simultaneously. The fix extracts the branch name using `branchNameFromRequest()` and correctly queries for child branch environments using `type: "PREVIEW"` and the specific `branchName`. This ensures that environment variable operations (create, update, get, list) properly target individual preview branches instead of affecting all preview environments.