### PR TITLE
fix(releases): add missing GH token in prerelease workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,8 @@ jobs:
 
       - name: Snapshot version
         run: pnpm exec changeset version --snapshot ${{ github.event.inputs.tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clean
         run: pnpm run clean --filter "@trigger.dev/*" --filter "trigger.dev"


### PR DESCRIPTION
The `changeset version` command needs the GH token too.
