### PR TITLE
fix: convert to BigInt before nanosecond multiplication to avoid precision loss

### DIFF
--- a/apps/webapp/app/v3/eventRepository/common.server.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.ts
@@ -21,7 +21,7 @@ export function extractContextFromCarrier(carrier: Record<string, unknown>) {
 }
 
 export function getNowInNanoseconds(): bigint {
-  return BigInt(new Date().getTime() * 1_000_000);
+  return BigInt(new Date().getTime()) * BigInt(1_000_000);
 }
 
 export function getDateFromNanoseconds(nanoseconds: bigint): Date {
@@ -35,7 +35,7 @@ export function calculateDurationFromStart(
 ) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  const duration = Number(BigInt($endtime.getTime() * 1_000_000) - startTime);
+  const duration = Number(BigInt($endtime.getTime()) * BigInt(1_000_000) - startTime);
 
   if (minimumDuration && duration < minimumDuration) {
     return minimumDuration;

--- a/apps/webapp/app/v3/eventRepository/index.server.ts
+++ b/apps/webapp/app/v3/eventRepository/index.server.ts
@@ -215,7 +215,7 @@ async function recordRunEvent(
         runId: foundRun.friendlyId,
         ...attributes,
       },
-      startTime: BigInt((startTime?.getTime() ?? Date.now()) * 1_000_000),
+      startTime: BigInt(startTime?.getTime() ?? Date.now()) * BigInt(1_000_000),
       ...optionsRest,
     });
 

--- a/apps/webapp/app/v3/runEngineHandlers.server.ts
+++ b/apps/webapp/app/v3/runEngineHandlers.server.ts
@@ -428,7 +428,7 @@ export function registerRunEngineEventBusHandlers() {
       const eventRepository = resolveEventRepositoryForStore(run.taskEventStore);
 
       await eventRepository.recordEvent(retryMessage, {
-        startTime: BigInt(time.getTime() * 1000000),
+        startTime: BigInt(time.getTime()) * BigInt(1_000_000),
         taskSlug: run.taskIdentifier,
         environment,
         attributes: {


### PR DESCRIPTION
## Summary

Closes #3292

Multiplying epoch milliseconds by 1,000,000 as a `Number` exceeds `Number.MAX_SAFE_INTEGER` (~9e15), causing IEEE 754 precision loss of ~256ns in ~0.2% of cases. The fix converts to `BigInt` first, then multiplies.

## Changes

4 locations fixed across 3 files:

| File | Function | Line |
|------|----------|------|
| `common.server.ts` | `getNowInNanoseconds()` | 24 |
| `common.server.ts` | `calculateDurationFromStart()` | 38 |
| `index.server.ts` | `recordRunDebugLog()` | 218 |
| `runEngineHandlers.server.ts` | retry event recording | 431 |

```typescript
// Before: multiplication in float-land (exceeds MAX_SAFE_INTEGER)
BigInt(new Date().getTime() * 1_000_000)

// After: multiplication in BigInt-land (exact)
BigInt(new Date().getTime()) * BigInt(1_000_000)
```

The correct pattern already existed in `convertDateToNanoseconds()` in the same file — these locations just weren't using it.

## Test plan

- [x] All 4 locations use BigInt multiplication instead of Number multiplication
- [x] No behavioral change for correctly-rounded timestamps (~99.8% of cases)
- [x] Eliminates ~256ns errors for the ~0.2% of timestamps that previously lost precision