### PR TITLE
fix: handle empty payloads in scheduled task test page (#3316)

### DIFF
--- a/apps/webapp/app/presenters/v3/TestTaskPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/TestTaskPresenter.server.ts
@@ -382,6 +382,11 @@ export class TestTaskPresenter {
 
 async function getScheduleTaskRunPayload(payload: string, payloadType: string) {
   const packet = await parsePacket({ data: payload, dataType: payloadType });
+
+  if (!packet) {
+    return { success: false as const, error: new Error("Empty payload") };
+  }
+
   if (!packet.timezone) {
     packet.timezone = "UTC";
   }


### PR DESCRIPTION
## Summary

Fixes #3316

In `TestTaskPresenter.server.ts`, `getScheduleTaskRunPayload` calls `parsePacket` which returns `undefined` when the payload data is empty (e.g. `""`). The function then accesses `.timezone` on `undefined`, throwing a `TypeError` that crashes the test page presenter.

**Fix:** Add a null guard after `parsePacket` — when the result is falsy, return a failed `SafeParse`-compatible result (`{ success: false }`). This causes the run to be filtered out by the existing `.filter(Boolean)` on line 355 and the template check on line 368, so the test page loads normally.

## Changes

- `apps/webapp/app/presenters/v3/TestTaskPresenter.server.ts`: Added early return in `getScheduleTaskRunPayload` when `parsePacket` returns `undefined`

## Testing

- Manual verification: empty-payload runs (`payload=""`, `payloadType="application/json"`) are skipped without crashing
- Standard task runs and scheduled tasks with valid payloads are unaffected