### PR TITLE
feat: add reverse replay tracking with "Replayed as" section in Details tab

### DIFF
--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -707,6 +707,40 @@ function RunBody({
                     </Property.Value>
                   </Property.Item>
                 )}
+                {run.replays && run.replays.length > 0 && (
+                  <Property.Item>
+                    <Property.Label>Replayed as</Property.Label>
+                    <Property.Value>
+                      <div className="flex flex-col gap-1">
+                        {run.replays.map((replay) => (
+                          <SimpleTooltip
+                            key={replay.friendlyId}
+                            button={
+                              <TextLink
+                                to={v3RunRedirectPath(organization, project, {
+                                  friendlyId: replay.friendlyId,
+                                })}
+                                className="flex items-center gap-1"
+                              >
+                                <CopyableText
+                                  value={replay.friendlyId}
+                                  copyValue={replay.friendlyId}
+                                  asChild
+                                />
+                                <TaskRunStatusCombo
+                                  status={replay.status as any}
+                                  className="text-xs"
+                                />
+                              </TextLink>
+                            }
+                            content={`Jump to replay run`}
+                            disableHoverableContent
+                          />
+                        ))}
+                      </div>
+                    </Property.Value>
+                  </Property.Item>
+                )}
                 {environment && (
                   <Property.Item>
                     <Property.Label>Environment</Property.Label>

--- a/apps/webapp/app/services/runsReplicationService.server.ts
+++ b/apps/webapp/app/services/runsReplicationService.server.ts
@@ -831,6 +831,7 @@ export class RunsReplicationService {
       concurrency_key: run.concurrencyKey ?? "",
       bulk_action_group_ids: run.bulkActionGroupIds ?? [],
       worker_queue: run.masterQueue,
+      replayed_from_friendly_id: run.replayedFromTaskRunFriendlyId ?? "",
       _version: _version.toString(),
       _is_deleted: event === "delete" ? 1 : 0,
     };

--- a/internal-packages/clickhouse/schema/012_add_task_runs_v2_replayed_from.sql
+++ b/internal-packages/clickhouse/schema/012_add_task_runs_v2_replayed_from.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+/*
+Add replayed_from_friendly_id column to track which run this was replayed from.
+ */
+ALTER TABLE trigger_dev.task_runs_v2
+ADD COLUMN replayed_from_friendly_id String DEFAULT '';
+
+-- +goose Down
+ALTER TABLE trigger_dev.task_runs_v2
+DROP COLUMN replayed_from_friendly_id;

--- a/internal-packages/clickhouse/src/index.ts
+++ b/internal-packages/clickhouse/src/index.ts
@@ -12,6 +12,7 @@ import {
   getTaskUsageByOrganization,
   getTaskRunsCountQueryBuilder,
   getTaskRunTagsQueryBuilder,
+  getRunReplays,
 } from "./taskRuns.js";
 import {
   getSpanDetailsQueryBuilder,
@@ -164,6 +165,7 @@ export class ClickHouse {
       getCurrentRunningStats: getCurrentRunningStats(this.reader),
       getAverageDurations: getAverageDurations(this.reader),
       getTaskUsageByOrganization: getTaskUsageByOrganization(this.reader),
+      getRunReplays: getRunReplays(this.reader),
     };
   }
 


### PR DESCRIPTION
- Add replayed_from_friendly_id column to ClickHouse task_runs_v2 table
- Create migration 012_add_task_runs_v2_replayed_from.sql
- Update replication service to include the new field
- Add getRunReplays query to ClickHouse client (optimized with org/project/env filter)
- Update SpanPresenter to query replays from ClickHouse
- Add "Replayed as" section in run Details tab showing linked replay runs with status

The ClickHouse query filters by organization_id, project_id, and environment_id
in the correct order to match the primary key for optimal query performance.

This enables users to see which runs have been replayed from the original run,
addressing the feedback about tracking replay status of failed runs.

Slack thread: https://triggerdotdev.slack.com/archives/C045W9WM3E1/p1767609682537389