### PR TITLE
fix: prevent silent failures when releasing stream reader locks

### DIFF
--- a/packages/core/src/v3/realtimeStreams/streamInstance.ts
+++ b/packages/core/src/v3/realtimeStreams/streamInstance.ts
@@ -153,5 +153,10 @@ async function* streamToAsyncIterator<T>(stream: ReadableStream<T>): AsyncIterab
 function safeReleaseLock(reader: ReadableStreamDefaultReader<any>) {
   try {
     reader.releaseLock();
-  } catch (error) {}
+  } catch (error) {
+    if (debug) {
+      // fallback if no logger available
+      console.warn("Failed to release stream reader lock", error);
+    }
+  }
 }

--- a/packages/core/src/v3/realtimeStreams/streamsWriterV1.ts
+++ b/packages/core/src/v3/realtimeStreams/streamsWriterV1.ts
@@ -464,5 +464,10 @@ async function* streamToAsyncIterator<T>(stream: ReadableStream<T>): AsyncIterab
 function safeReleaseLock(reader: ReadableStreamDefaultReader<any>) {
   try {
     reader.releaseLock();
-  } catch (error) {}
+  } catch (error) {
+    if (debug) {
+      // fallback if no logger available
+      console.warn("Failed to release stream reader lock", error);
+    }
+  }
 }

--- a/packages/core/src/v3/realtimeStreams/streamsWriterV2.ts
+++ b/packages/core/src/v3/realtimeStreams/streamsWriterV2.ts
@@ -212,5 +212,10 @@ async function* streamToAsyncIterator<T>(stream: ReadableStream<T>): AsyncIterab
 function safeReleaseLock(reader: ReadableStreamDefaultReader<any>) {
   try {
     reader.releaseLock();
-  } catch (error) {}
+  } catch (error) {
+    if (debug) {
+      // fallback if no logger available
+      console.warn("Failed to release stream reader lock", error);
+    }
+  }
 }


### PR DESCRIPTION
Closes #<Fixes silent error handling in stream reader lock release>

## ✅ Checklist

* I have followed every step in the contributing guide
* The PR title follows the convention
* I ran and tested the code works

---

## Testing

* Verified that calling `reader.releaseLock()` does not crash the application when an error occurs.
* Simulated edge cases where the reader is already released or invalid.
* Confirmed that errors are handled gracefully and logged only when debug mode is enabled.
* Ensured no impact on existing stream functionality.

---

## Changelog

* Added error handling for `reader.releaseLock()` to prevent silent failures.
* Introduced conditional debug logging for better observability.
* Improved consistency in stream handling logic.

---

