### PR TITLE
chore: pin react types to 18.x project-wide

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,8 @@
     "overrides": {
       "typescript": "5.5.4",
       "@types/node": "22.20.0",
+      "@types/react": "18.2.69",
+      "@types/react-dom": "18.2.7",
       "react@^18": "18.3.1",
       "react-dom@^18": "18.3.1",
       "ai@^6": "6.0.116",


### PR DESCRIPTION
Pins \@types/react\ and \@types/react-dom\ to \18.x\ project-wide using pnpm overrides.

## Changes
- Added \@types/react: 18.2.69\ and \@types/react-dom: 18.2.7\ to \overrides\ in root \package.json\
- Prevents TypeScript errors caused by mixed 18.x/19.x type definitions

## Testing
- Verified \package.json\ override syntax
- Lockfile regenerated cleanly after override addition

## Related
Fixes TypeScript compilation errors across the monorepo where some packages resolve to React 19 types.