### PR TITLE
fix(cli): respect --profile flag by deferring default evaluation

### DIFF
--- a/packages/cli-v3/src/cli/common.ts
+++ b/packages/cli-v3/src/cli/common.ts
@@ -13,7 +13,10 @@ export const CommonCommandOptions = z.object({
   apiUrl: z.string().optional(),
   logLevel: z.enum(["debug", "info", "log", "warn", "error", "none"]).default("log"),
   skipTelemetry: z.boolean().default(false),
-  profile: z.string().default(readAuthConfigCurrentProfileName()),
+  profile: z
+    .string()
+    .optional()
+    .transform((v) => v ?? readAuthConfigCurrentProfileName()),
 });
 
 export type CommonCommandOptions = z.infer<typeof CommonCommandOptions>;


### PR DESCRIPTION
## Bug

The \CommonCommandOptions\ Zod schema used \.default(readAuthConfigCurrentProfileName())\ which evaluates the default profile at module load time. This meant that even when a user passed \--profile <name>\ on the CLI, the parsed options would always fall back to the default profile name because the Zod schema's default was already populated.

## Fix

Changed the \profile\ field in \CommonCommandOptions\ to be \.optional().transform(v => v ?? readAuthConfigCurrentProfileName())\. 

This ensures that the fallback to the current profile name happens **lazily** during validation/parsing, allowing the value provided by the CLI flag (via Commander) to be correctly prioritized.

Fixes #2542