### PR TITLE
fix(sdk): export AnyOnStartAttemptHookFunction type

### DIFF
--- a/.changeset/export-start-attempt-hook-type.md
+++ b/.changeset/export-start-attempt-hook-type.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+Export `AnyOnStartAttemptHookFunction` type to allow defining `onStartAttempt` hooks for individual tasks.

--- a/packages/trigger-sdk/src/v3/hooks.ts
+++ b/packages/trigger-sdk/src/v3/hooks.ts
@@ -17,6 +17,7 @@ import {
 
 export type {
   AnyOnStartHookFunction,
+  AnyOnStartAttemptHookFunction,
   TaskStartHookParams,
   OnStartHookFunction,
   AnyOnFailureHookFunction,


### PR DESCRIPTION
Export AnyOnStartAttemptHookFunction type to allow defining onStartAttempt hooks for individual tasks.

https://claude.ai/code/session_018jgSVcFtKVyv65ktGNQFFq
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/triggerdotdev/trigger.dev/pull/2966">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
