### PR TITLE
fix(webapp): Truncate long branch names to prevent breaking the onboarding layout

### DIFF
--- a/apps/webapp/app/components/BlankStatePanels.tsx
+++ b/apps/webapp/app/components/BlankStatePanels.tsx
@@ -599,9 +599,9 @@ function DeploymentOnboardingSteps() {
   return (
     <PackageManagerProvider>
       <div className="mb-2 flex items-center justify-between border-b">
-        <div className="mb-2 flex items-center gap-2">
-          <EnvironmentIcon environment={environment} className="-ml-1 size-8" />
-          <Header1>Deploy your tasks to {environmentFullTitle(environment)}</Header1>
+        <div className="mb-2 flex min-w-0 items-center gap-2">
+          <EnvironmentIcon environment={environment} className="-ml-1 size-8 shrink-0" />
+          <Header1 className="truncate">Deploy your tasks to {environmentFullTitle(environment)}</Header1>
         </div>
         <div className="flex items-center">
           <SimpleTooltip


### PR DESCRIPTION
### Before
<img width="1736" height="964" alt="CleanShot 2026-01-21 at 20 11 08@2x" src="https://github.com/user-attachments/assets/76c6ed42-d2a0-4212-aaad-6fb848025c85" />

### After
<img width="1776" height="1032" alt="CleanShot 2026-01-27 at 17 32 47@2x" src="https://github.com/user-attachments/assets/030ba26e-6aad-4232-a9ff-f2fde9931f8c" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/triggerdotdev/trigger.dev/pull/2954">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
