### PR TITLE
fix(cli-v3): allow disabling source-map-support to prevent OOM with Sentry

### DIFF
--- a/.changeset/fix-sentry-oom-2920.md
+++ b/.changeset/fix-sentry-oom-2920.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/cli-v3": patch
+---
+
+Fix Sentry OOM: Allow disabling `source-map-support` via `TRIGGER_SOURCE_MAPS=false`. Also supports `node` for native source maps. (#2920)

--- a/packages/cli-v3/src/entryPoints/dev-index-worker.ts
+++ b/packages/cli-v3/src/entryPoints/dev-index-worker.ts
@@ -13,18 +13,14 @@ import {
 } from "@trigger.dev/core/v3/workers";
 import { sendMessageInCatalog, ZodSchemaParsedError } from "@trigger.dev/core/v3/zodMessageHandler";
 import { readFile } from "node:fs/promises";
-import sourceMapSupport from "source-map-support";
+import { installSourceMapSupport } from "../utilities/sourceMaps.js";
 import { registerResources } from "../indexing/registerResources.js";
 import { env } from "std-env";
 import { normalizeImportPath } from "../utilities/normalizeImportPath.js";
 import { detectRuntimeVersion } from "@trigger.dev/core/v3/build";
 import { schemaToJsonSchema } from "@trigger.dev/schema-to-json";
 
-sourceMapSupport.install({
-  handleUncaughtExceptions: false,
-  environment: "node",
-  hookRequire: false,
-});
+installSourceMapSupport();
 
 process.on("uncaughtException", function (error, origin) {
   if (error instanceof Error) {

--- a/packages/cli-v3/src/entryPoints/dev-run-worker.ts
+++ b/packages/cli-v3/src/entryPoints/dev-run-worker.ts
@@ -63,17 +63,9 @@ import {
 import { ZodIpcConnection } from "@trigger.dev/core/v3/zodIpc";
 import { readFile } from "node:fs/promises";
 import { setInterval, setTimeout } from "node:timers/promises";
-import sourceMapSupport from "source-map-support";
-import { env } from "std-env";
-import { normalizeImportPath } from "../utilities/normalizeImportPath.js";
-import { VERSION } from "../version.js";
-import { promiseWithResolvers } from "@trigger.dev/core/utils";
+import { installSourceMapSupport } from "../utilities/sourceMaps.js";
 
-sourceMapSupport.install({
-  handleUncaughtExceptions: false,
-  environment: "node",
-  hookRequire: false,
-});
+installSourceMapSupport();
 
 process.on("uncaughtException", function (error, origin) {
   logError("Uncaught exception", { error, origin });
@@ -109,9 +101,8 @@ process.on("uncaughtException", function (error, origin) {
   }
 });
 
-process.title = `trigger-dev-run-worker (${
-  getEnvVar("TRIGGER_WORKER_VERSION") ?? "unknown version"
-})`;
+process.title = `trigger-dev-run-worker (${getEnvVar("TRIGGER_WORKER_VERSION") ?? "unknown version"
+  })`;
 
 const heartbeatIntervalMs = getEnvVar("HEARTBEAT_INTERVAL_MS");
 
@@ -156,7 +147,7 @@ const standardRealtimeStreamsManager = new StandardRealtimeStreamsManager(
   apiClientManager.clientOrThrow(),
   getEnvVar("TRIGGER_STREAM_URL", getEnvVar("TRIGGER_API_URL")) ?? "https://api.trigger.dev",
   (getEnvVar("TRIGGER_STREAMS_DEBUG") === "1" || getEnvVar("TRIGGER_STREAMS_DEBUG") === "true") ??
-    false
+  false
 );
 realtimeStreams.setGlobalManager(standardRealtimeStreamsManager);
 
@@ -285,12 +276,12 @@ async function doBootstrap() {
 
 let bootstrapCache:
   | {
-      tracer: TriggerTracer;
-      tracingSDK: TracingSDK;
-      consoleInterceptor: ConsoleInterceptor;
-      config: TriggerConfig;
-      workerManifest: WorkerManifest;
-    }
+    tracer: TriggerTracer;
+    tracingSDK: TracingSDK;
+    consoleInterceptor: ConsoleInterceptor;
+    config: TriggerConfig;
+    workerManifest: WorkerManifest;
+  }
   | undefined;
 
 async function bootstrap() {

--- a/packages/cli-v3/src/entryPoints/managed-index-worker.ts
+++ b/packages/cli-v3/src/entryPoints/managed-index-worker.ts
@@ -13,18 +13,14 @@ import {
 } from "@trigger.dev/core/v3/workers";
 import { sendMessageInCatalog, ZodSchemaParsedError } from "@trigger.dev/core/v3/zodMessageHandler";
 import { readFile } from "node:fs/promises";
-import sourceMapSupport from "source-map-support";
+import { installSourceMapSupport } from "../utilities/sourceMaps.js";
 import { registerResources } from "../indexing/registerResources.js";
 import { env } from "std-env";
 import { normalizeImportPath } from "../utilities/normalizeImportPath.js";
 import { detectRuntimeVersion } from "@trigger.dev/core/v3/build";
 import { schemaToJsonSchema } from "@trigger.dev/schema-to-json";
 
-sourceMapSupport.install({
-  handleUncaughtExceptions: false,
-  environment: "node",
-  hookRequire: false,
-});
+installSourceMapSupport();
 
 process.on("uncaughtException", function (error, origin) {
   if (error instanceof Error) {
@@ -168,8 +164,8 @@ await sendMessageInCatalog(
         typeof processKeepAlive === "object"
           ? processKeepAlive
           : typeof processKeepAlive === "boolean"
-          ? { enabled: processKeepAlive }
-          : undefined,
+            ? { enabled: processKeepAlive }
+            : undefined,
       timings,
     },
     importErrors,

--- a/packages/cli-v3/src/entryPoints/managed-run-worker.ts
+++ b/packages/cli-v3/src/entryPoints/managed-run-worker.ts
@@ -63,17 +63,9 @@ import {
 import { ZodIpcConnection } from "@trigger.dev/core/v3/zodIpc";
 import { readFile } from "node:fs/promises";
 import { setInterval, setTimeout } from "node:timers/promises";
-import sourceMapSupport from "source-map-support";
-import { env } from "std-env";
-import { normalizeImportPath } from "../utilities/normalizeImportPath.js";
-import { VERSION } from "../version.js";
-import { promiseWithResolvers } from "@trigger.dev/core/utils";
+import { installSourceMapSupport } from "../utilities/sourceMaps.js";
 
-sourceMapSupport.install({
-  handleUncaughtExceptions: false,
-  environment: "node",
-  hookRequire: false,
-});
+installSourceMapSupport();
 
 process.on("uncaughtException", function (error, origin) {
   console.error("Uncaught exception", { error, origin });
@@ -136,7 +128,7 @@ const standardRealtimeStreamsManager = new StandardRealtimeStreamsManager(
   apiClientManager.clientOrThrow(),
   getEnvVar("TRIGGER_STREAM_URL", getEnvVar("TRIGGER_API_URL")) ?? "https://api.trigger.dev",
   (getEnvVar("TRIGGER_STREAMS_DEBUG") === "1" || getEnvVar("TRIGGER_STREAMS_DEBUG") === "true") ??
-    false
+  false
 );
 realtimeStreams.setGlobalManager(standardRealtimeStreamsManager);
 
@@ -262,12 +254,12 @@ async function doBootstrap() {
 
 let bootstrapCache:
   | {
-      tracer: TriggerTracer;
-      tracingSDK: TracingSDK;
-      consoleInterceptor: ConsoleInterceptor;
-      config: TriggerConfig;
-      workerManifest: WorkerManifest;
-    }
+    tracer: TriggerTracer;
+    tracingSDK: TracingSDK;
+    consoleInterceptor: ConsoleInterceptor;
+    config: TriggerConfig;
+    workerManifest: WorkerManifest;
+  }
   | undefined;
 
 async function bootstrap() {

--- a/packages/cli-v3/src/utilities/sourceMaps.test.ts
+++ b/packages/cli-v3/src/utilities/sourceMaps.test.ts
@@ -1,0 +1,62 @@
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import sourceMapSupport from "source-map-support";
+import { installSourceMapSupport } from "./sourceMaps.js";
+
+vi.mock("source-map-support", () => ({
+    default: {
+        install: vi.fn(),
+    },
+}));
+
+describe("installSourceMapSupport", () => {
+    const originalEnv = process.env;
+    const originalSetSourceMapsEnabled = process.setSourceMapsEnabled;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        process.env = { ...originalEnv };
+        // Mock setSourceMapsEnabled if it doesn't exist (Node < 16.6) or restore it
+        process.setSourceMapsEnabled = vi.fn();
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+        process.setSourceMapsEnabled = originalSetSourceMapsEnabled;
+    });
+
+    it("should install source-map-support by default (undefined env var)", () => {
+        delete process.env.TRIGGER_SOURCE_MAPS;
+        installSourceMapSupport();
+        expect(sourceMapSupport.install).toHaveBeenCalledWith({
+            handleUncaughtExceptions: false,
+            environment: "node",
+            hookRequire: false,
+        });
+    });
+
+    it("should install source-map-support if env var is 'true'", () => {
+        process.env.TRIGGER_SOURCE_MAPS = "true";
+        installSourceMapSupport();
+        expect(sourceMapSupport.install).toHaveBeenCalled();
+    });
+
+    it("should NOT install source-map-support if env var is 'false'", () => {
+        process.env.TRIGGER_SOURCE_MAPS = "false";
+        installSourceMapSupport();
+        expect(sourceMapSupport.install).not.toHaveBeenCalled();
+    });
+
+    it("should NOT install source-map-support if env var is '0'", () => {
+        process.env.TRIGGER_SOURCE_MAPS = "0";
+        installSourceMapSupport();
+        expect(sourceMapSupport.install).not.toHaveBeenCalled();
+    });
+
+    it("should enable native node source maps if env var is 'node'", () => {
+        process.env.TRIGGER_SOURCE_MAPS = "node";
+        installSourceMapSupport();
+        expect(sourceMapSupport.install).not.toHaveBeenCalled();
+        expect(process.setSourceMapsEnabled).toHaveBeenCalledWith(true);
+    });
+});

--- a/packages/cli-v3/src/utilities/sourceMaps.ts
+++ b/packages/cli-v3/src/utilities/sourceMaps.ts
@@ -1,0 +1,22 @@
+import sourceMapSupport from "source-map-support";
+
+export function installSourceMapSupport() {
+    const sourceMaps = process.env.TRIGGER_SOURCE_MAPS;
+
+    if (sourceMaps === "false" || sourceMaps === "0") {
+        return;
+    }
+
+    if (sourceMaps === "node") {
+        if (process.setSourceMapsEnabled) {
+            process.setSourceMapsEnabled(true);
+        }
+        return;
+    }
+
+    sourceMapSupport.install({
+        handleUncaughtExceptions: false,
+        environment: "node",
+        hookRequire: false,
+    });
+}


### PR DESCRIPTION
## Summary
Fixes #2920

## Problem
Sentry sourcemap injection adds \
ew Error().stack\ to bundled modules, causing \source-map-support\ to eagerly parse sourcemaps during module loading. This leads to OOM on small machines when bundling many files.

## Fix
Wrapped \sourceMapSupport.install()\ logic in \installSourceMapSupport\ utility across all worker entry points.

Introduced \TRIGGER_SOURCE_MAPS\ environment variable:
- \TRIGGER_SOURCE_MAPS=false\ or \
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/triggerdotdev/trigger.dev/pull/2989">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
