### PR TITLE
fix: explicitly set machineConfig to null when task machine is removed

### DIFF
--- a/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
@@ -276,7 +276,7 @@ async function createWorkerTask(
         exportName: task.exportName,
         retryConfig: task.retry,
         queueConfig: task.queue,
-        machineConfig: task.machine,
+        machineConfig: task.machine ?? null,
         triggerSource: task.triggerSource === "schedule" ? "SCHEDULED" : "STANDARD",
         fileId: tasksToBackgroundFiles?.get(task.id) ?? null,
         maxDurationInSeconds: task.maxDuration ? clampMaxDuration(task.maxDuration) : null,


### PR DESCRIPTION
This PR ensures that when a task machine is removed, the \machineConfig\ is explicitly set to \
ull\. This prevents inconsistent states in the background worker task definition.

Fixes #2796