### PR TITLE
fix: auto-detect Bun runtime when not explicitly set in trigger.config.ts

### DIFF
--- a/packages/cli-v3/src/config.ts
+++ b/packages/cli-v3/src/config.ts
@@ -191,7 +191,8 @@ async function resolveConfig(
     ["run_engine_v2" as const].concat(config.compatibilityFlags ?? [])
   );
 
-  const defaultRuntime: BuildRuntime = features.run_engine_v2 ? "node" : DEFAULT_RUNTIME;
+  const detectedRuntime: BuildRuntime = typeof process.versions.bun === "string" ? "bun" : "node";
+  const defaultRuntime: BuildRuntime = config.runtime ?? detectedRuntime;
 
   const mergedConfig = defu(
     {


### PR DESCRIPTION
Fixes #3105

## Problem
When a user runs their project with Bun (e.g. via a pre-build command like 
`bun run build`) but does not explicitly set `runtime: "bun"` in their 
trigger.config.ts, the deployment UI incorrectly shows "Node.js" as the runtime.

This happened because the default runtime was hardcoded to "node" regardless 
of what runtime was actually executing the process.

## Fix
Auto-detect the runtime by checking `process.versions.bun` at config resolution 
time. If Bun is detected and the user has not explicitly set a runtime in their 
config, we now correctly default to "bun" instead of "node".

The explicit user config always takes priority — this only affects the fallback.

## Changes
- `packages/cli-v3/src/config.ts`: replaced hardcoded `"node"` default with 
  runtime auto-detection using `process.versions.bun`