### PR TITLE
fix: OTLP nanosecond timestamp overflow from IEEE 754 precision loss

### DIFF
--- a/apps/webapp/app/v3/eventRepository/common.server.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.ts
@@ -21,7 +21,7 @@ export function extractContextFromCarrier(carrier: Record<string, unknown>) {
 }
 
 export function getNowInNanoseconds(): bigint {
-  return BigInt(new Date().getTime() * 1_000_000);
+  return BigInt(new Date().getTime()) * 1_000_000n;
 }
 
 export function getDateFromNanoseconds(nanoseconds: bigint): Date {
@@ -35,7 +35,7 @@ export function calculateDurationFromStart(
 ) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  const duration = Number(BigInt($endtime.getTime() * 1_000_000) - startTime);
+  const duration = Number(BigInt($endtime.getTime()) * 1_000_000n - startTime);
 
   if (minimumDuration && duration < minimumDuration) {
     return minimumDuration;

--- a/apps/webapp/app/v3/eventRepository/index.server.ts
+++ b/apps/webapp/app/v3/eventRepository/index.server.ts
@@ -215,7 +215,7 @@ async function recordRunEvent(
         runId: foundRun.friendlyId,
         ...attributes,
       },
-      startTime: BigInt((startTime?.getTime() ?? Date.now()) * 1_000_000),
+      startTime: BigInt(startTime?.getTime() ?? Date.now()) * 1_000_000n,
       ...optionsRest,
     });
 

--- a/apps/webapp/app/v3/runEngineHandlers.server.ts
+++ b/apps/webapp/app/v3/runEngineHandlers.server.ts
@@ -429,7 +429,7 @@ export function registerRunEngineEventBusHandlers() {
       const eventRepository = resolveEventRepositoryForStore(run.taskEventStore);
 
       await eventRepository.recordEvent(retryMessage, {
-        startTime: BigInt(time.getTime() * 1000000),
+        startTime: BigInt(time.getTime()) * 1_000_000n,
         taskSlug: run.taskIdentifier,
         environment,
         attributes: {


### PR DESCRIPTION
## Summary

Fixes #3292

Several places convert epoch milliseconds to nanoseconds by multiplying **before** converting to `BigInt`:

```typescript
// Bug: multiplication in float-land (~1.7e18 > MAX_SAFE_INTEGER ~9e15)
BigInt(date.getTime() * 1_000_000)

// Fix: convert to BigInt first, then multiply
BigInt(date.getTime()) * 1_000_000n
```

This matches the existing `convertDateToNanoseconds()` helper in the same file, which already does this correctly.

## Files changed

- `apps/webapp/app/v3/eventRepository/common.server.ts` — `getNowInNanoseconds()` and `calculateDurationFromStart()`
- `apps/webapp/app/v3/eventRepository/index.server.ts` — `recordRunEvent()` startTime
- `apps/webapp/app/v3/runEngineHandlers.server.ts` — retry event recording startTime

## Impact

~256ns errors in ~0.2% of timestamp conversions due to IEEE 754 precision loss. Low severity but prevents potential span ordering edge cases.