### PR TITLE
fix: convert to BigInt before nanosecond multiplication (all instances)

### DIFF
--- a/apps/webapp/app/v3/eventRepository/common.server.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.ts
@@ -21,7 +21,7 @@ export function extractContextFromCarrier(carrier: Record<string, unknown>) {
 }
 
 export function getNowInNanoseconds(): bigint {
-  return BigInt(new Date().getTime() * 1_000_000);
+  return BigInt(new Date().getTime()) * BigInt(1_000_000);
 }
 
 export function getDateFromNanoseconds(nanoseconds: bigint): Date {
@@ -35,7 +35,7 @@ export function calculateDurationFromStart(
 ) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  const duration = Number(BigInt($endtime.getTime() * 1_000_000) - startTime);
+  const duration = Number(BigInt($endtime.getTime()) * BigInt(1_000_000) - startTime);
 
   if (minimumDuration && duration < minimumDuration) {
     return minimumDuration;
@@ -47,7 +47,9 @@ export function calculateDurationFromStart(
 export function calculateDurationFromStartJsDate(startTime: Date, endTime: Date = new Date()) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  return ($endtime.getTime() - startTime.getTime()) * 1_000_000;
+  return Number(
+    (BigInt($endtime.getTime()) - BigInt(startTime.getTime())) * BigInt(1_000_000)
+  );
 }
 
 export function convertDateToNanoseconds(date: Date): bigint {

--- a/apps/webapp/app/v3/eventRepository/index.server.ts
+++ b/apps/webapp/app/v3/eventRepository/index.server.ts
@@ -215,7 +215,7 @@ async function recordRunEvent(
         runId: foundRun.friendlyId,
         ...attributes,
       },
-      startTime: BigInt((startTime?.getTime() ?? Date.now()) * 1_000_000),
+      startTime: BigInt(startTime?.getTime() ?? Date.now()) * BigInt(1_000_000),
       ...optionsRest,
     });
 

--- a/apps/webapp/app/v3/runEngineHandlers.server.ts
+++ b/apps/webapp/app/v3/runEngineHandlers.server.ts
@@ -429,7 +429,7 @@ export function registerRunEngineEventBusHandlers() {
       const eventRepository = resolveEventRepositoryForStore(run.taskEventStore);
 
       await eventRepository.recordEvent(retryMessage, {
-        startTime: BigInt(time.getTime() * 1000000),
+        startTime: BigInt(time.getTime()) * BigInt(1_000_000),
         taskSlug: run.taskIdentifier,
         environment,
         attributes: {


### PR DESCRIPTION
## Summary

Fixes #3292

This is a resubmission of #3378 which was closed because it missed one instance of the bug. This PR fixes ALL instances.

## Root Cause

Multiple functions compute nanosecond timestamps as `BigInt(milliseconds * 1_000_000)`. When milliseconds exceed `Number.MAX_SAFE_INTEGER / 1_000_000`, the multiplication overflows IEEE 754 precision before the BigInt conversion.

## Fix

Convert to BigInt **before** multiplication in all instances:
```typescript
BigInt(milliseconds) * BigInt(1_000_000)
```

### Files changed
- `apps/webapp/app/v3/eventRepository/common.server.ts` - `getNowInNanoseconds`, `calculateDurationFromStart`, `calculateDurationFromStartJsDate`
- `apps/webapp/app/v3/eventRepository/index.server.ts` - `recordRunDebugLog`
- `apps/webapp/app/v3/runEngineHandlers.server.ts` - startTime calculation (previously missed)
