### PR TITLE
fix(cli): update command should preserve existing package.json order

### DIFF
--- a/.changeset/cool-elephants-carry.md
+++ b/.changeset/cool-elephants-carry.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+fix(cli): update command should preserve existing package.json order

--- a/packages/cli-v3/src/commands/update.ts
+++ b/packages/cli-v3/src/commands/update.ts
@@ -1,12 +1,12 @@
 import { confirm, intro, isCancel, log, outro } from "@clack/prompts";
 import { Command } from "commander";
 import { detectPackageManager, installDependencies } from "nypm";
-import { basename, dirname, join, resolve } from "path";
+import { dirname, join, resolve } from "path";
 import { PackageJson, readPackageJSON, type ResolveOptions, resolvePackageJSON } from "pkg-types";
 import { z } from "zod";
 import { CommonCommandOptions, OutroCommandError, wrapCommandAction } from "../cli/common.js";
 import { chalkError, prettyError, prettyWarning } from "../utilities/cliOutput.js";
-import { removeFile, writeJSONFile } from "../utilities/fileSystem.js";
+import { removeFile, writeJSONFilePreserveOrder } from "../utilities/fileSystem.js";
 import { printStandloneInitialBanner, updateCheck } from "../utilities/initialBanner.js";
 import { logger } from "../utilities/logger.js";
 import { spinner } from "../utilities/windows.js";
@@ -227,7 +227,7 @@ export async function updateTriggerPackages(
 
   // Backup package.json
   const packageJsonBackupPath = `${packageJsonPath}.bak`;
-  await writeJSONFile(packageJsonBackupPath, readonlyPackageJson, true);
+  await writeJSONFilePreserveOrder(packageJsonBackupPath, readonlyPackageJson, true);
 
   const exitHandler = async (sig: any) => {
     log.warn(
@@ -241,10 +241,10 @@ export async function updateTriggerPackages(
 
   // Update package.json
   mutatePackageJsonWithUpdatedPackages(packageJson, mismatches, cliVersion);
-  await writeJSONFile(packageJsonPath, packageJson, true);
+  await writeJSONFilePreserveOrder(packageJsonPath, packageJson, true);
 
   async function revertPackageJsonChanges() {
-    await writeJSONFile(packageJsonPath, readonlyPackageJson, true);
+    await writeJSONFilePreserveOrder(packageJsonPath, readonlyPackageJson, true);
     await removeFile(packageJsonBackupPath);
   }
 

--- a/packages/cli-v3/src/utilities/fileSystem.ts
+++ b/packages/cli-v3/src/utilities/fileSystem.ts
@@ -159,8 +159,24 @@ export async function safeReadJSONFile(path: string) {
   }
 }
 
+/**
+ * Use this for deterministic builds. Uses `json-stable-stringify` to sort keys alphabetically.
+ * @param path - The path to the file to write
+ * @param json - The JSON object to write
+ * @param pretty - Whether to pretty print the JSON
+ */
 export async function writeJSONFile(path: string, json: any, pretty = false) {
   await safeWriteFile(path, stringify(json, pretty ? { space: 2 } : undefined) ?? "");
+}
+
+/**
+ * Use this when you want to preserve the original key ordering (e.g. user's package.json)
+ * @param path - The path to the file to write
+ * @param json - The JSON object to write
+ * @param pretty - Whether to pretty print the JSON
+ */
+export async function writeJSONFilePreserveOrder(path: string, json: any, pretty = false) {
+  await safeWriteFile(path, JSON.stringify(json, undefined, pretty ? 2 : undefined));
 }
 
 // Will create the directory if it doesn't exist


### PR DESCRIPTION
This fixes a regression introduced in #2778 - stable sort is required for deterministic builds, but we can safely preserve order for the user package.json during package updates