### PR TITLE
fix(otel): fix broken schedule run spans

### DIFF
--- a/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
@@ -273,6 +273,7 @@ export class SpanPresenter extends BasePresenter {
       spanId: run.spanId,
       isCached: !!originalRunId,
       machinePreset: machine?.name,
+      taskEventStore: run.taskEventStore,
       externalTraceId,
     };
   }

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -815,6 +815,10 @@ function RunBody({
                       <Property.Label>Span ID</Property.Label>
                       <Property.Value>{run.spanId}</Property.Value>
                     </Property.Item>
+                    <Property.Item>
+                      <Property.Label>Task event store</Property.Label>
+                      <Property.Value>{run.taskEventStore}</Property.Value>
+                    </Property.Item>
                   </div>
                 )}
               </Property.Table>

--- a/apps/webapp/app/v3/eventRepository/clickhouseEventRepository.server.ts
+++ b/apps/webapp/app/v3/eventRepository/clickhouseEventRepository.server.ts
@@ -1039,7 +1039,7 @@ export class ClickhouseEventRepository implements IEventRepository {
     endCreatedAt?: Date,
     options?: { includeDebugLogs?: boolean }
   ): Promise<TraceSummary | undefined> {
-    const startCreatedAtWithBuffer = new Date(startCreatedAt.getTime() - 1000);
+    const startCreatedAtWithBuffer = new Date(startCreatedAt.getTime() - 60_000);
     const endCreatedAtWithBuffer = endCreatedAt
       ? new Date(endCreatedAt.getTime() + 60_000)
       : undefined;


### PR DESCRIPTION
schedule spans can sometimes show as generic spans when using the `task_events_v2` table because of the inserted_at filter. Increasing the buffer for the start time does the trick and doesn’t cause any perf issues (and is in general just more robust)

<img width="536" height="263" alt="CleanShot 2025-12-02 at 17 04 35" src="https://github.com/user-attachments/assets/95f12009-95d5-4958-b928-5e406147357f" />

