### PR TITLE
fix(api): whitelist deployment endpoints from the general API rate limits

### DIFF
--- a/apps/webapp/app/services/apiRateLimit.server.ts
+++ b/apps/webapp/app/services/apiRateLimit.server.ts
@@ -61,6 +61,7 @@ export const apiRateLimiter = authorizationRateLimitMiddleware({
     "/api/v1/auth/jwt/claims",
     /^\/api\/v1\/runs\/[^\/]+\/attempts$/, // /api/v1/runs/$runFriendlyId/attempts
     /^\/api\/v1\/waitpoints\/tokens\/[^\/]+\/callback\/[^\/]+$/, // /api/v1/waitpoints/tokens/$waitpointFriendlyId/callback/$hash
+    /^\/api\/v1\/deployments/, // /api/v1/deployments/*
   ],
   log: {
     rejections: env.API_RATE_LIMIT_REJECTION_LOGS_ENABLED === "1",


### PR DESCRIPTION
Deployments are affected by general API rate limits, this is just a quick fix by whitelisting the deployment related endpoints. In a follow up PR we'll add a separate rate limiter for this group of endpoints.
