### PR TITLE
feat(webapp): Add MiddleTruncate component for long task names

### DIFF
--- a/apps/webapp/app/components/primitives/MiddleTruncate.tsx
+++ b/apps/webapp/app/components/primitives/MiddleTruncate.tsx
@@ -141,7 +141,7 @@ export function MiddleTruncate({ text, className }: MiddleTruncateProps) {
   const content = (
     <span
       ref={containerRef}
-      className={cn("block", isTruncated && "min-w-full", className)}
+      className={cn("block", isTruncated && "min-w-[360px]", className)}
     >
       {/* Hidden span for measuring text width */}
       <span

--- a/apps/webapp/app/components/runs/v3/RunFilters.tsx
+++ b/apps/webapp/app/components/runs/v3/RunFilters.tsx
@@ -655,7 +655,7 @@ function TasksDropdown({
                 <TaskTriggerSourceIcon source={item.triggerSource} className="size-4 flex-none" />
               }
             >
-              <MiddleTruncate text={item.slug} className="min-w-[360px]"/>
+              <MiddleTruncate text={item.slug}/>
             </SelectItem>
           ))}
         </SelectList>


### PR DESCRIPTION
Closes #

## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [ ] The PR title follows the convention.
- [ ] I ran and tested the code works

---

## Testing

Tested the MiddleTruncate component in the TasksDropdown by:
1. Verifying that long task names (e.g., "namespace:category:subcategory:task-name") are truncated in the middle
2. Confirming the full text appears in a tooltip on hover
3. Testing responsive behavior - truncation adjusts when the container is resized
4. Verifying that short task names that fit within the container are displayed in full without truncation

---

## Changelog

Added a new `MiddleTruncate` primitive component that intelligently truncates text in the middle while preserving the beginning and end portions. This is particularly useful for long hierarchical identifiers like task slugs.

**Key features:**
- Truncates text in the middle with an ellipsis (…) when it exceeds available width
- Shows full text in a tooltip on hover when truncated
- Responsive - recalculates truncation on container resize using ResizeObserver
- Maintains minimum character visibility (4 chars minimum on each side for readability)
- Integrated into TasksDropdown to handle long task names

**Changes:**
- Created new `MiddleTruncate.tsx` component with binary search algorithm for optimal character distribution
- Updated TasksDropdown to use MiddleTruncate for task slug display
- Increased TasksDropdown popover width from 240px to 360px to provide better space for truncated text

---

## Screenshots
💯

https://github.com/user-attachments/assets/a7a2191a-2e36-437e-ab3f-517fe7620b93


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/triggerdotdev/trigger.dev/pull/2946">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
