### PR TITLE
fix: convert epoch-ms to BigInt before nanosecond multiplication

### DIFF
--- a/apps/webapp/app/v3/eventRepository/common.server.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.ts
@@ -21,7 +21,7 @@ export function extractContextFromCarrier(carrier: Record<string, unknown>) {
 }
 
 export function getNowInNanoseconds(): bigint {
-  return BigInt(new Date().getTime() * 1_000_000);
+  return BigInt(new Date().getTime()) * BigInt(1_000_000);
 }
 
 export function getDateFromNanoseconds(nanoseconds: bigint): Date {
@@ -35,7 +35,7 @@ export function calculateDurationFromStart(
 ) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  const duration = Number(BigInt($endtime.getTime() * 1_000_000) - startTime);
+  const duration = Number(BigInt($endtime.getTime()) * BigInt(1_000_000) - startTime);
 
   if (minimumDuration && duration < minimumDuration) {
     return minimumDuration;

--- a/apps/webapp/app/v3/runEngineHandlers.server.ts
+++ b/apps/webapp/app/v3/runEngineHandlers.server.ts
@@ -428,7 +428,7 @@ export function registerRunEngineEventBusHandlers() {
       const eventRepository = resolveEventRepositoryForStore(run.taskEventStore);
 
       await eventRepository.recordEvent(retryMessage, {
-        startTime: BigInt(time.getTime() * 1000000),
+        startTime: BigInt(time.getTime()) * BigInt(1_000_000),
         taskSlug: run.taskIdentifier,
         environment,
         attributes: {


### PR DESCRIPTION
## Summary

Fixes #3292

Several OTLP timestamp conversions multiply epoch milliseconds by 1,000,000 **before** converting to `BigInt`. Since epoch-ms × 1e6 is ~1.7e18 (exceeding `Number.MAX_SAFE_INTEGER` ~9e15), this causes IEEE 754 precision loss of ±256ns in ~0.2% of cases.

The correct pattern (already used in `convertDateToNanoseconds()` in the same file) is:
```ts
BigInt(date.getTime()) * BigInt(1_000_000)
```

## Changes

| Location | Before | After |
|----------|--------|-------|
| `getNowInNanoseconds()` | `BigInt(new Date().getTime() * 1_000_000)` | `BigInt(new Date().getTime()) * BigInt(1_000_000)` |
| `calculateDurationFromStart()` | `BigInt($endtime.getTime() * 1_000_000)` | `BigInt($endtime.getTime()) * BigInt(1_000_000)` |
| `runEngineHandlers.server.ts` | `BigInt(time.getTime() * 1000000)` | `BigInt(time.getTime()) * BigInt(1_000_000)` |