### PR TITLE
docs: fix waitpoint token completion request body field

### DIFF
--- a/docs/wait-for-token.mdx
+++ b/docs/wait-for-token.mdx
@@ -177,7 +177,7 @@ You can complete a token using a raw HTTP request or from another language.
 curl -X POST "https://api.trigger.dev/api/v1/waitpoints/tokens/{tokenId}/complete" \
   -H "Authorization: Bearer {token}" \
   -H "Content-Type: application/json" \
-  -d '{"output": { "status": "approved"}}'
+  -d '{"data": { "status": "approved"}}'
 ```
 
 ```python python
@@ -186,7 +186,7 @@ import requests
 response = requests.post(
   "https://api.trigger.dev/api/v1/waitpoints/tokens/{tokenId}/complete",
   headers={"Authorization": f"Bearer {token}"},
-  json={"output": { "status": "approved"}}
+  json={"data": { "status": "approved"}}
 )
 ```
 
@@ -199,7 +199,7 @@ http = Net::HTTP.new(uri.host, uri.port)
 request = Net::HTTP::Post.new(uri)
 request["Authorization"] = "Bearer {token}"
 request["Content-Type"] = "application/json"
-request.body = JSON.generate({ output: { status: "approved" } })
+request.body = JSON.generate({ data: { status: "approved" } })
 
 response = http.request(request)
 ```
@@ -218,7 +218,7 @@ func main() {
 	url := "https://api.trigger.dev/api/v1/waitpoints/tokens/{tokenId}/complete"
 
 	payload := map[string]interface{}{
-		"output": map[string]interface{}{
+		"data": map[string]interface{}{
 			"status": "approved",
 		},
 	}


### PR DESCRIPTION
Fixed documentation examples to use correct 'data' field instead of 'output' for the waitpoint token completion endpoint.

The API schema expects 'data' in the request body, but all code examples (curl, Python, Ruby, Go) incorrectly showed 'output', causing waitpoints to complete with empty/undefined output when users followed the docs.

Fixes #2872

Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

_[Describe the steps you took to test this change]_
This is simple doc fix
---

## Changelog

_[Short description of what has changed]_
Documentation example  for the specific api route  had a wrong field, fixed that to have correct field

---

## Screenshots

_[Screenshots]_
<img width="780" height="252" alt="Screenshot 2026-01-14 at 10 49 50 PM" src="https://github.com/user-attachments/assets/50a03f2c-edfb-4bd4-bb72-a0fd79e77216" />
The above image shows the correct request format, but docs previously had incorrect payload.
<img width="723" height="307" alt="Screenshot 2026-01-14 at 11 24 01 PM" src="https://github.com/user-attachments/assets/b9096225-3f7c-4511-b8c2-e8144c896900" />
This is the exact wrong field in docs, that was fixed https://trigger.dev/docs/wait-for-token#from-another-language


💯
