### PR TITLE
ci: pin vouch action version

### DIFF
--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -13,7 +13,7 @@ jobs:
   check-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: mitchellh/vouch/action/check-pr@v1.4.2
+      - uses: mitchellh/vouch/action/check-pr@c6d80ead49839655b61b422700b7a3bc9d0804a9 # v1.4.2
         with:
           pr-number: ${{ github.event.pull_request.number }}
           auto-close: true

--- a/.github/workflows/vouch-manage-by-issue.yml
+++ b/.github/workflows/vouch-manage-by-issue.yml
@@ -16,7 +16,7 @@ jobs:
       contains(github.event.comment.body, 'denounce') ||
       contains(github.event.comment.body, 'unvouch')
     steps:
-      - uses: mitchellh/vouch/action/manage-by-issue@v1.4.2
+      - uses: mitchellh/vouch/action/manage-by-issue@c6d80ead49839655b61b422700b7a3bc9d0804a9 # v1.4.2
         with:
           comment-id: ${{ github.event.comment.id }}
           issue-id: ${{ github.event.issue.number }}


### PR DESCRIPTION
Pins vouch actions to `c6d80ead49839655b61b422700b7a3bc9d0804a9` (v1.4.2) in favor of security practices. We were previously using the `@main` tag.

Also removes the checkout steps as they're not needed in these workflows.
