### PR TITLE
fix(python): remove hardcoded OTEL_LOG_LEVEL=DEBUG that caused stderr deadlocks

### DIFF
--- a/.changeset/python-stderr-deadlock-fix.md
+++ b/.changeset/python-stderr-deadlock-fix.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/python": patch
+---
+
+Fix `python.runScript()` deadlock when the Python subprocess produces more than ~64KB of stderr output. The previous implementation hardcoded `OTEL_LOG_LEVEL: "DEBUG"` in the subprocess environment, which caused OTEL-aware Python libraries (mlflow, opentelemetry-sdk, etc.) to emit verbose debug-level logging to stderr during import. Once stderr exceeded the OS pipe buffer, the Python process would block on `write()` indefinitely. Removing the hardcoded debug log level brings `runScript()` in line with `run()`, `runInline()`, and the streaming variants — none of which set `OTEL_LOG_LEVEL`.

--- a/packages/python/src/index.ts
+++ b/packages/python/src/index.ts
@@ -97,7 +97,6 @@ export const python = {
                 }=trigger,${Object.entries(taskContext.attributes)
                   .map(([key, value]) => `${key}=${value}`)
                   .join(",")}`,
-                OTEL_LOG_LEVEL: "DEBUG",
               },
             },
             throwOnError: false,


### PR DESCRIPTION
Per #3357, `python.runScript()` deadlocks any Python subprocess that writes more than ~64KB to stderr.

The previous implementation hardcoded `OTEL_LOG_LEVEL: 'DEBUG'` in the subprocess environment ([line 100](https://github.com/triggerdotdev/trigger.dev/blob/main/packages/python/src/index.ts#L100)), which caused OTEL-aware Python libraries (mlflow, opentelemetry-sdk, etc.) to emit verbose debug-level logging to stderr during import. Once stderr exceeded the OS pipe buffer, the Python process blocked on its next `write()` syscall indefinitely — a silent, permanent hang with no error or timeout (unless `maxDuration` was set).

This PR removes that single line, bringing `runScript()` in line with `run()`, `runInline()`, and the streaming variants — **none of which set `OTEL_LOG_LEVEL`**. The original line was almost certainly leftover dev instrumentation that shipped accidentally.

A patch changeset is included.

Closes #3357