### PR TITLE
feat(runs): add clientConfig support to runs.retrieve() and runs.poll()

### DIFF
--- a/.changeset/runs-retrieve-request-options.md
+++ b/.changeset/runs-retrieve-request-options.md
@@ -1,0 +1,11 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+feat(runs): add clientConfig support to runs.retrieve() and runs.poll()
+
+This change updates `runs.retrieve()` and `runs.poll()` to accept `TriggerApiRequestOptions` instead of `ApiRequestOptions`, enabling per-request client configuration via the `clientConfig` property.
+
+This aligns `runs.retrieve()` with other SDK methods like `tasks.trigger()` that already support `clientConfig` for multi-project scenarios where different access tokens are needed per request.
+
+Fixes #2769

--- a/packages/trigger-sdk/src/v3/runs.ts
+++ b/packages/trigger-sdk/src/v3/runs.ts
@@ -16,6 +16,7 @@ import type {
   AsyncIterableStream,
   ApiPromise,
   RealtimeRunSkipColumns,
+  TriggerApiRequestOptions,
 } from "@trigger.dev/core/v3";
 import {
   CanceledRunResponse,
@@ -167,9 +168,9 @@ type RunId<TRunId> = TRunId extends AnyRunHandle | AnyBatchedRunHandle
 
 function retrieveRun<TRunId extends AnyRunHandle | AnyBatchedRunHandle | AnyTask | string>(
   runId: RunId<TRunId>,
-  requestOptions?: ApiRequestOptions
+  requestOptions?: TriggerApiRequestOptions
 ): ApiPromise<RetrieveRunResult<TRunId>> {
-  const apiClient = apiClientManager.clientOrThrow();
+  const apiClient = apiClientManager.clientOrThrow(requestOptions?.clientConfig);
 
   const $requestOptions = mergeRequestOptions(
     {
@@ -316,7 +317,7 @@ const MAX_POLL_ATTEMPTS = 500;
 async function poll<TRunId extends AnyRunHandle | AnyTask | string>(
   runId: RunId<TRunId>,
   options?: { pollIntervalMs?: number },
-  requestOptions?: ApiRequestOptions
+  requestOptions?: TriggerApiRequestOptions
 ) {
   let attempts = 0;
 


### PR DESCRIPTION
This PR fixes the missing `requestOptions.clientConfig` support in `runs.retrieve()` and `runs.poll()`.

## What changed

- Changed `requestOptions` parameter type from `ApiRequestOptions` to `TriggerApiRequestOptions` in `runs.retrieve()` and `runs.poll()`
- Added `requestOptions?.clientConfig` parameter to `apiClientManager.clientOrThrow()` call

## Why it failed before

`runs.retrieve()` accepted `ApiRequestOptions` which lacks the `clientConfig` property. Users with multiple trigger projects (different access tokens) could not pass per-request client configuration, unlike `tasks.trigger()` which already supports this pattern.

## Why this fix works

`TriggerApiRequestOptions` extends `ApiRequestOptions` with `clientConfig` and `publicAccessToken` properties. The `apiClientManager.clientOrThrow()` already accepts `clientConfig` as an optional parameter. This change aligns `runs.retrieve()` with other SDK methods that already support per-request configuration.

## Risk assessment

Low risk:
- Backward compatible: `TriggerApiRequestOptions` extends `ApiRequestOptions`
- No behavioral change for callers not using `clientConfig`
- Pattern already established in `tasks.trigger()` and other SDK methods

---

To make this production-safe, the remaining work is:
- Audit all other `runs.*` methods for missing `clientConfig` support (`replay`, `cancel`, `reschedule`, `list`, `subscribeToRun`, etc.)
- Audit all SDK modules for consistent `TriggerApiRequestOptions` usage
- Add integration tests for multi-project scenarios

This is ~2-3 days.
I can own this as a short paid engagement; otherwise this PR stands on its own.

Fixes #2769