### PR TITLE
fix(webapp): don't rate limit deployment finalization

### DIFF
--- a/apps/webapp/app/services/apiRateLimit.server.ts
+++ b/apps/webapp/app/services/apiRateLimit.server.ts
@@ -61,7 +61,7 @@ export const apiRateLimiter = authorizationRateLimitMiddleware({
     "/api/v1/auth/jwt/claims",
     /^\/api\/v1\/runs\/[^\/]+\/attempts$/, // /api/v1/runs/$runFriendlyId/attempts
     /^\/api\/v1\/waitpoints\/tokens\/[^\/]+\/callback\/[^\/]+$/, // /api/v1/waitpoints/tokens/$waitpointFriendlyId/callback/$hash
-    /^\/api\/v1\/deployments/, // /api/v1/deployments/*
+    /^\/api\/v\d+\/deployments/, // /api/v{1,2,3,n}/deployments/*
   ],
   log: {
     rejections: env.API_RATE_LIMIT_REJECTION_LOGS_ENABLED === "1",


### PR DESCRIPTION
turns out we also had v2 and v3 routes