### PR TITLE
Add OSOP workflow example — background job pipeline in portable format

### DIFF
--- a/examples/osop/README.md
+++ b/examples/osop/README.md
@@ -1,0 +1,36 @@
+# OSOP Workflow Example — Trigger.dev Background Job Pipeline
+
+This directory contains a portable workflow definition for a **background job pipeline** pattern, written in [OSOP](https://github.com/osop-org/osop-spec) format.
+
+## What is OSOP?
+
+**OSOP** (Open Standard for Orchestration Protocols) is a YAML-based workflow standard that describes multi-step processes — including background jobs, event-driven pipelines, and AI agent workflows — in a portable, tool-agnostic format. Think of it as "OpenAPI for workflows."
+
+- Any tool can read and render an `.osop` file
+- Workflows become shareable, diffable, and version-controllable
+- No vendor lock-in: the same workflow runs across different orchestration engines
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `background-job-pipeline.osop` | Long-running background job: receive request, validate, AI processing with retry, store results, webhook callback, and cleanup |
+
+## How to use
+
+You can read the `.osop` file as plain YAML. To validate or visualize it:
+
+```bash
+# Validate the workflow
+pip install osop
+osop validate background-job-pipeline.osop
+
+# Generate a visual report
+npx osop-report background-job-pipeline.osop -o report.html
+```
+
+## Learn more
+
+- [OSOP Spec](https://github.com/osop-org/osop-spec) — Full specification
+- [OSOP Examples](https://github.com/osop-org/osop-examples) — 30+ workflow templates
+- [Trigger.dev Documentation](https://trigger.dev/docs) — Trigger.dev platform docs

--- a/examples/osop/background-job-pipeline.osop
+++ b/examples/osop/background-job-pipeline.osop
@@ -1,0 +1,61 @@
+osop_version: "1.0"
+id: triggerdev-background-jobs
+name: Trigger.dev Background Job Pipeline
+description: Long-running background job with progress tracking, retry logic, and webhook callbacks.
+tags: [trigger-dev, background-jobs, queue, serverless]
+
+nodes:
+  - id: receive-job
+    type: api
+    name: Receive Job Request
+    description: Accept job submission via API or event trigger.
+
+  - id: validate-input
+    type: system
+    name: Validate Input
+    description: Check job parameters and required permissions.
+
+  - id: process-ai
+    type: agent
+    name: AI Processing
+    description: Run the main AI processing task (e.g., document analysis, code generation).
+    runtime:
+      provider: openai
+      model: gpt-4o
+    timeout_sec: 300
+
+  - id: store-result
+    type: db
+    name: Store Result
+    description: Save the processing output to the database.
+
+  - id: webhook-callback
+    type: api
+    name: Webhook Callback
+    description: Notify the caller that the job is complete via webhook.
+
+  - id: cleanup
+    type: system
+    name: Cleanup
+    description: Remove temporary files and release resources.
+
+edges:
+  - from: receive-job
+    to: validate-input
+    mode: sequential
+  - from: validate-input
+    to: process-ai
+    mode: sequential
+  - from: process-ai
+    to: store-result
+    mode: sequential
+  - from: store-result
+    to: webhook-callback
+    mode: sequential
+  - from: webhook-callback
+    to: cleanup
+    mode: sequential
+  - from: process-ai
+    to: receive-job
+    mode: fallback
+    label: Retry on failure


### PR DESCRIPTION
## Summary

- Adds an OSOP (Open Standard for Orchestration Protocols) workflow example under `examples/osop/`
- The example models a typical **background job pipeline**: receive job request, validate input, AI processing with timeout and retry, store results, webhook callback, and cleanup
- Includes a README explaining the OSOP format and how to validate/visualize the workflow

## What is OSOP?

OSOP is a portable YAML-based workflow standard — think "OpenAPI for workflows." It lets you describe multi-step processes (including background jobs and event-driven pipelines) in a tool-agnostic format that any orchestration engine can read.

- [OSOP Spec](https://github.com/osop-org/osop-spec)
- [OSOP Examples](https://github.com/osop-org/osop-examples)

## Why this PR?

This is a non-invasive, additive-only contribution. The `.osop` file provides a portable representation of a Trigger.dev-style background job pipeline that can be shared, diffed, and rendered by any OSOP-compatible tool — useful for documentation, onboarding, and cross-tool interoperability.

No existing files are modified.