### PR TITLE
fix: handle invalid source map columns in Bun runtime

### DIFF
--- a/packages/cli-v3/src/entryPoints/dev-index-worker.ts
+++ b/packages/cli-v3/src/entryPoints/dev-index-worker.ts
@@ -13,18 +13,14 @@ import {
 } from "@trigger.dev/core/v3/workers";
 import { sendMessageInCatalog, ZodSchemaParsedError } from "@trigger.dev/core/v3/zodMessageHandler";
 import { readFile } from "node:fs/promises";
-import sourceMapSupport from "source-map-support";
 import { registerResources } from "../indexing/registerResources.js";
+import { installSourceMapSupport } from "../utilities/installSourceMapSupport.js";
 import { env } from "std-env";
 import { normalizeImportPath } from "../utilities/normalizeImportPath.js";
 import { detectRuntimeVersion } from "@trigger.dev/core/v3/build";
 import { schemaToJsonSchema } from "@trigger.dev/schema-to-json";
 
-sourceMapSupport.install({
-  handleUncaughtExceptions: false,
-  environment: "node",
-  hookRequire: false,
-});
+installSourceMapSupport();
 
 process.on("uncaughtException", function (error, origin) {
   if (error instanceof Error) {

--- a/packages/cli-v3/src/entryPoints/dev-run-worker.ts
+++ b/packages/cli-v3/src/entryPoints/dev-run-worker.ts
@@ -63,17 +63,13 @@ import {
 import { ZodIpcConnection } from "@trigger.dev/core/v3/zodIpc";
 import { readFile } from "node:fs/promises";
 import { setInterval, setTimeout } from "node:timers/promises";
-import sourceMapSupport from "source-map-support";
 import { env } from "std-env";
 import { normalizeImportPath } from "../utilities/normalizeImportPath.js";
+import { installSourceMapSupport } from "../utilities/installSourceMapSupport.js";
 import { VERSION } from "../version.js";
 import { promiseWithResolvers } from "@trigger.dev/core/utils";
 
-sourceMapSupport.install({
-  handleUncaughtExceptions: false,
-  environment: "node",
-  hookRequire: false,
-});
+installSourceMapSupport();
 
 process.on("uncaughtException", function (error, origin) {
   logError("Uncaught exception", { error, origin });

--- a/packages/cli-v3/src/entryPoints/managed-index-worker.ts
+++ b/packages/cli-v3/src/entryPoints/managed-index-worker.ts
@@ -13,18 +13,14 @@ import {
 } from "@trigger.dev/core/v3/workers";
 import { sendMessageInCatalog, ZodSchemaParsedError } from "@trigger.dev/core/v3/zodMessageHandler";
 import { readFile } from "node:fs/promises";
-import sourceMapSupport from "source-map-support";
 import { registerResources } from "../indexing/registerResources.js";
+import { installSourceMapSupport } from "../utilities/installSourceMapSupport.js";
 import { env } from "std-env";
 import { normalizeImportPath } from "../utilities/normalizeImportPath.js";
 import { detectRuntimeVersion } from "@trigger.dev/core/v3/build";
 import { schemaToJsonSchema } from "@trigger.dev/schema-to-json";
 
-sourceMapSupport.install({
-  handleUncaughtExceptions: false,
-  environment: "node",
-  hookRequire: false,
-});
+installSourceMapSupport();
 
 process.on("uncaughtException", function (error, origin) {
   if (error instanceof Error) {

--- a/packages/cli-v3/src/entryPoints/managed-run-worker.ts
+++ b/packages/cli-v3/src/entryPoints/managed-run-worker.ts
@@ -63,17 +63,13 @@ import {
 import { ZodIpcConnection } from "@trigger.dev/core/v3/zodIpc";
 import { readFile } from "node:fs/promises";
 import { setInterval, setTimeout } from "node:timers/promises";
-import sourceMapSupport from "source-map-support";
 import { env } from "std-env";
 import { normalizeImportPath } from "../utilities/normalizeImportPath.js";
+import { installSourceMapSupport } from "../utilities/installSourceMapSupport.js";
 import { VERSION } from "../version.js";
 import { promiseWithResolvers } from "@trigger.dev/core/utils";
 
-sourceMapSupport.install({
-  handleUncaughtExceptions: false,
-  environment: "node",
-  hookRequire: false,
-});
+installSourceMapSupport();
 
 process.on("uncaughtException", function (error, origin) {
   console.error("Uncaught exception", { error, origin });

--- a/packages/cli-v3/src/utilities/installSourceMapSupport.ts
+++ b/packages/cli-v3/src/utilities/installSourceMapSupport.ts
@@ -1,0 +1,32 @@
+import sourceMapSupport from "source-map-support";
+
+/**
+ * Installs source-map-support with a workaround for Bun's source map handling.
+ *
+ * Bun's runtime can produce source maps with column values of -1, which causes
+ * source-map@0.6.1 (used by source-map-support) to throw:
+ * "Column must be greater than or equal to 0, got -1"
+ *
+ * This wraps the prepareStackTrace hook so that if source map processing fails,
+ * it falls back to default stack trace formatting instead of crashing.
+ *
+ * See: https://github.com/oven-sh/bun/issues/8087
+ */
+export function installSourceMapSupport() {
+  sourceMapSupport.install({
+    handleUncaughtExceptions: false,
+    environment: "node",
+    hookRequire: false,
+  });
+
+  const _prepareStackTrace = (Error as any).prepareStackTrace;
+  if (_prepareStackTrace) {
+    (Error as any).prepareStackTrace = (error: Error, stackTraces: NodeJS.CallSite[]) => {
+      try {
+        return _prepareStackTrace(error, stackTraces);
+      } catch {
+        return `${error}\n` + stackTraces.map((s) => `    at ${s}`).join("\n");
+      }
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Wraps `source-map-support`'s `prepareStackTrace` hook to catch errors from invalid source maps instead of crashing
- Extracted into a shared `installSourceMapSupport` utility used by all 4 entry points
- When `source-map` processing fails (e.g. column value of `-1`), falls back to default stack trace formatting

## Context

Bun's runtime can produce source maps with column values of `-1`, which causes `source-map@0.6.1` (transitive dep via `source-map-support@0.5.21`) to throw during the indexing phase:

```
TypeError: Column must be greater than or equal to 0, got -1
    at SourceMapConsumer_findMapping (source-map/lib/source-map-consumer.js:588:13)
    at registerResources (trigger.dev/src/indexing/registerResources.ts:32:11)
```

This is a known Bun issue: https://github.com/oven-sh/bun/issues/8087

Fixes #3045

## Test plan

- [ ] Deploy a project with `runtime: 'bun'` that previously failed with the column error
- [ ] Verify indexing completes successfully
- [ ] Verify stack traces still work (just with column 0 fallback when source map is invalid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)