### PR TITLE
fix: explicitly set machineConfig to null when task machine is removed

### DIFF
--- a/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
@@ -276,7 +276,7 @@ async function createWorkerTask(
         exportName: task.exportName,
         retryConfig: task.retry,
         queueConfig: task.queue,
-        machineConfig: task.machine,
+        machineConfig: task.machine ?? null,
         triggerSource: task.triggerSource === "schedule" ? "SCHEDULED" : "STANDARD",
         fileId: tasksToBackgroundFiles?.get(task.id) ?? null,
         maxDurationInSeconds: task.maxDuration ? clampMaxDuration(task.maxDuration) : null,


### PR DESCRIPTION
## Summary
Fixes #2796

When a user removes the `machine` configuration from a task and redeploys, `task.machine` becomes `undefined`. Prisma's `create()` silently skips `undefined` fields for `Json?` columns rather than setting them to `NULL`. This means the `machineConfig` column may not be properly cleared, causing runs to continue executing on the previously configured machine preset.

## Changes
- **`createBackgroundWorker.server.ts`**: Changed `machineConfig: task.machine` to `machineConfig: task.machine ?? null` to explicitly set the column to `NULL` when machine config is removed from a task.

## How to reproduce the bug
1. Set a task machine to something other than the default, e.g. `medium-1x`
2. Deploy
3. Remove the task machine config
4. Deploy
5. Runs will still execute on `medium-1x`

## How this fix works
By using `?? null`, we ensure the `machineConfig` column is always explicitly set — either to the machine config value or to `NULL`. At dequeue time, both V1 and V2 engines correctly fall back to the default `small-1x` when `machineConfig` is `NULL`.