### PR TITLE
fix: defer source-map-support loading to prevent OOM with Sentry debug injection

### DIFF
--- a/packages/cli-v3/src/entryPoints/managed-run-worker.ts
+++ b/packages/cli-v3/src/entryPoints/managed-run-worker.ts
@@ -63,17 +63,28 @@ import {
 import { ZodIpcConnection } from "@trigger.dev/core/v3/zodIpc";
 import { readFile } from "node:fs/promises";
 import { setInterval, setTimeout } from "node:timers/promises";
-import sourceMapSupport from "source-map-support";
 import { env } from "std-env";
 import { normalizeImportPath } from "../utilities/normalizeImportPath.js";
 import { VERSION } from "../version.js";
 import { promiseWithResolvers } from "@trigger.dev/core/utils";
 
-sourceMapSupport.install({
-  handleUncaughtExceptions: false,
-  environment: "node",
-  hookRequire: false,
-});
+let sourceMapSupportInstalled = false;
+
+async function installSourceMapSupport() {
+  if (sourceMapSupportInstalled) return;
+  sourceMapSupportInstalled = true;
+
+  try {
+    const sourceMapSupport = await import("source-map-support");
+    sourceMapSupport.default.install({
+      handleUncaughtExceptions: false,
+      environment: "node",
+      hookRequire: false,
+    });
+  } catch (error) {
+    console.warn("Failed to install source-map-support:", error);
+  }
+}
 
 process.on("uncaughtException", function (error, origin) {
   console.error("Uncaught exception", { error, origin });
@@ -248,6 +259,11 @@ async function doBootstrap() {
         id: "config",
         fn: handleError as AnyOnCatchErrorHookFunction,
       });
+    }
+
+    // Install source-map-support after config is loaded (deferred to avoid OOM with Sentry debug ID injection)
+    if (config.sourceMapSupport !== false) {
+      installSourceMapSupport();
     }
 
     return {

--- a/packages/core/src/v3/config.ts
+++ b/packages/core/src/v3/config.ts
@@ -171,6 +171,15 @@ export type TriggerConfig = {
    */
   disableConsoleInterceptor?: boolean;
 
+  /**
+   * Enable or disable source-map-support for enhanced stack traces.
+   * Disabling this can help prevent OOM issues when using Sentry's debug ID injection
+   * with large projects that have many bundled files.
+   *
+   * @default true
+   */
+  sourceMapSupport?: boolean;
+
   build?: {
     /**
      * Add custom conditions to the esbuild build. For example, if you are importing `ai/rsc`, you'll need to add "react-server" condition.


### PR DESCRIPTION
### Description
Fixes #2920 - Prevents OOM crashes when using Sentry's debug ID injection with large projects on small machines.

### Problem
- Sentry injects `new Error().stack` into all `.mjs` files
- `source-map-support` eagerly parses all sourcemaps during module loading
- 2000+ files × sourcemap parsing = OOM on `small-1x` (0.5GB RAM)

### Solution
- Defer `source-map-support` installation until after config loads
- Use async import to avoid blocking module initialization
- Add `sourceMapSupport` config option (default: true) to allow disabling
- Add error handling for graceful degradation

### Changes
- `packages/cli-v3/src/entryPoints/dev-index-worker.ts` - Deferred loading
- `packages/cli-v3/src/entryPoints/dev-run-worker.ts` - Deferred loading
- `packages/cli-v3/src/entryPoints/managed-index-worker.ts` - Deferred loading
- `packages/cli-v3/src/entryPoints/managed-run-worker.ts` - Deferred loading
- `packages/core/src/v3/config.ts` - New `sourceMapSupport` option