### PR TITLE
Fix(webapp): Increase the max width of task run filter popover

### DIFF
--- a/apps/webapp/app/components/runs/v3/RunFilters.tsx
+++ b/apps/webapp/app/components/runs/v3/RunFilters.tsx
@@ -634,7 +634,7 @@ function TasksDropdown({
     <SelectProvider value={values("tasks")} setValue={handleChange} virtualFocus={true}>
       {trigger}
       <SelectPopover
-        className="min-w-0 max-w-[min(240px,var(--popover-available-width))]"
+        className="min-w-0 max-w-[min(650px,var(--popover-available-width))]"
         hideOnEscape={() => {
           if (onClose) {
             onClose();


### PR DESCRIPTION
### Before
<img width="1800" height="1574" alt="CleanShot 2026-01-27 at 17 48 00@2x" src="https://github.com/user-attachments/assets/6fc64acd-7b40-4a7a-83a2-8d9527d0b73e" />

### After
<img width="1400" height="1556" alt="CleanShot 2026-01-27 at 18 00 51@2x" src="https://github.com/user-attachments/assets/e4ef6647-889b-4a3e-a3cc-92171df8f4b8" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/triggerdotdev/trigger.dev/pull/2955">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
