### PR TITLE
fix: Scheduled task test page crashes on empty payloads

### DIFF
--- a/apps/webapp/app/presenters/v3/TestTaskPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/TestTaskPresenter.server.ts
@@ -382,6 +382,9 @@ export class TestTaskPresenter {
 
 async function getScheduleTaskRunPayload(payload: string, payloadType: string) {
   const packet = await parsePacket({ data: payload, dataType: payloadType });
+  if (!packet) {
+    return { success: false as const };
+  }
   if (!packet.timezone) {
     packet.timezone = "UTC";
   }


### PR DESCRIPTION
## Summary

Fixes #3316

The test page for a scheduled task throws an uncaught `TypeError` and fails to load when any run for that task has an empty payload (`""`).

## Problem

In `TestTaskPresenter.server.ts`, `getScheduleTaskRunPayload` calls `parsePacket` which returns `undefined` when `data` is empty. The function then accesses `packet.timezone` on `undefined`, throwing a `TypeError` that crashes the presenter.

## Fix

Added a null guard for `packet` in `getScheduleTaskRunPayload`. When `parsePacket` returns `undefined` (empty/malformed payload), the function now returns `{ success: false }` instead of crashing. The existing `.filter(Boolean)` in the caller already handles this case by silently skipping invalid runs.

## Reproduction

1. Deploy a scheduled task to a staging/production environment
2. Insert a `TaskRun` record with `payload = ""` and `payloadType = "application/json"`
3. Navigate to the test page for that task
4. **Before fix:** Page fails to load
5. **After fix:** Page loads normally, empty-payload runs are skipped