### PR TITLE
chore(releases): minor improvements to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,13 +146,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.inputs.ref }}
 
-      - name: Verify ref is on main
-        run: |
-          if ! git merge-base --is-ancestor ${{ github.event.inputs.ref }} origin/main; then
-            echo "Error: ref must be an ancestor of main (i.e., already merged)"
-            exit 1
-          fi
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
Changes in this PR:
- Arbitrary refs are now allowed when triggering the release workflow manually (ref must be on the main branch).
- Release summary is now displayed in the GH job output; makes for a nicer experience when approving the release workflow.
