### PR TITLE
fix(webapp): progress native self-hosted deployments instead of dead enqueue path

### DIFF
--- a/apps/webapp/app/v3/services/initializeDeployment.server.ts
+++ b/apps/webapp/app/v3/services/initializeDeployment.server.ts
@@ -249,12 +249,16 @@ export class InitializeDeploymentService extends BaseService {
         new Date(Date.now() + timeoutMs)
       );
 
-      // For github integration there is no artifactKey, hence we skip it here
+      // For self-hosted native builds, progressing the deployment is the action that actually
+      // transitions the deployment out of PENDING and starts the local build path.
+      // For github integration there is no artifactKey, hence we skip it here.
       if (payload.isNativeBuild && payload.artifactKey && !payload.skipEnqueue) {
         const result = await deploymentService
-          .enqueueBuild(environment, deployment, payload.artifactKey, {
-            skipPromotion: payload.skipPromotion,
-            configFilePath: payload.configFilePath,
+          .progressDeployment(environment, deployment.friendlyId, {
+            contentHash: payload.contentHash,
+            git: payload.gitMeta,
+            runtime: payload.runtime,
+            buildServerMetadata,
           })
           .orElse((error) => {
             logger.error("Failed to enqueue build", {


### PR DESCRIPTION
## Summary
In self-hosted native deployments, deployments could remain stuck on `PENDING` or later `TIMED_OUT` because the expected build transition was not happening through the current enqueue path.

In our self-hosted reproduction, progressing the deployment was the action that actually moved the deployment forward and allowed the build/runtime flow to continue.

## What changed
- replace the native self-hosted build transition call from `enqueueBuild(...)` to `progressDeployment(...)`

## Why
- native self-hosted deployments already have the necessary deployment metadata
- the current enqueue behavior can leave deployments stuck without a real build transition

## Real-world failure mode
- deployment initializes successfully
- deployment remains `PENDING`
- eventually deployment becomes `TIMED_OUT`

## Notes
- this change is intentionally narrow
- it only targets the native self-hosted build transition path

Closes #3256