### PR TITLE
fix(docker): stop injecting secure=true into CLICKHOUSE_URL

### DIFF
--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -18,17 +18,8 @@ if [ -n "$CLICKHOUSE_URL" ] && [ "$SKIP_CLICKHOUSE_MIGRATIONS" != "1" ]; then
   echo "Running ClickHouse migrations..."
   export GOOSE_DRIVER=clickhouse
   
-  # Ensure secure=true is in the connection string
-  if echo "$CLICKHOUSE_URL" | grep -q "secure="; then
-    # secure parameter already exists, use as is
-    export GOOSE_DBSTRING="$CLICKHOUSE_URL"
-  elif echo "$CLICKHOUSE_URL" | grep -q "?"; then
-    # URL has query parameters, append secure=true
-    export GOOSE_DBSTRING="${CLICKHOUSE_URL}&secure=true"
-  else
-    # URL has no query parameters, add secure=true
-    export GOOSE_DBSTRING="${CLICKHOUSE_URL}?secure=true"
-  fi
+# Use the provided ClickHouse URL directly
+export GOOSE_DBSTRING="$CLICKHOUSE_URL"
   
   export GOOSE_MIGRATION_DIR=/triggerdotdev/internal-packages/clickhouse/schema
   /usr/local/bin/goose up


### PR DESCRIPTION
Closes #3184

## ✅ Checklist

- [x] I have followed every step in the contributing guide
- [x] The PR title follows the convention
- [x] I ran and tested the code works

---

## Testing

Steps taken to test the change:

1. Ran the Trigger.dev Docker setup locally.
2. Confirmed the server previously failed with:
   `Error: Unknown URL parameters: secure`
3. Removed the logic that automatically injects `secure=true` into the ClickHouse connection string.
4. Restarted the containers and verified that:
   - ClickHouse migrations run successfully
   - The server starts normally
   - No `Unknown URL parameters: secure` error occurs.

---

## Changelog

Fix Docker entrypoint script to stop automatically injecting `secure=true` into `CLICKHOUSE_URL`.  
Some ClickHouse clients (including the Node client used by Trigger.dev) do not support this parameter, which causes startup failures.

The script now uses the provided `CLICKHOUSE_URL` directly.

---

## Screenshots

N/A (backend / Docker configuration change)