### PR TITLE
fix(fair-queue): Prevent unbounded memory growth from metrics cardinality explosion

### DIFF
--- a/packages/redis-worker/src/fair-queue/telemetry.ts
+++ b/packages/redis-worker/src/fair-queue/telemetry.ts
@@ -324,7 +324,8 @@ export class FairQueueTelemetry {
   // ============================================================================
 
   /**
-   * Create standard attributes for a message operation.
+   * Create standard attributes for a message operation (for spans/traces).
+   * Use this for span attributes where high cardinality is acceptable.
    */
   messageAttributes(params: {
     queueId?: string;


### PR DESCRIPTION
Fix: Prevent unbounded memory growth from metrics cardinality explosion

  Problem

  After deploying the batch queue system, the engine worker service experienced event loop lag (5-8+ seconds) that
  would build up over 5-6 hours of operation and resolve on restart. Investigation revealed that OpenTelemetry metrics
   were being recorded with high-cardinality attributes (messageId, queueId), causing the metrics SDK to accumulate
  unbounded aggregator state over time.

  Changes

  - Remove high-cardinality attributes from all metric recording calls in FairQueue
  - Metrics are now recorded without dimensions to prevent cardinality explosion
  - Span/trace attributes remain unchanged for detailed per-message observability
  - Simplify getDynamicAttributes callback to only include cache sizes

  Why this works

  Each unique attribute combination in OpenTelemetry metrics creates a new time series with its own aggregator. With
  messageId (unique per message) and queueId (unique per batch) as attributes, the SDK was accumulating millions of
  aggregators over hours of operation, causing:
  - Slow memory growth
  - Network TX growing faster than memory (more data to export)
  - Event loop blocking during SDK operations (export, GC)