### PR TITLE
Admin endpoint to set concurrency burst factor

### DIFF
--- a/apps/webapp/app/routes/admin.api.v1.environments.$environmentId.burst-factor.ts
+++ b/apps/webapp/app/routes/admin.api.v1.environments.$environmentId.burst-factor.ts
@@ -1,0 +1,30 @@
+import { type ActionFunctionArgs, json } from "@remix-run/server-runtime";
+import { z } from "zod";
+import { prisma } from "~/db.server";
+import { requireAdminApiRequest } from "~/services/personalAccessToken.server";
+import { updateEnvConcurrencyLimits } from "~/v3/runQueue.server";
+
+const ParamsSchema = z.object({
+  environmentId: z.string(),
+});
+
+const RequestBodySchema = z.object({
+  burstFactor: z.number().positive(),
+});
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  await requireAdminApiRequest(request);
+
+  const { environmentId } = ParamsSchema.parse(params);
+  const body = RequestBodySchema.parse(await request.json());
+
+  const environment = await prisma.runtimeEnvironment.update({
+    where: { id: environmentId },
+    data: { concurrencyLimitBurstFactor: body.burstFactor },
+    include: { organization: true, project: true },
+  });
+
+  await updateEnvConcurrencyLimits(environment);
+
+  return json({ success: true });
+}


### PR DESCRIPTION
Example cURL call using an admin user PAT (replace with a real one):

```sh
curl -X PUT https://cloud.trigger.dev/admin/api/v1/environments/<environmentId>/burst-factor \
    -H "Authorization: Bearer tr_pat_1234" \
    -H "Content-Type: application/json" \
    -d '{"burstFactor": 1.5}'
```