### PR TITLE
fix(releases): use `contents: write` permission in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm-publish
     permissions:
-      contents: read
+      contents: write
       packages: write
       id-token: write
     if: |


### PR DESCRIPTION
Needed to push tags
