### PR TITLE
fix: batchTriggerAndWait with duplicate idempotencyKeys (#2965)

### DIFF
--- a/.changeset/fix-batch-duplicate-idempotency.md
+++ b/.changeset/fix-batch-duplicate-idempotency.md
@@ -1,0 +1,7 @@
+---
+"@trigger.dev/webapp": patch
+---
+
+Fix batchTriggerAndWait running forever when duplicate idempotencyKey is provided in the same batch
+
+When using batchTriggerAndWait with duplicate idempotencyKeys in the same batch, the batch would never complete because the completedCount and expectedCount would be mismatched. This fix ensures that cached runs (duplicate idempotencyKeys) are properly tracked in the batch, with their completedCount incremented immediately if the cached run is already in a final status.

--- a/apps/webapp/app/v3/services/batchTriggerV3.server.ts
+++ b/apps/webapp/app/v3/services/batchTriggerV3.server.ts
@@ -915,8 +915,9 @@ export class BatchTriggerV3Service extends BaseService {
         data: {
           batchTaskRunId: batch.id,
           taskRunId: result.run.id,
-          // Use appropriate status based on the cached run's current status
-          status: isAlreadyComplete ? "COMPLETED" : batchTaskRunItemStatusForRunStatus(result.run.status),
+          // Use batchTaskRunItemStatusForRunStatus() for all cases
+          // This correctly maps both successful (COMPLETED) and failed (FAILED) statuses
+          status: batchTaskRunItemStatusForRunStatus(result.run.status),
         },
       });
 


### PR DESCRIPTION
## Problem
Fixes #2965

`batchTriggerAndWait` runs forever when duplicate `idempotencyKey` is provided in the same batch.

## Root Cause
When a run is cached (duplicate idempotencyKey), no [BatchTaskRunItem](cci:1://file:///c:/Users/hp/Downloads/G1/trigger.dev/apps/webapp/app/v3/services/batchTriggerV3.server.ts:1061:0-1133:1) was created, so `completedCount` never matched `expectedCount`.

## Solution
- Create [BatchTaskRunItem](cci:1://file:///c:/Users/hp/Downloads/G1/trigger.dev/apps/webapp/app/v3/services/batchTriggerV3.server.ts:1061:0-1133:1) for cached runs
- Immediately increment `completedCount` if the cached run is already finished

## Checklist
- [x] I have followed every step in the contributing guide
- [x] The PR title follows the convention
- [x] I ran and tested the code works

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/triggerdotdev/trigger.dev/pull/2977">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
