### PR TITLE
fix(webapp): Removes the `collapsible` option from the query inspector to avoid firefox bug

### DIFF
--- a/apps/webapp/app/components/query/QueryEditor.tsx
+++ b/apps/webapp/app/components/query/QueryEditor.tsx
@@ -945,11 +945,9 @@ export function QueryEditor({
           <ResizableHandle id="query-handle" />
           <ResizablePanel
             id="query-help"
-            min="200px"
-            collapsible
-            collapsedSize="20px"
+            min="380px"
             default="400px"
-            max="500px"
+            max="800px"
             className="w-full"
           >
             <QueryHelpSidebar


### PR DESCRIPTION
There's a bug in react-window-splitter on Firefox. When trying to expand the inspector panel in the query editor, it checks if the main panel has space but gets an object instead of a number for the auto-sized query-main panel. This causes the expand calculation to fail and it snaps it back to collapsed.

I've removed this behavior for now as it's not an important feature.