### PR TITLE
fix(webapp): remove Spline 3D animation to reduce bundle size by ~47%

### DIFF
--- a/apps/webapp/app/components/ErrorDisplay.tsx
+++ b/apps/webapp/app/components/ErrorDisplay.tsx
@@ -1,11 +1,9 @@
 import { HomeIcon } from "@heroicons/react/20/solid";
 import { isRouteErrorResponse, useRouteError } from "@remix-run/react";
-import { motion } from "framer-motion";
 import { friendlyErrorDisplay } from "~/utils/httpErrors";
 import { LinkButton } from "./primitives/Buttons";
 import { Header1 } from "./primitives/Headers";
 import { Paragraph } from "./primitives/Paragraph";
-import Spline from "@splinetool/react-spline";
 import { type ReactNode } from "react";
 
 type ErrorDisplayOptions = {
@@ -44,8 +42,8 @@ type DisplayOptionsProps = {
 
 export function ErrorDisplay({ title, message, button }: DisplayOptionsProps) {
   return (
-    <div className="relative flex min-h-screen flex-col items-center justify-center bg-[#16181C]">
-      <div className="z-10 mt-[30vh] flex flex-col items-center gap-8">
+    <div className="flex min-h-screen flex-col items-center justify-center bg-[#16181C]">
+      <div className="flex flex-col items-center gap-8">
         <Header1>{title}</Header1>
         {message && <Paragraph>{message}</Paragraph>}
         <LinkButton
@@ -57,14 +55,6 @@ export function ErrorDisplay({ title, message, button }: DisplayOptionsProps) {
           {button ? button.title : "Go to homepage"}
         </LinkButton>
       </div>
-      <motion.div
-        className="pointer-events-none absolute inset-0 overflow-hidden"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ delay: 0.5, duration: 2, ease: "easeOut" }}
-      >
-        <Spline scene="https://prod.spline.design/wRly8TZN-e0Twb8W/scene.splinecode" />
-      </motion.div>
     </div>
   );
 }

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -109,7 +109,6 @@
     "@sentry/remix": "9.46.0",
     "@slack/web-api": "7.9.1",
     "@socket.io/redis-adapter": "^8.3.0",
-    "@splinetool/react-spline": "^2.2.6",
     "@tabler/icons-react": "^2.39.0",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tanstack/react-virtual": "^3.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,9 +449,6 @@ importers:
       '@socket.io/redis-adapter':
         specifier: ^8.3.0
         version: 8.3.0(socket.io-adapter@2.5.4(bufferutil@4.0.9))
-      '@splinetool/react-spline':
-        specifier: ^2.2.6
-        version: 2.2.6(@splinetool/runtime@1.11.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tabler/icons-react':
         specifier: ^2.39.0
         version: 2.47.0(react@18.2.0)
@@ -9911,16 +9908,6 @@ packages:
   '@sodaru/yup-to-json-schema@2.0.1':
     resolution: {integrity: sha512-lWb0Wiz8KZ9ip/dY1eUqt7fhTPmL24p6Hmv5Fd9pzlzAdw/YNcWZr+tiCT4oZ4Zyxzi9+1X4zv82o7jYvcFxYA==}
 
-  '@splinetool/react-spline@2.2.6':
-    resolution: {integrity: sha512-y9L2VEbnC6FNZZu8XMmWM9YTTTWal6kJVfP05Amf0QqDNzCSumKsJxZyGUODvuCmiAvy0PfIfEsiVKnSxvhsDw==}
-    peerDependencies:
-      '@splinetool/runtime': '*'
-      react: '>=17.0.0'
-      react-dom: '>=17.0.0'
-
-  '@splinetool/runtime@1.11.2':
-    resolution: {integrity: sha512-rFz3KOQQRHQGzWBvPKRZcI7fZe5qxNYX1FmmCqzsbJkAU/hJdifaxpyN4xESpbkdta6s7riSmoz5lmPGIpZRRQ==}
-
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -16237,10 +16224,6 @@ packages:
     resolution: {integrity: sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==}
     engines: {node: ^10.13.0 || >=12.0.0}
 
-  on-change@4.0.2:
-    resolution: {integrity: sha512-cMtCyuJmTx/bg2HCpHo3ZLeF7FZnBOapLqZHr2AlLeJ5Ul0Zu2mUJJz051Fdwu/Et2YW04ZD+TtU+gVy0ACNCA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -17367,9 +17350,6 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
-  react-merge-refs@2.1.1:
-    resolution: {integrity: sha512-jLQXJ/URln51zskhgppGJ2ub7b2WFKGq3cl3NYKtlHoTG+dN2q7EzWrn3hN3EgPsTMvpR9tpq5ijdp7YwFZkag==}
-
   react-popper@2.3.0:
     resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
     peerDependencies:
@@ -17946,9 +17926,6 @@ packages:
 
   sembear@0.5.2:
     resolution: {integrity: sha512-Ij1vCAdFgWABd7zTg50Xw1/p0JgESNxuLlneEAsmBrKishA06ulTTL/SHGmNy2Zud7+rKrHTKNI6moJsn1ppAQ==}
-
-  semver-compare@1.0.0:
-    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
 
   semver@5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
@@ -30067,19 +30044,6 @@ snapshots:
 
   '@sodaru/yup-to-json-schema@2.0.1': {}
 
-  '@splinetool/react-spline@2.2.6(@splinetool/runtime@1.11.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@splinetool/runtime': 1.11.2
-      lodash.debounce: 4.0.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-merge-refs: 2.1.1
-
-  '@splinetool/runtime@1.11.2':
-    dependencies:
-      on-change: 4.0.2
-      semver-compare: 1.0.0
-
   '@standard-schema/spec@1.0.0': {}
 
   '@stricli/auto-complete@1.2.0':
@@ -37550,8 +37514,6 @@ snapshots:
   oidc-token-hash@5.0.3:
     optional: true
 
-  on-change@4.0.2: {}
-
   on-exit-leak-free@2.1.2: {}
 
   on-finished@2.3.0:
@@ -38898,8 +38860,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-merge-refs@2.1.1: {}
-
   react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@popperjs/core': 2.11.8
@@ -39642,8 +39602,6 @@ snapshots:
     dependencies:
       '@types/semver': 6.2.3
       semver: 6.3.1
-
-  semver-compare@1.0.0: {}
 
   semver@5.7.1: {}
 


### PR DESCRIPTION
I noticed the dashboard takes a while(20-30seconds) to load sometimes and that led me investigate the reason. I found out one of the JS chunks is 2035kb, which is almost half of the whole JS chunks. 

[That chunk](https://cloud.trigger.dev/build/_shared/chunk-TNKKYXTE.js) is three.js library. Which is a dependency for `@splinetool/react-spline`, which is only being used to render a spline scene on the error page. 

As a user, I prefer to have a fast loading dashboard instead of a fancy 3D animation on an error page. Though, same/similar animation can be achieved via lottie or as css animation probably, which will have much smaller size.   

This change basically **reduces JS bundle size from 4283kb to 2248kb**. Even though the assets are being cached I get this slow loading dashboard several times per day. I find that a bit poor UX. 

Further optimization is possible by implementing tree shaking to [companyicons](https://github.com/triggerdotdev/companyicons) to bundle only used icons to the build instead of all the icons. That would probably cut another ~600kb since [webapp is using only 5 icons from there](https://github.com/search?q=repo%3Atriggerdotdev%2Ftrigger.dev+companyicons+path%3A%2F%5Eapps%5C%2Fwebapp%5C%2F%2F&type=code) but loading whole 748kb.

Also noticed the assets are being served without gzip on production, which would improve the situation if you want to keep the animation.

```bash
 > curl -I -H "Accept-Encoding: gzip, br" https://cloud.trigger.dev/build/_shared/chunk-TNKKYXTE.js 2>&1

content-type: application/javascript; charset=UTF-8
```

I'm noticing this issue since currently I'm in Türkiye and have a high latency to US-East. Probably a CDN would help a lot too!

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Ran locally and went to a 404 page.

---

## Changelog

fix(webapp): remove Spline 3D animation to reduce bundle size

---

## Screenshots

### Before

<img width="580" height="438" alt="image" src="https://github.com/user-attachments/assets/209792f8-7c84-4e26-86ed-345f0add5b43" />

### After 

<img width="893" height="713" alt="image" src="https://github.com/user-attachments/assets/48436331-e2f3-46c1-b38d-0c46cae98ca3" />

### Resources

<img width="1153" height="480" alt="image" src="https://github.com/user-attachments/assets/0a8afce3-9890-4540-ad15-07e90d95d9b7" />

💯
