### PR TITLE
fix(deployments): ecr repo exists check

### DIFF
--- a/apps/webapp/app/v3/getDeploymentImageRef.server.ts
+++ b/apps/webapp/app/v3/getDeploymentImageRef.server.ts
@@ -342,7 +342,10 @@ async function getEcrRepository({
 
     return result.repositories[0];
   } catch (error) {
-    if (error instanceof RepositoryNotFoundException) {
+    if (
+      error instanceof RepositoryNotFoundException ||
+      (error instanceof Error && error.message?.includes("does not exist"))
+    ) {
       logger.debug("ECR repository not found: RepositoryNotFoundException", {
         repositoryName,
         region,


### PR DESCRIPTION
We recently upgraded the ECR sdk version. Our ECR repo exists check relies on the type of the error thrown and the new ECR sdk version seems to have broken that behavior. This PR adds a workaround to the issue.
