### PR TITLE
fix(cli): header will always print the correct profile

### DIFF
--- a/.changeset/healthy-cherries-joke.md
+++ b/.changeset/healthy-cherries-joke.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+fix(cli): header will always print the correct profile

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -162,7 +162,7 @@ export function configureDeployCommand(program: Command) {
       )
       .action(async (path, options) => {
         await handleTelemetry(async () => {
-          await printStandloneInitialBanner(true);
+          await printStandloneInitialBanner(true, options.profile);
           await deployCommand(path, options);
         });
       })

--- a/packages/cli-v3/src/commands/dev.ts
+++ b/packages/cli-v3/src/commands/dev.ts
@@ -205,7 +205,7 @@ async function startDev(options: StartDevOptions) {
       logger.loggerLevel = options.logLevel;
     }
 
-    await printStandloneInitialBanner(true);
+    await printStandloneInitialBanner(true, options.profile);
 
     let displayedUpdateMessage = false;
 

--- a/packages/cli-v3/src/commands/env.ts
+++ b/packages/cli-v3/src/commands/env.ts
@@ -71,7 +71,7 @@ export function configureEnvCommand(program: Command) {
       )
   ).action(async (options) => {
     await handleTelemetry(async () => {
-      await printInitialBanner(false);
+      await printInitialBanner(false, options.profile);
       await envListCommand(options);
     });
   });
@@ -95,7 +95,7 @@ export function configureEnvCommand(program: Command) {
   ).action(async (name, options) => {
     await handleTelemetry(async () => {
       if (!options.raw) {
-        await printInitialBanner(false);
+        await printInitialBanner(false, options.profile);
       }
       await envGetCommand({ ...options, name });
     });
@@ -120,7 +120,7 @@ export function configureEnvCommand(program: Command) {
       .option("--force", "Overwrite the output file if it exists")
   ).action(async (options) => {
     await handleTelemetry(async () => {
-      await printInitialBanner(false);
+      await printInitialBanner(false, options.profile);
       await envPullCommand(options);
     });
   });

--- a/packages/cli-v3/src/commands/init.ts
+++ b/packages/cli-v3/src/commands/init.ts
@@ -98,7 +98,7 @@ export function configureInitCommand(program: Command) {
     )
     .action(async (path, options) => {
       await handleTelemetry(async () => {
-        await printStandloneInitialBanner(true);
+        await printStandloneInitialBanner(true, options.profile);
         await initCommand(path, options);
       });
     });

--- a/packages/cli-v3/src/commands/login.ts
+++ b/packages/cli-v3/src/commands/login.ts
@@ -50,7 +50,7 @@ export function configureLoginCommand(program: Command) {
     .version(VERSION, "-v, --version", "Display the version number")
     .action(async (options) => {
       await handleTelemetry(async () => {
-        await printInitialBanner(false);
+        await printInitialBanner(false, options.profile);
         await loginCommand(options);
       });
     });

--- a/packages/cli-v3/src/commands/logout.ts
+++ b/packages/cli-v3/src/commands/logout.ts
@@ -18,7 +18,7 @@ export function configureLogoutCommand(program: Command) {
   return commonOptions(program.command("logout").description("Logout of Trigger.dev")).action(
     async (options) => {
       await handleTelemetry(async () => {
-        await printInitialBanner(false);
+        await printInitialBanner(false, options.profile);
         await logoutCommand(options);
       });
     }

--- a/packages/cli-v3/src/commands/mcp.ts
+++ b/packages/cli-v3/src/commands/mcp.ts
@@ -58,7 +58,7 @@ export function configureMcpCommand(program: Command) {
 
 export async function mcpCommand(options: McpCommandOptions) {
   if (process.stdout.isTTY) {
-    await printStandloneInitialBanner(true);
+    await printStandloneInitialBanner(true, options.profile);
 
     intro("Welcome to the Trigger.dev MCP server install wizard 🧙");
 

--- a/packages/cli-v3/src/commands/preview.ts
+++ b/packages/cli-v3/src/commands/preview.ts
@@ -53,7 +53,7 @@ export function configurePreviewCommand(program: Command) {
       )
   ).action(async (path, options) => {
     await handleTelemetry(async () => {
-      await printStandloneInitialBanner(true);
+      await printStandloneInitialBanner(true, options.profile);
       await previewArchiveCommand(path, options);
     });
   });

--- a/packages/cli-v3/src/commands/promote.ts
+++ b/packages/cli-v3/src/commands/promote.ts
@@ -49,7 +49,7 @@ export function configurePromoteCommand(program: Command) {
       )
   ).action(async (version, options) => {
     await handleTelemetry(async () => {
-      await printStandloneInitialBanner(true);
+      await printStandloneInitialBanner(true, options.profile);
       await promoteCommand(version, options);
     });
   });

--- a/packages/cli-v3/src/commands/trigger.ts
+++ b/packages/cli-v3/src/commands/trigger.ts
@@ -48,7 +48,7 @@ export function configureTriggerTaskCommand(program: Command) {
 
 export async function triggerTaskCommand(taskName: string, options: unknown) {
   return await wrapCommandAction("trigger", TriggerTaskOptions, options, async (opts) => {
-    await printInitialBanner(false);
+    await printInitialBanner(false, opts.profile);
     return await triggerTask(taskName, opts);
   });
 }

--- a/packages/cli-v3/src/commands/whoami.ts
+++ b/packages/cli-v3/src/commands/whoami.ts
@@ -56,7 +56,7 @@ export function configureWhoamiCommand(program: Command) {
       )
   ).action(async (options) => {
     await handleTelemetry(async () => {
-      await printInitialBanner(false);
+      await printInitialBanner(false, options.profile);
       await whoAmICommand(options);
     });
   });

--- a/packages/cli-v3/src/commands/workers/build.ts
+++ b/packages/cli-v3/src/commands/workers/build.ts
@@ -121,7 +121,7 @@ export function configureWorkersBuildCommand(program: Command) {
     .option("--save-logs", "If provided, will save logs even for successful builds")
     .action(async (path, options) => {
       await handleTelemetry(async () => {
-        await printStandloneInitialBanner(true);
+        await printStandloneInitialBanner(true, options.profile);
         await workersBuildCommand(path, options);
       });
     });

--- a/packages/cli-v3/src/commands/workers/create.ts
+++ b/packages/cli-v3/src/commands/workers/create.ts
@@ -40,7 +40,7 @@ export function configureWorkersCreateCommand(program: Command) {
       )
       .action(async (path, options) => {
         await handleTelemetry(async () => {
-          await printStandloneInitialBanner(true);
+          await printStandloneInitialBanner(true, options.profile);
           await workersCreateCommand(path, options);
         });
       })

--- a/packages/cli-v3/src/commands/workers/list.ts
+++ b/packages/cli-v3/src/commands/workers/list.ts
@@ -39,7 +39,7 @@ export function configureWorkersListCommand(program: Command) {
       )
       .action(async (path, options) => {
         await handleTelemetry(async () => {
-          await printStandloneInitialBanner(true);
+          await printStandloneInitialBanner(true, options.profile);
           await workersListCommand(path, options);
         });
       })

--- a/packages/cli-v3/src/commands/workers/run.ts
+++ b/packages/cli-v3/src/commands/workers/run.ts
@@ -44,7 +44,7 @@ export function configureWorkersRunCommand(program: Command) {
       .option("--network <mode>", "The networking mode for the container", "host")
       .action(async (path, options) => {
         await handleTelemetry(async () => {
-          await printStandloneInitialBanner(true);
+          await printStandloneInitialBanner(true, options.profile);
           await workersRunCommand(path, options);
         });
       })

--- a/packages/cli-v3/src/utilities/initialBanner.ts
+++ b/packages/cli-v3/src/utilities/initialBanner.ts
@@ -11,8 +11,8 @@ import {
 } from "./configFiles.js";
 import { CLOUD_API_URL } from "../consts.js";
 
-function getProfileInfo() {
-  const currentProfile = readAuthConfigCurrentProfileName();
+function getProfileInfo(profileName?: string) {
+  const currentProfile = profileName ?? readAuthConfigCurrentProfileName();
   const profile = readAuthConfigProfile(currentProfile);
 
   if (currentProfile === DEFFAULT_PROFILE || !profile) {
@@ -24,8 +24,8 @@ function getProfileInfo() {
   }`;
 }
 
-export async function printInitialBanner(performUpdateCheck = true) {
-  const profileInfo = getProfileInfo();
+export async function printInitialBanner(performUpdateCheck = true, profile?: string) {
+  const profileInfo = getProfileInfo(profile);
 
   const text = `\n${logo()} ${chalkGrey(`(${VERSION})`)}${
     profileInfo ? chalkGrey(` | ${profileInfo}`) : ""
@@ -62,8 +62,8 @@ After installation, run Trigger.dev with \`npx trigger.dev\`.`
   }
 }
 
-export async function printStandloneInitialBanner(performUpdateCheck = true) {
-  const profileInfo = getProfileInfo();
+export async function printStandloneInitialBanner(performUpdateCheck = true, profile?: string) {
+  const profileInfo = getProfileInfo(profile);
   const profileText = profileInfo ? chalkGrey(` | ${profileInfo}`) : "";
 
   let versionText = `\n${logo()} ${chalkGrey(`(${VERSION})`)}`;


### PR DESCRIPTION
`--profile <name>` overrides were not considered previously, now they are