### PR TITLE
fix: increase realtime createdAt filter max from 24h to 7d

### DIFF
--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -226,7 +226,7 @@ const EnvironmentSchema = z
     REALTIME_MAXIMUM_CREATED_AT_FILTER_AGE_IN_MS: z.coerce
       .number()
       .int()
-      .default(24 * 60 * 60 * 1000), // 1 day in milliseconds
+      .default(7 * 24 * 60 * 60 * 1000), // 7 days in milliseconds
 
     PUBSUB_REDIS_HOST: z
       .string()


### PR DESCRIPTION
## Summary

Increases the `REALTIME_MAXIMUM_CREATED_AT_FILTER_AGE_IN_MS` default from 24 hours to 7 days.

## Problem

When using `useRealtimeRunsWithTag` with `createdAt: '1w'`, runs older than 24 hours are silently excluded because the server caps the filter to `REALTIME_MAXIMUM_CREATED_AT_FILTER_AGE_IN_MS` (default 24h), regardless of what the client requests.

This causes confusion when monitoring long-running jobs that have been in progress for more than a day - they simply don't appear in the realtime hook despite being visible in `runs.list` and the dashboard.

## Solution

Increase the default cap from 24 hours to 7 days to match common user expectations. Users requesting `createdAt: '1w'` will now see runs from the past week as expected.

The environment variable remains configurable for deployments that need stricter limits.

## Changes

- `apps/webapp/app/env.server.ts`: Change default from `24 * 60 * 60 * 1000` to `7 * 24 * 60 * 60 * 1000`

Fixes #3018
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/triggerdotdev/trigger.dev/pull/3027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
