### PR TITLE
fix(webapp): reduce error-level log noise for handled/benign cases

### DIFF
--- a/apps/webapp/app/routes/api.v1.waitpoints.tokens.$waitpointFriendlyId.complete.ts
+++ b/apps/webapp/app/routes/api.v1.waitpoints.tokens.$waitpointFriendlyId.complete.ts
@@ -72,7 +72,16 @@ const { action, loader } = createActionApiRoute(
         { status: 200 }
       );
     } catch (error) {
-      logger.error("Failed to complete waitpoint token", { error });
+      // Re-throw Response objects (intentional HTTP responses like the 404 above) so the
+      // client gets the correct status code instead of a 500, and we don't log them as errors.
+      if (error instanceof Response) throw error;
+
+      logger.error("Failed to complete waitpoint token", {
+        error:
+          error instanceof Error
+            ? { name: error.name, message: error.message, stack: error.stack }
+            : error,
+      });
       throw json({ error: "Failed to complete waitpoint token" }, { status: 500 });
     }
   }

--- a/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
+++ b/apps/webapp/app/v3/marqs/sharedQueueConsumer.server.ts
@@ -600,7 +600,7 @@ export class SharedQueueConsumer {
       (!retryingFromCheckpoint &&
         !EXECUTABLE_RUN_STATUSES.withoutCheckpoint.includes(existingTaskRun.status))
     ) {
-      logger.error("Task run has invalid status for execution. Going to ack", {
+      logger.warn("Task run has invalid status for execution. Going to ack", {
         queueMessage: message.data,
         messageId: message.messageId,
         taskRun: existingTaskRun.id,


### PR DESCRIPTION
Two changes to cut error volume from logs that represent handled
conditions, not real errors (combined ~1600/hr in prod):

1. api.v1.waitpoints.tokens.$waitpointFriendlyId.complete.ts

The route throws `json(..., { status: 404 })` when a waitpoint
isn't found, but the generic catch block caught that Response,
logged it as an error (with an empty {} body because Error fields
are non-enumerable), and rethrew as a 500 — so clients saw a 500
instead of the intended 404, and every stale-waitpoint request
produced a Sentry event.

Fix: re-throw Response objects unchanged so the correct status
propagates and we don't log user 404s as errors. Also serialize
remaining Error instances explicitly (name/message/stack) so the
logs are actionable when we do hit a real error.

2. v3/marqs/sharedQueueConsumer.server.ts:603

"Task run has invalid status for execution. Going to ack" — the
message itself says we're handling it gracefully. Benign race
between dequeue and completion/cancellation. Demote to warn.