### PR TITLE
fix(webapp): strip secure param from query ClickHouse URL

### DIFF
--- a/.server-changes/fix-clickhouse-query-client-secure-param.md
+++ b/.server-changes/fix-clickhouse-query-client-secure-param.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Strip `secure` query parameter from QUERY_CLICKHOUSE_URL before passing to ClickHouse client. This was already done for the main and logs ClickHouse clients but was missing for the query client, causing a startup crash with `Error: Unknown URL parameters: secure`.

--- a/apps/webapp/app/services/clickhouseInstance.server.ts
+++ b/apps/webapp/app/services/clickhouseInstance.server.ts
@@ -83,6 +83,9 @@ function initializeQueryClickhouseClient() {
 
   const url = new URL(env.QUERY_CLICKHOUSE_URL);
 
+  // Remove secure param
+  url.searchParams.delete("secure");
+
   return new ClickHouse({
     url: url.toString(),
     name: "query-clickhouse",


### PR DESCRIPTION
## Summary

- The `initializeQueryClickhouseClient()` function in `clickhouseInstance.server.ts` was missing the `url.searchParams.delete("secure")` call that the other two sibling ClickHouse client init functions (`initializeClickhouseClient` and `initializeLogsClickhouseClient`) already had
- This caused the webapp to crash on startup with `Error: Unknown URL parameters: secure` when `QUERY_CLICKHOUSE_URL` fell back to `CLICKHOUSE_URL` (which contains `?secure=false`)
- Affects self-hosted Docker Compose deployments out of the box

Fixes #3184