### PR TITLE
fix(cli): respect --profile flag by lazily evaluating default profile name

### DIFF
--- a/packages/cli-v3/src/cli/common.ts
+++ b/packages/cli-v3/src/cli/common.ts
@@ -13,14 +13,17 @@ export const CommonCommandOptions = z.object({
   apiUrl: z.string().optional(),
   logLevel: z.enum(["debug", "info", "log", "warn", "error", "none"]).default("log"),
   skipTelemetry: z.boolean().default(false),
-  profile: z.string().default(readAuthConfigCurrentProfileName()),
+  profile: z
+    .string()
+    .optional()
+    .transform((v) => v ?? readAuthConfigCurrentProfileName()),
 });
 
 export type CommonCommandOptions = z.infer<typeof CommonCommandOptions>;
 
 export function commonOptions(command: Command) {
   return command
-    .option("--profile <profile>", "The login profile to use", readAuthConfigCurrentProfileName())
+    .option("--profile <profile>", "The login profile to use")
     .option("-a, --api-url <value>", "Override the API URL", CLOUD_API_URL)
     .option(
       "-l, --log-level <level>",
@@ -30,9 +33,9 @@ export function commonOptions(command: Command) {
     .option("--skip-telemetry", "Opt-out of sending telemetry");
 }
 
-export class SkipLoggingError extends Error {}
-export class SkipCommandError extends Error {}
-export class OutroCommandError extends SkipCommandError {}
+export class SkipLoggingError extends Error { }
+export class SkipCommandError extends Error { }
+export class OutroCommandError extends SkipCommandError { }
 
 export async function handleTelemetry(action: () => Promise<void>) {
   try {


### PR DESCRIPTION
## Bug
The \--profile\ flag was being ignored in many CLI commands because the Zod schema was evaluating the default profile name eagerly at module load time.

## Fix
Changed the \profile\ field in \CommonCommandOptions\ to use \.optional().transform()\, which lazily evaluates the default profile name only if the value is missing. Also removed the eager default from the Commander option definition.

Fixes #2542