### PR TITLE
Logs query use_query_condition_cache=1

### DIFF
--- a/internal-packages/clickhouse/src/taskEvents.ts
+++ b/internal-packages/clickhouse/src/taskEvents.ts
@@ -279,6 +279,9 @@ export function getLogsSearchListQueryBuilder(ch: ClickhouseReader) {
       "attributes_text",
       "triggered_timestamp",
     ],
+    settings: {
+      use_query_condition_cache: 1,
+    },
   });
 }
 


### PR DESCRIPTION
In theory this will make Log queries faster