### PR TITLE
fix(run-engine): use reader for pending version queries

### DIFF
--- a/apps/webapp/app/v3/services/executeTasksWaitingForDeploy.ts
+++ b/apps/webapp/app/v3/services/executeTasksWaitingForDeploy.ts
@@ -33,7 +33,7 @@ export class ExecuteTasksWaitingForDeployService extends BaseService {
 
     const maxCount = env.LEGACY_RUN_ENGINE_WAITING_FOR_DEPLOY_BATCH_SIZE;
 
-    const runsWaitingForDeploy = await this._prisma.taskRun.findMany({
+    const runsWaitingForDeploy = await this._replica.taskRun.findMany({
       where: {
         runtimeEnvironmentId: backgroundWorker.runtimeEnvironmentId,
         projectId: backgroundWorker.projectId,

--- a/internal-packages/run-engine/src/engine/index.ts
+++ b/internal-packages/run-engine/src/engine/index.ts
@@ -268,6 +268,7 @@ export class RunEngine {
 
     const resources: SystemResources = {
       prisma: this.prisma,
+      readOnlyPrisma: this.readOnlyPrisma,
       worker: this.worker,
       eventBus: this.eventBus,
       logger: this.logger,

--- a/internal-packages/run-engine/src/engine/systems/pendingVersionSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/pendingVersionSystem.ts
@@ -50,7 +50,7 @@ export class PendingVersionSystem {
       queues: backgroundWorker.queues.map((queue) => queue.name),
     });
 
-    const pendingRuns = await this.$.prisma.taskRun.findMany({
+    const pendingRuns = await this.$.readOnlyPrisma.taskRun.findMany({
       where: {
         runtimeEnvironmentId: backgroundWorker.runtimeEnvironmentId,
         projectId: backgroundWorker.projectId,

--- a/internal-packages/run-engine/src/engine/systems/systems.ts
+++ b/internal-packages/run-engine/src/engine/systems/systems.ts
@@ -1,6 +1,6 @@
 import { Meter, Tracer } from "@internal/tracing";
 import { Logger } from "@trigger.dev/core/logger";
-import { PrismaClient } from "@trigger.dev/database";
+import { PrismaClient, PrismaReplicaClient } from "@trigger.dev/database";
 import { RunQueue } from "../../run-queue/index.js";
 import { EventBus } from "../eventBus.js";
 import { RunLocker } from "../locking.js";
@@ -9,6 +9,7 @@ import { RaceSimulationSystem } from "./raceSimulationSystem.js";
 
 export type SystemResources = {
   prisma: PrismaClient;
+  readOnlyPrisma: PrismaReplicaClient;
   worker: EngineWorker;
   eventBus: EventBus;
   logger: Logger;


### PR DESCRIPTION
Move expensive findMany queries for PENDING_VERSION and WAITING_FOR_DEPLOY
runs to read replicas to avoid blocking migrations on the primary database.

Changes:
- Add readOnlyPrisma to SystemResources type
- Pass readOnlyPrisma to systems in RunEngine constructor  
- Update pendingVersionSystem to use readOnlyPrisma for findMany
- Update executeTasksWaitingForDeploy to use _replica for findMany