### PR TITLE
fix: explicitly set machineConfig to null when task machine is removed

### DIFF
--- a/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
@@ -276,7 +276,7 @@ async function createWorkerTask(
         exportName: task.exportName,
         retryConfig: task.retry,
         queueConfig: task.queue,
-        machineConfig: task.machine,
+        machineConfig: task.machine ?? null,
         triggerSource: task.triggerSource === "schedule" ? "SCHEDULED" : "STANDARD",
         fileId: tasksToBackgroundFiles?.get(task.id) ?? null,
         maxDurationInSeconds: task.maxDuration ? clampMaxDuration(task.maxDuration) : null,


### PR DESCRIPTION
Fixes #2796. When task.machine is undefined (user removed machine config), Prisma skips undefined fields for Json columns rather than setting NULL. Changed machineConfig: task.machine to machineConfig: task.machine ?? null to explicitly clear it.