### PR TITLE
fix: machine preset not resetting to default when removing config

### DIFF
--- a/.changeset/fix-machine-preset-reset.md
+++ b/.changeset/fix-machine-preset-reset.md
@@ -1,0 +1,7 @@
+---
+"@trigger.dev/webapp": patch
+---
+
+Fix machine preset not resetting to default when removing machine config from task (#2796)
+
+When a task's `machine` configuration was removed and the project redeployed, runs would still execute on the old machine preset instead of resetting to the default (small-1x). This fix ensures the current deployment's machine config is always used when resolving the machine preset for a run.

--- a/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
+++ b/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
@@ -262,7 +262,7 @@ export class SharedQueueConsumer {
 
     console.log("✅ Started the SharedQueueConsumer");
 
-    this.#doWork().finally(() => {});
+    this.#doWork().finally(() => { });
   }
 
   #endCurrentSpan() {
@@ -417,7 +417,7 @@ export class SharedQueueConsumer {
           span.end();
 
           setTimeout(() => {
-            this.#doWork().finally(() => {});
+            this.#doWork().finally(() => { });
           }, nextInterval);
         }
       });
@@ -620,8 +620,8 @@ export class SharedQueueConsumer {
       return existingTaskRun.lockedById
         ? await getWorkerDeploymentFromWorkerTask(existingTaskRun.lockedById)
         : existingTaskRun.lockedToVersionId
-        ? await getWorkerDeploymentFromWorker(existingTaskRun.lockedToVersionId)
-        : await findCurrentWorkerDeployment({
+          ? await getWorkerDeploymentFromWorker(existingTaskRun.lockedToVersionId)
+          : await findCurrentWorkerDeployment({
             environmentId: existingTaskRun.runtimeEnvironmentId,
             type: "V1",
           });
@@ -718,9 +718,9 @@ export class SharedQueueConsumer {
     }
 
     const lockedAt = new Date();
-    const machinePreset =
-      existingTaskRun.machinePreset ??
-      machinePresetFromConfig(backgroundTask.machineConfig ?? {}).name;
+    // Always use current deployment's machine config to ensure preset resets correctly
+    // when machine config is removed from task (fixes #2796)
+    const machinePreset = machinePresetFromConfig(backgroundTask.machineConfig ?? {}).name;
     const maxDurationInSeconds = getMaxDuration(
       existingTaskRun.maxDurationInSeconds,
       backgroundTask.maxDurationInSeconds
@@ -1900,9 +1900,9 @@ class SharedQueueTasks {
 
   async getResumePayload(attemptId: string): Promise<
     | {
-        execution: V3ProdTaskRunExecution;
-        completion: TaskRunExecutionResult;
-      }
+      execution: V3ProdTaskRunExecution;
+      completion: TaskRunExecutionResult;
+    }
     | undefined
   > {
     const attempt = await prisma.taskRunAttempt.findFirst({


### PR DESCRIPTION
## Summary
Fixes #2796

## Problem
When a task's machine configuration was removed and the project redeployed, runs would still execute on the old machine preset instead of resetting to the default (small-1x).

## Root Cause
In sharedQueueConsumer.server.ts, the code was prioritizing existingTaskRun.machinePreset (stale value) over the current deployment's backgroundTask.machineConfig.

## Fix
Changed machine preset resolution to always use current deployment's machine config.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/triggerdotdev/trigger.dev/pull/2986">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
