### PR TITLE
fix(cli): ensure .env.local overrides .env values in dev command

### DIFF
--- a/packages/cli-v3/src/utilities/dotEnv.ts
+++ b/packages/cli-v3/src/utilities/dotEnv.ts
@@ -3,10 +3,10 @@ import { resolve } from "node:path";
 import { env } from "std-env";
 
 const ENVVAR_FILES = [
-  ".env",
-  ".env.development",
-  ".env.local",
   ".env.development.local",
+  ".env.local",
+  ".env.development",
+  ".env",
   "dev.vars",
 ];
 


### PR DESCRIPTION
## Bug
When using the dev command, values defined in .env.local do not override those in .env.

## Root Cause
The ENVVAR_FILES array in dotEnv.ts listed .env before .env.local. The dotenv library uses first-match-wins when given an array of paths.

## Fix
Reversed the array order so more specific files take proper precedence:
1. .env.development.local (highest priority)
2. .env.local
3. .env.development
4. .env (lowest priority)
5. dev.vars (kept last as a fallback)

Fixes #2999