### PR TITLE
fix: prevent IEEE 754 precision loss in OTLP nanosecond timestamps

### DIFF
--- a/apps/webapp/app/v3/eventRepository/common.server.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.ts
@@ -21,7 +21,7 @@ export function extractContextFromCarrier(carrier: Record<string, unknown>) {
 }
 
 export function getNowInNanoseconds(): bigint {
-  return BigInt(new Date().getTime() * 1_000_000);
+  return BigInt(new Date().getTime()) * BigInt(1_000_000);
 }
 
 export function getDateFromNanoseconds(nanoseconds: bigint): Date {
@@ -35,7 +35,7 @@ export function calculateDurationFromStart(
 ) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  const duration = Number(BigInt($endtime.getTime() * 1_000_000) - startTime);
+  const duration = Number(BigInt($endtime.getTime()) * BigInt(1_000_000) - startTime);
 
   if (minimumDuration && duration < minimumDuration) {
     return minimumDuration;
@@ -47,7 +47,7 @@ export function calculateDurationFromStart(
 export function calculateDurationFromStartJsDate(startTime: Date, endTime: Date = new Date()) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  return ($endtime.getTime() - startTime.getTime()) * 1_000_000;
+  return Number(BigInt($endtime.getTime() - startTime.getTime()) * BigInt(1_000_000));
 }
 
 export function convertDateToNanoseconds(date: Date): bigint {

--- a/apps/webapp/app/v3/eventRepository/index.server.ts
+++ b/apps/webapp/app/v3/eventRepository/index.server.ts
@@ -215,7 +215,7 @@ async function recordRunEvent(
         runId: foundRun.friendlyId,
         ...attributes,
       },
-      startTime: BigInt((startTime?.getTime() ?? Date.now()) * 1_000_000),
+      startTime: BigInt(startTime?.getTime() ?? Date.now()) * BigInt(1_000_000),
       ...optionsRest,
     });
 


### PR DESCRIPTION
## Summary

Several places in the webapp multiply epoch milliseconds by 1,000,000 **before** converting to `BigInt`, which causes IEEE 754 precision loss (~256ns errors in ~0.2% of cases). The result exceeds `Number.MAX_SAFE_INTEGER` (~9e15) since epoch-ms × 1e6 is ~1.7e18.

## Root Cause

```typescript
// Bug: multiplication in float-land before BigInt conversion
BigInt(new Date().getTime() * 1_000_000);

// Fix: multiply after BigInt conversion
BigInt(new Date().getTime()) * BigInt(1_000_000);
```

The correct pattern already existed in `convertDateToNanoseconds()` in the same file — the other functions just didn't use it.

## Changes

- **`common.server.ts`**: Fix `getNowInNanoseconds()`, `calculateDurationFromStart()`, and `calculateDurationFromStartJsDate()`
- **`index.server.ts`**: Fix `recordRunDebugLog()` startTime calculation

All four locations now convert to `BigInt` before multiplication, consistent with the existing `convertDateToNanoseconds()` implementation.

Fixes #3292


Made with [Cursor](https://cursor.com)