### PR TITLE
fix: handle empty payloads in scheduled task runs to prevent crash

### DIFF
--- a/apps/webapp/app/presenters/v3/TestTaskPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/TestTaskPresenter.server.ts
@@ -382,6 +382,10 @@ export class TestTaskPresenter {
 
 async function getScheduleTaskRunPayload(payload: string, payloadType: string) {
   const packet = await parsePacket({ data: payload, dataType: payloadType });
+  if (!packet) {
+    return { success: false }; //  handle packet undefined
+  }
+
   if (!packet.timezone) {
     packet.timezone = "UTC";
   }


### PR DESCRIPTION
Closes #3316

## ✅ Checklist
- [x] I have followed every step in the contributing guide
- [x] The PR title follows the convention
- [x] I ran and tested the code locally

---

## 🧪 Testing

- Started the app locally using `pnpm run dev --filter webapp`
- Simulated a scheduled task run with an empty payload (`""`)
- Verified that previously the app crashed due to `packet` being undefined
- After the fix, the app no longer crashes and empty payload runs are safely ignored

---

## 🔧 Changes

- Added a null check for `packet` in `getScheduleTaskRunPayload`
- Prevents accessing `packet.timezone` when `packet` is undefined
- Ensures graceful handling of empty or invalid payloads

---

## 📸 Screenshots

<img width="1274" height="418" alt="image" src="https://github.com/user-attachments/assets/d46f1936-6e0e-44c0-9dc6-96893ea0d6e7" />



<img width="698" height="292" alt="image" src="https://github.com/user-attachments/assets/7dd1ef11-bd09-4bec-8df7-126ace3847e6" />





