### PR TITLE
Fix(webapp): consistent query button width

### DIFF
--- a/apps/webapp/app/components/query/QueryEditor.tsx
+++ b/apps/webapp/app/components/query/QueryEditor.tsx
@@ -1009,7 +1009,7 @@ function QueryTitle({
   if (isTitleLoading)
     return (
       <span className="flex items-center gap-2 text-text-dimmed">
-        <Spinner className="size-3" /> Generating title…
+        <Spinner className="size-4" /> Generating title…
       </span>
     );
 


### PR DESCRIPTION
Prevents layout shift by keeping the button width the same when isLoading

Normal state
<img width="423" height="186" alt="CleanShot 2026-02-16 at 10 31 23" src="https://github.com/user-attachments/assets/232bc14f-dc2c-4092-9b46-f6d652568633" />

isLoading
<img width="403" height="137" alt="CleanShot 2026-02-16 at 10 31 43" src="https://github.com/user-attachments/assets/e9215b48-c2cc-4ede-91ff-08bbdb2382a0" />
