### PR TITLE
fix(webapp): concurrency limits modal cancels and resets limit on enter

### DIFF
--- a/apps/webapp/app/components/primitives/FormButtons.tsx
+++ b/apps/webapp/app/components/primitives/FormButtons.tsx
@@ -3,10 +3,12 @@ import { cn } from "~/utils/cn";
 export function FormButtons({
   cancelButton,
   confirmButton,
+  defaultAction,
   className,
 }: {
   cancelButton?: React.ReactNode;
   confirmButton: React.ReactNode;
+  defaultAction?: { name: string; value: string; disabled?: boolean };
   className?: string;
 }) {
   return (
@@ -16,6 +18,17 @@ export function FormButtons({
         className
       )}
     >
+      {defaultAction && (
+        <button
+          type="submit"
+          name={defaultAction.name}
+          value={defaultAction.value}
+          disabled={defaultAction.disabled}
+          className="hidden"
+          tabIndex={-1}
+          aria-hidden="true"
+        />
+      )}
       {cancelButton ? cancelButton : <div />} {confirmButton}
     </div>
   );

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -984,16 +984,6 @@ function QueueOverrideConcurrencyButton({
             </Paragraph>
           )}
           <Form method="post" onSubmit={() => setIsOpen(false)} className="space-y-3">
-            {/* Hidden button to capture Enter key for primary action */}
-            <button
-              type="submit"
-              name="action"
-              value="queue-override"
-              disabled={isLoading || !concurrencyLimit}
-              className="hidden"
-              tabIndex={-1}
-              aria-hidden="true"
-            />
             <input type="hidden" name="friendlyId" value={queue.id} />
             <div className="space-y-2">
               <label htmlFor="concurrencyLimit" className="text-sm text-text-bright">
@@ -1013,6 +1003,11 @@ function QueueOverrideConcurrencyButton({
             </div>
 
             <FormButtons
+              defaultAction={{
+                name: "action",
+                value: "queue-override",
+                disabled: isLoading || !concurrencyLimit,
+              }}
               confirmButton={
                 <Button
                   type="submit"


### PR DESCRIPTION
The Override concurrency limit modal has 2 type="submit" buttons. The first one in the DOM was firing when the "enter" key is hit which canceled and reset the limit instead which is a bad UX.

### The fix
This fix adds a hidden button above in the DOM order which mirrors the Update Override button. Having a double submit button is rare in our modals so feels safe to add this to the specific modal that needs it.

### Alternative solution
Switching the order of the buttons in the main FormButton component, then using `flex-row-reverse` to flip them back in CSS works, but it reverses the tab order. Adding a `tabIndex` to fix that issue didn't seem to work reliably.