### PR TITLE
fix(core): harden zodSocket protocol detection against payload field ambiguity

### DIFF
--- a/packages/core/test/zodSocket.test.ts
+++ b/packages/core/test/zodSocket.test.ts
@@ -1,0 +1,389 @@
+import { describe, it, expect, vi } from "vitest";
+import { ZodSocketMessageHandler } from "../src/v3/zodSocket.js";
+import { z } from "zod";
+import { EventEmitter } from "events";
+
+describe("ZodSocketMessageHandler", () => {
+    describe("normalizeMessage - Protocol Detection", () => {
+        it("should correctly identify wrapped messages with version and payload", async () => {
+            const catalog = {
+                TEST: {
+                    message: z.object({
+                        data: z.string(),
+                    }),
+                },
+            };
+
+            const handlerFn = vi.fn();
+            const handler = new ZodSocketMessageHandler({
+                schema: catalog,
+                handlers: {
+                    TEST: async (data) => {
+                        handlerFn(data);
+                    },
+                },
+            });
+
+            const mockSocket = new EventEmitter();
+            handler.registerHandlers(mockSocket as any);
+
+            // Send a properly wrapped message (as ZodMessageSender would)
+            mockSocket.emit("TEST", {
+                version: "v1",
+                payload: { data: "hello" },
+            });
+
+            // Should receive the unwrapped payload
+            expect(handlerFn).toHaveBeenCalledWith({ data: "hello" });
+        });
+
+        it("should wrap unwrapped messages that lack version", async () => {
+            const catalog = {
+                TEST: {
+                    message: z.object({
+                        data: z.string(),
+                    }),
+                },
+            };
+
+            const handlerFn = vi.fn();
+            const handler = new ZodSocketMessageHandler({
+                schema: catalog,
+                handlers: {
+                    TEST: async (data) => {
+                        handlerFn(data);
+                    },
+                },
+            });
+
+            const mockSocket = new EventEmitter();
+            handler.registerHandlers(mockSocket as any);
+
+            // Send an unwrapped message (raw user data) with version
+            mockSocket.emit("TEST", { version: "v1", data: "hello" });
+
+            // Should receive the data as-is
+            expect(handlerFn).toHaveBeenCalledWith({ data: "hello" });
+        });
+
+        it("should handle user data that contains a 'payload' property (THE BUG FIX)", async () => {
+            const catalog = {
+                TEST: {
+                    message: z.object({
+                        payload: z.string(), // User's schema uses 'payload' as a field name
+                    }),
+                },
+            };
+
+            const handlerFn = vi.fn();
+            const handler = new ZodSocketMessageHandler({
+                schema: catalog,
+                handlers: {
+                    TEST: async (data) => {
+                        handlerFn(data);
+                    },
+                },
+            });
+
+            const mockSocket = new EventEmitter();
+            handler.registerHandlers(mockSocket as any);
+
+            // User sends data where their schema field is named "payload"
+            // With version present, this is treated as unwrapped user data
+            mockSocket.emit("TEST", { version: "v1", payload: "my-data" });
+
+            // Should receive the full object, not just "my-data"
+            expect(handlerFn).toHaveBeenCalledWith({ payload: "my-data" });
+        });
+
+        it("should reject user data with 'version' as non-string type", async () => {
+            const catalog = {
+                TEST: {
+                    message: z.object({
+                        payload: z.string(),
+                        version: z.number(), // User's version is a number, not the protocol string
+                    }),
+                },
+            };
+
+            const handlerFn = vi.fn();
+            const errorLogFn = vi.fn();
+
+            const handler = new ZodSocketMessageHandler({
+                schema: catalog,
+                handlers: {
+                    TEST: handlerFn,
+                },
+                logger: {
+                    log: vi.fn(),
+                    debug: vi.fn(),
+                    info: vi.fn(),
+                    warn: vi.fn(),
+                    error: errorLogFn,
+                    child: vi.fn().mockReturnThis(),
+                } as any,
+            });
+
+            const mockSocket = new EventEmitter();
+            handler.registerHandlers(mockSocket as any);
+
+            // User sends data with both 'payload' and 'version' properties
+            // Since version is a number (not string "v1"), this will be detected as wrapped
+            // but fail validation because version must be a string
+            mockSocket.emit("TEST", { payload: "data", version: 2 });
+
+            // Wait for async handling
+            await new Promise((resolve) => setTimeout(resolve, 10));
+
+            // Handler should NOT be called (validation fails)
+            expect(handlerFn).not.toHaveBeenCalled();
+
+            // Error should be logged
+            expect(errorLogFn).toHaveBeenCalled();
+        });
+
+        it("should handle complex nested user data", async () => {
+            const catalog = {
+                TEST: {
+                    message: z.object({
+                        user: z.object({
+                            name: z.string(),
+                            age: z.number(),
+                        }),
+                        metadata: z.record(z.unknown()),
+                    }),
+                },
+            };
+
+            const handlerFn = vi.fn();
+            const handler = new ZodSocketMessageHandler({
+                schema: catalog,
+                handlers: {
+                    TEST: async (data) => {
+                        handlerFn(data);
+                    },
+                },
+            });
+
+            const mockSocket = new EventEmitter();
+            handler.registerHandlers(mockSocket as any);
+
+            const userData = {
+                user: { name: "Alice", age: 30 },
+                metadata: { role: "admin" },
+            };
+
+            mockSocket.emit("TEST", { version: "v1", ...userData });
+
+            expect(handlerFn).toHaveBeenCalledWith(userData);
+        });
+
+        it("should handle messages with callbacks", async () => {
+            const catalog = {
+                TEST: {
+                    message: z.object({ data: z.string() }),
+                    callback: z.object({ success: z.boolean() }),
+                },
+            };
+
+            const handlerFn = vi.fn().mockResolvedValue({ success: true });
+            const handler = new ZodSocketMessageHandler({
+                schema: catalog,
+                handlers: {
+                    TEST: handlerFn,
+                },
+            });
+
+            const mockSocket = new EventEmitter();
+            handler.registerHandlers(mockSocket as any);
+
+            const callbackFn = vi.fn();
+
+            // Emit with callback
+            mockSocket.emit("TEST", { version: "v1", payload: { data: "test" } }, callbackFn);
+
+            // Wait for async handling
+            await new Promise((resolve) => setTimeout(resolve, 10));
+
+            expect(handlerFn).toHaveBeenCalledWith({ data: "test" });
+            expect(callbackFn).toHaveBeenCalledWith({ success: true });
+        });
+
+        it("should reject invalid messages with proper error logging", async () => {
+            const catalog = {
+                TEST: {
+                    message: z.object({
+                        data: z.string(),
+                    }),
+                },
+            };
+
+            const handlerFn = vi.fn();
+            const errorLogFn = vi.fn();
+
+            const handler = new ZodSocketMessageHandler({
+                schema: catalog,
+                handlers: {
+                    TEST: handlerFn,
+                },
+                logger: {
+                    log: vi.fn(),
+                    debug: vi.fn(),
+                    info: vi.fn(),
+                    warn: vi.fn(),
+                    error: errorLogFn,
+                    child: vi.fn().mockReturnThis(),
+                } as any,
+            });
+
+            const mockSocket = new EventEmitter();
+            handler.registerHandlers(mockSocket as any);
+
+            // Send invalid data (number instead of string)
+            mockSocket.emit("TEST", { version: "v1", payload: { data: 123 } });
+
+            // Wait for async handling
+            await new Promise((resolve) => setTimeout(resolve, 10));
+
+            // Handler should NOT be called
+            expect(handlerFn).not.toHaveBeenCalled();
+
+            // Error should be logged
+            expect(errorLogFn).toHaveBeenCalled();
+        });
+
+        it("should handle payload as non-object (string)", async () => {
+            const catalog = {
+                TEST: {
+                    message: z.object({
+                        payload: z.string(),
+                    }),
+                },
+            };
+
+            const handlerFn = vi.fn();
+            const handler = new ZodSocketMessageHandler({
+                schema: catalog,
+                handlers: {
+                    TEST: async (data) => {
+                        handlerFn(data);
+                    },
+                },
+            });
+
+            const mockSocket = new EventEmitter();
+            handler.registerHandlers(mockSocket as any);
+
+            // Send message where payload is a string (not an object)
+            // hasValidPayload will be false, so it wraps the entire message
+            mockSocket.emit("TEST", { version: "v1", payload: "string-value" });
+
+            // Should receive the wrapped data
+            expect(handlerFn).toHaveBeenCalledWith({ payload: "string-value" });
+        });
+
+        it("should handle payload as array", async () => {
+            const catalog = {
+                TEST: {
+                    message: z.object({
+                        payload: z.array(z.number()),
+                    }),
+                },
+            };
+
+            const handlerFn = vi.fn();
+            const handler = new ZodSocketMessageHandler({
+                schema: catalog,
+                handlers: {
+                    TEST: async (data) => {
+                        handlerFn(data);
+                    },
+                },
+            });
+
+            const mockSocket = new EventEmitter();
+            handler.registerHandlers(mockSocket as any);
+
+            // Send message where payload is an array (not a plain object)
+            // isObject([1,2,3]) returns false, so it wraps the entire message
+            mockSocket.emit("TEST", { version: "v1", payload: [1, 2, 3] });
+
+            // Should receive the wrapped data
+            expect(handlerFn).toHaveBeenCalledWith({ payload: [1, 2, 3] });
+        });
+
+        it("should handle payload as null", async () => {
+            const catalog = {
+                TEST: {
+                    message: z.object({
+                        payload: z.null(),
+                    }),
+                },
+            };
+
+            const handlerFn = vi.fn();
+            const handler = new ZodSocketMessageHandler({
+                schema: catalog,
+                handlers: {
+                    TEST: async (data) => {
+                        handlerFn(data);
+                    },
+                },
+            });
+
+            const mockSocket = new EventEmitter();
+            handler.registerHandlers(mockSocket as any);
+
+            // Send message where payload is null
+            // isObject(null) returns false, so it wraps the entire message
+            mockSocket.emit("TEST", { version: "v1", payload: null });
+
+            // Should receive the wrapped data
+            expect(handlerFn).toHaveBeenCalledWith({ payload: null });
+        });
+
+        it("should reject messages without version field", async () => {
+            const catalog = {
+                TEST: {
+                    message: z.object({
+                        data: z.string(),
+                    }),
+                },
+            };
+
+            const handlerFn = vi.fn();
+            const errorLogFn = vi.fn();
+
+            const handler = new ZodSocketMessageHandler({
+                schema: catalog,
+                handlers: {
+                    TEST: handlerFn,
+                },
+                logger: {
+                    log: vi.fn(),
+                    debug: vi.fn(),
+                    info: vi.fn(),
+                    warn: vi.fn(),
+                    error: errorLogFn,
+                    child: vi.fn().mockReturnThis(),
+                } as any,
+            });
+
+            const mockSocket = new EventEmitter();
+            handler.registerHandlers(mockSocket as any);
+
+            // Send message without version field
+            // version will be undefined, which fails messageSchema validation
+            mockSocket.emit("TEST", { data: "hello" });
+
+            // Wait for async handling
+            await new Promise((resolve) => setTimeout(resolve, 10));
+
+            // Handler should NOT be called (validation fails)
+            expect(handlerFn).not.toHaveBeenCalled();
+
+            // Error should be logged
+            expect(errorLogFn).toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
## Problem
Fixed a critical bug where user messages containing a `payload` property were incorrectly identified as protocol-wrapped messages, causing data corruption.
The original implementation only checked for the presence of `payload` to determine if a message was wrapped, leading to false positives when user data legitimately contained a `payload` field.

## Solution
Enhanced protocol detection to require **both** `payload` AND `version` properties, plus validation that `payload` is a plain object (not array/null/primitive).

Changes:
- Enhanced hasValidPayload check to require both 'payload' AND 'version'
- Added isObject() helper to exclude arrays and null values
- Refactored message normalization into dedicated normalizeMessage() method
- Added comprehensive test suite with 11 test cases covering all edge cases

The fix ensures that only messages with the full protocol signature (version + payload as object) are treated as wrapped messages.

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

✅ Added a new test file covering 11 cases
✅ All 11 new tests passing
✅ All 392 existing core tests passing
---

## Changelog
Fixes: Protocol ambiguity where user data with 'payload' field was misinterpreted
Added Tests: 11/11 passing, including edge cases for non-object payloads and missing version

## Screenshots

<img width="1194" height="277" alt="Screenshot 2026-01-16 at 2 22 36 PM" src="https://github.com/user-attachments/assets/c7d1a5ea-425d-48ca-a665-9343c7cb19f0" />
<img width="1189" height="238" alt="Screenshot 2026-01-16 at 2 24 49 PM" src="https://github.com/user-attachments/assets/7e7016ab-08f4-4cab-b580-ec31e608c6b1" />


💯
