### PR TITLE
fix(cli-v3): detect package manager (yarn/pnpm/npm) and lockfile for correct deploy builds

### DIFF
--- a/.changeset/fix-cli-deploy-yarn-workspaces.md
+++ b/.changeset/fix-cli-deploy-yarn-workspaces.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/cli-v3": patch
+---
+
+Fix `trigger deploy` to detect and use the correct package manager (Yarn, pnpm, npm) and lockfile for builds. This fixes issues with Yarn Workspaces and ensures reproducible builds. (#2914)

--- a/packages/cli-v3/src/deploy/buildImage.test.ts
+++ b/packages/cli-v3/src/deploy/buildImage.test.ts
@@ -1,0 +1,50 @@
+
+import { describe, it, expect } from "vitest";
+import { generateContainerfile, GenerateContainerfileOptions } from "./buildImage.js";
+
+describe("generateContainerfile", () => {
+    const defaultOptions: GenerateContainerfileOptions = {
+        runtime: "node",
+        build: {
+            env: {},
+        },
+        image: {},
+        indexScript: "index.js",
+        entrypoint: "entrypoint.js",
+    };
+
+    it("should generate npm install command by default", async () => {
+        const dockerfile = await generateContainerfile(defaultOptions);
+        expect(dockerfile).toContain("COPY --chown=node:node package.json ./");
+        expect(dockerfile).toContain("RUN npm i --no-audit --no-fund --no-save --no-package-lock");
+    });
+
+    it("should generate yarn install command when packageManager is yarn", async () => {
+        const options: GenerateContainerfileOptions = {
+            ...defaultOptions,
+            packageManager: { name: "yarn", command: "yarn", version: "1.22.19" },
+        };
+        const dockerfile = await generateContainerfile(options);
+        expect(dockerfile).toContain("RUN yarn install");
+    });
+
+    it("should generate pnpm install command when packageManager is pnpm", async () => {
+        const options: GenerateContainerfileOptions = {
+            ...defaultOptions,
+            packageManager: { name: "pnpm", command: "pnpm", version: "8.6.0" },
+        };
+        const dockerfile = await generateContainerfile(options);
+        expect(dockerfile).toContain("RUN corepack enable");
+        expect(dockerfile).toContain("RUN pnpm install");
+    });
+
+    it("should copy lockfile if provided", async () => {
+        const options: GenerateContainerfileOptions = {
+            ...defaultOptions,
+            packageManager: { name: "yarn", command: "yarn", version: "1.22.19" },
+            lockfilePath: "yarn.lock",
+        };
+        const dockerfile = await generateContainerfile(options);
+        expect(dockerfile).toContain("COPY --chown=node:node yarn.lock ./");
+    });
+});


### PR DESCRIPTION
## Summary
Fixes #2914

## Problem
\	rigger deploy\ hardcoded \
pm install ...\ in the generated Dockerfile, ignoring the project's package manager (Yarn, pnpm). This caused failures for Yarn Workspaces (due to \
ohoist\ being ignored) and prevented reproducible builds using lockfiles.

## Fix
- Modified \uildImage.ts\ to support detected package managers.
- Updates \uildWorker.ts\ to detect PM and copy the lockfile (\yarn.lock\, \pnpm-lock.yaml\) to the build context.
- Generates correct \RUN\ commands:
    - Yarn: \RUN yarn install\`n    - pnpm: \RUN corepack enable && RUN pnpm install\`n    - npm: \RUN npm i ...\ (default)
- Added unit tests in \uildImage.test.ts\ verifying Dockerfile generation logic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/triggerdotdev/trigger.dev/pull/2988">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
