### PR TITLE
fix(cli): strip workspaces from package.json before bun install

### DIFF
--- a/packages/cli-v3/src/deploy/buildImage.ts
+++ b/packages/cli-v3/src/deploy/buildImage.ts
@@ -764,6 +764,9 @@ ${buildArgs}
 ${buildEnvVars}
 
 COPY --chown=bun:bun package.json ./
+# Strip workspaces from package.json before bun install to avoid "Workspace not found" error
+# Bun strictly validates workspaces exist, unlike npm/node which just warns
+RUN node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));delete p.workspaces;fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
 RUN bun install --production --no-save
 
 # Now copy all the files


### PR DESCRIPTION
Bun strictly validates that all workspaces exist before installing, unlike npm/node which just warns. This causes deployments to fail with 'Workspace not found' error when using runtime: 'bun' in projects with workspaces defined in package.json.

The fix strips the workspaces field from package.json before running bun install, preventing the validation error.

Fixes #3272