### PR TITLE
fix(core): truncate large error stacks and messages to prevent OOM

### DIFF
--- a/.changeset/truncate-error-stacks.md
+++ b/.changeset/truncate-error-stacks.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Truncate large error stacks and messages to prevent OOM crashes. Stack traces are capped at 50 frames (keeping top 5 + bottom 45 with an omission notice), individual stack lines at 1024 chars, and error messages at 1000 chars. Applied in parseError, sanitizeError, and OTel span recording.

--- a/packages/core/src/v3/errors.ts
+++ b/packages/core/src/v3/errors.ts
@@ -160,7 +160,9 @@ const MAX_STACK_LINE_LENGTH = 1024;
 const MAX_MESSAGE_LENGTH = 1_000;
 
 /** Truncate a stack trace to at most MAX_STACK_FRAMES frames, keeping
- *  the top (closest to throw) and bottom (entry points) frames. */
+ *  the top (closest to throw) and bottom (entry points) frames.
+ *  Individual lines (including message lines) are capped at MAX_STACK_LINE_LENGTH
+ *  to prevent OOM from huge error messages embedded in the stack. */
 export function truncateStack(stack: string | undefined): string {
   if (!stack) return "";
 
@@ -171,15 +173,14 @@ export function truncateStack(stack: string | undefined): string {
   const frameLines: string[] = [];
 
   for (const line of lines) {
+    const safe =
+      line.length > MAX_STACK_LINE_LENGTH
+        ? line.slice(0, MAX_STACK_LINE_LENGTH) + "...[truncated]"
+        : line;
     if (frameLines.length === 0 && !line.trimStart().startsWith("at ")) {
-      messageLines.push(line);
+      messageLines.push(safe);
     } else {
-      // Truncate individual lines to prevent regex DoS in downstream parsers
-      frameLines.push(
-        line.length > MAX_STACK_LINE_LENGTH
-          ? line.slice(0, MAX_STACK_LINE_LENGTH) + "...[truncated]"
-          : line
-      );
+      frameLines.push(safe);
     }
   }
 
@@ -317,9 +318,17 @@ export function sanitizeError(error: TaskRunError): TaskRunError {
       };
     }
     case "CUSTOM_ERROR": {
+      // CUSTOM_ERROR.raw holds JSON.stringify(error) which is later parsed by
+      // JSON.parse in createErrorTaskError. Naive truncation would cut mid-token
+      // and produce invalid JSON — wrap the preview in a valid JSON envelope.
+      const clean = error.raw.replace(/\0/g, "");
+      const safeRaw =
+        clean.length > MAX_MESSAGE_LENGTH
+          ? JSON.stringify({ truncated: true, preview: clean.slice(0, MAX_MESSAGE_LENGTH) })
+          : clean;
       return {
         type: "CUSTOM_ERROR",
-        raw: truncateMessage(error.raw.replace(/\0/g, "")),
+        raw: safeRaw,
       };
     }
     case "INTERNAL_ERROR": {

--- a/packages/core/src/v3/errors.ts
+++ b/packages/core/src/v3/errors.ts
@@ -332,11 +332,20 @@ export function sanitizeError(error: TaskRunError): TaskRunError {
       };
     }
     case "INTERNAL_ERROR": {
+      // message and stackTrace are optional for INTERNAL_ERROR — preserve
+      // `undefined` so the `error.message ?? "Internal error (CODE)"` fallback
+      // in createErrorTaskError still kicks in (empty string is not nullish).
       return {
         type: "INTERNAL_ERROR",
         code: error.code,
-        message: truncateMessage(error.message?.replace(/\0/g, "")),
-        stackTrace: truncateStack(error.stackTrace?.replace(/\0/g, "")),
+        message:
+          error.message != null
+            ? truncateMessage(error.message.replace(/\0/g, ""))
+            : undefined,
+        stackTrace:
+          error.stackTrace != null
+            ? truncateStack(error.stackTrace.replace(/\0/g, ""))
+            : undefined,
       };
     }
   }

--- a/packages/core/src/v3/errors.ts
+++ b/packages/core/src/v3/errors.ts
@@ -154,13 +154,64 @@ export function isCompleteTaskWithOutput(error: unknown): error is CompleteTaskW
   return error instanceof Error && error.name === "CompleteTaskWithOutput";
 }
 
+const MAX_STACK_FRAMES = 50;
+const KEEP_TOP_FRAMES = 5;
+const MAX_STACK_LINE_LENGTH = 1024;
+const MAX_MESSAGE_LENGTH = 1_000;
+
+/** Truncate a stack trace to at most MAX_STACK_FRAMES frames, keeping
+ *  the top (closest to throw) and bottom (entry points) frames. */
+export function truncateStack(stack: string | undefined): string {
+  if (!stack) return "";
+
+  const lines = stack.split("\n");
+
+  // First line(s) before the first frame are the error message
+  const messageLines: string[] = [];
+  const frameLines: string[] = [];
+
+  for (const line of lines) {
+    if (frameLines.length === 0 && !line.trimStart().startsWith("at ")) {
+      messageLines.push(line);
+    } else {
+      // Truncate individual lines to prevent regex DoS in downstream parsers
+      frameLines.push(
+        line.length > MAX_STACK_LINE_LENGTH
+          ? line.slice(0, MAX_STACK_LINE_LENGTH) + "...[truncated]"
+          : line
+      );
+    }
+  }
+
+  if (frameLines.length <= MAX_STACK_FRAMES) {
+    return [...messageLines, ...frameLines].join("\n");
+  }
+
+  const keepBottom = MAX_STACK_FRAMES - KEEP_TOP_FRAMES;
+  const omitted = frameLines.length - MAX_STACK_FRAMES;
+
+  return [
+    ...messageLines,
+    ...frameLines.slice(0, KEEP_TOP_FRAMES),
+    `    ... ${omitted} frames omitted ...`,
+    ...frameLines.slice(-keepBottom),
+  ].join("\n");
+}
+
+export function truncateMessage(message: string | undefined): string {
+  if (!message) return "";
+  return message.length > MAX_MESSAGE_LENGTH
+    ? message.slice(0, MAX_MESSAGE_LENGTH) + "...[truncated]"
+    : message;
+}
+
 export function parseError(error: unknown): TaskRunError {
   if (isInternalError(error)) {
     return {
       type: "INTERNAL_ERROR",
       code: error.code,
-      message: error.message,
-      stackTrace: error.stack ?? "",
+      message: truncateMessage(error.message),
+      stackTrace: truncateStack(error.stack),
     };
   }
 
@@ -168,8 +219,8 @@ export function parseError(error: unknown): TaskRunError {
     return {
       type: "BUILT_IN_ERROR",
       name: error.name,
-      message: error.message,
-      stackTrace: error.stack ?? "",
+      message: truncateMessage(error.message),
+      stackTrace: truncateStack(error.stack),
     };
   }
 
@@ -248,35 +299,35 @@ export function createJsonErrorObject(error: TaskRunError): SerializedError {
   }
 }
 
-// Removes any null characters from the error message
+// Removes null characters and truncates oversized fields to prevent OOM
 export function sanitizeError(error: TaskRunError): TaskRunError {
   switch (error.type) {
     case "BUILT_IN_ERROR": {
       return {
         type: "BUILT_IN_ERROR",
-        message: error.message?.replace(/\0/g, ""),
+        message: truncateMessage(error.message?.replace(/\0/g, "")),
         name: error.name?.replace(/\0/g, ""),
-        stackTrace: error.stackTrace?.replace(/\0/g, ""),
+        stackTrace: truncateStack(error.stackTrace?.replace(/\0/g, "")),
       };
     }
     case "STRING_ERROR": {
       return {
         type: "STRING_ERROR",
-        raw: error.raw.replace(/\0/g, ""),
+        raw: truncateMessage(error.raw.replace(/\0/g, "")),
       };
     }
     case "CUSTOM_ERROR": {
       return {
         type: "CUSTOM_ERROR",
-        raw: error.raw.replace(/\0/g, ""),
+        raw: truncateMessage(error.raw.replace(/\0/g, "")),
       };
     }
     case "INTERNAL_ERROR": {
       return {
         type: "INTERNAL_ERROR",
         code: error.code,
-        message: error.message?.replace(/\0/g, ""),
-        stackTrace: error.stackTrace?.replace(/\0/g, ""),
+        message: truncateMessage(error.message?.replace(/\0/g, "")),
+        stackTrace: truncateStack(error.stackTrace?.replace(/\0/g, "")),
       };
     }
   }

--- a/packages/core/src/v3/otel/utils.ts
+++ b/packages/core/src/v3/otel/utils.ts
@@ -3,19 +3,36 @@ import { truncateStack, truncateMessage } from "../errors.js";
 
 const MAX_GENERIC_LENGTH = 5_000;
 
+function truncateGeneric(value: string): string {
+  return value.length > MAX_GENERIC_LENGTH
+    ? value.slice(0, MAX_GENERIC_LENGTH) + "...[truncated]"
+    : value;
+}
+
+function serializeFallback(error: unknown): string {
+  // JSON.stringify can throw (circular refs, BigInt) or return undefined
+  // (symbol, undefined, function). Fall back to String() in both cases so we
+  // never mask the original error being recorded.
+  try {
+    const json = JSON.stringify(error);
+    if (json != null) return json;
+  } catch {
+    // fall through
+  }
+  try {
+    return String(error);
+  } catch {
+    return "[unserializable error]";
+  }
+}
+
 export function recordSpanException(span: Span, error: unknown) {
   if (error instanceof Error) {
     span.recordException(sanitizeSpanError(error));
   } else if (typeof error === "string") {
-    const clean = error.replace(/\0/g, "");
-    span.recordException(
-      clean.length > MAX_GENERIC_LENGTH ? clean.slice(0, MAX_GENERIC_LENGTH) + "...[truncated]" : clean
-    );
+    span.recordException(truncateGeneric(error.replace(/\0/g, "")));
   } else {
-    const json = JSON.stringify(error).replace(/\0/g, "");
-    span.recordException(
-      json.length > MAX_GENERIC_LENGTH ? json.slice(0, MAX_GENERIC_LENGTH) + "...[truncated]" : json
-    );
+    span.recordException(truncateGeneric(serializeFallback(error).replace(/\0/g, "")));
   }
 
   span.setStatus({ code: SpanStatusCode.ERROR });

--- a/packages/core/src/v3/otel/utils.ts
+++ b/packages/core/src/v3/otel/utils.ts
@@ -1,22 +1,30 @@
 import { type Span, SpanStatusCode, context, propagation } from "@opentelemetry/api";
+import { truncateStack, truncateMessage } from "../errors.js";
+
+const MAX_GENERIC_LENGTH = 5_000;
 
 export function recordSpanException(span: Span, error: unknown) {
   if (error instanceof Error) {
     span.recordException(sanitizeSpanError(error));
   } else if (typeof error === "string") {
-    span.recordException(error.replace(/\0/g, ""));
+    const clean = error.replace(/\0/g, "");
+    span.recordException(
+      clean.length > MAX_GENERIC_LENGTH ? clean.slice(0, MAX_GENERIC_LENGTH) + "...[truncated]" : clean
+    );
   } else {
-    span.recordException(JSON.stringify(error).replace(/\0/g, ""));
+    const json = JSON.stringify(error).replace(/\0/g, "");
+    span.recordException(
+      json.length > MAX_GENERIC_LENGTH ? json.slice(0, MAX_GENERIC_LENGTH) + "...[truncated]" : json
+    );
   }
 
   span.setStatus({ code: SpanStatusCode.ERROR });
 }
 
 function sanitizeSpanError(error: Error) {
-  // Create a new error object with the same name, message and stack trace
-  const sanitizedError = new Error(error.message.replace(/\0/g, ""));
+  const sanitizedError = new Error(truncateMessage(error.message.replace(/\0/g, "")));
   sanitizedError.name = error.name.replace(/\0/g, "");
-  sanitizedError.stack = error.stack?.replace(/\0/g, "");
+  sanitizedError.stack = truncateStack(error.stack?.replace(/\0/g, "")) || undefined;
 
   return sanitizedError;
 }

--- a/packages/core/src/v3/tracer.ts
+++ b/packages/core/src/v3/tracer.ts
@@ -145,11 +145,7 @@ export class TriggerTracer {
           }
 
           if (!spanEnded) {
-            if (typeof e === "string" || e instanceof Error) {
-              span.recordException(e);
-            }
-
-            span.setStatus({ code: SpanStatusCode.ERROR });
+            recordSpanException(span, e);
           }
 
           throw e;

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -162,4 +162,49 @@ describe("sanitizeError truncation", () => {
       expect(result.raw).toContain("...[truncated]");
     }
   });
+
+  it("preserves small CUSTOM_ERROR raw as valid JSON", () => {
+    const originalJson = JSON.stringify({ foo: "bar", nested: { baz: 1 } });
+    const result = sanitizeError({
+      type: "CUSTOM_ERROR",
+      raw: originalJson,
+    });
+
+    if (result.type === "CUSTOM_ERROR") {
+      // Small JSON should pass through unchanged and remain parseable
+      expect(result.raw).toBe(originalJson);
+      expect(() => JSON.parse(result.raw)).not.toThrow();
+    }
+  });
+
+  it("wraps oversized CUSTOM_ERROR raw in a valid JSON envelope", () => {
+    const hugeJson = JSON.stringify({ data: "x".repeat(5000) });
+    const result = sanitizeError({
+      type: "CUSTOM_ERROR",
+      raw: hugeJson,
+    });
+
+    if (result.type === "CUSTOM_ERROR") {
+      // Must remain valid JSON (critical: createErrorTaskError calls JSON.parse on this)
+      expect(() => JSON.parse(result.raw)).not.toThrow();
+      const parsed = JSON.parse(result.raw);
+      expect(parsed.truncated).toBe(true);
+      expect(typeof parsed.preview).toBe("string");
+      expect(parsed.preview.length).toBeLessThanOrEqual(1000);
+    }
+  });
+});
+
+describe("truncateStack message line bounding", () => {
+  it("truncates huge error messages embedded in the stack", () => {
+    // V8 format: "Error: <message>\n    at ..."
+    // A huge message on the first line must still be bounded.
+    const hugeMessage = "x".repeat(100_000);
+    const stack = `Error: ${hugeMessage}\n    at fn (/path.ts:1:1)`;
+    const result = truncateStack(stack);
+
+    // Total output should be bounded (not 100KB+)
+    expect(result.length).toBeLessThan(5_000);
+    expect(result).toContain("...[truncated]");
+  });
 });

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import { truncateStack, truncateMessage, parseError, sanitizeError } from "../src/v3/errors.js";
+
+// Helper: build a fake stack with N frames
+function buildStack(messageLines: string[], frameCount: number): string {
+  const frames = Array.from(
+    { length: frameCount },
+    (_, i) => `    at functionName${i} (/path/to/file${i}.ts:${i + 1}:${i + 10})`
+  );
+  return [...messageLines, ...frames].join("\n");
+}
+
+describe("truncateStack", () => {
+  it("returns empty string for undefined", () => {
+    expect(truncateStack(undefined)).toBe("");
+  });
+
+  it("returns empty string for empty string", () => {
+    expect(truncateStack("")).toBe("");
+  });
+
+  it("preserves a short stack unchanged", () => {
+    const stack = buildStack(["Error: something broke"], 10);
+    expect(truncateStack(stack)).toBe(stack);
+  });
+
+  it("preserves exactly 50 frames", () => {
+    const stack = buildStack(["Error: at the limit"], 50);
+    const result = truncateStack(stack);
+    expect(result).toBe(stack);
+    expect(result.split("\n").filter((l) => l.trimStart().startsWith("at ")).length).toBe(50);
+  });
+
+  it("truncates to 50 frames when exceeding the limit", () => {
+    const stack = buildStack(["Error: too many frames"], 200);
+    const result = truncateStack(stack);
+    const lines = result.split("\n");
+
+    // Message line + 5 top + 1 omitted notice + 45 bottom = 52 lines
+    expect(lines[0]).toBe("Error: too many frames");
+    expect(lines).toContain("    ... 150 frames omitted ...");
+
+    const frameLines = lines.filter((l) => l.trimStart().startsWith("at "));
+    expect(frameLines.length).toBe(50);
+
+    // First kept frame is frame 0 (top of stack)
+    expect(frameLines[0]).toContain("functionName0");
+    // Last kept frame is the last original frame
+    expect(frameLines[frameLines.length - 1]).toContain("functionName199");
+  });
+
+  it("preserves multi-line error messages before frames", () => {
+    const stack = buildStack(["TypeError: cannot read property", "  caused by: something"], 60);
+    const result = truncateStack(stack);
+    const lines = result.split("\n");
+
+    expect(lines[0]).toBe("TypeError: cannot read property");
+    expect(lines[1]).toBe("  caused by: something");
+    expect(lines).toContain("    ... 10 frames omitted ...");
+  });
+
+  it("truncates individual lines longer than 1024 chars", () => {
+    const longFrame = `    at someFn (${"x".repeat(2000)}:1:1)`;
+    const stack = ["Error: long line", longFrame].join("\n");
+    const result = truncateStack(stack);
+    const frameLine = result.split("\n")[1]!;
+
+    expect(frameLine.length).toBeLessThan(1100);
+    expect(frameLine).toContain("...[truncated]");
+  });
+});
+
+describe("truncateMessage", () => {
+  it("returns empty string for undefined", () => {
+    expect(truncateMessage(undefined)).toBe("");
+  });
+
+  it("returns empty string for empty string", () => {
+    expect(truncateMessage("")).toBe("");
+  });
+
+  it("preserves a short message", () => {
+    expect(truncateMessage("hello")).toBe("hello");
+  });
+
+  it("truncates messages over 1000 chars", () => {
+    const long = "x".repeat(5000);
+    const result = truncateMessage(long);
+    expect(result.length).toBeLessThan(1100);
+    expect(result).toContain("...[truncated]");
+  });
+
+  it("preserves a message at exactly 1000 chars", () => {
+    const exact = "x".repeat(1000);
+    expect(truncateMessage(exact)).toBe(exact);
+  });
+});
+
+describe("parseError truncation", () => {
+  it("truncates large stack traces in Error objects", () => {
+    const error = new Error("boom");
+    error.stack = buildStack(["Error: boom"], 200);
+    const parsed = parseError(error);
+
+    expect(parsed.type).toBe("BUILT_IN_ERROR");
+    if (parsed.type === "BUILT_IN_ERROR") {
+      const frameLines = parsed.stackTrace.split("\n").filter((l) => l.trimStart().startsWith("at "));
+      expect(frameLines.length).toBe(50);
+      expect(parsed.stackTrace).toContain("frames omitted");
+    }
+  });
+
+  it("truncates large error messages", () => {
+    const error = new Error("x".repeat(5000));
+    const parsed = parseError(error);
+
+    if (parsed.type === "BUILT_IN_ERROR") {
+      expect(parsed.message.length).toBeLessThan(1100);
+      expect(parsed.message).toContain("...[truncated]");
+    }
+  });
+});
+
+describe("sanitizeError truncation", () => {
+  it("truncates stack traces during sanitization", () => {
+    const result = sanitizeError({
+      type: "BUILT_IN_ERROR",
+      name: "Error",
+      message: "boom",
+      stackTrace: buildStack(["Error: boom"], 200),
+    });
+
+    if (result.type === "BUILT_IN_ERROR") {
+      const frameLines = result.stackTrace.split("\n").filter((l) => l.trimStart().startsWith("at "));
+      expect(frameLines.length).toBe(50);
+    }
+  });
+
+  it("strips null bytes and truncates", () => {
+    const result = sanitizeError({
+      type: "BUILT_IN_ERROR",
+      name: "Error\0",
+      message: "hello\0world",
+      stackTrace: "Error: hello\0world\n    at fn (/path.ts:1:1)",
+    });
+
+    if (result.type === "BUILT_IN_ERROR") {
+      expect(result.name).toBe("Error");
+      expect(result.message).toBe("helloworld");
+      expect(result.stackTrace).not.toContain("\0");
+    }
+  });
+
+  it("truncates STRING_ERROR raw field", () => {
+    const result = sanitizeError({
+      type: "STRING_ERROR",
+      raw: "x".repeat(5000),
+    });
+
+    if (result.type === "STRING_ERROR") {
+      expect(result.raw.length).toBeLessThan(1100);
+      expect(result.raw).toContain("...[truncated]");
+    }
+  });
+});

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -195,6 +195,36 @@ describe("sanitizeError truncation", () => {
   });
 });
 
+describe("sanitizeError INTERNAL_ERROR optional fields", () => {
+  it("preserves undefined message (does not convert to empty string)", () => {
+    const result = sanitizeError({
+      type: "INTERNAL_ERROR",
+      code: "SOME_INTERNAL_CODE" as any,
+      // message and stackTrace intentionally undefined
+    });
+
+    if (result.type === "INTERNAL_ERROR") {
+      // Must stay undefined so `error.message ?? fallback` works downstream
+      expect(result.message).toBeUndefined();
+      expect(result.stackTrace).toBeUndefined();
+    }
+  });
+
+  it("truncates INTERNAL_ERROR message when present", () => {
+    const result = sanitizeError({
+      type: "INTERNAL_ERROR",
+      code: "SOME_INTERNAL_CODE" as any,
+      message: "x".repeat(5000),
+    });
+
+    if (result.type === "INTERNAL_ERROR") {
+      expect(result.message).toBeDefined();
+      expect(result.message!.length).toBeLessThan(1100);
+      expect(result.message).toContain("...[truncated]");
+    }
+  });
+});
+
 describe("truncateStack message line bounding", () => {
   it("truncates huge error messages embedded in the stack", () => {
     // V8 format: "Error: <message>\n    at ..."

--- a/packages/core/test/recordSpanException.test.ts
+++ b/packages/core/test/recordSpanException.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import { recordSpanException } from "../src/v3/otel/utils.js";
+import type { Span } from "@opentelemetry/api";
+
+function createMockSpan() {
+  return {
+    recordException: vi.fn(),
+    setStatus: vi.fn(),
+  } as unknown as Span & { recordException: ReturnType<typeof vi.fn>; setStatus: ReturnType<typeof vi.fn> };
+}
+
+describe("recordSpanException", () => {
+  it("records Error instances with truncated message and stack", () => {
+    const span = createMockSpan();
+    const error = new Error("x".repeat(5_000));
+    recordSpanException(span, error);
+
+    expect(span.recordException).toHaveBeenCalledTimes(1);
+    const recorded = (span.recordException as any).mock.calls[0][0] as Error;
+    expect(recorded).toBeInstanceOf(Error);
+    expect(recorded.message.length).toBeLessThan(1100);
+  });
+
+  it("records string errors with truncation", () => {
+    const span = createMockSpan();
+    recordSpanException(span, "x".repeat(10_000));
+
+    const recorded = (span.recordException as any).mock.calls[0][0] as string;
+    expect(typeof recorded).toBe("string");
+    expect(recorded.length).toBeLessThan(5_100);
+    expect(recorded).toContain("...[truncated]");
+  });
+
+  it("does not throw on circular references", () => {
+    const span = createMockSpan();
+    const circular: any = { foo: "bar" };
+    circular.self = circular;
+
+    expect(() => recordSpanException(span, circular)).not.toThrow();
+    expect(span.recordException).toHaveBeenCalledTimes(1);
+    expect(span.setStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw on BigInt values", () => {
+    const span = createMockSpan();
+    const error = { count: BigInt(123) };
+
+    expect(() => recordSpanException(span, error)).not.toThrow();
+    expect(span.recordException).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles symbol values (JSON.stringify returns undefined)", () => {
+    const span = createMockSpan();
+    const sym = Symbol("test");
+
+    expect(() => recordSpanException(span, sym)).not.toThrow();
+    expect(span.recordException).toHaveBeenCalledTimes(1);
+    const recorded = (span.recordException as any).mock.calls[0][0] as string;
+    expect(typeof recorded).toBe("string");
+    expect(recorded).toContain("Symbol");
+  });
+
+  it("handles function values (JSON.stringify returns undefined)", () => {
+    const span = createMockSpan();
+    const fn = () => "test";
+
+    expect(() => recordSpanException(span, fn)).not.toThrow();
+    expect(span.recordException).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles undefined (JSON.stringify returns undefined)", () => {
+    const span = createMockSpan();
+
+    expect(() => recordSpanException(span, undefined)).not.toThrow();
+    expect(span.recordException).toHaveBeenCalledTimes(1);
+    const recorded = (span.recordException as any).mock.calls[0][0] as string;
+    expect(typeof recorded).toBe("string");
+  });
+
+  it("always calls setStatus ERROR", () => {
+    const span = createMockSpan();
+    recordSpanException(span, new Error("test"));
+    recordSpanException(span, "string");
+    recordSpanException(span, { obj: true });
+
+    expect(span.setStatus).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary

Large error stacks and messages can OOM the worker process when serialized into OTel spans or `TaskRunError` objects. This was reported when throwing an error with a massive `.stack` property from a chat agent hook.

This adds frame-based stack truncation (similar to Sentry's approach) plus message length limits, applied consistently across all error serialization paths.

### What changed

**`packages/core/src/v3/errors.ts`**
- `truncateStack()` — parses `error.stack` into message lines + frame lines, caps at 50 frames (keep top 5 closest to throw + bottom 45 entry points, with "... N frames omitted ..." in between). Individual lines capped at 1024 chars.
- `truncateMessage()` — caps error messages at 1000 chars
- Applied in `parseError()` and `sanitizeError()`

**`packages/core/src/v3/otel/utils.ts`**
- `sanitizeSpanError()` now uses `truncateStack` and `truncateMessage` from `errors.ts` instead of duplicating truncation logic
- Non-Error values (strings, JSON) capped at 5000 chars

**`packages/core/src/v3/tracer.ts`**
- `startActiveSpan` catch block now delegates to `recordSpanException()` instead of calling `span.recordException()` directly

### Limits

| What | Limit | Rationale |
|------|-------|-----------|
| Stack frames | 50 | Matches Sentry's `STACKTRACE_FRAME_LIMIT` |
| Top frames kept | 5 | Closest to throw site |
| Bottom frames kept | 45 | Entry points / framework frames |
| Per-line length | 1024 | Matches Sentry, prevents regex DoS |
| Message length | 1000 | Bounded but generous |
| Generic string (non-Error) | 5000 | Fallback for JSON/string errors in spans |

## Test plan

- [x] 17 unit tests in `packages/core/test/errors.test.ts`
- [x] E2E: threw a 300-frame / 5000-char-message error in the ai-chat reference app, verified truncated stack and message in span via `get_span_details`
- [x] Verified the run survived the error (no OOM, continued waiting for next message)