### PR TITLE
docs: Query page output dot notation and metadata availability

### DIFF
--- a/docs/insights/query.mdx
+++ b/docs/insights/query.mdx
@@ -388,7 +388,7 @@ WHERE notEmpty(tags)
 
 ### JSON functions
 
-The `output` column is already JSON, so use dot notation to read or filter on it. You don't need `JSONExtract*` for `output` (those are for string columns).
+The `output`, `error`, and `metrics.attributes` columns are already JSON, so use dot notation to read or filter on them. You don't need `JSONExtract*` for these (those are for string columns).
 
 ```sql
 SELECT


### PR DESCRIPTION
Clarifies in the Query docs that run metadata is not available on the Query page and that the output column is JSON, so dot notation (e.g. output.externalId) should be used for selecting and filtering. Adds an example that filters by an output field in WHERE