### PR TITLE
fix(webapp): Fix backwards nextCursor for runs edge case

### DIFF
--- a/apps/webapp/app/services/runsRepository/clickhouseRunsRepository.server.ts
+++ b/apps/webapp/app/services/runsRepository/clickhouseRunsRepository.server.ts
@@ -101,7 +101,11 @@ export class ClickHouseRunsRepository implements IRunsRepository {
           previousCursor = reversedRunIds.at(1) ?? null;
           nextCursor = reversedRunIds.at(options.page.size) ?? null;
         } else {
-          nextCursor = reversedRunIds.at(options.page.size - 1) ?? null;
+          // Use the last item (oldest run) as the forward cursor.
+          // We can't use a fixed index (pageSize - 1) because the result set
+          // may have fewer items than pageSize (e.g., when new runs were created
+          // while the user was browsing, shifting page boundaries).
+          nextCursor = reversedRunIds.at(reversedRunIds.length - 1) ?? null;
         }
 
         break;

--- a/apps/webapp/app/services/runsRepository/postgresRunsRepository.server.ts
+++ b/apps/webapp/app/services/runsRepository/postgresRunsRepository.server.ts
@@ -75,7 +75,11 @@ export class PostgresRunsRepository implements IRunsRepository {
           previousCursor = reversedRuns.at(1)?.id ?? null;
           nextCursor = reversedRuns.at(options.page.size)?.id ?? null;
         } else {
-          nextCursor = reversedRuns.at(options.page.size - 1)?.id ?? null;
+          // Use the last item (oldest run) as the forward cursor.
+          // We can't use a fixed index (pageSize - 1) because the result set
+          // may have fewer items than pageSize (e.g., when new runs were created
+          // while the user was browsing, shifting page boundaries).
+          nextCursor = reversedRuns.at(reversedRuns.length - 1)?.id ?? null;
         }
         break;
       }


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Created a new run, moved forwards and backwards between run list pages. The issue did not reporduce.

---

## Changelog

Changed runs list backwards cursor  to take into account runs length not page size.

---

## Screenshots


https://github.com/user-attachments/assets/6aa7c23d-d88a-4d17-9a1a-b1ae574bc56b

