### PR TITLE
fix(cli): push localhost registry images in self-hosted local builds

### DIFF
--- a/packages/cli-v3/src/deploy/buildImage.ts
+++ b/packages/cli-v3/src/deploy/buildImage.ts
@@ -1076,7 +1076,9 @@ const BuildKitMetadata = z.object({
   "image.name": z.string().optional(),
 });
 
-// Don't push if the image tag is a local address, unless the user explicitly wants to push
+// Self-hosted installations commonly use a local registry such as localhost:5000.
+// In that case we still need to push, otherwise the deployment can complete while the
+// supervisor later fails with "No such image".
 function shouldPush(imageTag: string, push?: boolean) {
   switch (push) {
     case true: {
@@ -1086,11 +1088,7 @@ function shouldPush(imageTag: string, push?: boolean) {
       return false;
     }
     case undefined: {
-      return imageTag.startsWith("localhost") ||
-        imageTag.startsWith("127.0.0.1") ||
-        imageTag.startsWith("0.0.0.0")
-        ? false
-        : true;
+      return true;
     }
     default: {
       assertExhaustive(push);


### PR DESCRIPTION
## Summary
Self-hosted Trigger.dev installations commonly use a local registry such as `localhost:5000`.

The current `shouldPush()` behavior treats localhost-style image tags as non-push by default. In practice this can produce a deployment that appears complete while the supervisor later fails with `No such image`, because the image was never pushed to the local registry.

## What changed
- changed `shouldPush()` so local builds do not silently skip pushing localhost-tagged images

## Why
- self-hosted local registry setups still require a push step
- skipping the push creates a broken deployment/runtime split

## Real-world failure mode
- deployment version is created
- runtime later tries to start the container
- supervisor fails with:
  - `No such image: localhost:5000/...`

## Notes
- this is specifically important for self-hosted local-registry setups
- it avoids a misleading deployment success state when the runtime image is unavailable

Closes #3257