### PR TITLE
feat(mcp): add timeout parameter to wait_for_run_to_complete tool

### DIFF
--- a/.changeset/mcp-wait-timeout.md
+++ b/.changeset/mcp-wait-timeout.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Add optional `timeoutInSeconds` parameter to the `wait_for_run_to_complete` MCP tool. Defaults to 60 seconds. If the run doesn't complete within the timeout, the current state of the run is returned instead of waiting indefinitely.

--- a/packages/cli-v3/src/mcp/config.ts
+++ b/packages/cli-v3/src/mcp/config.ts
@@ -68,7 +68,7 @@ export const toolsMetadata = {
     name: "wait_for_run_to_complete",
     title: "Wait for Run to Complete",
     description:
-      "Wait for a run to complete. The run ID is the ID of the run that was triggered. It starts with run_",
+      "Wait for a run to complete. The run ID is the ID of the run that was triggered. It starts with run_. Has an optional timeoutInSeconds parameter (default 60s) - if the run doesn't complete within that time, the current state of the run will be returned.",
   },
   cancel_run: {
     name: "cancel_run",

--- a/packages/cli-v3/src/mcp/schemas.ts
+++ b/packages/cli-v3/src/mcp/schemas.ts
@@ -123,6 +123,17 @@ export const CommonRunsInput = CommonProjectsInput.extend({
 
 export type CommonRunsInput = z.output<typeof CommonRunsInput>;
 
+export const WaitForRunInput = CommonRunsInput.extend({
+  timeoutInSeconds: z
+    .number()
+    .describe(
+      "The maximum time in seconds to wait for the run to complete. If the run doesn't complete within this time, the current state of the run will be returned. Defaults to 60 seconds."
+    )
+    .default(60),
+});
+
+export type WaitForRunInput = z.output<typeof WaitForRunInput>;
+
 export const GetRunDetailsInput = CommonRunsInput.extend({
   maxTraceLines: z
     .number()


### PR DESCRIPTION
## Summary

- Adds an optional `timeoutInSeconds` parameter (default 60s) to the `wait_for_run_to_complete` MCP tool
- If the run doesn't complete within the timeout, returns the current run state instead of blocking indefinitely
- Uses `AbortSignal.timeout()` combined with the existing MCP signal

Fixes #3032