### PR TITLE
fix(sdk): Re-export schemaTask types to prevent the TypeScript error TS2742

### DIFF
--- a/.changeset/light-donkeys-retire.md
+++ b/.changeset/light-donkeys-retire.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+fix(sdk): Re-export schemaTask types to prevent the TypeScript error TS2742: The inferred type of 'task' cannot be named without a reference to '@trigger.dev/core/v3'. This is likely not portable.

--- a/packages/trigger-sdk/src/v3/shared.ts
+++ b/packages/trigger-sdk/src/v3/shared.ts
@@ -28,7 +28,6 @@ import {
   TaskRunExecutionResult,
   TaskRunPromise,
 } from "@trigger.dev/core/v3";
-import { PollOptions, runs } from "./runs.js";
 import { tracer } from "./tracer.js";
 
 import type {
@@ -115,6 +114,10 @@ export type {
   TaskPayload,
   TaskRunResult,
   TriggerOptions,
+  TaskWithSchema,
+  TaskWithSchemaOptions,
+  TaskSchema,
+  TaskOptionsWithSchema,
 };
 
 export { SubtaskUnwrapError, TaskRunPromise };

--- a/packages/trigger-sdk/src/v3/tasks.ts
+++ b/packages/trigger-sdk/src/v3/tasks.ts
@@ -39,6 +39,10 @@ import type {
   TriggerOptions,
   TaskRunResult,
   TaskFromIdentifier,
+  TaskWithSchemaOptions,
+  TaskSchema,
+  TaskWithSchema,
+  TaskOptionsWithSchema,
 } from "./shared.js";
 
 export type {
@@ -56,6 +60,10 @@ export type {
   TriggerOptions,
   TaskRunResult,
   TaskFromIdentifier,
+  TaskWithSchemaOptions,
+  TaskSchema,
+  TaskWithSchema,
+  TaskOptionsWithSchema,
 };
 
 export type * from "./hooks.js";


### PR DESCRIPTION
Fixes this type of error when exporting a `schemaTask` in a monorepo:

```
error TS2742: The inferred type of 'helloWorldSchema' cannot be named without a reference to '@trigger.dev/core/v3'. This is likely not portable.
```