### PR TITLE
docs: fix some mermaid diagrams not rendering

### DIFF
--- a/docs/guides/use-cases/data-processing-etl.mdx
+++ b/docs/guides/use-cases/data-processing-etl.mdx
@@ -89,15 +89,12 @@ graph TB
 graph TB
     A[runETLPipeline] --> B[coordinateExtraction]
     B --> C[batchTriggerAndWait]
-
     C --> D[extractFromAPI]
     C --> E[extractFromDatabase]
     C --> F[extractFromS3]
-
     D --> G[transformData]
     E --> G
     F --> G
-
     G --> H[validateData]
     H --> I[loadToWarehouse]
 ```
@@ -114,15 +111,12 @@ graph TB
 graph TB
     A[scrapeSite] --> B[coordinateScraping]
     B --> C[batchTriggerAndWait]
-
     C --> D[scrapePage1]
     C --> E[scrapePage2]
     C --> F[scrapePageN]
-
     D --> G[cleanData]
     E --> G
     F --> G
-
     G --> H[normalizeData]
     H --> I[storeInDatabase]
 ```
@@ -140,15 +134,12 @@ graph TB
     A[enrichRecords] --> B[fetchRecordsToEnrich]
     B --> C[coordinateEnrichment]
     C --> D[batchTriggerAndWait]
-
     D --> E[enrichRecord1]
     D --> F[enrichRecord2]
     D --> G[enrichRecordN]
-
     E --> H[validateEnrichedData]
     F --> H
     G --> H
-
     H --> I[updateDatabase]
 ```
 

--- a/docs/guides/use-cases/marketing.mdx
+++ b/docs/guides/use-cases/marketing.mdx
@@ -81,7 +81,7 @@ graph TB
 graph TB
     A[startCampaign] --> B[fetchUserProfile]
     B --> C[selectChannel]
-    C --> D{Preferred<br/>Channel?}
+    C --> D{Channel?}
     D -->|Email| E[sendEmail1]
     D -->|SMS| F[sendSMS1]
     D -->|Push| G[sendPush1]

--- a/docs/guides/use-cases/marketing.mdx
+++ b/docs/guides/use-cases/marketing.mdx
@@ -67,7 +67,6 @@ graph TB
     C --> D[sendProductTipsEmail]
     D --> E[wait.for 7d]
     E --> F[sendFeedbackEmail]
-
 ```
 
 </div>
@@ -83,15 +82,12 @@ graph TB
     A[startCampaign] --> B[fetchUserProfile]
     B --> C[selectChannel]
     C --> D{Preferred<br/>Channel?}
-
     D -->|Email| E[sendEmail1]
     D -->|SMS| F[sendSMS1]
     D -->|Push| G[sendPush1]
-
     E --> H[wait.for 2d]
     F --> H
     G --> H
-
     H --> I[sendFollowUp]
     I --> J[trackConversion]
 ```
@@ -109,7 +105,6 @@ graph TB
     A[createCampaignAssets] --> B[generateAIContent]
     B --> C[wait.forToken approval]
     C --> D{Approved?}
-
     D -->|Yes| E[publishToChannels]
     D -->|Needs revision| F[applyFeedback]
     F --> B
@@ -127,15 +122,12 @@ graph TB
 graph TB
     A[processSurveyResponse] --> B[coordinateEnrichment]
     B --> C[batchTriggerAndWait]
-
     C --> D[fetchCRMData]
     C --> E[fetchAnalytics]
     C --> F[fetchBehaviorData]
-
     D --> G[analyzeAndScore]
     E --> G
     F --> G
-
     G --> H[updateCRMProfile]
     H --> I[triggerFollowUp]
 ```

--- a/docs/guides/use-cases/media-generation.mdx
+++ b/docs/guides/use-cases/media-generation.mdx
@@ -74,7 +74,6 @@ graph TB
     A[generateContent] --> B[createWithAI]
     B --> C[wait.forToken approval]
     C --> D{Approved?}
-
     D -->|Yes| E[publishContent]
     D -->|Needs revision| F[applyFeedback]
     F --> B
@@ -106,15 +105,12 @@ graph TB
 graph TB
     A[processBatch] --> B[coordinateGeneration]
     B --> C[batchTriggerAndWait]
-
     C --> D[generateImage1]
     C --> E[generateImage2]
     C --> F[generateImageN]
-
     D --> G[validateResults]
     E --> G
     F --> G
-
     G --> H[storeResults]
     H --> I[notifyCompletion]
 ```

--- a/docs/guides/use-cases/media-processing.mdx
+++ b/docs/guides/use-cases/media-processing.mdx
@@ -71,7 +71,7 @@ graph TB
 ```mermaid
 graph TB
     A[processVideoUpload] --> B[analyzeMetadata]
-    B --> C{Source<br/>Resolution?}
+    B --> C{Resolution?}
     C -->|4K Source| D[transcode4K]
     C -->|HD Source| E[transcodeHD]
     C -->|SD Source| F[transcodeSD]
@@ -99,7 +99,7 @@ graph TB
 ```mermaid
 graph TB
     A[processImageUpload] --> B[analyzeContent]
-    B --> C{Content<br/>Type?}
+    B --> C{Content Type?}
     C -->|Product| D[removeBackground]
     C -->|Portrait| E[detectFaces]
     C -->|Landscape| F[analyzeScene]
@@ -157,7 +157,7 @@ graph TB
     F -->|Invoice| G[extractLineItems]
     F -->|Contract| H[extractClauses]
     F -->|Receipt| I[extractExpenses]
-    G --> J{Needs<br/>Review?}
+    G --> J{Needs Review?}
     H --> J
     I --> J
     J -->|Yes| K[wait.forToken approval]

--- a/docs/guides/use-cases/media-processing.mdx
+++ b/docs/guides/use-cases/media-processing.mdx
@@ -52,11 +52,9 @@ Build media processing pipelines that handle large files and long-running operat
 graph TB
     A[processVideo] --> B[downloadFromStorage]
     B --> C[batchTriggerAndWait]
-
     C --> D[transcodeToHD]
     C --> E[transcodeToSD]
     C --> F[extractThumbnail]
-
     D --> G[uploadToStorage]
     E --> G
     F --> G
@@ -74,24 +72,19 @@ graph TB
 graph TB
     A[processVideoUpload] --> B[analyzeMetadata]
     B --> C{Source<br/>Resolution?}
-
     C -->|4K Source| D[transcode4K]
     C -->|HD Source| E[transcodeHD]
     C -->|SD Source| F[transcodeSD]
-
     D --> G[coordinatePostProcessing]
     E --> G
     F --> G
-
     G --> H[batchTriggerAndWait]
     H --> I[extractThumbnails]
     H --> J[generatePreview]
     H --> K[detectChapters]
-
     I --> L[uploadToStorage]
     J --> L
     K --> L
-
     L --> M[notifyComplete]
 ```
 
@@ -107,20 +100,16 @@ graph TB
 graph TB
     A[processImageUpload] --> B[analyzeContent]
     B --> C{Content<br/>Type?}
-
     C -->|Product| D[removeBackground]
     C -->|Portrait| E[detectFaces]
     C -->|Landscape| F[analyzeScene]
-
     D --> G[upscaleWithAI]
     E --> G
     F --> G
-
     G --> H[batchTriggerAndWait]
     H --> I[generateWebP]
     H --> J[generateThumbnails]
     H --> K[generateSocialCrops]
-
     I --> L[uploadToStorage]
     J --> L
     K --> L
@@ -138,16 +127,13 @@ graph TB
 graph TB
     A[processAudioUpload] --> B[cleanAudio]
     B --> C[coordinateProcessing]
-
     C --> D[batchTriggerAndWait]
     D --> E[transcribeWithDeepgram]
     D --> F[enhanceAudio]
     D --> G[detectChapters]
-
     E --> H[generateShowNotes]
     F --> H
     G --> H
-
     H --> I[publishToPlatforms]
 ```
 
@@ -162,23 +148,18 @@ graph TB
 ```mermaid
 graph TB
     A[processDocumentUpload] --> B[detectFileType]
-
     B -->|PDF| C[extractText]
     B -->|Word/Excel| D[convertToPDF]
     B -->|Image| E[runOCR]
-
     C --> F[classifyDocument]
     D --> F
     E --> F
-
     F -->|Invoice| G[extractLineItems]
     F -->|Contract| H[extractClauses]
     F -->|Receipt| I[extractExpenses]
-
     G --> J{Needs<br/>Review?}
     H --> J
     I --> J
-
     J -->|Yes| K[wait.forToken approval]
     J -->|No| L[processAndIntegrate]
     K --> L


### PR DESCRIPTION
Remove blank lines from mermaid code blocks that were causing diagrams to not render in non-first tabs. Mintlify's mermaid parser interprets blank lines inside code blocks as terminating the diagram definition.

Closes #2827 