### PR TITLE
Error page graph: for a time bucket don't fill zeros for a version with no errors

### DIFF
--- a/apps/webapp/app/presenters/v3/ErrorGroupPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ErrorGroupPresenter.server.ts
@@ -242,10 +242,15 @@ export class ErrorGroupPresenter extends BasePresenter {
 
     const sortedVersions = sortVersionsDescending([...versionSet]);
 
+    // Build the data for the graph
+    // For each time bucket, if a value exists for a version set the value (don't add zeros)
     const data = buckets.map((epoch) => {
       const point: Record<string, number | Date> = { date: new Date(epoch * 1000) };
       for (const version of sortedVersions) {
-        point[version] = byBucketVersion.get(`${epoch}:${version}`) ?? 0;
+        const versionValue = byBucketVersion.get(`${epoch}:${version}`);
+        if (versionValue) {
+          point[version] = versionValue;
+        }
       }
       return point;
     });


### PR DESCRIPTION
This caused performance issues with large numbers of versions, and bad UX when hovering the graph (showing irrelevant versions)