### PR TITLE
fix(api): triggering a batch on a v4 project via the v3 SDK no longer results in errors

### DIFF
--- a/apps/webapp/app/v3/services/batchTriggerV3.server.ts
+++ b/apps/webapp/app/v3/services/batchTriggerV3.server.ts
@@ -849,7 +849,7 @@ export class BatchTriggerV3Service extends BaseService {
         triggerVersion: options?.triggerVersion,
         traceContext: options?.traceContext,
         spanParentAsLink: options?.spanParentAsLink,
-        batchId: batch.friendlyId,
+        batchId: batch.id,
         skipChecks: true,
         runFriendlyId: task.runId,
         realtimeStreamsVersion: options?.realtimeStreamsVersion,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `BatchTriggerV3Service` to send `batch.id` (not `friendlyId`) as `batchId` to `TriggerTaskService.call`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68bf8df4a29bdcac5bfb2806bc417541f69ffd6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->