### PR TITLE
feat(webapp): allow marking env vars as secret after creation

### DIFF
--- a/.server-changes/mark-environment-variables-secret.md
+++ b/.server-changes/mark-environment-variables-secret.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: feature
+---
+
+Existing environment variables can now be permanently marked as secret from the dashboard.

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.environment-variables/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.environment-variables/route.tsx
@@ -36,6 +36,7 @@ import { Fieldset } from "~/components/primitives/Fieldset";
 import { FormButtons } from "~/components/primitives/FormButtons";
 import { FormError } from "~/components/primitives/FormError";
 import { Header2 } from "~/components/primitives/Headers";
+import { Hint } from "~/components/primitives/Hint";
 import { Input } from "~/components/primitives/Input";
 import { InputGroup } from "~/components/primitives/InputGroup";
 import { Label } from "~/components/primitives/Label";
@@ -808,6 +809,7 @@ function EditEnvironmentVariablePanel({
   revealAll: boolean;
 }) {
   const [isOpen, setIsOpen] = useState(false);
+  const [isSecret, setIsSecret] = useState(variable.isSecret);
   const fetcher = useFetcher<typeof action>();
   const lastSubmission = fetcher.data as any;
 
@@ -840,6 +842,7 @@ function EditEnvironmentVariablePanel({
         <DialogHeader>Edit environment variable</DialogHeader>
         <fetcher.Form method="post" {...getFormProps(form)}>
           <input type="hidden" name="action" value="edit" />
+          <input type="hidden" name="isSecret" value={isSecret ? "true" : "false"} />
           <input {...getInputProps(id, { type: "hidden" })} value={variable.id} />
           <input
             {...getInputProps(environmentId, { type: "hidden" })}
@@ -856,6 +859,22 @@ function EditEnvironmentVariablePanel({
             <InputGroup fullWidth>
               <Label>Environment</Label>
               <EnvironmentCombo environment={variable.environment} className="text-sm" />
+            </InputGroup>
+
+            <InputGroup className="w-auto">
+              <Switch
+                variant="medium"
+                label={<span className="text-text-bright">Secret value</span>}
+                checked={isSecret}
+                disabled={variable.isSecret}
+                className="-ml-2 inline-flex w-fit"
+                onCheckedChange={setIsSecret}
+              />
+              <Hint className="-mt-1">
+                {variable.isSecret
+                  ? "This variable is secret and cannot be changed back."
+                  : "Once enabled, the value will be hidden and cannot be revealed again."}
+              </Hint>
             </InputGroup>
 
             <InputGroup fullWidth>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.environment-variables/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.environment-variables/route.tsx
@@ -20,7 +20,15 @@ import {
 import { json } from "@remix-run/server-runtime";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { fromPromise } from "neverthrow";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, type RefObject } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+  type RefObject,
+} from "react";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { z } from "zod";
 import { UserAvatar } from "~/components/UserProfilePhoto";
@@ -815,6 +823,26 @@ function EditEnvironmentVariablePanel({
 
   const isLoading = fetcher.state !== "idle";
 
+  function handleOpenChange(open: boolean) {
+    if (open) {
+      setIsSecret(variable.isSecret);
+    }
+
+    setIsOpen(open);
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    if (
+      isSecret &&
+      !variable.isSecret &&
+      !window.confirm(
+        "Making this variable secret is irreversible. The value will be hidden and cannot be revealed again. Continue?"
+      )
+    ) {
+      event.preventDefault();
+    }
+  }
+
   // Close dialog on successful submission
   useEffect(() => {
     if (lastSubmission?.success && fetcher.state === "idle") {
@@ -834,13 +862,13 @@ function EditEnvironmentVariablePanel({
   });
 
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         <Button variant="small-menu-item" LeadingIcon={PencilSquareIcon} fullWidth textAlignLeft />
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>Edit environment variable</DialogHeader>
-        <fetcher.Form method="post" {...getFormProps(form)}>
+        <fetcher.Form method="post" {...getFormProps(form)} onSubmit={handleSubmit}>
           <input type="hidden" name="action" value="edit" />
           <input type="hidden" name="isSecret" value={isSecret ? "true" : "false"} />
           <input {...getInputProps(id, { type: "hidden" })} value={variable.id} />
@@ -898,7 +926,11 @@ function EditEnvironmentVariablePanel({
                 </Button>
               }
               cancelButton={
-                <Button onClick={() => setIsOpen(false)} variant="tertiary/medium" type="button">
+                <Button
+                  onClick={() => handleOpenChange(false)}
+                  variant="tertiary/medium"
+                  type="button"
+                >
                   Cancel
                 </Button>
               }

--- a/apps/webapp/app/v3/environmentVariables/environmentVariablesRepository.server.ts
+++ b/apps/webapp/app/v3/environmentVariables/environmentVariablesRepository.server.ts
@@ -505,6 +505,7 @@ export class EnvironmentVariablesRepository implements Repository {
               increment: 1,
             },
             lastUpdatedBy: options.lastUpdatedBy ? options.lastUpdatedBy : undefined,
+            isSecret: options.isSecret ? true : undefined,
           },
         });
       });

--- a/apps/webapp/app/v3/environmentVariables/repository.ts
+++ b/apps/webapp/app/v3/environmentVariables/repository.ts
@@ -69,6 +69,7 @@ export const EditEnvironmentVariableValue = z.object({
   environmentId: z.string(),
   value: z.string(),
   lastUpdatedBy: EnvironmentVariableUpdaterSchema.optional(),
+  isSecret: z.preprocess((val) => val === "true" || val === true, z.boolean()).optional(),
 });
 export type EditEnvironmentVariableValue = z.infer<typeof EditEnvironmentVariableValue>;
 

--- a/apps/webapp/app/v3/environmentVariables/repository.ts
+++ b/apps/webapp/app/v3/environmentVariables/repository.ts
@@ -69,7 +69,10 @@ export const EditEnvironmentVariableValue = z.object({
   environmentId: z.string(),
   value: z.string(),
   lastUpdatedBy: EnvironmentVariableUpdaterSchema.optional(),
-  isSecret: z.preprocess((val) => val === "true" || val === true, z.boolean()).optional(),
+  isSecret: z.preprocess(
+    (val) => (val === undefined ? undefined : val === "true" || val === true),
+    z.boolean().optional()
+  ),
 });
 export type EditEnvironmentVariableValue = z.infer<typeof EditEnvironmentVariableValue>;
 

--- a/apps/webapp/test/environmentVariablesRepository.test.ts
+++ b/apps/webapp/test/environmentVariablesRepository.test.ts
@@ -257,3 +257,112 @@ describe("EnvironmentVariablesRepository.getVariableValuesForKeys", () => {
     }
   );
 });
+
+describe("EnvironmentVariablesRepository.editValue", () => {
+  postgresTest(
+    "permanently marks an existing value as secret while updating its value",
+    async ({ prisma }) => {
+      const { user, organization, project } = await createTestOrgProjectWithMember(prisma);
+      const environment = await createRuntimeEnvironment(prisma, {
+        projectId: project.id,
+        organizationId: organization.id,
+        type: "PRODUCTION",
+      });
+      const repository = new EnvironmentVariablesRepository(prisma, prisma);
+
+      await createEnvironmentVariable(repository, project.id, {
+        environmentId: environment.id,
+        key: "BECOMES_SECRET",
+        value: "plain-value",
+        userId: user.id,
+      });
+
+      const variable = await prisma.environmentVariable.findFirstOrThrow({
+        where: { projectId: project.id, key: "BECOMES_SECRET" },
+        include: { values: { where: { environmentId: environment.id } } },
+      });
+      const originalVersion = variable.values[0]!.version;
+
+      const result = await repository.editValue(project.id, {
+        id: variable.id,
+        environmentId: environment.id,
+        value: "new-secret-value",
+        isSecret: true,
+        lastUpdatedBy: { type: "user", userId: user.id },
+      });
+
+      expect(result).toEqual({ success: true });
+
+      const updatedValue = await prisma.environmentVariableValue.findUniqueOrThrow({
+        where: {
+          variableId_environmentId: {
+            variableId: variable.id,
+            environmentId: environment.id,
+          },
+        },
+      });
+      expect(updatedValue.isSecret).toBe(true);
+      expect(updatedValue.version).toBe(originalVersion + 1);
+
+      const unredacted = await repository.getEnvironment(project.id, environment.id);
+      expect(unredacted).toEqual([
+        expect.objectContaining({ key: "BECOMES_SECRET", value: "new-secret-value" }),
+      ]);
+
+      const redacted = await repository.getEnvironmentWithRedactedSecrets(
+        project.id,
+        environment.id
+      );
+      expect(redacted).toEqual([
+        expect.objectContaining({ key: "BECOMES_SECRET", value: "<redacted>", isSecret: true }),
+      ]);
+    }
+  );
+
+  postgresTest("does not change an existing secret value back to plaintext", async ({ prisma }) => {
+    const { user, organization, project } = await createTestOrgProjectWithMember(prisma);
+    const environment = await createRuntimeEnvironment(prisma, {
+      projectId: project.id,
+      organizationId: organization.id,
+      type: "PRODUCTION",
+    });
+    const repository = new EnvironmentVariablesRepository(prisma, prisma);
+
+    await createEnvironmentVariable(repository, project.id, {
+      environmentId: environment.id,
+      key: "STAYS_SECRET",
+      value: "original-secret",
+      isSecret: true,
+      userId: user.id,
+    });
+
+    const variable = await prisma.environmentVariable.findFirstOrThrow({
+      where: { projectId: project.id, key: "STAYS_SECRET" },
+    });
+
+    const result = await repository.editValue(project.id, {
+      id: variable.id,
+      environmentId: environment.id,
+      value: "updated-secret",
+      isSecret: false,
+      lastUpdatedBy: { type: "user", userId: user.id },
+    });
+
+    expect(result).toEqual({ success: true });
+
+    const updatedValue = await prisma.environmentVariableValue.findUniqueOrThrow({
+      where: {
+        variableId_environmentId: {
+          variableId: variable.id,
+          environmentId: environment.id,
+        },
+      },
+    });
+    expect(updatedValue.isSecret).toBe(true);
+
+    const unredacted = await repository.getEnvironment(project.id, environment.id);
+    expect(unredacted).toEqual([
+      expect.objectContaining({ key: "STAYS_SECRET", value: "updated-secret" }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add an irreversible "Make secret" toggle to the edit environment variable dialog
- The toggle is part of the edit form and submits on Save (not as a separate request)
- Once toggled on and saved, the value is hidden and the switch becomes disabled — it cannot be reverted
- Adds an optional `isSecret` field to the `editValue` repository method and Zod schema
- Removes the standalone `makeSecret` action in favor of the unified form-based approach

Implements: https://feedback.trigger.dev/p/ability-to-set-a-non-secret-env-var-to-secret

### Tested on local:
Before saving:
<img width="716" height="549" alt="image" src="https://github.com/user-attachments/assets/42a72c92-f7c5-4c56-8e01-25edf7c70d92" />
After saving:
<img width="753" height="581" alt="image" src="https://github.com/user-attachments/assets/6aaa2e55-5efc-4792-acfd-1ea2d0ff10a1" />
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/triggerdotdev/trigger.dev/pull/2969">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
