### PR TITLE
Fix(webapp) prevent incidents url being called every frame

### DIFF
--- a/apps/webapp/app/routes/resources.incidents.tsx
+++ b/apps/webapp/app/routes/resources.incidents.tsx
@@ -2,7 +2,7 @@ import { ExclamationTriangleIcon } from "@heroicons/react/20/solid";
 import { json } from "@remix-run/node";
 import { useFetcher } from "@remix-run/react";
 import { motion } from "framer-motion";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect } from "react";
 import { LinkButton } from "~/components/primitives/Buttons";
 import { Paragraph } from "~/components/primitives/Paragraph";
 import { Popover, PopoverContent, PopoverTrigger } from "~/components/primitives/Popover";
@@ -26,12 +26,10 @@ export async function loader() {
 export function IncidentStatusPanel({ isCollapsed = false }: { isCollapsed?: boolean }) {
   const { isManagedCloud } = useFeatures();
   const fetcher = useFetcher<typeof loader>();
-  const fetcherRef = useRef(fetcher);
-  fetcherRef.current = fetcher;
 
   const fetchIncidents = useCallback(() => {
-    if (fetcherRef.current.state === "idle") {
-      fetcherRef.current.load("/resources/incidents");
+    if (fetcher.state === "idle") {
+      fetcher.load("/resources/incidents");
     }
   }, []);
 


### PR DESCRIPTION
Removes the fetcher from the dependency array
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/triggerdotdev/trigger.dev/pull/2956">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
