### PR TITLE
TRQL: always add FINAL keyword

### DIFF
--- a/internal-packages/tsql/src/query/printer.ts
+++ b/internal-packages/tsql/src/query/printer.ts
@@ -1559,9 +1559,14 @@ export class ClickHousePrinter {
       joinStrings.push(`AS ${this.printIdentifier(node.alias)}`);
     }
 
-    // Add FINAL
-    if (node.table_final) {
-      joinStrings.push("FINAL");
+    // Always add FINAL for direct table references to ensure deduplicated results
+    // from ReplacingMergeTree tables in ClickHouse
+    if (node.table) {
+      const tableExpr = node.table;
+      const isDirectTable = (tableExpr as Field).expression_type === "field";
+      if (isDirectTable) {
+        joinStrings.push("FINAL");
+      }
     }
 
     // Add SAMPLE


### PR DESCRIPTION
For now we’re going to always add FINAL to TRQL queries for data correctness.

In the future we will implement an automated optimization where we use `SELECT argMax(column, _version)` and `WHERE _is_deleted = 0`. But this is a more complex change and needs more investigation of downsides.