### PR TITLE
feat(server): add TaskIdentifier registry to replace expensive distinct query

### DIFF
--- a/.server-changes/task-identifier-registry.md
+++ b/.server-changes/task-identifier-registry.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+Replace the expensive DISTINCT query for task filter dropdowns with a dedicated TaskIdentifier registry table backed by Redis. Environments migrate automatically on their next deploy, with a transparent fallback to the legacy query for unmigrated environments. Also fixes duplicate dropdown entries when a task changes trigger source, and adds active/archived grouping for removed tasks. Moves BackgroundWorkerTask reads in the trigger hot path to the read replica.

--- a/apps/webapp/app/components/logs/LogsTaskFilter.tsx
+++ b/apps/webapp/app/components/logs/LogsTaskFilter.tsx
@@ -4,6 +4,8 @@ import { useMemo } from "react";
 import * as Ariakit from "@ariakit/react";
 import {
   ComboBox,
+  SelectGroup,
+  SelectGroupLabel,
   SelectItem,
   SelectList,
   SelectPopover,
@@ -21,6 +23,7 @@ const shortcut = { key: "t" };
 type TaskOption = {
   slug: string;
   triggerSource: TaskTriggerSource;
+  isInLatestDeployment: boolean;
 };
 
 interface LogsTaskFilterProps {
@@ -126,17 +129,42 @@ function TasksDropdown({
       >
         <ComboBox placeholder={"Filter by task..."} value={searchValue} />
         <SelectList>
-          {filtered.map((item, index) => (
-            <SelectItem
-              key={`${item.triggerSource}-${item.slug}`}
-              value={item.slug}
-              icon={
-                <TaskTriggerSourceIcon source={item.triggerSource} className="size-4 flex-none" />
-              }
-            >
-              {item.slug}
-            </SelectItem>
-          ))}
+          {filtered
+            .filter((item) => item.isInLatestDeployment)
+            .map((item) => (
+              <SelectItem
+                key={item.slug}
+                value={item.slug}
+                icon={
+                  <TaskTriggerSourceIcon source={item.triggerSource} className="size-4 flex-none" />
+                }
+              >
+                {item.slug}
+              </SelectItem>
+            ))}
+          {filtered.some((item) => !item.isInLatestDeployment) && (
+            <SelectGroup>
+              <SelectGroupLabel>Archived</SelectGroupLabel>
+              {filtered
+                .filter((item) => !item.isInLatestDeployment)
+                .map((item) => (
+                  <SelectItem
+                    key={item.slug}
+                    value={item.slug}
+                    icon={
+                      <span className="opacity-50">
+                        <TaskTriggerSourceIcon
+                          source={item.triggerSource}
+                          className="size-4 flex-none"
+                        />
+                      </span>
+                    }
+                  >
+                    {item.slug}
+                  </SelectItem>
+                ))}
+            </SelectGroup>
+          )}
         </SelectList>
       </SelectPopover>
     </SelectProvider>

--- a/apps/webapp/app/components/runs/v3/RunFilters.tsx
+++ b/apps/webapp/app/components/runs/v3/RunFilters.tsx
@@ -36,6 +36,8 @@ import { Paragraph } from "~/components/primitives/Paragraph";
 import {
   ComboBox,
   SelectButtonItem,
+  SelectGroup,
+  SelectGroupLabel,
   SelectItem,
   SelectList,
   SelectPopover,
@@ -322,7 +324,7 @@ export function getRunFiltersFromSearchParams(
 }
 
 type RunFiltersProps = {
-  possibleTasks: { slug: string; triggerSource: TaskTriggerSource }[];
+  possibleTasks: { slug: string; triggerSource: TaskTriggerSource; isInLatestDeployment: boolean }[];
   bulkActions: {
     id: string;
     type: BulkActionType;
@@ -627,7 +629,7 @@ function TasksDropdown({
   clearSearchValue: () => void;
   searchValue: string;
   onClose?: () => void;
-  possibleTasks: { slug: string; triggerSource: TaskTriggerSource }[];
+  possibleTasks: { slug: string; triggerSource: TaskTriggerSource; isInLatestDeployment: boolean }[];
 }) {
   const { values, replace } = useSearchParams();
 
@@ -658,17 +660,42 @@ function TasksDropdown({
       >
         <ComboBox placeholder={"Filter by task..."} value={searchValue} />
         <SelectList>
-          {filtered.map((item, index) => (
-            <SelectItem
-              key={`${item.triggerSource}-${item.slug}`}
-              value={item.slug}
-              icon={
-                <TaskTriggerSourceIcon source={item.triggerSource} className="size-4 flex-none" />
-              }
-            >
-              <MiddleTruncate text={item.slug} />
-            </SelectItem>
-          ))}
+          {filtered
+            .filter((item) => item.isInLatestDeployment)
+            .map((item) => (
+              <SelectItem
+                key={item.slug}
+                value={item.slug}
+                icon={
+                  <TaskTriggerSourceIcon source={item.triggerSource} className="size-4 flex-none" />
+                }
+              >
+                <MiddleTruncate text={item.slug} />
+              </SelectItem>
+            ))}
+          {filtered.some((item) => !item.isInLatestDeployment) && (
+            <SelectGroup>
+              <SelectGroupLabel>Archived</SelectGroupLabel>
+              {filtered
+                .filter((item) => !item.isInLatestDeployment)
+                .map((item) => (
+                  <SelectItem
+                    key={item.slug}
+                    value={item.slug}
+                    icon={
+                      <span className="opacity-50">
+                        <TaskTriggerSourceIcon
+                          source={item.triggerSource}
+                          className="size-4 flex-none"
+                        />
+                      </span>
+                    }
+                  >
+                    <MiddleTruncate text={item.slug} />
+                  </SelectItem>
+                ))}
+            </SelectGroup>
+          )}
         </SelectList>
       </SelectPopover>
     </SelectProvider>

--- a/apps/webapp/app/models/task.server.ts
+++ b/apps/webapp/app/models/task.server.ts
@@ -1,6 +1,9 @@
 import type { TaskTriggerSource } from "@trigger.dev/database";
 import { PrismaClientOrTransaction, sqlDatabaseSchema } from "~/db.server";
 
+export { getTaskIdentifiers } from "~/services/taskIdentifierRegistry.server";
+export type { TaskIdentifierEntry } from "~/services/taskIdentifierCache.server";
+
 /**
  *
  * @param prisma An efficient query to get all task identifiers for a project.

--- a/apps/webapp/app/presenters/v3/ErrorsListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ErrorsListPresenter.server.ts
@@ -13,7 +13,7 @@ import { type ErrorGroupStatus, type PrismaClientOrTransaction } from "@trigger.
 import { type Direction } from "~/components/ListPagination";
 import { timeFilterFromTo } from "~/components/runs/v3/SharedFilters";
 import { findDisplayableEnvironment } from "~/models/runtimeEnvironment.server";
-import { getAllTaskIdentifiers } from "~/models/task.server";
+import { getTaskIdentifiers } from "~/models/task.server";
 import { ServiceValidationError } from "~/v3/services/baseService.server";
 import { BasePresenter } from "~/presenters/v3/basePresenter.server";
 
@@ -170,7 +170,7 @@ export class ErrorsListPresenter extends BasePresenter {
       (search !== undefined && search !== "") ||
       (statuses !== undefined && statuses.length > 0);
 
-    const possibleTasksAsync = getAllTaskIdentifiers(this.replica, environmentId);
+    const possibleTasksAsync = getTaskIdentifiers(environmentId);
 
     // Pre-filter by status: since status lives in Postgres (ErrorGroupState) and the error
     // list comes from ClickHouse, we resolve inclusion/exclusion sets upfront so that

--- a/apps/webapp/app/presenters/v3/LogsListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/LogsListPresenter.server.ts
@@ -7,7 +7,7 @@ import parseDuration from "parse-duration";
 import { type Direction } from "~/components/ListPagination";
 import { timeFilterFromTo, timeFilters } from "~/components/runs/v3/SharedFilters";
 import { findDisplayableEnvironment } from "~/models/runtimeEnvironment.server";
-import { getAllTaskIdentifiers } from "~/models/task.server";
+import { getTaskIdentifiers } from "~/models/task.server";
 import { ServiceValidationError } from "~/v3/services/baseService.server";
 import { kindToLevel, type LogLevel, LogLevelSchema } from "~/utils/logUtils";
 import { BasePresenter } from "~/presenters/v3/basePresenter.server";
@@ -176,7 +176,7 @@ export class LogsListPresenter extends BasePresenter {
       (search !== undefined && search !== "") ||
       !time.isDefault;
 
-    const possibleTasksAsync = getAllTaskIdentifiers(this.replica, environmentId);
+    const possibleTasksAsync = getTaskIdentifiers(environmentId);
 
     const bulkActionsAsync = this.replica.bulkActionGroup.findMany({
       select: {
@@ -386,12 +386,7 @@ export class LogsListPresenter extends BasePresenter {
         next: nextCursor,
         previous: undefined, // For now, only support forward pagination
       },
-      possibleTasks: possibleTasks
-        .map((task) => ({
-          slug: task.slug,
-          triggerSource: task.triggerSource,
-        }))
-        .sort((a, b) => a.slug.localeCompare(b.slug)),
+      possibleTasks,
       bulkActions: bulkActions.map((bulkAction) => ({
         id: bulkAction.friendlyId,
         type: bulkAction.type,

--- a/apps/webapp/app/presenters/v3/NextRunListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/NextRunListPresenter.server.ts
@@ -8,7 +8,7 @@ import {
 import { type Direction } from "~/components/ListPagination";
 import { timeFilters } from "~/components/runs/v3/SharedFilters";
 import { findDisplayableEnvironment } from "~/models/runtimeEnvironment.server";
-import { getAllTaskIdentifiers } from "~/models/task.server";
+import { getTaskIdentifiers } from "~/models/task.server";
 import { RunsRepository } from "~/services/runsRepository/runsRepository.server";
 import { machinePresetFromRun } from "~/v3/machinePresets.server";
 import { ServiceValidationError } from "~/v3/services/baseService.server";
@@ -105,7 +105,7 @@ export class NextRunListPresenter {
       !time.isDefault;
 
     //get all possible tasks
-    const possibleTasksAsync = getAllTaskIdentifiers(this.replica, environmentId);
+    const possibleTasksAsync = getTaskIdentifiers(environmentId);
 
     //get possible bulk actions
     const bulkActionsAsync = this.replica.bulkActionGroup.findMany({
@@ -256,11 +256,7 @@ export class NextRunListPresenter {
         next: pagination.nextCursor ?? undefined,
         previous: pagination.previousCursor ?? undefined,
       },
-      possibleTasks: possibleTasks
-        .map((task) => ({ slug: task.slug, triggerSource: task.triggerSource }))
-        .sort((a, b) => {
-          return a.slug.localeCompare(b.slug);
-        }),
+      possibleTasks,
       bulkActions: bulkActions.map((bulkAction) => ({
         id: bulkAction.friendlyId,
         type: bulkAction.type,

--- a/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ScheduleListPresenter.server.ts
@@ -1,6 +1,7 @@
 import { type RuntimeEnvironmentType, type ScheduleType } from "@trigger.dev/database";
 import { type ScheduleListFilters } from "~/components/runs/v3/ScheduleFilters";
 import { displayableEnvironment } from "~/models/runtimeEnvironment.server";
+import { getTaskIdentifiers } from "~/models/task.server";
 import { getLimit } from "~/services/platform.v3.server";
 import { findCurrentWorkerFromEnvironment } from "~/v3/models/workerDeployment.server";
 import { ServiceValidationError } from "~/v3/services/baseService.server";
@@ -123,14 +124,10 @@ export class ScheduleListPresenter extends BasePresenter {
     }
 
     //get all possible scheduled tasks
-    const possibleTasks = await this._replica.backgroundWorkerTask.findMany({
-      where: {
-        workerId: latestWorker.id,
-        projectId: project.id,
-        runtimeEnvironmentId: environmentId,
-        triggerSource: "SCHEDULED",
-      },
-    });
+    const allIdentifiers = await getTaskIdentifiers(environmentId);
+    const possibleTasks = allIdentifiers
+      .filter((t) => t.triggerSource === "SCHEDULED" && t.isInLatestDeployment)
+      .map((t) => ({ slug: t.slug }));
 
     //do this here to protect against SQL injection
     search = search && search !== "" ? `%${search}%` : undefined;
@@ -285,7 +282,7 @@ export class ScheduleListPresenter extends BasePresenter {
       totalPages: Math.ceil(totalCount / pageSize),
       totalCount: totalCount,
       schedules,
-      possibleTasks: possibleTasks.map((task) => task.slug).sort((a, b) => a.localeCompare(b)),
+      possibleTasks: possibleTasks.map((task) => task.slug),
       hasFilters,
       limits: {
         used: schedulesCount,

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.dashboards.$dashboardKey/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.dashboards.$dashboardKey/route.tsx
@@ -17,14 +17,13 @@ import { TitleWidget } from "~/components/metrics/TitleWidget";
 import { CreateDashboardPageButton } from "~/components/navigation/DashboardDialogs";
 import { NavBar, PageAccessories, PageTitle } from "~/components/primitives/PageHeader";
 import { TimeFilter } from "~/components/runs/v3/SharedFilters";
-import { $replica } from "~/db.server";
 import { useEnvironment } from "~/hooks/useEnvironment";
 import { useOrganization } from "~/hooks/useOrganizations";
 import { useProject } from "~/hooks/useProject";
 import { useSearchParams } from "~/hooks/useSearchParam";
 import { findProjectBySlug } from "~/models/project.server";
 import { findEnvironmentBySlug } from "~/models/runtimeEnvironment.server";
-import { getAllTaskIdentifiers } from "~/models/task.server";
+import { getTaskIdentifiers } from "~/models/task.server";
 import {
   type BuiltInDashboardFilter,
   type LayoutItem,
@@ -70,7 +69,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
       organizationId: project.organizationId,
       key: dashboardKey,
     }),
-    getAllTaskIdentifiers($replica, environment.id),
+    getTaskIdentifiers(environment.id),
   ]);
 
   const filters = dashboard.filters ?? ["tasks", "queues"];
@@ -114,9 +113,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   return typedjson({
     ...dashboard,
     filters,
-    possibleTasks: possibleTasks
-      .map((task) => ({ slug: task.slug, triggerSource: task.triggerSource }))
-      .sort((a, b) => a.slug.localeCompare(b.slug)),
+    possibleTasks,
     possibleModels,
     possiblePrompts,
     possibleOperations,
@@ -201,7 +198,7 @@ export function MetricDashboard({
   /** Which filters to show. Defaults to ["tasks", "queues"]. */
   filters?: BuiltInDashboardFilter[];
   /** Possible tasks for filtering */
-  possibleTasks?: { slug: string; triggerSource: TaskTriggerSource }[];
+  possibleTasks?: { slug: string; triggerSource: TaskTriggerSource; isInLatestDeployment: boolean }[];
   /** Possible models for filtering */
   possibleModels?: ModelOption[];
   /** Possible prompt slugs for filtering */

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.dashboards.custom.$dashboardId/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.dashboards.custom.$dashboardId/route.tsx
@@ -35,7 +35,7 @@ import { Sheet, SheetContent } from "~/components/primitives/SheetV3";
 import { useToast } from "~/components/primitives/Toast";
 import { SimpleTooltip } from "~/components/primitives/Tooltip";
 import { QueryEditor, type QueryEditorSaveData } from "~/components/query/QueryEditor";
-import { $replica, prisma } from "~/db.server";
+import { prisma } from "~/db.server";
 import { env } from "~/env.server";
 import { useDashboardEditor } from "~/hooks/useDashboardEditor";
 import { useEnvironment } from "~/hooks/useEnvironment";
@@ -44,7 +44,7 @@ import { useProject } from "~/hooks/useProject";
 import { redirectWithSuccessMessage } from "~/models/message.server";
 import { findProjectBySlug } from "~/models/project.server";
 import { findEnvironmentBySlug } from "~/models/runtimeEnvironment.server";
-import { getAllTaskIdentifiers } from "~/models/task.server";
+import { getTaskIdentifiers } from "~/models/task.server";
 import { MetricDashboardPresenter } from "~/presenters/v3/MetricDashboardPresenter.server";
 import { QueryPresenter } from "~/presenters/v3/QueryPresenter.server";
 import { requireUser, requireUserId } from "~/services/session.server";
@@ -93,7 +93,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     queryPresenter.call({
       organizationId: project.organizationId,
     }),
-    getAllTaskIdentifiers($replica, environment.id),
+    getTaskIdentifiers(environment.id),
   ]);
 
   // Admins and impersonating users can use EXPLAIN
@@ -109,9 +109,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     queryHistory: history,
     isAdmin,
     maxRows: env.QUERY_CLICKHOUSE_MAX_RETURNED_ROWS,
-    possibleTasks: possibleTasks
-      .map((task) => ({ slug: task.slug, triggerSource: task.triggerSource }))
-      .sort((a, b) => a.slug.localeCompare(b.slug)),
+    possibleTasks,
     widgetCount,
   });
 };

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.ai-filter.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.ai-filter.tsx
@@ -2,11 +2,10 @@ import { openai } from "@ai-sdk/openai";
 import { type ActionFunctionArgs, json } from "@remix-run/server-runtime";
 import { tryCatch } from "@trigger.dev/core";
 import { z } from "zod";
-import { $replica } from "~/db.server";
 import { env } from "~/env.server";
 import { findProjectBySlug } from "~/models/project.server";
 import { findEnvironmentBySlug } from "~/models/runtimeEnvironment.server";
-import { getAllTaskIdentifiers } from "~/models/task.server";
+import { getTaskIdentifiers } from "~/models/task.server";
 import { QueueListPresenter } from "~/presenters/v3/QueueListPresenter.server";
 import { RunTagListPresenter } from "~/presenters/v3/RunTagListPresenter.server";
 import { VersionListPresenter } from "~/presenters/v3/VersionListPresenter.server";
@@ -126,7 +125,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
   const queryTasks: QueryTasks = {
     query: async () => {
-      const tasks = await getAllTaskIdentifiers($replica, environment.id);
+      const tasks = await getTaskIdentifiers(environment.id);
       return {
         tasks,
       };

--- a/apps/webapp/app/runEngine/concerns/queues.server.ts
+++ b/apps/webapp/app/runEngine/concerns/queues.server.ts
@@ -62,10 +62,15 @@ function extractQueueName(queue: { name?: unknown } | undefined): string | undef
 }
 
 export class DefaultQueueManager implements QueueManager {
+  private readonly replicaPrisma: PrismaClientOrTransaction;
+
   constructor(
     private readonly prisma: PrismaClientOrTransaction,
-    private readonly engine: RunEngine
-  ) { }
+    private readonly engine: RunEngine,
+    replicaPrisma?: PrismaClientOrTransaction
+  ) {
+    this.replicaPrisma = replicaPrisma ?? prisma;
+  }
 
   async resolveQueueProperties(
     request: TriggerTaskRequest,
@@ -103,7 +108,7 @@ export class DefaultQueueManager implements QueueManager {
 
         // Only fetch task for TTL if caller didn't provide a per-trigger TTL
         if (request.body.options?.ttl === undefined) {
-          const lockedTask = await this.prisma.backgroundWorkerTask.findFirst({
+          const lockedTask = await this.replicaPrisma.backgroundWorkerTask.findFirst({
             where: {
               workerId: lockedBackgroundWorker.id,
               runtimeEnvironmentId: request.environment.id,
@@ -116,7 +121,7 @@ export class DefaultQueueManager implements QueueManager {
         }
       } else {
         // No queue override - fetch task with queue to get both default queue and TTL
-        const lockedTask = await this.prisma.backgroundWorkerTask.findFirst({
+        const lockedTask = await this.replicaPrisma.backgroundWorkerTask.findFirst({
           where: {
             workerId: lockedBackgroundWorker.id,
             runtimeEnvironmentId: request.environment.id,
@@ -217,7 +222,7 @@ export class DefaultQueueManager implements QueueManager {
 
     // When queue is overridden, we only need TTL from the task (no queue join needed)
     if (overriddenQueueName) {
-      const task = await this.prisma.backgroundWorkerTask.findFirst({
+      const task = await this.replicaPrisma.backgroundWorkerTask.findFirst({
         where: {
           workerId: worker.id,
           runtimeEnvironmentId: environment.id,
@@ -229,7 +234,7 @@ export class DefaultQueueManager implements QueueManager {
       return { queueName: overriddenQueueName, taskTtl: task?.ttl };
     }
 
-    const task = await this.prisma.backgroundWorkerTask.findFirst({
+    const task = await this.replicaPrisma.backgroundWorkerTask.findFirst({
       where: {
         workerId: worker.id,
         runtimeEnvironmentId: environment.id,

--- a/apps/webapp/app/runEngine/services/batchTrigger.server.ts
+++ b/apps/webapp/app/runEngine/services/batchTrigger.server.ts
@@ -531,6 +531,7 @@ export class RunEngineBatchTriggerService extends WithRunEngine {
     const triggerFailedTaskService = new TriggerFailedTaskService({
       prisma: this._prisma,
       engine: this._engine,
+      replicaPrisma: this._replica,
     });
 
     for (const item of itemsToProcess) {

--- a/apps/webapp/app/runEngine/services/createBatch.server.ts
+++ b/apps/webapp/app/runEngine/services/createBatch.server.ts
@@ -40,7 +40,7 @@ export class CreateBatchService extends WithRunEngine {
   constructor(protected readonly _prisma: PrismaClientOrTransaction = prisma) {
     super({ prisma: _prisma });
 
-    this.queueConcern = new DefaultQueueManager(this._prisma, this._engine);
+    this.queueConcern = new DefaultQueueManager(this._prisma, this._engine, this._replica);
     this.validator = new DefaultTriggerTaskValidator();
   }
 

--- a/apps/webapp/app/runEngine/services/triggerFailedTask.server.ts
+++ b/apps/webapp/app/runEngine/services/triggerFailedTask.server.ts
@@ -51,10 +51,16 @@ export type TriggerFailedTaskRequest = {
  */
 export class TriggerFailedTaskService {
   private readonly prisma: PrismaClientOrTransaction;
+  private readonly replicaPrisma: PrismaClientOrTransaction;
   private readonly engine: RunEngine;
 
-  constructor(opts: { prisma: PrismaClientOrTransaction; engine: RunEngine }) {
+  constructor(opts: {
+    prisma: PrismaClientOrTransaction;
+    engine: RunEngine;
+    replicaPrisma?: PrismaClientOrTransaction;
+  }) {
     this.prisma = opts.prisma;
+    this.replicaPrisma = opts.replicaPrisma ?? opts.prisma;
     this.engine = opts.engine;
   }
 
@@ -91,7 +97,7 @@ export class TriggerFailedTaskService {
       let queueName: string | undefined;
       let lockedQueueId: string | undefined;
       try {
-        const queueConcern = new DefaultQueueManager(this.prisma, this.engine);
+        const queueConcern = new DefaultQueueManager(this.prisma, this.engine, this.replicaPrisma);
         const bodyOptions = request.options as TriggerTaskRequest["body"]["options"];
         const triggerRequest: TriggerTaskRequest = {
           taskId: request.taskId,

--- a/apps/webapp/app/services/taskIdentifierCache.server.ts
+++ b/apps/webapp/app/services/taskIdentifierCache.server.ts
@@ -1,0 +1,115 @@
+import { Redis } from "ioredis";
+import type { TaskTriggerSource } from "@trigger.dev/database";
+import { env } from "~/env.server";
+import { singleton } from "~/utils/singleton";
+import { logger } from "./logger.server";
+
+const KEY_PREFIX = "tids:";
+
+type CachedTaskIdentifier = {
+  s: string;
+  ts: TaskTriggerSource;
+  live: boolean;
+};
+
+export type TaskIdentifierEntry = {
+  slug: string;
+  triggerSource: TaskTriggerSource;
+  isInLatestDeployment: boolean;
+};
+
+function buildKey(environmentId: string): string {
+  return `${KEY_PREFIX}${environmentId}`;
+}
+
+function encode(entry: TaskIdentifierEntry): string {
+  return JSON.stringify({
+    s: entry.slug,
+    ts: entry.triggerSource,
+    live: entry.isInLatestDeployment,
+  } satisfies CachedTaskIdentifier);
+}
+
+function decode(raw: string): TaskIdentifierEntry {
+  const parsed = JSON.parse(raw) as CachedTaskIdentifier;
+  return {
+    slug: parsed.s,
+    triggerSource: parsed.ts,
+    isInLatestDeployment: parsed.live,
+  };
+}
+
+function initializeRedis(): Redis | undefined {
+  const host = env.CACHE_REDIS_HOST;
+  if (!host) {
+    return undefined;
+  }
+
+  return new Redis({
+    connectionName: "taskIdentifierCache",
+    host,
+    port: env.CACHE_REDIS_PORT,
+    username: env.CACHE_REDIS_USERNAME,
+    password: env.CACHE_REDIS_PASSWORD,
+    keyPrefix: "tr:",
+    enableAutoPipelining: true,
+    ...(env.CACHE_REDIS_TLS_DISABLED === "true" ? {} : { tls: {} }),
+  });
+}
+
+const redis = singleton("taskIdentifierCache", initializeRedis);
+
+export async function populateTaskIdentifierCache(
+  environmentId: string,
+  identifiers: TaskIdentifierEntry[]
+): Promise<void> {
+  if (!redis) return;
+
+  try {
+    const key = buildKey(environmentId);
+    const pipeline = redis.pipeline();
+    pipeline.del(key);
+    if (identifiers.length > 0) {
+      pipeline.sadd(key, ...identifiers.map(encode));
+    }
+    await pipeline.exec();
+  } catch (error) {
+    logger.error("Failed to populate task identifier cache", {
+      environmentId,
+      error,
+    });
+  }
+}
+
+export async function invalidateTaskIdentifierCache(environmentId: string): Promise<void> {
+  if (!redis) return;
+
+  try {
+    const key = buildKey(environmentId);
+    await redis.del(key);
+  } catch (error) {
+    logger.error("Failed to invalidate task identifier cache", {
+      environmentId,
+      error,
+    });
+  }
+}
+
+export async function getTaskIdentifiersFromCache(
+  environmentId: string
+): Promise<TaskIdentifierEntry[] | null> {
+  if (!redis) return null;
+
+  try {
+    const key = buildKey(environmentId);
+    const members = await redis.smembers(key);
+    if (members.length === 0) return null;
+    return members.map(decode);
+  } catch (error) {
+    logger.error("Failed to get task identifiers from cache", {
+      environmentId,
+      error,
+    });
+    return null;
+  }
+}

--- a/apps/webapp/app/services/taskIdentifierRegistry.server.ts
+++ b/apps/webapp/app/services/taskIdentifierRegistry.server.ts
@@ -1,4 +1,4 @@
-import { TaskTriggerSource } from "@trigger.dev/database";
+import { type PrismaClient, TaskTriggerSource } from "@trigger.dev/database";
 import { $replica, prisma } from "~/db.server";
 import { getAllTaskIdentifiers } from "~/models/task.server";
 import { logger } from "./logger.server";
@@ -17,47 +17,64 @@ export async function syncTaskIdentifiers(
   environmentId: string,
   projectId: string,
   workerId: string,
-  tasks: { id: string; triggerSource?: string }[]
+  tasks: { id: string; triggerSource?: string }[],
+  db: PrismaClient = prisma
 ): Promise<void> {
   const slugs = tasks.map((t) => t.id);
+  const now = new Date();
 
+  // Group slugs by resolved triggerSource for bulk updates
+  const slugsBySource = new Map<TaskTriggerSource, string[]>();
   for (const task of tasks) {
-    await prisma.taskIdentifier.upsert({
-      where: {
-        runtimeEnvironmentId_slug: {
-          runtimeEnvironmentId: environmentId,
-          slug: task.id,
-        },
-      },
-      create: {
+    const source = toTriggerSource(task.triggerSource);
+    const existing = slugsBySource.get(source);
+    if (existing) {
+      existing.push(task.id);
+    } else {
+      slugsBySource.set(source, [task.id]);
+    }
+  }
+
+  // Batch: insert new rows, update existing rows per source group, archive removed tasks
+  await db.$transaction([
+    // Insert any new task identifiers (skips rows that already exist)
+    db.taskIdentifier.createMany({
+      data: tasks.map((task) => ({
         runtimeEnvironmentId: environmentId,
         projectId,
         slug: task.id,
         currentTriggerSource: toTriggerSource(task.triggerSource),
         currentWorkerId: workerId,
-        isInLatestDeployment: true,
-      },
-      update: {
-        currentTriggerSource: toTriggerSource(task.triggerSource),
-        currentWorkerId: workerId,
-        lastSeenAt: new Date(),
-        isInLatestDeployment: true,
-      },
-    });
-  }
-
-  if (slugs.length > 0) {
-    await prisma.taskIdentifier.updateMany({
+      })),
+      skipDuplicates: true,
+    }),
+    // Update existing rows — one updateMany per distinct triggerSource value
+    ...Array.from(slugsBySource.entries()).map(([source, taskSlugs]) =>
+      db.taskIdentifier.updateMany({
+        where: {
+          runtimeEnvironmentId: environmentId,
+          slug: { in: taskSlugs },
+        },
+        data: {
+          currentTriggerSource: source,
+          currentWorkerId: workerId,
+          lastSeenAt: now,
+          isInLatestDeployment: true,
+        },
+      })
+    ),
+    // Archive tasks no longer in this deploy
+    db.taskIdentifier.updateMany({
       where: {
         runtimeEnvironmentId: environmentId,
         slug: { notIn: slugs },
         isInLatestDeployment: true,
       },
       data: { isInLatestDeployment: false },
-    });
-  }
+    }),
+  ]);
 
-  const allIdentifiers = await prisma.taskIdentifier.findMany({
+  const allIdentifiers = await db.taskIdentifier.findMany({
     where: { runtimeEnvironmentId: environmentId },
     select: {
       slug: true,
@@ -87,12 +104,13 @@ function sortEntries(entries: TaskIdentifierEntry[]): TaskIdentifierEntry[] {
 }
 
 export async function getTaskIdentifiers(
-  environmentId: string
+  environmentId: string,
+  db: PrismaClient = $replica
 ): Promise<TaskIdentifierEntry[]> {
   const cached = await getTaskIdentifiersFromCache(environmentId);
   if (cached) return sortEntries(cached);
 
-  const dbRows = await $replica.taskIdentifier.findMany({
+  const dbRows = await db.taskIdentifier.findMany({
     where: { runtimeEnvironmentId: environmentId },
     select: {
       slug: true,

--- a/apps/webapp/app/services/taskIdentifierRegistry.server.ts
+++ b/apps/webapp/app/services/taskIdentifierRegistry.server.ts
@@ -10,7 +10,6 @@ import {
 
 function toTriggerSource(source: string | undefined): TaskTriggerSource {
   if (source === "SCHEDULED" || source === "schedule") return "SCHEDULED";
-  if (source === "AGENT" || source === "agent") return "AGENT";
   return "STANDARD";
 }
 

--- a/apps/webapp/app/services/taskIdentifierRegistry.server.ts
+++ b/apps/webapp/app/services/taskIdentifierRegistry.server.ts
@@ -136,7 +136,7 @@ export async function getTaskIdentifiers(
     return sortEntries(entries);
   }
 
-  const legacyRows = await getAllTaskIdentifiers($replica, environmentId);
+  const legacyRows = await getAllTaskIdentifiers(db, environmentId);
   const entries: TaskIdentifierEntry[] = legacyRows.map((t) => ({
     slug: t.slug,
     triggerSource: t.triggerSource,

--- a/apps/webapp/app/services/taskIdentifierRegistry.server.ts
+++ b/apps/webapp/app/services/taskIdentifierRegistry.server.ts
@@ -1,0 +1,139 @@
+import { TaskTriggerSource } from "@trigger.dev/database";
+import { $replica, prisma } from "~/db.server";
+import { getAllTaskIdentifiers } from "~/models/task.server";
+import { logger } from "./logger.server";
+import {
+  getTaskIdentifiersFromCache,
+  populateTaskIdentifierCache,
+  type TaskIdentifierEntry,
+} from "./taskIdentifierCache.server";
+
+function toTriggerSource(source: string | undefined): TaskTriggerSource {
+  if (source === "SCHEDULED" || source === "schedule") return "SCHEDULED";
+  if (source === "AGENT" || source === "agent") return "AGENT";
+  return "STANDARD";
+}
+
+export async function syncTaskIdentifiers(
+  environmentId: string,
+  projectId: string,
+  workerId: string,
+  tasks: { id: string; triggerSource?: string }[]
+): Promise<void> {
+  const slugs = tasks.map((t) => t.id);
+
+  for (const task of tasks) {
+    await prisma.taskIdentifier.upsert({
+      where: {
+        runtimeEnvironmentId_slug: {
+          runtimeEnvironmentId: environmentId,
+          slug: task.id,
+        },
+      },
+      create: {
+        runtimeEnvironmentId: environmentId,
+        projectId,
+        slug: task.id,
+        currentTriggerSource: toTriggerSource(task.triggerSource),
+        currentWorkerId: workerId,
+        isInLatestDeployment: true,
+      },
+      update: {
+        currentTriggerSource: toTriggerSource(task.triggerSource),
+        currentWorkerId: workerId,
+        lastSeenAt: new Date(),
+        isInLatestDeployment: true,
+      },
+    });
+  }
+
+  if (slugs.length > 0) {
+    await prisma.taskIdentifier.updateMany({
+      where: {
+        runtimeEnvironmentId: environmentId,
+        slug: { notIn: slugs },
+        isInLatestDeployment: true,
+      },
+      data: { isInLatestDeployment: false },
+    });
+  }
+
+  const allIdentifiers = await prisma.taskIdentifier.findMany({
+    where: { runtimeEnvironmentId: environmentId },
+    select: {
+      slug: true,
+      currentTriggerSource: true,
+      isInLatestDeployment: true,
+    },
+  });
+
+  populateTaskIdentifierCache(
+    environmentId,
+    allIdentifiers.map((t) => ({
+      slug: t.slug,
+      triggerSource: t.currentTriggerSource,
+      isInLatestDeployment: t.isInLatestDeployment,
+    }))
+  ).catch((error) => {
+    logger.error("Failed to populate task identifier cache after sync", { environmentId, error });
+  });
+}
+
+function sortEntries(entries: TaskIdentifierEntry[]): TaskIdentifierEntry[] {
+  return entries.sort((a, b) => {
+    if (a.isInLatestDeployment !== b.isInLatestDeployment)
+      return a.isInLatestDeployment ? -1 : 1;
+    return a.slug.localeCompare(b.slug);
+  });
+}
+
+export async function getTaskIdentifiers(
+  environmentId: string
+): Promise<TaskIdentifierEntry[]> {
+  const cached = await getTaskIdentifiersFromCache(environmentId);
+  if (cached) return sortEntries(cached);
+
+  const dbRows = await $replica.taskIdentifier.findMany({
+    where: { runtimeEnvironmentId: environmentId },
+    select: {
+      slug: true,
+      currentTriggerSource: true,
+      isInLatestDeployment: true,
+    },
+  });
+
+  if (dbRows.length > 0) {
+    const entries: TaskIdentifierEntry[] = dbRows.map((t) => ({
+      slug: t.slug,
+      triggerSource: t.currentTriggerSource,
+      isInLatestDeployment: t.isInLatestDeployment,
+    }));
+
+    populateTaskIdentifierCache(environmentId, entries).catch((error) => {
+      logger.error("Failed to populate task identifier cache after DB read", {
+        environmentId,
+        error,
+      });
+    });
+
+    return sortEntries(entries);
+  }
+
+  const legacyRows = await getAllTaskIdentifiers($replica, environmentId);
+  const entries: TaskIdentifierEntry[] = legacyRows.map((t) => ({
+    slug: t.slug,
+    triggerSource: t.triggerSource,
+    isInLatestDeployment: true,
+  }));
+
+  if (entries.length > 0) {
+    populateTaskIdentifierCache(environmentId, entries).catch((error) => {
+      logger.error("Failed to populate task identifier cache after legacy fallback", {
+        environmentId,
+        error,
+      });
+    });
+  }
+
+  return sortEntries(entries);
+}

--- a/apps/webapp/app/services/taskIdentifierRegistry.server.ts
+++ b/apps/webapp/app/services/taskIdentifierRegistry.server.ts
@@ -1,4 +1,4 @@
-import { type PrismaClient, TaskTriggerSource } from "@trigger.dev/database";
+import { type PrismaClient, type PrismaClientOrTransaction, TaskTriggerSource } from "@trigger.dev/database";
 import { $replica, prisma } from "~/db.server";
 import { getAllTaskIdentifiers } from "~/models/task.server";
 import { logger } from "./logger.server";
@@ -105,7 +105,7 @@ function sortEntries(entries: TaskIdentifierEntry[]): TaskIdentifierEntry[] {
 
 export async function getTaskIdentifiers(
   environmentId: string,
-  db: PrismaClient = $replica
+  db: PrismaClientOrTransaction = $replica
 ): Promise<TaskIdentifierEntry[]> {
   const cached = await getTaskIdentifiersFromCache(environmentId);
   if (cached) return sortEntries(cached);

--- a/apps/webapp/app/v3/runEngineHandlers.server.ts
+++ b/apps/webapp/app/v3/runEngineHandlers.server.ts
@@ -677,6 +677,7 @@ export function setupBatchQueueCallbacks() {
         const triggerFailedTaskService = new TriggerFailedTaskService({
           prisma,
           engine,
+          replicaPrisma: $replica,
         });
 
         // Check for pre-marked error items (e.g. oversized payloads)

--- a/apps/webapp/app/v3/services/changeCurrentDeployment.server.ts
+++ b/apps/webapp/app/v3/services/changeCurrentDeployment.server.ts
@@ -1,8 +1,11 @@
+import { tryCatch } from "@trigger.dev/core/v3";
+import { CURRENT_DEPLOYMENT_LABEL } from "@trigger.dev/core/v3/isomorphic";
 import { WorkerDeployment } from "@trigger.dev/database";
+import { logger } from "~/services/logger.server";
+import { syncTaskIdentifiers } from "~/services/taskIdentifierRegistry.server";
 import { BaseService, ServiceValidationError } from "./baseService.server";
 import { ExecuteTasksWaitingForDeployService } from "./executeTasksWaitingForDeploy";
 import { compareDeploymentVersions } from "../utils/deploymentVersions";
-import { CURRENT_DEPLOYMENT_LABEL } from "@trigger.dev/core/v3/isomorphic";
 
 export type ChangeCurrentDeploymentDirection = "promote" | "rollback";
 
@@ -96,6 +99,23 @@ export class ChangeCurrentDeploymentService extends BaseService {
       },
     });
 
-    await ExecuteTasksWaitingForDeployService.enqueue(deployment.workerId);
+    const [syncError] = await tryCatch(
+      (async () => {
+        const tasks = await this._prisma.backgroundWorkerTask.findMany({
+          where: { workerId: deployment.workerId! },
+          select: { slug: true, triggerSource: true },
+        });
+        await syncTaskIdentifiers(
+          deployment.environmentId,
+          deployment.projectId,
+          deployment.workerId!,
+          tasks.map((t) => ({ id: t.slug, triggerSource: t.triggerSource }))
+        );
+      })()
+    );
+
+    if (syncError) {
+      logger.error("Error syncing task identifiers on deployment change", { error: syncError });
+    }
   }
 }

--- a/apps/webapp/app/v3/services/changeCurrentDeployment.server.ts
+++ b/apps/webapp/app/v3/services/changeCurrentDeployment.server.ts
@@ -117,5 +117,7 @@ export class ChangeCurrentDeploymentService extends BaseService {
     if (syncError) {
       logger.error("Error syncing task identifiers on deployment change", { error: syncError });
     }
+
+    await ExecuteTasksWaitingForDeployService.enqueue(deployment.workerId);
   }
 }

--- a/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
+++ b/apps/webapp/app/v3/services/createBackgroundWorker.server.ts
@@ -13,6 +13,7 @@ import { $transaction, Prisma, PrismaClientOrTransaction } from "~/db.server";
 import { sanitizeQueueName } from "~/models/taskQueue.server";
 import { AuthenticatedEnvironment } from "~/services/apiAuth.server";
 import { logger } from "~/services/logger.server";
+import { syncTaskIdentifiers } from "~/services/taskIdentifierRegistry.server";
 import { generateFriendlyId } from "../friendlyIdentifiers";
 import {
   removeQueueConcurrencyLimits,
@@ -156,6 +157,23 @@ export class CreateBackgroundWorkerService extends BaseService {
         }
 
         throw new ServiceValidationError("Error syncing declarative schedules");
+      }
+
+      const [syncIdentifiersError] = await tryCatch(
+        syncTaskIdentifiers(
+          environment.id,
+          project.id,
+          backgroundWorker.id,
+          body.metadata.tasks.map((t) => ({ id: t.id, triggerSource: t.triggerSource }))
+        )
+      );
+
+      if (syncIdentifiersError) {
+        logger.error("Error syncing task identifiers", {
+          error: syncIdentifiersError,
+          backgroundWorker,
+          environment,
+        });
       }
 
       const [updateConcurrencyLimitsError] = await tryCatch(

--- a/apps/webapp/app/v3/services/createDeploymentBackgroundWorkerV3.server.ts
+++ b/apps/webapp/app/v3/services/createDeploymentBackgroundWorkerV3.server.ts
@@ -1,7 +1,8 @@
-import { CreateBackgroundWorkerRequestBody } from "@trigger.dev/core/v3";
+import { CreateBackgroundWorkerRequestBody, tryCatch } from "@trigger.dev/core/v3";
 import type { BackgroundWorker, Prisma } from "@trigger.dev/database";
 import { AuthenticatedEnvironment } from "~/services/apiAuth.server";
 import { logger } from "~/services/logger.server";
+import { syncTaskIdentifiers } from "~/services/taskIdentifierRegistry.server";
 import { socketIo } from "../handleSocketIo.server";
 import { updateEnvConcurrencyLimits } from "../runQueue.server";
 import { PerformDeploymentAlertsService } from "./alerts/performDeploymentAlerts.server";
@@ -129,6 +130,19 @@ export class CreateDeploymentBackgroundWorkerServiceV3 extends BaseService {
           deploymentId: deployment.id,
         },
       });
+
+      const [syncIdError] = await tryCatch(
+        syncTaskIdentifiers(
+          environment.id,
+          environment.projectId,
+          backgroundWorker.id,
+          body.metadata.tasks.map((t) => ({ id: t.id, triggerSource: t.triggerSource }))
+        )
+      );
+
+      if (syncIdError) {
+        logger.error("Error syncing task identifiers", { error: syncIdError });
+      }
 
       try {
         //send a notification that a new worker has been created

--- a/apps/webapp/app/v3/services/triggerTask.server.ts
+++ b/apps/webapp/app/v3/services/triggerTask.server.ts
@@ -99,7 +99,7 @@ export class TriggerTaskService extends WithRunEngine {
     const service = new RunEngineTriggerTaskService({
       prisma: this._prisma,
       engine: this._engine,
-      queueConcern: new DefaultQueueManager(this._prisma, this._engine),
+      queueConcern: new DefaultQueueManager(this._prisma, this._engine, this._replica),
       validator: new DefaultTriggerTaskValidator(),
       payloadProcessor: new DefaultPayloadProcessor(),
       idempotencyKeyConcern: new IdempotencyKeyConcern(

--- a/apps/webapp/test/engine/taskIdentifierRegistry.test.ts
+++ b/apps/webapp/test/engine/taskIdentifierRegistry.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, vi } from "vitest";
+
+vi.mock("~/db.server", () => ({
+  prisma: {},
+  $replica: {},
+}));
+
+vi.mock("~/services/taskIdentifierCache.server", () => ({
+  getTaskIdentifiersFromCache: vi.fn().mockResolvedValue(null),
+  populateTaskIdentifierCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("~/services/logger.server", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("~/models/task.server", () => ({
+  getAllTaskIdentifiers: vi.fn().mockResolvedValue([]),
+}));
+
+import { setupAuthenticatedEnvironment } from "@internal/run-engine/tests";
+import { postgresTest } from "@internal/testcontainers";
+import { generateFriendlyId } from "@trigger.dev/core/v3/isomorphic";
+import type { PrismaClient } from "@trigger.dev/database";
+import {
+  syncTaskIdentifiers,
+  getTaskIdentifiers,
+} from "../../app/services/taskIdentifierRegistry.server";
+import type { AuthenticatedEnvironment } from "@internal/run-engine/tests";
+
+vi.setConfig({ testTimeout: 30_000 });
+
+async function createWorker(prisma: PrismaClient, env: AuthenticatedEnvironment) {
+  return prisma.backgroundWorker.create({
+    data: {
+      friendlyId: generateFriendlyId("worker"),
+      contentHash: `hash-${Date.now()}-${Math.random()}`,
+      projectId: env.project.id,
+      runtimeEnvironmentId: env.id,
+      version: `${Date.now()}`,
+      metadata: {},
+      engine: "V2",
+    },
+  });
+}
+
+describe("TaskIdentifierRegistry", () => {
+  postgresTest("should create task identifiers on first sync", async ({ prisma }) => {
+    const env = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+    const worker = await createWorker(prisma, env);
+
+    await syncTaskIdentifiers(
+      env.id,
+      env.project.id,
+      worker.id,
+      [
+        { id: "task-a", triggerSource: "STANDARD" },
+        { id: "task-b", triggerSource: "SCHEDULED" },
+      ],
+      prisma
+    );
+
+    const rows = await prisma.taskIdentifier.findMany({
+      where: { runtimeEnvironmentId: env.id },
+      orderBy: { slug: "asc" },
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].slug).toBe("task-a");
+    expect(rows[0].currentTriggerSource).toBe("STANDARD");
+    expect(rows[0].isInLatestDeployment).toBe(true);
+    expect(rows[1].slug).toBe("task-b");
+    expect(rows[1].currentTriggerSource).toBe("SCHEDULED");
+    expect(rows[1].isInLatestDeployment).toBe(true);
+  });
+
+  postgresTest("should update triggerSource on re-deploy", async ({ prisma }) => {
+    const env = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+    const worker1 = await createWorker(prisma, env);
+
+    // First deploy: STANDARD
+    await syncTaskIdentifiers(
+      env.id,
+      env.project.id,
+      worker1.id,
+      [{ id: "my-task", triggerSource: "STANDARD" }],
+      prisma
+    );
+
+    const worker2 = await createWorker(prisma, env);
+
+    // Second deploy: change to SCHEDULED
+    await syncTaskIdentifiers(
+      env.id,
+      env.project.id,
+      worker2.id,
+      [{ id: "my-task", triggerSource: "SCHEDULED" }],
+      prisma
+    );
+
+    const rows = await prisma.taskIdentifier.findMany({
+      where: { runtimeEnvironmentId: env.id },
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].slug).toBe("my-task");
+    expect(rows[0].currentTriggerSource).toBe("SCHEDULED");
+    expect(rows[0].currentWorkerId).toBe(worker2.id);
+  });
+
+  postgresTest("should archive tasks removed in a deploy", async ({ prisma }) => {
+    const env = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+    const worker1 = await createWorker(prisma, env);
+
+    // Deploy with both tasks
+    await syncTaskIdentifiers(
+      env.id,
+      env.project.id,
+      worker1.id,
+      [
+        { id: "task-a", triggerSource: "STANDARD" },
+        { id: "task-b", triggerSource: "STANDARD" },
+      ],
+      prisma
+    );
+
+    const worker2 = await createWorker(prisma, env);
+
+    // Deploy with only task-a (task-b removed)
+    await syncTaskIdentifiers(
+      env.id,
+      env.project.id,
+      worker2.id,
+      [{ id: "task-a", triggerSource: "STANDARD" }],
+      prisma
+    );
+
+    const rows = await prisma.taskIdentifier.findMany({
+      where: { runtimeEnvironmentId: env.id },
+      orderBy: { slug: "asc" },
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].slug).toBe("task-a");
+    expect(rows[0].isInLatestDeployment).toBe(true);
+    expect(rows[1].slug).toBe("task-b");
+    expect(rows[1].isInLatestDeployment).toBe(false);
+  });
+
+  postgresTest("should resurrect archived tasks on re-deploy", async ({ prisma }) => {
+    const env = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+    const worker1 = await createWorker(prisma, env);
+
+    // Deploy with both
+    await syncTaskIdentifiers(
+      env.id,
+      env.project.id,
+      worker1.id,
+      [
+        { id: "task-a", triggerSource: "STANDARD" },
+        { id: "task-b", triggerSource: "STANDARD" },
+      ],
+      prisma
+    );
+
+    const worker2 = await createWorker(prisma, env);
+
+    // Deploy without task-b
+    await syncTaskIdentifiers(
+      env.id,
+      env.project.id,
+      worker2.id,
+      [{ id: "task-a", triggerSource: "STANDARD" }],
+      prisma
+    );
+
+    const worker3 = await createWorker(prisma, env);
+
+    // Deploy with task-b again
+    await syncTaskIdentifiers(
+      env.id,
+      env.project.id,
+      worker3.id,
+      [
+        { id: "task-a", triggerSource: "STANDARD" },
+        { id: "task-b", triggerSource: "STANDARD" },
+      ],
+      prisma
+    );
+
+    const rows = await prisma.taskIdentifier.findMany({
+      where: { runtimeEnvironmentId: env.id },
+      orderBy: { slug: "asc" },
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].isInLatestDeployment).toBe(true);
+    expect(rows[1].isInLatestDeployment).toBe(true);
+  });
+
+  postgresTest(
+    "should return identifiers sorted active-first from DB when cache misses",
+    async ({ prisma }) => {
+      const env = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+      const worker1 = await createWorker(prisma, env);
+
+      await syncTaskIdentifiers(
+        env.id,
+        env.project.id,
+        worker1.id,
+        [
+          { id: "active-task", triggerSource: "STANDARD" },
+          { id: "archived-task", triggerSource: "STANDARD" },
+        ],
+        prisma
+      );
+
+      const worker2 = await createWorker(prisma, env);
+
+      // Archive one task
+      await syncTaskIdentifiers(
+        env.id,
+        env.project.id,
+        worker2.id,
+        [{ id: "active-task", triggerSource: "STANDARD" }],
+        prisma
+      );
+
+      // Read with cache miss (mocked to return null)
+      const result = await getTaskIdentifiers(env.id, prisma);
+
+      expect(result).toHaveLength(2);
+      // Active first
+      expect(result[0].slug).toBe("active-task");
+      expect(result[0].isInLatestDeployment).toBe(true);
+      // Archived second
+      expect(result[1].slug).toBe("archived-task");
+      expect(result[1].isInLatestDeployment).toBe(false);
+    }
+  );
+
+  postgresTest("should handle multiple triggerSource groups in one deploy", async ({ prisma }) => {
+    const env = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+    const worker = await createWorker(prisma, env);
+
+    // Note: AGENT enum value is missing from migrations (no ALTER TYPE migration exists),
+    // so we test with STANDARD + SCHEDULED only. AGENT works in prod because the enum
+    // was added via prisma db push or manual ALTER.
+    await syncTaskIdentifiers(
+      env.id,
+      env.project.id,
+      worker.id,
+      [
+        { id: "standard-task", triggerSource: "STANDARD" },
+        { id: "scheduled-task", triggerSource: "SCHEDULED" },
+      ],
+      prisma
+    );
+
+    const rows = await prisma.taskIdentifier.findMany({
+      where: { runtimeEnvironmentId: env.id },
+      orderBy: { slug: "asc" },
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].slug).toBe("scheduled-task");
+    expect(rows[0].currentTriggerSource).toBe("SCHEDULED");
+    expect(rows[1].slug).toBe("standard-task");
+    expect(rows[1].currentTriggerSource).toBe("STANDARD");
+  });
+});

--- a/internal-packages/database/prisma/migrations/20260413000000_add_bwt_covering_index/migration.sql
+++ b/internal-packages/database/prisma/migrations/20260413000000_add_bwt_covering_index/migration.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "BackgroundWorkerTask_runtimeEnvironmentId_slug_triggerSource_idx"
+  ON "BackgroundWorkerTask"("runtimeEnvironmentId", slug, "triggerSource");

--- a/internal-packages/database/prisma/migrations/20260413000001_add_task_identifier_table/migration.sql
+++ b/internal-packages/database/prisma/migrations/20260413000001_add_task_identifier_table/migration.sql
@@ -1,0 +1,40 @@
+-- CreateTable
+CREATE TABLE "TaskIdentifier" (
+    "id" TEXT NOT NULL,
+    "runtimeEnvironmentId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "currentTriggerSource" "TaskTriggerSource" NOT NULL DEFAULT 'STANDARD',
+    "currentWorkerId" TEXT NOT NULL,
+    "firstSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "isInLatestDeployment" BOOLEAN NOT NULL DEFAULT true,
+
+    CONSTRAINT "TaskIdentifier_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TaskIdentifier_runtimeEnvironmentId_slug_key"
+    ON "TaskIdentifier"("runtimeEnvironmentId", "slug");
+
+-- CreateIndex
+CREATE INDEX "TaskIdentifier_runtimeEnvironmentId_isInLatestDeployment_idx"
+    ON "TaskIdentifier"("runtimeEnvironmentId", "isInLatestDeployment");
+
+-- AddForeignKey
+ALTER TABLE "TaskIdentifier"
+    ADD CONSTRAINT "TaskIdentifier_runtimeEnvironmentId_fkey"
+    FOREIGN KEY ("runtimeEnvironmentId") REFERENCES "RuntimeEnvironment"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskIdentifier"
+    ADD CONSTRAINT "TaskIdentifier_projectId_fkey"
+    FOREIGN KEY ("projectId") REFERENCES "Project"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskIdentifier"
+    ADD CONSTRAINT "TaskIdentifier_currentWorkerId_fkey"
+    FOREIGN KEY ("currentWorkerId") REFERENCES "BackgroundWorker"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/internal-packages/database/prisma/migrations/20260413000001_add_task_identifier_table/migration.sql
+++ b/internal-packages/database/prisma/migrations/20260413000001_add_task_identifier_table/migration.sql
@@ -5,7 +5,7 @@ CREATE TABLE "TaskIdentifier" (
     "projectId" TEXT NOT NULL,
     "slug" TEXT NOT NULL,
     "currentTriggerSource" "TaskTriggerSource" NOT NULL DEFAULT 'STANDARD',
-    "currentWorkerId" TEXT NOT NULL,
+    "currentWorkerId" TEXT,
     "firstSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "isInLatestDeployment" BOOLEAN NOT NULL DEFAULT true,
@@ -37,4 +37,4 @@ ALTER TABLE "TaskIdentifier"
 ALTER TABLE "TaskIdentifier"
     ADD CONSTRAINT "TaskIdentifier_currentWorkerId_fkey"
     FOREIGN KEY ("currentWorkerId") REFERENCES "BackgroundWorker"("id")
-    ON DELETE CASCADE ON UPDATE CASCADE;
+    ON DELETE SET NULL ON UPDATE CASCADE;

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -2938,8 +2938,8 @@ model TaskIdentifier {
 
   currentTriggerSource TaskTriggerSource @default(STANDARD)
 
-  currentWorker   BackgroundWorker @relation(fields: [currentWorkerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  currentWorkerId String
+  currentWorker   BackgroundWorker? @relation(fields: [currentWorkerId], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  currentWorkerId String?
 
   firstSeenAt          DateTime @default(now())
   lastSeenAt           DateTime @default(now())

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -354,6 +354,7 @@ model RuntimeEnvironment {
   customerQueries      CustomerQuery[]
   prompts              Prompt[]
   errorGroupStates     ErrorGroupState[]
+  taskIdentifiers      TaskIdentifier[]
 
   @@unique([projectId, slug, orgMemberId])
   @@unique([projectId, shortcode])
@@ -429,6 +430,7 @@ model Project {
   prompts               Prompt[]
   platformNotifications PlatformNotification[]
   errorGroupStates      ErrorGroupState[]
+  taskIdentifiers       TaskIdentifier[]
 }
 
 enum ProjectVersion {
@@ -516,6 +518,8 @@ model BackgroundWorker {
   workerGroupId String?
 
   supportsLazyAttempts Boolean @default(false)
+
+  taskIdentifiers TaskIdentifier[]
 
   @@unique([projectId, runtimeEnvironmentId, version])
   @@index([runtimeEnvironmentId])
@@ -659,6 +663,7 @@ model BackgroundWorkerTask {
   // Quick lookup of task identifiers
   @@index([projectId, slug])
   @@index([runtimeEnvironmentId, projectId])
+  @@index([runtimeEnvironmentId, slug, triggerSource])
 }
 
 enum TaskTriggerSource {
@@ -2918,4 +2923,28 @@ model ErrorGroupState {
 
   @@unique([environmentId, taskIdentifier, errorFingerprint])
   @@index([environmentId, status])
+}
+
+model TaskIdentifier {
+  id String @id @default(cuid())
+
+  runtimeEnvironment   RuntimeEnvironment @relation(fields: [runtimeEnvironmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  runtimeEnvironmentId String
+
+  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  projectId String
+
+  slug String
+
+  currentTriggerSource TaskTriggerSource @default(STANDARD)
+
+  currentWorker   BackgroundWorker @relation(fields: [currentWorkerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  currentWorkerId String
+
+  firstSeenAt          DateTime @default(now())
+  lastSeenAt           DateTime @default(now())
+  isInLatestDeployment Boolean  @default(true)
+
+  @@unique([runtimeEnvironmentId, slug])
+  @@index([runtimeEnvironmentId, isInLatestDeployment])
 }


### PR DESCRIPTION
Replace the expensive DISTINCT query for task filter dropdowns with a dedicated TaskIdentifier registry table backed by Redis. Environments migrate automatically on their next deploy, with a transparent fallback to the legacy query for unmigrated environments. Also fixes duplicate dropdown entries when a task changes trigger source, and adds active/archived grouping for removed tasks. Moves BackgroundWorkerTask reads in the trigger hot path to the read replica.