### PR TITLE
fix(webapp): cancel button in API key regeneration modal

### DIFF
--- a/apps/webapp/app/components/environments/RegenerateApiKeyModal.tsx
+++ b/apps/webapp/app/components/environments/RegenerateApiKeyModal.tsx
@@ -94,7 +94,11 @@ const RegenerateApiKeyModalContent = ({ id, randomWord, title, closeModal }: Mod
                 Regenerate
               </Button>
             }
-            cancelButton={<Button variant={"tertiary/medium"}>Cancel</Button>}
+            cancelButton={
+              <Button variant={"tertiary/medium"} type="button" onClick={closeModal}>
+                Cancel
+              </Button>
+            }
           />
         </Fieldset>
       </fetcher.Form>


### PR DESCRIPTION
The Cancel button was missing an onClick handler to close the modal dialog. This caused confusing behavior where clicking Cancel would not dismiss the dialog. Also added type="button" to prevent form submission since the button is inside a form.
