### PR TITLE
chore(releases): automatically update the lockfile in changeset PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,14 @@ jobs:
           package_version=$(echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[0].version')
           echo "package_version=${package_version}" >> "$GITHUB_OUTPUT"
 
+      # this triggers the publish workflow for the docker images
+      - name: 🏷️ Create and push docker tag
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          set -e
+          git tag "v.docker.${{ steps.get_version.outputs.package_version }}"
+          git push origin "v.docker.${{ steps.get_version.outputs.package_version }}"
+
       - name: Update PR title with version
         if: steps.changesets.outputs.published != 'true'
         env:


### PR DESCRIPTION
This is a step which we currently need to do manually and it's rather painful. The lockfile update is necessary due to cross references in our packages.

Added it as a separate job instead of a step to start from fresh workspace, as the state that the `changeset` step leaves the workdir is not explicitly clear to the reader.
