### PR TITLE
feat(vercel): Vercel SDK fixes and correct env vars behavior for staging envs

### DIFF
--- a/apps/webapp/app/components/integrations/VercelBuildSettings.tsx
+++ b/apps/webapp/app/components/integrations/VercelBuildSettings.tsx
@@ -34,31 +34,31 @@ export function BuildSettingsFields({
     <>
       {/* Pull env vars before build */}
       <div>
-        <div className="mb-2 flex items-center justify-between">
-          <div>
+        <div className="mb-2">
+          <div className="flex items-center justify-between">
             <Label>Pull env vars before build</Label>
-            <Hint>
-              Select which environments should pull environment variables from Vercel before each
-              build.{" "}
-              {envVarsConfigLink && (
-                <>
-                  <TextLink to={envVarsConfigLink}>Configure which variables to pull</TextLink>.
-                </>
-              )}
-            </Hint>
+            {availableEnvSlugs.length > 1 && (
+              <Switch
+                variant="small"
+                checked={
+                  availableEnvSlugs.length > 0 &&
+                  availableEnvSlugs.every((s) => pullEnvVarsBeforeBuild.includes(s))
+                }
+                onCheckedChange={(checked) => {
+                  onPullEnvVarsChange(checked ? [...availableEnvSlugs] : []);
+                }}
+              />
+            )}
           </div>
-          {availableEnvSlugs.length > 1 && (
-            <Switch
-              variant="small"
-              checked={
-                availableEnvSlugs.length > 0 &&
-                availableEnvSlugs.every((s) => pullEnvVarsBeforeBuild.includes(s))
-              }
-              onCheckedChange={(checked) => {
-                onPullEnvVarsChange(checked ? [...availableEnvSlugs] : []);
-              }}
-            />
-          )}
+          <Hint className="pr-6">
+            Select which environments should pull environment variables from Vercel before each
+            build.{" "}
+            {envVarsConfigLink && (
+              <>
+                <TextLink to={envVarsConfigLink}>Configure which variables to pull</TextLink>.
+              </>
+            )}
+          </Hint>
         </div>
         <div className="flex flex-col gap-2 rounded border bg-charcoal-800 p-3">
           {availableEnvSlugs.map((slug) => {
@@ -90,34 +90,34 @@ export function BuildSettingsFields({
 
       {/* Discover new env vars */}
       <div>
-        <div className="mb-2 flex items-center justify-between">
-          <div>
+        <div className="mb-2">
+          <div className="flex items-center justify-between">
             <Label>Discover new env vars</Label>
-            <Hint>
-              Select which environments should automatically discover and create new environment
-              variables from Vercel during builds.
-            </Hint>
+            {availableEnvSlugs.length > 1 && (
+              <Switch
+                variant="small"
+                checked={
+                  availableEnvSlugs.length > 0 &&
+                  availableEnvSlugs.every(
+                    (s) => discoverEnvVars.includes(s) || !pullEnvVarsBeforeBuild.includes(s)
+                  ) &&
+                  availableEnvSlugs.some((s) => discoverEnvVars.includes(s))
+                }
+                disabled={!availableEnvSlugs.some((s) => pullEnvVarsBeforeBuild.includes(s))}
+                onCheckedChange={(checked) => {
+                  onDiscoverEnvVarsChange(
+                    checked
+                      ? availableEnvSlugs.filter((s) => pullEnvVarsBeforeBuild.includes(s))
+                      : []
+                  );
+                }}
+              />
+            )}
           </div>
-          {availableEnvSlugs.length > 1 && (
-            <Switch
-              variant="small"
-              checked={
-                availableEnvSlugs.length > 0 &&
-                availableEnvSlugs.every(
-                  (s) => discoverEnvVars.includes(s) || !pullEnvVarsBeforeBuild.includes(s)
-                ) &&
-                availableEnvSlugs.some((s) => discoverEnvVars.includes(s))
-              }
-              disabled={!availableEnvSlugs.some((s) => pullEnvVarsBeforeBuild.includes(s))}
-              onCheckedChange={(checked) => {
-                onDiscoverEnvVarsChange(
-                  checked
-                    ? availableEnvSlugs.filter((s) => pullEnvVarsBeforeBuild.includes(s))
-                    : []
-                );
-              }}
-            />
-          )}
+          <Hint className="pr-6">
+            Select which environments should automatically discover and create new environment
+            variables from Vercel during builds.
+          </Hint>
         </div>
         <div className="flex flex-col gap-2 rounded border bg-charcoal-800 p-3">
           {availableEnvSlugs.map((slug) => {
@@ -155,13 +155,7 @@ export function BuildSettingsFields({
       {/* Atomic deployments */}
       <div>
         <div className="flex items-center justify-between">
-          <div>
-            <Label>Atomic deployments</Label>
-            <Hint>
-              When enabled, production deployments wait for Vercel deployment to complete before
-              promoting the Trigger.dev deployment.
-            </Hint>
-          </div>
+          <Label>Atomic deployments</Label>
           <Switch
             variant="small"
             checked={atomicBuilds.includes("prod")}
@@ -170,6 +164,16 @@ export function BuildSettingsFields({
             }}
           />
         </div>
+        <Hint className="pr-6">
+          When enabled, production deployments wait for Vercel deployment to complete before
+          promoting the Trigger.dev deployment. This will disable the "Auto-assign Custom
+          Production Domains" option in your Vercel project settings to perform staged
+          deployments.{" "}
+          <TextLink href="https://trigger.dev/docs/vercel-integration#atomic-deployments" target="_blank">
+            Learn more
+          </TextLink>
+          .
+        </Hint>
       </div>
     </>
   );

--- a/apps/webapp/app/components/integrations/VercelOnboardingModal.tsx
+++ b/apps/webapp/app/components/integrations/VercelOnboardingModal.tsx
@@ -679,7 +679,7 @@ export function VercelOnboardingModal({
         onClose();
       }
     }}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-lg" onInteractOutside={(e) => e.preventDefault()}>
         <DialogHeader>
           <div className="flex items-center gap-2">
             <VercelLogo className="size-5" />
@@ -799,6 +799,20 @@ export function VercelOnboardingModal({
                   </SelectItem>
                 ))}
               </Select>
+
+              <Callout variant="info">
+                <p className="text-xs">
+                  If you skip this step, the{" "}
+                  <code className="rounded bg-charcoal-700 px-1 py-0.5 text-text-bright">TRIGGER_SECRET_KEY</code>{" "}
+                  will not be installed for the staging environment in Vercel. You can configure this later in
+                  project settings.
+                </p>
+              </Callout>
+
+              <Paragraph className="text-xs text-text-dimmed">
+                Make sure the staging branch in your Vercel project's Git settings matches the staging branch
+                configured in your GitHub integration.
+              </Paragraph>
 
               <div className="flex items-center justify-between gap-2">
                 <Button

--- a/apps/webapp/app/models/vercelSdkRecovery.server.ts
+++ b/apps/webapp/app/models/vercelSdkRecovery.server.ts
@@ -1,0 +1,195 @@
+import { z } from "zod";
+import { ResultAsync, okAsync, errAsync } from "neverthrow";
+import { logger } from "~/services/logger.server";
+import type { VercelApiError } from "./vercelIntegration.server";
+
+// ---------------------------------------------------------------------------
+// Recovery utilities for Vercel SDK validation errors
+// ---------------------------------------------------------------------------
+//
+// The Vercel SDK (Speakeasy-generated) validates API responses with strict Zod
+// schemas. When the API returns valid data but a field doesn't match the SDK's
+// type (e.g., `deletedAt: null` vs `number`), a `ResponseValidationError` is
+// thrown — even though the response contains all the data we need.
+//
+// Error hierarchy:
+//   VercelError.body         → raw HTTP body text (HTTP errors — never recover)
+//   ResponseValidationError.rawValue → parsed JSON that failed validation
+//   SDKValidationError.rawValue      → same pattern, different base class
+//
+// Recovery: gate on validation error type → extract rawValue → validate → return.
+// ---------------------------------------------------------------------------
+
+/**
+ * Only attempt recovery for SDK validation errors — not HTTP errors (401/403).
+ *
+ * ResponseValidationError and SDKValidationError both carry `rawValue` with the
+ * parsed JSON that failed schema validation. VercelError (HTTP errors) carries
+ * `body` instead — we must NOT recover from those since the response is an error
+ * payload, not the data we asked for.
+ */
+function isValidationError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  if (!(error instanceof Error)) return false;
+
+  return (
+    error.constructor.name === "ResponseValidationError" ||
+    error.constructor.name === "SDKValidationError" ||
+    "rawValue" in error
+  );
+}
+
+function extractRawValue(error: unknown): unknown | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  if ("rawValue" in error) {
+    return (error as { rawValue: unknown }).rawValue;
+  }
+  return undefined;
+}
+
+/**
+ * Attempt to recover usable data from a Vercel SDK error.
+ *
+ * Returns the validated data on success, or `undefined` if recovery fails.
+ */
+export function recoverFromVercelSdkError<T>(
+  error: unknown,
+  schema: z.ZodType<any>,
+  options?: { context?: string }
+): T | undefined {
+  if (!isValidationError(error)) return undefined;
+
+  const raw = extractRawValue(error);
+  if (raw === undefined) return undefined;
+
+  const result = schema.safeParse(raw);
+  if (!result.success) return undefined;
+
+  logger.warn("Recovered data from Vercel SDK validation error", {
+    context: options?.context,
+    errorMessage: error instanceof Error ? error.message : String(error),
+    errorType: error?.constructor?.name,
+  });
+
+  return result.data;
+}
+
+/**
+ * Wrap a Vercel SDK promise with automatic recovery on validation errors.
+ *
+ * On success: returns the SDK result as-is.
+ * On error: attempts recovery via rawValue + schema validation (validation errors only).
+ */
+export function callVercelWithRecovery<T>(
+  sdkCall: Promise<T>,
+  schema: z.ZodType<any>,
+  options?: { context?: string }
+): ResultAsync<T, unknown> {
+  return ResultAsync.fromPromise(sdkCall, (error) => error).orElse((error) => {
+    const recovered = recoverFromVercelSdkError<T>(error, schema, options);
+    if (recovered !== undefined) {
+      return okAsync(recovered);
+    }
+    return errAsync(error);
+  });
+}
+
+/**
+ * Drop-in replacement for `wrapVercelCall` with SDK error recovery.
+ *
+ * Wraps a Vercel SDK promise in ResultAsync with structured error logging,
+ * attempting to recover from validation errors before treating as failure.
+ */
+export function wrapVercelCallWithRecovery<T>(
+  promise: Promise<T>,
+  schema: z.ZodType<any>,
+  message: string,
+  context: Record<string, unknown>,
+  toError: (error: unknown) => VercelApiError
+): ResultAsync<T, VercelApiError> {
+  return callVercelWithRecovery(promise, schema, { context: message }).mapErr((error) => {
+    const apiError = toError(error);
+    logger.error(message, { ...context, error, authInvalid: apiError.authInvalid });
+    return apiError;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Minimal Zod schemas — validate only the fields we actually use.
+// All use .passthrough() to preserve extra fields from the API response.
+// ---------------------------------------------------------------------------
+
+export const VercelSchemas = {
+  getTeam: z.object({ slug: z.string() }).passthrough(),
+
+  getAuthUser: z
+    .object({ user: z.object({ username: z.string() }).passthrough() })
+    .passthrough(),
+
+  getCustomEnvironments: z
+    .object({
+      environments: z
+        .array(
+          z
+            .object({
+              id: z.string(),
+              slug: z.string(),
+              description: z.string().optional(),
+              branchMatcher: z.unknown().optional(),
+            })
+            .passthrough()
+        )
+        .optional(),
+    })
+    .passthrough(),
+
+  filterProjectEnvs: z
+    .union([
+      z
+        .object({
+          envs: z.array(z.record(z.unknown())),
+          pagination: z.unknown().optional(),
+        })
+        .passthrough(),
+      z.array(z.record(z.unknown())),
+    ])
+    .transform((val) => (Array.isArray(val) ? { envs: val } : val)),
+
+  getProjectEnv: z.object({ key: z.string(), value: z.string().optional() }).passthrough(),
+
+  getProjects: z.union([
+    z.array(z.object({ id: z.string(), name: z.string() }).passthrough()),
+    z
+      .object({
+        projects: z.array(
+          z.object({ id: z.string(), name: z.string() }).passthrough()
+        ),
+        pagination: z.unknown().optional(),
+      })
+      .passthrough(),
+  ]),
+
+  listSharedEnvVariable: z
+    .object({
+      data: z
+        .array(
+          z
+            .object({
+              id: z.string().optional(),
+              key: z.string().optional(),
+              type: z.string().optional(),
+              target: z.unknown().optional(),
+              value: z.string().optional(),
+            })
+            .passthrough()
+        )
+        .optional(),
+    })
+    .passthrough(),
+
+  getSharedEnvVar: z.object({ value: z.string().optional() }).passthrough(),
+
+  updateProject: z
+    .object({ id: z.string(), name: z.string(), autoAssignCustomDomains: z.boolean().optional() })
+    .passthrough(),
+} as const;

--- a/docs/vercel-integration.mdx
+++ b/docs/vercel-integration.mdx
@@ -113,6 +113,34 @@ You can control sync behavior per-variable from your project's Vercel settings. 
 
 Atomic deployments ensure your Vercel app and Trigger.dev tasks are deployed in sync. When enabled, Trigger.dev gates your Vercel deployment until the task build completes, then triggers a Vercel redeployment with the correct `TRIGGER_VERSION` set. This guarantees your app always uses the matching version of your tasks.
 
+```mermaid
+sequenceDiagram
+  participant Dev as Developer
+  participant GH as GitHub
+  participant V as Vercel
+  participant TD as Trigger.dev
+
+  Dev->>GH: Push code
+  GH->>V: Webhook: new commit
+  V->>V: Start deployment
+  V->>TD: Deployment created
+  Dev->>GH: Create pull request
+  GH->>TD: Pull request created
+  TD->>TD: Start task build
+
+  V->>TD: Deployment check
+  TD-->>V: Check pending (gate deployment)
+  TD->>TD: Build completes
+  TD->>V: Set TRIGGER_VERSION env var
+  TD->>V: Trigger redeployment
+  V->>V: Redeploy with correct TRIGGER_VERSION
+  V->>TD: Deployment check (redeployment)
+  TD-->>V: Check passed
+  V->>V: Promote deployment
+  V->>TD: Deployment promoted
+  TD->>TD: Promote build
+```
+
 Atomic deployments are enabled for the production environment by default.
 
 <Note>


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Vercel onboarding
---

## Changelog

- Import callVercelWithRecovery, wrapVercelCallWithRecovery and VercelSchemas and plug them into vercelIntegration flows.
- Use wrapVercelCallWithRecovery for team/user lookups, project env listings, environment variable listings and shared env endpoints so responses are validated and errors are converted consistently.
- Replace several ResultAsync.fromPromise usages with callVercelWithRecovery to attach schema checks and contextual metadata (e.g. validateVercelToken,
 resolveEnvVarValue).
- Thread through toVercelApiError where appropriate to normalize error mapping.


---

## Screenshots


💯
