### PR TITLE
chore(ci): add manual trigger to the image publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: 🚀 Publish Trigger.dev Docker
 
 on:
+  repository_dispatch:
   workflow_call:
     inputs:
       image_tag:


### PR DESCRIPTION
Useful to retry failures manually.
