### PR TITLE
fix(cli-v3): ignore engine checks during deployment install to prevent build server failures

### DIFF
--- a/.changeset/fix-github-install-node-version-2913.md
+++ b/.changeset/fix-github-install-node-version-2913.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/cli-v3": patch
+---
+
+Fix: Ignore engine checks during deployment install phase to prevent failure on build server when Node version mismatch exists. (#2913)

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -252,7 +252,7 @@ async function _deployCommand(dir: string, options: DeployCommandOptions) {
   }
 
   if (!options.skipUpdateCheck) {
-    await updateTriggerPackages(dir, { ...options }, true, true);
+    await updateTriggerPackages(dir, { ...options, ignoreEngines: true }, true, true);
   }
 
   const cwd = process.cwd();
@@ -489,9 +489,8 @@ async function _deployCommand(dir: string, options: DeployCommandOptions) {
   const version = deployment.version;
 
   const rawDeploymentLink = `${authorization.dashboardUrl}/projects/v3/${resolvedConfig.project}/deployments/${deployment.shortCode}`;
-  const rawTestLink = `${authorization.dashboardUrl}/projects/v3/${
-    resolvedConfig.project
-  }/test?environment=${options.env === "prod" ? "prod" : "stg"}`;
+  const rawTestLink = `${authorization.dashboardUrl}/projects/v3/${resolvedConfig.project
+    }/test?environment=${options.env === "prod" ? "prod" : "stg"}`;
 
   const deploymentLink = cliLink("View deployment", rawDeploymentLink);
   const testLink = cliLink("Test tasks", rawTestLink);
@@ -708,8 +707,7 @@ async function _deployCommand(dir: string, options: DeployCommandOptions) {
     }
   } else {
     outro(
-      `Version ${version} deployed with ${taskCount} detected task${taskCount === 1 ? "" : "s"} ${
-        isLinksSupported ? `| ${deploymentLink} | ${testLink}` : ""
+      `Version ${version} deployed with ${taskCount} detected task${taskCount === 1 ? "" : "s"} ${isLinksSupported ? `| ${deploymentLink} | ${testLink}` : ""
       }`
     );
 
@@ -733,18 +731,16 @@ async function _deployCommand(dir: string, options: DeployCommandOptions) {
       TRIGGER_VERSION: version,
       TRIGGER_DEPLOYMENT_SHORT_CODE: deployment.shortCode,
       TRIGGER_DEPLOYMENT_URL: `${authorization.dashboardUrl}/projects/v3/${resolvedConfig.project}/deployments/${deployment.shortCode}`,
-      TRIGGER_TEST_URL: `${authorization.dashboardUrl}/projects/v3/${
-        resolvedConfig.project
-      }/test?environment=${options.env === "prod" ? "prod" : "stg"}`,
+      TRIGGER_TEST_URL: `${authorization.dashboardUrl}/projects/v3/${resolvedConfig.project
+        }/test?environment=${options.env === "prod" ? "prod" : "stg"}`,
     },
     outputs: {
       deploymentVersion: version,
       workerVersion: version,
       deploymentShortCode: deployment.shortCode,
       deploymentUrl: `${authorization.dashboardUrl}/projects/v3/${resolvedConfig.project}/deployments/${deployment.shortCode}`,
-      testUrl: `${authorization.dashboardUrl}/projects/v3/${
-        resolvedConfig.project
-      }/test?environment=${options.env === "prod" ? "prod" : "stg"}`,
+      testUrl: `${authorization.dashboardUrl}/projects/v3/${resolvedConfig.project
+        }/test?environment=${options.env === "prod" ? "prod" : "stg"}`,
       needsPromotion: options.skipPromotion ? "true" : "false",
     },
   });
@@ -787,8 +783,7 @@ async function failDeploy(
       checkLogsForErrors(logs);
 
       outro(
-        `${chalkError(`${prefix}:`)} ${
-          error.message
+        `${chalkError(`${prefix}:`)} ${error.message
         }. Full build logs have been saved to ${logPath}`
       );
 
@@ -1088,9 +1083,8 @@ async function handleNativeBuildServerDeploy({
   const deployment = initializeDeploymentResult.data;
 
   const rawDeploymentLink = `${dashboardUrl}/projects/v3/${config.project}/deployments/${deployment.shortCode}`;
-  const rawTestLink = `${dashboardUrl}/projects/v3/${config.project}/test?environment=${
-    options.env === "prod" ? "prod" : "stg"
-  }`;
+  const rawTestLink = `${dashboardUrl}/projects/v3/${config.project}/test?environment=${options.env === "prod" ? "prod" : "stg"
+    }`;
 
   const exposedDeploymentLink = isLinksSupported
     ? cliLink(chalk.bold(rawDeploymentLink), rawDeploymentLink)
@@ -1156,8 +1150,7 @@ async function handleNativeBuildServerDeploy({
     log.warn(`Failed streaming build logs, open the deployment in the dashboard to view the logs`);
 
     outro(
-      `Version ${deployment.version} is being deployed ${
-        isLinksSupported ? `| ${cliLink("View deployment", rawDeploymentLink)}` : ""
+      `Version ${deployment.version} is being deployed ${isLinksSupported ? `| ${cliLink("View deployment", rawDeploymentLink)}` : ""
       }`
     );
 
@@ -1204,10 +1197,10 @@ async function handleNativeBuildServerDeploy({
           level === "error"
             ? chalk.bold(chalkError(message))
             : level === "warn"
-            ? chalkWarning(message)
-            : level === "debug"
-            ? chalkGrey(message)
-            : message;
+              ? chalkWarning(message)
+              : level === "debug"
+                ? chalkGrey(message)
+                : message;
 
         // We use console.log here instead of clack's logger as the current version does not support changing the line spacing.
         // And the logs look verbose with the default spacing.
@@ -1240,8 +1233,7 @@ async function handleNativeBuildServerDeploy({
     log.error("Failed dequeueing build, please try again shortly");
 
     throw new OutroCommandError(
-      `Version ${deployment.version} ${
-        isLinksSupported ? `| ${cliLink("View deployment", rawDeploymentLink)}` : ""
+      `Version ${deployment.version} ${isLinksSupported ? `| ${cliLink("View deployment", rawDeploymentLink)}` : ""
       }`
     );
   }
@@ -1256,8 +1248,7 @@ async function handleNativeBuildServerDeploy({
     }
 
     throw new OutroCommandError(
-      `Version ${deployment.version} ${
-        isLinksSupported ? `| ${cliLink("View deployment", rawDeploymentLink)}` : ""
+      `Version ${deployment.version} ${isLinksSupported ? `| ${cliLink("View deployment", rawDeploymentLink)}` : ""
       }`
     );
   }
@@ -1283,13 +1274,12 @@ async function handleNativeBuildServerDeploy({
       }
 
       outro(
-        `Version ${deployment.version} was deployed ${
-          isLinksSupported
-            ? `| ${cliLink("Test tasks", rawTestLink)} | ${cliLink(
-                "View deployment",
-                rawDeploymentLink
-              )}`
-            : ""
+        `Version ${deployment.version} was deployed ${isLinksSupported
+          ? `| ${cliLink("Test tasks", rawTestLink)} | ${cliLink(
+            "View deployment",
+            rawDeploymentLink
+          )}`
+          : ""
         }`
       );
       return process.exit(0);
@@ -1303,14 +1293,13 @@ async function handleNativeBuildServerDeploy({
         chalk.bold(
           chalkError(
             "Deployment failed" +
-              (finalDeploymentEvent.message ? `: ${finalDeploymentEvent.message}` : "")
+            (finalDeploymentEvent.message ? `: ${finalDeploymentEvent.message}` : "")
           )
         )
       );
 
       throw new OutroCommandError(
-        `Version ${deployment.version} deployment failed ${
-          isLinksSupported ? `| ${cliLink("View deployment", rawDeploymentLink)}` : ""
+        `Version ${deployment.version} deployment failed ${isLinksSupported ? `| ${cliLink("View deployment", rawDeploymentLink)}` : ""
         }`
       );
     }
@@ -1323,14 +1312,13 @@ async function handleNativeBuildServerDeploy({
         chalk.bold(
           chalkError(
             "Deployment timed out" +
-              (finalDeploymentEvent.message ? `: ${finalDeploymentEvent.message}` : "")
+            (finalDeploymentEvent.message ? `: ${finalDeploymentEvent.message}` : "")
           )
         )
       );
 
       throw new OutroCommandError(
-        `Version ${deployment.version} deployment timed out ${
-          isLinksSupported ? `| ${cliLink("View deployment", rawDeploymentLink)}` : ""
+        `Version ${deployment.version} deployment timed out ${isLinksSupported ? `| ${cliLink("View deployment", rawDeploymentLink)}` : ""
         }`
       );
     }
@@ -1343,14 +1331,13 @@ async function handleNativeBuildServerDeploy({
         chalk.bold(
           chalkError(
             "Deployment was canceled" +
-              (finalDeploymentEvent.message ? `: ${finalDeploymentEvent.message}` : "")
+            (finalDeploymentEvent.message ? `: ${finalDeploymentEvent.message}` : "")
           )
         )
       );
 
       throw new OutroCommandError(
-        `Version ${deployment.version} deployment canceled ${
-          isLinksSupported ? `| ${cliLink("View deployment", rawDeploymentLink)}` : ""
+        `Version ${deployment.version} deployment canceled ${isLinksSupported ? `| ${cliLink("View deployment", rawDeploymentLink)}` : ""
         }`
       );
     }
@@ -1369,13 +1356,12 @@ async function handleNativeBuildServerDeploy({
       }
 
       outro(
-        `Version ${deployment.version} ${
-          isLinksSupported
-            ? `| ${cliLink("Test tasks", rawTestLink)} | ${cliLink(
-                "View deployment",
-                rawDeploymentLink
-              )}`
-            : ""
+        `Version ${deployment.version} ${isLinksSupported
+          ? `| ${cliLink("Test tasks", rawTestLink)} | ${cliLink(
+            "View deployment",
+            rawDeploymentLink
+          )}`
+          : ""
         }`
       );
       return process.exit(0);

--- a/packages/cli-v3/src/commands/update.test.ts
+++ b/packages/cli-v3/src/commands/update.test.ts
@@ -1,0 +1,113 @@
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { updateTriggerPackages } from "./update.js";
+import * as nypm from "nypm";
+import * as pkgTypes from "pkg-types";
+import * as fs from "node:fs/promises";
+import * as clack from "@clack/prompts";
+import path from "node:path";
+
+// Mock dependencies
+vi.mock("nypm");
+vi.mock("pkg-types");
+vi.mock("node:fs/promises");
+vi.mock("@clack/prompts");
+vi.mock("std-env", () => ({
+    hasTTY: true,
+    isCI: false,
+}));
+vi.mock("../utilities/initialBanner.js", () => ({
+    updateCheck: vi.fn().mockResolvedValue(undefined),
+    printStandloneInitialBanner: vi.fn(),
+}));
+vi.mock("../version.js", () => ({
+    VERSION: "3.0.0",
+}));
+vi.mock("../cli/common.js", () => ({
+    CommonCommandOptions: { pick: () => ({}) },
+}));
+vi.mock("../utilities/cliOutput.js", () => ({
+    chalkError: vi.fn(),
+    prettyError: vi.fn(),
+    prettyWarning: vi.fn(),
+}));
+vi.mock("../utilities/fileSystem.js", () => ({
+    removeFile: vi.fn(),
+    writeJSONFilePreserveOrder: vi.fn(),
+}));
+vi.mock("../utilities/logger.js", () => ({
+    logger: {
+        debug: vi.fn(),
+        log: vi.fn(),
+        table: vi.fn(),
+    },
+}));
+vi.mock("../utilities/windows.js", () => ({
+    spinner: () => ({
+        start: vi.fn(),
+        message: vi.fn(),
+        stop: vi.fn(),
+    }),
+}));
+
+describe("updateTriggerPackages", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+
+        // Default mocks
+        vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+        vi.mocked(fs.rm).mockResolvedValue(undefined);
+        vi.mocked(pkgTypes.readPackageJSON).mockResolvedValue({
+            dependencies: {
+                "@trigger.dev/sdk": "2.0.0", // Mismatch
+            },
+        });
+        vi.mocked(pkgTypes.resolvePackageJSON).mockResolvedValue("/path/to/package.json");
+        vi.mocked(clack.confirm).mockResolvedValue(true); // User confirms update
+        vi.mocked(nypm.installDependencies).mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("should pass --no-engine-strict for npm when ignoreEngines is true", async () => {
+        vi.mocked(nypm.detectPackageManager).mockResolvedValue({ name: "npm", command: "npm", version: "1.0.0" } as any);
+
+        await updateTriggerPackages(".", { ignoreEngines: true } as any, true, true);
+
+        expect(nypm.installDependencies).toHaveBeenCalledWith(expect.objectContaining({
+            args: ["--no-engine-strict"],
+        }));
+    });
+
+    it("should pass --config.engine-strict=false for pnpm when ignoreEngines is true", async () => {
+        vi.mocked(nypm.detectPackageManager).mockResolvedValue({ name: "pnpm", command: "pnpm", version: "1.0.0" } as any);
+
+        await updateTriggerPackages(".", { ignoreEngines: true } as any, true, true);
+
+        expect(nypm.installDependencies).toHaveBeenCalledWith(expect.objectContaining({
+            args: ["--config.engine-strict=false"],
+        }));
+    });
+
+    it("should pass --ignore-engines for yarn when ignoreEngines is true", async () => {
+        vi.mocked(nypm.detectPackageManager).mockResolvedValue({ name: "yarn", command: "yarn", version: "1.0.0" } as any);
+
+        await updateTriggerPackages(".", { ignoreEngines: true } as any, true, true);
+
+        expect(nypm.installDependencies).toHaveBeenCalledWith(expect.objectContaining({
+            args: ["--ignore-engines"],
+        }));
+    });
+
+    it("should NOT pass engine flags if ignoreEngines is false (default)", async () => {
+        vi.mocked(nypm.detectPackageManager).mockResolvedValue({ name: "npm", command: "npm", version: "1.0.0" } as any);
+
+        await updateTriggerPackages(".", { ignoreEngines: false } as any, true, true);
+
+        expect(nypm.installDependencies).toHaveBeenCalledWith(expect.objectContaining({
+            args: [],
+        }));
+    });
+});


### PR DESCRIPTION
## Summary
Fixes #2913

## Problem
GitHub Integration runs `trigger deploy` which executes `npm install` (or equivalent) in a Node 20 environment. If a project has strict `engines.node` requirements (e.g., "22"), the install phase fails before reaching the Docker build phase where the runtime config is respected.

## Fix
- Updated `updateTriggerPackages` in `packages/cli-v3/src/commands/update.ts` to accept an `ignoreEngines` option.
- Passed appropriate flags to `installDependencies` based on package manager:
  - npm: `--no-engine-strict`
  - pnpm: `--config.engine-strict=false`
  - yarn: `--ignore-engines`
- Updated `deploy.ts` to pass `ignoreEngines: true` when running package updates during deployment.

## Verification
- Added unit tests in `packages/cli-v3/src/commands/update.test.ts` to verify the correct flags are passed.
- Verified locally via unit tests.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/triggerdotdev/trigger.dev/pull/2990">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
