### PR TITLE
fix(core): escape dotted keys in flattenAttributes to correct log rendering

### DIFF
--- a/.changeset/fix-dotted-keys-logging.md
+++ b/.changeset/fix-dotted-keys-logging.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Fix issue where logging objects with keys containing dots resulted in incorrect nested object structure in logs (#1510)

--- a/packages/core/test/flattenAttributes.test.ts
+++ b/packages/core/test/flattenAttributes.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest";
 import { flattenAttributes, unflattenAttributes } from "../src/v3/utils/flattenAttributes.js";
 
 describe("flattenAttributes", () => {
@@ -297,9 +298,9 @@ describe("flattenAttributes", () => {
   });
 
   it("handles function values correctly", () => {
-    function namedFunction() {}
-    const anonymousFunction = function () {};
-    const arrowFunction = () => {};
+    function namedFunction() { }
+    const anonymousFunction = function () { };
+    const arrowFunction = () => { };
 
     const result = flattenAttributes({
       named: namedFunction,
@@ -317,7 +318,7 @@ describe("flattenAttributes", () => {
   it("handles mixed problematic types", () => {
     const complexObj = {
       error: new Error("Mixed error"),
-      func: function testFunc() {},
+      func: function testFunc() { },
       date: new Date("2023-01-01"),
       normal: "string",
       number: 42,
@@ -415,10 +416,10 @@ describe("flattenAttributes", () => {
   it("handles Promise objects correctly", () => {
     const resolvedPromise = Promise.resolve("value");
     const rejectedPromise = Promise.reject(new Error("failed"));
-    const pendingPromise = new Promise(() => {}); // Never resolves
+    const pendingPromise = new Promise(() => { }); // Never resolves
 
     // Catch the rejection to avoid unhandled promise rejection warnings
-    rejectedPromise.catch(() => {});
+    rejectedPromise.catch(() => { });
 
     const result = flattenAttributes({
       resolved: resolvedPromise,
@@ -481,7 +482,7 @@ describe("flattenAttributes", () => {
   it("handles complex mixed object with all special types", () => {
     const complexObj = {
       error: new Error("Test error"),
-      func: function testFunc() {},
+      func: function testFunc() { },
       date: new Date("2023-01-01"),
       mySet: new Set([1, 2, 3]),
       myMap: new Map([["key", "value"]]),


### PR DESCRIPTION
## Summary
Fixes #1510

## Problem
Logging objects with keys containing dots (e.g. \{ 'Key 0.002mm': 31.4 }\) resulted in incorrect nested object structure in the UI/logs (e.g. \{ 'Key 0': { '002mm': 31.4 } }\) because dots were treated as separators during unflattening.

## Fix
Implemented key escaping in \lattenAttributes.ts\:
- \lattenAttributes\ now escapes dots in keys (e.g. \.\ -> \\\\.\)
- \unflattenAttributes\ now respects escaped dots when splitting keys

This ensures dotted keys are preserved as single keys during the flatten/unflatten cycle.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/triggerdotdev/trigger.dev/pull/2987">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
