### PR TITLE
feat(webapp): set application_name on prisma connections

### DIFF
--- a/.server-changes/prisma-application-name.md
+++ b/.server-changes/prisma-application-name.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+Set `application_name` on Prisma connections from SERVICE_NAME so DB load can be attributed by service

--- a/apps/webapp/app/db.server.ts
+++ b/apps/webapp/app/db.server.ts
@@ -113,6 +113,7 @@ function getClient() {
     connection_limit: env.DATABASE_CONNECTION_LIMIT.toString(),
     pool_timeout: env.DATABASE_POOL_TIMEOUT.toString(),
     connection_timeout: env.DATABASE_CONNECTION_TIMEOUT.toString(),
+    application_name: env.SERVICE_NAME,
   });
 
   console.log(`🔌 setting up prisma client to ${redactUrlSecrets(databaseUrl)}`);
@@ -236,6 +237,7 @@ function getReplicaClient() {
     connection_limit: env.DATABASE_CONNECTION_LIMIT.toString(),
     pool_timeout: env.DATABASE_POOL_TIMEOUT.toString(),
     connection_timeout: env.DATABASE_CONNECTION_TIMEOUT.toString(),
+    application_name: env.SERVICE_NAME,
   });
 
   console.log(`🔌 setting up read replica connection to ${redactUrlSecrets(replicaUrl)}`);


### PR DESCRIPTION
Sets `application_name` on the Prisma writer and replica connection strings using the existing `SERVICE_NAME` env var, so DB load can be attributed by service.