### PR TITLE
fix(sdk): batch triggerAndWait variants now return correct run.taskIdentifier instead of unknown

### DIFF
--- a/.changeset/metal-steaks-try.md
+++ b/.changeset/metal-steaks-try.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+fix(sdk): batch triggerAndWait variants now return correct run.taskIdentifier instead of unknown


### PR DESCRIPTION
Fixes #2942