### PR TITLE
Fix realtime connections pricing tier from 100 to 1000

### DIFF
--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.select-plan.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.select-plan.tsx
@@ -210,7 +210,7 @@ const pricingDefinitions = {
   },
   additionalRealtimeConnections: {
     title: "Additional Realtime connections",
-    content: "Then $10/month per 100",
+    content: "Then $10/month per 1000",
   },
   additionalSeats: {
     title: "Additional seats",


### PR DESCRIPTION
Closes #

## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [ ] The PR title follows the convention.
- [ ] I ran and tested the code works

---

## Testing

Verified the pricing definition displays the correct tier amount on the plan selection page.

---

## Changelog

Fixed incorrect pricing tier for additional realtime connections from $10/month per 100 to $10/month per 1000.

---

## Screenshots

N/A

💯

https://claude.ai/code/session_015QrZZJHPWta3QCBnhX2Pff