### PR TITLE
feat(otel): support for custom resource attributes via config#telemetry.resource and OTEL_RESOURCE_ATTRIBUTES env var

### DIFF
--- a/.changeset/lucky-cameras-shave.md
+++ b/.changeset/lucky-cameras-shave.md
@@ -1,0 +1,6 @@
+---
+"@trigger.dev/sdk": patch
+"trigger.dev": patch
+---
+
+feat: add ability to set custom resource properties through trigger.config.ts or via the OTEL_RESOURCE_ATTRIBUTES env var

--- a/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
@@ -497,7 +497,18 @@ export class SpanPresenter extends BasePresenter {
       duration: span.duration,
       events: span.events,
       style: span.style,
-      properties: span.properties ? JSON.stringify(span.properties, null, 2) : undefined,
+      properties:
+        span.properties &&
+        typeof span.properties === "object" &&
+        Object.keys(span.properties).length > 0
+          ? JSON.stringify(span.properties, null, 2)
+          : undefined,
+      resourceProperties:
+        span.resourceProperties &&
+        typeof span.resourceProperties === "object" &&
+        Object.keys(span.resourceProperties).length > 0
+          ? JSON.stringify(span.resourceProperties, null, 2)
+          : undefined,
       entity: span.entity,
       metadata: span.metadata,
       triggeredRuns,

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -1071,6 +1071,17 @@ function SpanEntity({ span }: { span: Span }) {
             showOpenInModal
           />
         ) : null}
+        {span.resourceProperties !== undefined ? (
+          <CodeBlock
+            rowTitle="Resource properties"
+            code={span.resourceProperties}
+            maxLines={20}
+            showLineNumbers={false}
+            showCopyButton
+            showTextWrapping
+            showOpenInModal
+          />
+        ) : null}
       </div>
     );
   }

--- a/apps/webapp/app/v3/environmentVariables/environmentVariablesRepository.server.ts
+++ b/apps/webapp/app/v3/environmentVariables/environmentVariablesRepository.server.ts
@@ -825,11 +825,15 @@ export async function resolveVariablesForEnvironment(
   runtimeEnvironment: RuntimeEnvironmentForEnvRepo,
   parentEnvironment?: RuntimeEnvironmentForEnvRepo
 ) {
-  const projectSecrets = await environmentVariablesRepository.getEnvironmentVariables(
+  let projectSecrets = await environmentVariablesRepository.getEnvironmentVariables(
     runtimeEnvironment.projectId,
     runtimeEnvironment.id,
     parentEnvironment?.id
   );
+
+  projectSecrets = renameVariables(projectSecrets, {
+    OTEL_RESOURCE_ATTRIBUTES: "CUSTOM_OTEL_RESOURCE_ATTRIBUTES",
+  });
 
   const overridableTriggerVariables = await resolveOverridableTriggerVariables(runtimeEnvironment);
 
@@ -851,6 +855,15 @@ export async function resolveVariablesForEnvironment(
   ]);
 
   return result;
+}
+
+function renameVariables(variables: EnvironmentVariable[], renameMap: Record<string, string>) {
+  return variables.map((variable) => {
+    return {
+      ...variable,
+      key: renameMap[variable.key] ?? variable.key,
+    };
+  });
 }
 
 async function resolveOverridableTriggerVariables(

--- a/apps/webapp/app/v3/eventRepository/eventRepository.types.ts
+++ b/apps/webapp/app/v3/eventRepository/eventRepository.types.ts
@@ -53,6 +53,7 @@ export type CreateEventInput = Omit<
   | "links"
 > & {
   properties: Attributes;
+  resourceProperties?: Attributes;
   metadata: Attributes | undefined;
   style: Attributes | undefined;
 };
@@ -209,6 +210,7 @@ export type SpanDetail = {
   events: SpanEvents; // Timeline events, SpanEvents component
   style: TaskEventStyle; // Icons, variants, accessories (RunIcon, SpanTitle)
   properties: Record<string, unknown> | string | number | boolean | null | undefined; // Displayed as JSON in span properties (CodeBlock)
+  resourceProperties?: Record<string, unknown> | string | number | boolean | null | undefined; // Displayed as JSON in span resource properties (CodeBlock)
 
   // ============================================================================
   // Entity & Relationships

--- a/apps/webapp/app/v3/otlpExporter.server.ts
+++ b/apps/webapp/app/v3/otlpExporter.server.ts
@@ -204,6 +204,24 @@ function convertLogsToCreateableEvents(
 
   const resourceProperties = extractEventProperties(resourceAttributes);
 
+  const userDefinedResourceAttributes = truncateAttributes(
+    convertKeyValueItemsToMap(resourceAttributes ?? [], [], undefined, [
+      SemanticInternalAttributes.USAGE,
+      SemanticInternalAttributes.SPAN,
+      SemanticInternalAttributes.METADATA,
+      SemanticInternalAttributes.STYLE,
+      SemanticInternalAttributes.METRIC_EVENTS,
+      SemanticInternalAttributes.TRIGGER,
+      "process",
+      "sdk",
+      "service",
+      "ctx",
+      "cli",
+      "cloud",
+    ]),
+    spanAttributeValueLengthLimit
+  );
+
   const taskEventStore =
     extractStringAttribute(resourceAttributes, [SemanticInternalAttributes.TASK_EVENT_STORE]) ??
     env.EVENT_REPOSITORY_DEFAULT_STORE;
@@ -249,6 +267,7 @@ function convertLogsToCreateableEvents(
           status: logLevelToEventStatus(log.severityNumber),
           startTime: log.timeUnixNano,
           properties,
+          resourceProperties: userDefinedResourceAttributes,
           style: convertKeyValueItemsToMap(
             pickAttributes(log.attributes ?? [], SemanticInternalAttributes.STYLE),
             []
@@ -284,6 +303,24 @@ function convertSpansToCreateableEvents(
   const resourceAttributes = resourceSpan.resource?.attributes ?? [];
 
   const resourceProperties = extractEventProperties(resourceAttributes);
+
+  const userDefinedResourceAttributes = truncateAttributes(
+    convertKeyValueItemsToMap(resourceAttributes ?? [], [], undefined, [
+      SemanticInternalAttributes.USAGE,
+      SemanticInternalAttributes.SPAN,
+      SemanticInternalAttributes.METADATA,
+      SemanticInternalAttributes.STYLE,
+      SemanticInternalAttributes.METRIC_EVENTS,
+      SemanticInternalAttributes.TRIGGER,
+      "process",
+      "sdk",
+      "service",
+      "ctx",
+      "cli",
+      "cloud",
+    ]),
+    spanAttributeValueLengthLimit
+  );
 
   const taskEventStore =
     extractStringAttribute(resourceAttributes, [SemanticInternalAttributes.TASK_EVENT_STORE]) ??
@@ -336,6 +373,7 @@ function convertSpansToCreateableEvents(
           events: spanEventsToEventEvents(span.events ?? []),
           duration: span.endTimeUnixNano - span.startTimeUnixNano,
           properties,
+          resourceProperties: userDefinedResourceAttributes,
           style: convertKeyValueItemsToMap(
             pickAttributes(span.attributes ?? [], SemanticInternalAttributes.STYLE),
             []

--- a/packages/cli-v3/src/dev/devSupervisor.ts
+++ b/packages/cli-v3/src/dev/devSupervisor.ts
@@ -455,9 +455,6 @@ class DevSupervisor implements WorkerRuntime {
       TRIGGER_API_URL: this.options.client.apiURL,
       TRIGGER_SECRET_KEY: this.options.client.accessToken!,
       OTEL_EXPORTER_OTLP_COMPRESSION: "none",
-      OTEL_RESOURCE_ATTRIBUTES: JSON.stringify({
-        [SemanticInternalAttributes.PROJECT_DIR]: this.options.config.workingDir,
-      }),
       OTEL_IMPORT_HOOK_INCLUDES,
     };
   }

--- a/packages/cli-v3/src/entryPoints/dev-run-worker.ts
+++ b/packages/cli-v3/src/entryPoints/dev-run-worker.ts
@@ -209,6 +209,7 @@ async function doBootstrap() {
       logExporters: config.telemetry?.logExporters ?? [],
       diagLogLevel: (env.TRIGGER_OTEL_LOG_LEVEL as TracingDiagnosticLogLevel) ?? "none",
       forceFlushTimeoutMillis: 30_000,
+      resource: config.telemetry?.resource,
     });
 
     const otelTracer: Tracer = tracingSDK.getTracer("trigger-dev-worker", VERSION);

--- a/packages/cli-v3/src/entryPoints/managed-run-worker.ts
+++ b/packages/cli-v3/src/entryPoints/managed-run-worker.ts
@@ -188,6 +188,7 @@ async function doBootstrap() {
       forceFlushTimeoutMillis: 30_000,
       exporters: config.telemetry?.exporters ?? [],
       logExporters: config.telemetry?.logExporters ?? [],
+      resource: config.telemetry?.resource,
     });
 
     const otelTracer: Tracer = tracingSDK.getTracer("trigger-dev-worker", VERSION);

--- a/packages/cli-v3/src/utilities/dotEnv.ts
+++ b/packages/cli-v3/src/utilities/dotEnv.ts
@@ -2,7 +2,13 @@ import dotenv from "dotenv";
 import { resolve } from "node:path";
 import { env } from "std-env";
 
-const ENVVAR_FILES = [".env", ".env.development", ".env.local", ".env.development.local", "dev.vars"];
+const ENVVAR_FILES = [
+  ".env",
+  ".env.development",
+  ".env.local",
+  ".env.development.local",
+  "dev.vars",
+];
 
 export function resolveDotEnvVars(cwd?: string, envFile?: string) {
   const result: { [key: string]: string } = {};
@@ -22,6 +28,11 @@ export function resolveDotEnvVars(cwd?: string, envFile?: string) {
   delete result.TRIGGER_API_URL;
   delete result.TRIGGER_SECRET_KEY;
   delete result.OTEL_EXPORTER_OTLP_ENDPOINT;
+
+  if (result.OTEL_RESOURCE_ATTRIBUTES) {
+    result.CUSTOM_OTEL_RESOURCE_ATTRIBUTES = result.OTEL_RESOURCE_ATTRIBUTES;
+    delete result.OTEL_RESOURCE_ATTRIBUTES;
+  }
 
   return result;
 }

--- a/packages/core/src/v3/config.ts
+++ b/packages/core/src/v3/config.ts
@@ -12,6 +12,7 @@ import type {
 import type { LogLevel } from "./logger/taskLogger.js";
 import type { MachinePresetName } from "./schemas/common.js";
 import { LogRecordExporter } from "@opentelemetry/sdk-logs";
+import type { Resource } from "@opentelemetry/resources";
 
 export type CompatibilityFlag = "run_engine_v2";
 
@@ -107,6 +108,13 @@ export type TriggerConfig = {
      * @see https://trigger.dev/docs/config/config-file#exporters
      */
     logExporters?: Array<LogRecordExporter>;
+
+    /**
+     * Resource to use for OpenTelemetry. This is useful if you want to add custom resources to your tasks.
+     *
+     * @see https://trigger.dev/docs/config/config-file#resource
+     */
+    resource?: Resource;
   };
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2593,6 +2593,25 @@ importers:
         specifier: ^5
         version: 5.5.4
 
+  references/telemetry:
+    dependencies:
+      '@opentelemetry/resources':
+        specifier: 2.2.0
+        version: 2.2.0(@opentelemetry/api@1.9.0)
+      '@trigger.dev/sdk':
+        specifier: workspace:*
+        version: link:../../packages/trigger-sdk
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.14.14
+      trigger.dev:
+        specifier: workspace:*
+        version: link:../../packages/cli-v3
+      typescript:
+        specifier: ^5
+        version: 5.5.4
+
   references/test-tasks:
     dependencies:
       '@trigger.dev/sdk':
@@ -9909,6 +9928,16 @@ packages:
       '@opentelemetry/semantic-conventions': 1.36.0
     dev: false
 
+  /@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0):
+    resolution: {integrity: sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.36.0
+    dev: false
+
   /@opentelemetry/exporter-logs-otlp-grpc@0.203.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-g/2Y2noc/l96zmM+g0LdeuyYKINyBwN6FJySoU15LHPLcMN/1a0wNk2SegwKcxrRdE7Xsm7fkIR5n6XFe3QpPw==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -10657,6 +10686,17 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+    dev: false
+
+  /@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0):
+    resolution: {integrity: sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.36.0
     dev: false
 

--- a/references/telemetry/package.json
+++ b/references/telemetry/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "references-telemetry",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "trigger dev",
+    "deploy": "trigger deploy"
+  },
+  "dependencies": {
+    "@trigger.dev/sdk": "workspace:*",
+    "@opentelemetry/resources": "2.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "trigger.dev": "workspace:*",
+    "typescript": "^5"
+  }
+}

--- a/references/telemetry/src/trigger/tasks.ts
+++ b/references/telemetry/src/trigger/tasks.ts
@@ -1,0 +1,9 @@
+import { logger, task } from "@trigger.dev/sdk";
+
+export const telemetryTestTask = task({
+  id: "telemetry-test",
+  run: async (payload: any, { ctx }) => {
+    logger.info("Hello, world!", { payload, ctx });
+    return { message: "Hello, world!" };
+  },
+});

--- a/references/telemetry/trigger.config.ts
+++ b/references/telemetry/trigger.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "@trigger.dev/sdk";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+
+export default defineConfig({
+  project: process.env.TRIGGER_PROJECT_REF!,
+  dirs: ["./src/trigger"],
+  maxDuration: 3600,
+  telemetry: {
+    resource: resourceFromAttributes({
+      "foo.bar": "telemetry-test",
+      "foo.baz": "1.0.0",
+    }),
+  },
+});

--- a/references/telemetry/tsconfig.json
+++ b/references/telemetry/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "customConditions": ["@triggerdotdev/source"],
+    "jsx": "preserve",
+    "lib": ["DOM", "DOM.Iterable"],
+    "noEmit": true
+  },
+  "include": ["./src/**/*.ts", "trigger.config.ts"]
+}


### PR DESCRIPTION
It's now possible to set custom resource attributes on exported spans and logs using two different methods

### Config

You can set a set of custom resource attributes via the new `resource` property in your `trigger.config.ts` file:

```ts
import { defineConfig } from "@trigger.dev/sdk";
import { resourceFromAttributes } from "@opentelemetry/resources";

export default defineConfig({
  project: "<your project ref>",
  maxDuration: 3600,
  telemetry: {
    resource: resourceFromAttributes({
      "custom-resource.name": "telemetry-test",
      "custom-resource.version": "1.0.0",
    }),
  },
});
```

### Env vars

We now support the official `OTEL_RESOURCE_ATTRIBUTES` env var ([docs](https://opentelemetry.io/docs/languages/js/resources/#adding-resources-with-environment-variables)):

```
OTEL_RESOURCE_ATTRIBUTES="custom-resource.name=telemetry-test,custom-resource.version=1.0.0"
```

Resource attributes will now show in the Span & Log inspector under "Resource properties":

<img width="436" height="513" alt="CleanShot 2025-11-24 at 13 23 42" src="https://github.com/user-attachments/assets/f56ab2bd-2856-4201-bd8b-be331a8d873e" />

Fixes #2648 