### PR TITLE
chore: adopt TypeScript 7.0 beta (tsgo) for typecheck

### DIFF
--- a/.configs/tsconfig.base.json
+++ b/.configs/tsconfig.base.json
@@ -26,7 +26,6 @@
     "esModuleInterop": true,
     "emitDecoratorMetadata": false,
     "experimentalDecorators": false,
-    "downlevelIteration": true,
     "isolatedModules": true,
     "noUncheckedIndexedAccess": true,
 

--- a/apps/coordinator/package.json
+++ b/apps/coordinator/package.json
@@ -10,7 +10,7 @@
     "build:image": "docker build -f Containerfile . -t coordinator",
     "dev": "tsx --no-warnings=ExperimentalWarning --require dotenv/config --watch src/index.ts",
     "start": "tsx src/index.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/apps/docker-provider/package.json
+++ b/apps/docker-provider/package.json
@@ -10,7 +10,7 @@
     "build:image": "docker build -f Containerfile . -t docker-provider",
     "dev": "tsx --no-warnings=ExperimentalWarning --require dotenv/config --watch src/index.ts",
     "start": "tsx src/index.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/apps/kubernetes-provider/package.json
+++ b/apps/kubernetes-provider/package.json
@@ -10,7 +10,7 @@
     "build:image": "docker build -f Containerfile . -t kubernetes-provider",
     "dev": "tsx --no-warnings=ExperimentalWarning --require dotenv/config --watch src/index.ts",
     "start": "tsx src/index.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/apps/supervisor/package.json
+++ b/apps/supervisor/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "test:run": "vitest --no-file-parallelism --run",
     "test:watch": "vitest --no-file-parallelism",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@aws-sdk/client-ecr": "^3.839.0",

--- a/apps/webapp/app/routes/otel.v1.logs.ts
+++ b/apps/webapp/app/routes/otel.v1.logs.ts
@@ -19,7 +19,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
       const exportResponse = await otlpExporter.exportLogs(exportRequest);
 
-      return new Response(ExportLogsServiceResponse.encode(exportResponse).finish(), {
+      return new Response(ExportLogsServiceResponse.encode(exportResponse).finish() as BodyInit, {
         status: 200,
       });
     } else {

--- a/apps/webapp/app/routes/otel.v1.metrics.ts
+++ b/apps/webapp/app/routes/otel.v1.metrics.ts
@@ -24,7 +24,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
       const exportResponse = await otlpExporter.exportMetrics(exportRequest);
 
-      return new Response(ExportMetricsServiceResponse.encode(exportResponse).finish(), {
+      return new Response(ExportMetricsServiceResponse.encode(exportResponse).finish() as BodyInit, {
         status: 200,
       });
     } else {

--- a/apps/webapp/app/routes/otel.v1.traces.ts
+++ b/apps/webapp/app/routes/otel.v1.traces.ts
@@ -19,7 +19,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
       const exportResponse = await otlpExporter.exportTraces(exportRequest);
 
-      return new Response(ExportTraceServiceResponse.encode(exportResponse).finish(), {
+      return new Response(ExportTraceServiceResponse.encode(exportResponse).finish() as BodyInit, {
         status: 200,
       });
     } else {

--- a/apps/webapp/app/services/realtime/redisRealtimeStreams.server.ts
+++ b/apps/webapp/app/services/realtime/redisRealtimeStreams.server.ts
@@ -313,7 +313,9 @@ export class RedisRealtimeStreams implements StreamIngestor, StreamResponder {
     let currentChunkIndex = startChunk;
 
     try {
-      const textStream = stream.pipeThrough(new TextDecoderStream());
+      const textStream = stream.pipeThrough(
+        new TextDecoderStream() as unknown as ReadableWritablePair<string, Uint8Array>
+      );
       const reader = textStream.getReader();
 
       while (true) {

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "cross-env NODE_ENV=production node --max-old-space-size=8192 ./build/server.js",
     "start:local": "cross-env node --max-old-space-size=8192 ./build/server.js",
-    "typecheck": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" tsc --noEmit -p ./tsconfig.check.json",
+    "typecheck": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" tsgo --noEmit -p ./tsconfig.check.json",
     "db:seed": "tsx seed.mts",
     "db:seed:ai-spans": "tsx seed-ai-spans.mts",
     "upload:sourcemaps": "bash ./upload-sourcemaps.sh",

--- a/apps/webapp/test/setup-test-env.ts
+++ b/apps/webapp/test/setup-test-env.ts
@@ -1,4 +1,3 @@
 import { installGlobals } from "@remix-run/node";
-import "@testing-library/jest-dom/extend-expect";
 
 installGlobals();

--- a/apps/webapp/tsconfig.json
+++ b/apps/webapp/tsconfig.json
@@ -17,7 +17,6 @@
     "skipLibCheck": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "baseUrl": ".",
     "paths": {
       "~/*": ["./app/*"],
       "@/*": ["./*"]

--- a/internal-packages/cache/package.json
+++ b/internal-packages/cache/package.json
@@ -14,7 +14,7 @@
     "superjson": "^2.2.1"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "test": "vitest",
     "test:watch": "vitest"
   }

--- a/internal-packages/clickhouse/package.json
+++ b/internal-packages/clickhouse/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "typecheck": "tsc --noEmit -p tsconfig.build.json",
+    "typecheck": "tsgo --noEmit -p tsconfig.build.json",
     "build": "pnpm run clean && tsc -p tsconfig.build.json",
     "dev": "tsc --watch  -p tsconfig.build.json",
     "db:migrate": "docker compose -p triggerdotdev-docker -f ../../docker/docker-compose.yml up clickhouse_migrator --build",

--- a/internal-packages/clickhouse/src/client/client.ts
+++ b/internal-packages/clickhouse/src/client/client.ts
@@ -492,7 +492,7 @@ export class ClickhouseClient implements ClickhouseReader, ClickhouseWriter {
           }
 
           for (const row of rows) {
-            const rowData = row.json();
+            const rowData = row.json<Record<number, unknown>>();
 
             const hydratedRow: Record<string, any> = {};
             for (let i = 0; i < req.columns.length; i++) {

--- a/internal-packages/compute/package.json
+++ b/internal-packages/compute/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "build": "pnpm run clean && tsc -p tsconfig.build.json",
     "dev": "tsc --watch -p tsconfig.build.json"
   }

--- a/internal-packages/database/package.json
+++ b/internal-packages/database/package.json
@@ -21,7 +21,7 @@
     "db:push": "prisma db push",
     "db:studio": "prisma studio",
     "db:reset": "prisma migrate reset",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit -p tsconfig.typecheck.json",
     "build": "pnpm run clean && tsc --noEmit false --outDir dist --declaration",
     "dev": "tsc --noEmit false --outDir dist --declaration --watch"
   }

--- a/internal-packages/database/tsconfig.typecheck.json
+++ b/internal-packages/database/tsconfig.typecheck.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler"
+  }
+}

--- a/internal-packages/emails/package.json
+++ b/internal-packages/emails/package.json
@@ -7,7 +7,7 @@
   "types": "./src/index.tsx",
   "scripts": {
     "dev": "PORT=3080 email dev",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@aws-sdk/client-sesv2": "^3.716.0",

--- a/internal-packages/emails/tsconfig.json
+++ b/internal-packages/emails/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/internal-packages/llm-model-catalog/package.json
+++ b/internal-packages/llm-model-catalog/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "test": "vitest --sequence.concurrent=false --no-file-parallelism",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "generate": "node scripts/generate.mjs",
     "sync-prices": "bash scripts/sync-model-prices.sh && node scripts/generate.mjs",
     "sync-prices:check": "bash scripts/sync-model-prices.sh --check",

--- a/internal-packages/otlp-importer/package.json
+++ b/internal-packages/otlp-importer/package.json
@@ -24,7 +24,7 @@
     "protos": "npm run submodule && npm run protos:generate",
     "protos:generate": "node ./scripts/generate-protos.mjs",
     "submodule": "node ./scripts/submodule.mjs",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/internal-packages/otlp-importer/tsconfig.json
+++ b/internal-packages/otlp-importer/tsconfig.json
@@ -4,7 +4,8 @@
     "isolatedDeclarations": false,
     "composite": true,
     "sourceMap": true,
-    "stripInternal": true
+    "stripInternal": true,
+    "types": ["node"]
   },
   "include": ["./src/**/*.ts"]
 }

--- a/internal-packages/redis/package.json
+++ b/internal-packages/redis/package.json
@@ -10,6 +10,6 @@
     "@trigger.dev/core": "workspace:*"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   }
 }

--- a/internal-packages/replication/package.json
+++ b/internal-packages/replication/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "typecheck": "tsc --noEmit -p tsconfig.build.json",
+    "typecheck": "tsgo --noEmit -p tsconfig.build.json",
     "build": "pnpm run clean && tsc -p tsconfig.build.json",
     "dev": "tsc --watch  -p tsconfig.build.json",
     "test": "vitest --sequence.concurrent=false --no-file-parallelism",

--- a/internal-packages/run-engine/package.json
+++ b/internal-packages/run-engine/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "typecheck": "tsc --noEmit -p tsconfig.build.json",
+    "typecheck": "tsgo --noEmit -p tsconfig.build.json",
     "test": "vitest --sequence.concurrent=false --no-file-parallelism",
     "test:coverage": "vitest --sequence.concurrent=false --no-file-parallelism --coverage.enabled",
     "build": "pnpm run clean && tsc -p tsconfig.build.json",

--- a/internal-packages/schedule-engine/package.json
+++ b/internal-packages/schedule-engine/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "typecheck": "tsc --noEmit -p tsconfig.build.json",
+    "typecheck": "tsgo --noEmit -p tsconfig.build.json",
     "test": "vitest --sequence.concurrent=false --no-file-parallelism",
     "test:coverage": "vitest --sequence.concurrent=false --no-file-parallelism --coverage.enabled",
     "build": "pnpm run clean && tsc -p tsconfig.build.json",

--- a/internal-packages/sdk-compat-tests/package.json
+++ b/internal-packages/sdk-compat-tests/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "vitest",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@trigger.dev/sdk": "workspace:*"

--- a/internal-packages/testcontainers/package.json
+++ b/internal-packages/testcontainers/package.json
@@ -19,6 +19,6 @@
     "tinyexec": "^0.3.0"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   }
 }

--- a/internal-packages/testcontainers/tsconfig.json
+++ b/internal-packages/testcontainers/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "target": "es2022",
     "lib": ["ES2022", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
-    "module": "CommonJS",
-    "moduleResolution": "Node",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "moduleDetection": "force",
     "types": ["vitest/globals"],
     "esModuleInterop": true,

--- a/internal-packages/tracing/package.json
+++ b/internal-packages/tracing/package.json
@@ -12,6 +12,6 @@
     "@trigger.dev/core": "workspace:*"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   }
 }

--- a/internal-packages/tsql/package.json
+++ b/internal-packages/tsql/package.json
@@ -11,7 +11,7 @@
     "zod": "3.25.76"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "grammar:build": "pnpm grammar:build:typescript",
     "grammar:build:typescript": "cat src/grammar/TSQLLexer.typescript.g4 > src/grammar/TSQLLexer.g4 && tail -n +2 src/grammar/TSQLLexer.common.g4 |sed s/isOpeningTag/self.isOpeningTag/ >> src/grammar/TSQLLexer.g4 && antlr4ts src/grammar/TSQLLexer.g4 && rm src/grammar/TSQLLexer.g4 && antlr4ts -visitor -no-listener -Dlanguage=TypeScript src/grammar/TSQLParser.g4",
     "test": "vitest --sequence.concurrent=false --no-file-parallelism",

--- a/internal-packages/tsql/tsconfig.json
+++ b/internal-packages/tsql/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2019",
     "lib": ["ES2019", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "moduleDetection": "force",
     "verbatimModuleSyntax": false,
     "types": ["vitest/globals"],

--- a/internal-packages/zod-worker/package.json
+++ b/internal-packages/zod-worker/package.json
@@ -17,6 +17,6 @@
     "@types/pg": "8.6.6"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   }
 }

--- a/internal-packages/zod-worker/tsconfig.json
+++ b/internal-packages/zod-worker/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "target": "ES2019",
     "lib": ["ES2019", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
-    "module": "CommonJS",
-    "moduleResolution": "Node",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "moduleDetection": "force",
     "verbatimModuleSyntax": false,
     "types": ["vitest/globals"],

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "@manypkg/cli": "^0.19.2",
     "@playwright/test": "^1.36.2",
     "@trigger.dev/database": "workspace:*",
-    "@types/node": "20.14.14",
+    "@types/node": "20.19.39",
+    "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "@vitest/coverage-v8": "3.1.4",
     "autoprefixer": "^10.4.12",
     "eslint-plugin-turbo": "^2.0.4",
@@ -87,7 +88,7 @@
     },
     "overrides": {
       "typescript": "5.5.4",
-      "@types/node": "20.14.14",
+      "@types/node": "20.19.39",
       "express@^4>body-parser": "1.20.3",
       "@remix-run/dev@2.17.4>tar-fs": "2.1.4",
       "testcontainers@10.28.0>tar-fs": "3.1.1",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -72,7 +72,7 @@
     "clean": "rimraf dist .tshy .tshy-build .turbo",
     "build": "tshy && pnpm run update-version",
     "dev": "tshy --watch",
-    "typecheck": "tsc --noEmit -p tsconfig.src.json",
+    "typecheck": "tsgo --noEmit -p tsconfig.src.json",
     "update-version": "tsx ../../scripts/updateVersion.ts",
     "check-exports": "attw --pack ."
   },

--- a/packages/cli-v3/package.json
+++ b/packages/cli-v3/package.json
@@ -71,7 +71,7 @@
   },
   "scripts": {
     "clean": "rimraf dist .tshy .tshy-build .turbo",
-    "typecheck": "tsc -p tsconfig.src.json --noEmit",
+    "typecheck": "tsgo -p tsconfig.src.json --noEmit",
     "build": "tshy && pnpm run update-version",
     "dev": "tshy --watch",
     "test": "vitest",

--- a/packages/cli-v3/src/apiClient.ts
+++ b/packages/cli-v3/src/apiClient.ts
@@ -485,8 +485,8 @@ export class CliApiClient {
     source.onConnectionError((error) => {
       let message = error.message ?? "Unknown error";
 
-      if (error.status !== undefined) {
-        message = `HTTP ${error.status} ${message}`;
+      if (error.code !== undefined) {
+        message = `HTTP ${error.code} ${message}`;
       }
 
       resolvePromise({

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -162,7 +162,7 @@
     "bundle-vendor": "node scripts/bundle-superjson.mjs",
     "build": "pnpm run bundle-vendor && tshy && node scripts/bundle-superjson.mjs --copy && pnpm run update-version",
     "dev": "pnpm run bundle-vendor && tshy --watch",
-    "typecheck": "pnpm run bundle-vendor && tsc --noEmit -p tsconfig.src.json",
+    "typecheck": "pnpm run bundle-vendor && tsgo --noEmit -p tsconfig.src.json",
     "pretest": "pnpm run bundle-vendor",
     "test": "vitest",
     "check-exports": "attw --pack ."

--- a/packages/python/package.json
+++ b/packages/python/package.json
@@ -40,7 +40,7 @@
     "clean": "rimraf dist",
     "build": "tshy && pnpm run update-version",
     "dev": "tshy --watch",
-    "typecheck": "tsc --noEmit -p tsconfig.src.json",
+    "typecheck": "tsgo --noEmit -p tsconfig.src.json",
     "update-version": "tsx ../../scripts/updateVersion.ts",
     "check-exports": "attw --pack ."
   },
@@ -49,7 +49,7 @@
     "tinyexec": "^0.3.2"
   },
   "devDependencies": {
-    "@types/node": "20.14.14",
+    "@types/node": "20.19.39",
     "rimraf": "6.0.1",
     "tshy": "^3.0.2",
     "typescript": "^5.5.4",

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -32,7 +32,7 @@
     "clean": "rimraf dist .tshy .tshy-build .turbo",
     "build": "tshy && pnpm run update-version",
     "dev": "tshy --watch",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "update-version": "tsx ../../scripts/updateVersion.ts",
     "check-exports": "attw --pack ."
   },

--- a/packages/redis-worker/package.json
+++ b/packages/redis-worker/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist .turbo",
     "build": "tsup",
     "dev": "tsup --watch",
-    "typecheck": "tsc --noEmit -p tsconfig.src.json",
+    "typecheck": "tsgo --noEmit -p tsconfig.src.json",
     "test": "vitest --sequence.concurrent=false --no-file-parallelism"
   },
   "dependencies": {

--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -32,7 +32,7 @@
     "clean": "rimraf dist .tshy .tshy-build .turbo",
     "build": "tshy && pnpm run update-version",
     "dev": "tshy --watch",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "update-version": "tsx ../../scripts/updateVersion.ts",
     "check-exports": "attw --pack ."
   },

--- a/packages/schema-to-json/package.json
+++ b/packages/schema-to-json/package.json
@@ -35,7 +35,7 @@
     "build": "pnpm run clean && pnpm run build:tshy && pnpm run update-version",
     "build:tshy": "tshy",
     "dev": "tshy --watch",
-    "typecheck": "tsc -p tsconfig.src.json --noEmit",
+    "typecheck": "tsgo -p tsconfig.src.json --noEmit",
     "test": "vitest",
     "update-version": "tsx ../../scripts/updateVersion.ts",
     "check-exports": "attw --pack ."

--- a/packages/trigger-sdk/package.json
+++ b/packages/trigger-sdk/package.json
@@ -44,7 +44,7 @@
     "clean": "rimraf dist .tshy .tshy-build .turbo",
     "build": "tshy && pnpm run update-version",
     "dev": "tshy --watch",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "test": "vitest",
     "update-version": "tsx ../../scripts/updateVersion.ts",
     "check-exports": "attw --pack ."

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   typescript: 5.5.4
-  '@types/node': 20.14.14
+  '@types/node': 20.19.39
   express@^4>body-parser: 1.20.3
   '@remix-run/dev@2.17.4>tar-fs': 2.1.4
   testcontainers@10.28.0>tar-fs: 3.1.1
@@ -77,11 +77,14 @@ importers:
         specifier: workspace:*
         version: link:internal-packages/database
       '@types/node':
-        specifier: 20.14.14
-        version: 20.14.14
+        specifier: 20.19.39
+        version: 20.19.39
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260421.2
       '@vitest/coverage-v8':
         specifier: 3.1.4
-        version: 3.1.4(vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1))
+        version: 3.1.4(vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1))
       autoprefixer:
         specifier: ^10.4.12
         version: 10.4.13(postcss@8.5.6)
@@ -108,13 +111,13 @@ importers:
         version: 5.5.4
       vite:
         specifier: ^5.4.21
-        version: 5.4.21(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1)
+        version: 5.4.21(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1)
       vite-tsconfig-paths:
         specifier: ^4.0.5
         version: 4.0.5(typescript@5.5.4)
       vitest:
         specifier: 3.1.4
-        version: 3.1.4(@types/debug@4.1.12)(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1)
+        version: 3.1.4(@types/debug@4.1.12)(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1)
 
   apps/coordinator:
     dependencies:
@@ -851,7 +854,7 @@ importers:
         version: link:../../internal-packages/testcontainers
       '@remix-run/dev':
         specifier: 2.17.4
-        version: 2.17.4(@remix-run/react@2.17.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4))(@remix-run/serve@2.17.4(typescript@5.5.4))(@types/node@20.14.14)(bufferutil@4.0.9)(lightningcss@1.29.2)(terser@5.44.1)(typescript@5.5.4)(vite@5.4.21(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1))
+        version: 2.17.4(@remix-run/react@2.17.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4))(@remix-run/serve@2.17.4(typescript@5.5.4))(@types/node@20.19.39)(bufferutil@4.0.9)(lightningcss@1.29.2)(terser@5.44.1)(typescript@5.5.4)(vite@5.4.21(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1))
       '@remix-run/eslint-config':
         specifier: 2.17.4
         version: 2.17.4(eslint@8.31.0)(react@18.2.0)(typescript@5.5.4)
@@ -1138,7 +1141,7 @@ importers:
         version: 18.3.1
       react-email:
         specifier: ^2.1.1
-        version: 2.1.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.15)(bufferutil@4.0.9)(eslint@8.31.0)
+        version: 2.1.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.15)(eslint@8.31.0)
       resend:
         specifier: ^3.2.0
         version: 3.2.0
@@ -1170,7 +1173,7 @@ importers:
         version: link:../testcontainers
       vitest:
         specifier: 3.1.4
-        version: 3.1.4(@types/debug@4.1.12)(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1)
+        version: 3.1.4(@types/debug@4.1.12)(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1)
 
   internal-packages/otlp-importer:
     dependencies:
@@ -1182,8 +1185,8 @@ importers:
         version: 7.3.2
     devDependencies:
       '@types/node':
-        specifier: 20.14.14
-        version: 20.14.14
+        specifier: 20.19.39
+        version: 20.19.39
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1331,7 +1334,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: 3.1.4
-        version: 3.1.4(@types/debug@4.1.12)(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1)
+        version: 3.1.4(@types/debug@4.1.12)(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1)
 
   internal-packages/testcontainers:
     dependencies:
@@ -1898,8 +1901,8 @@ importers:
         specifier: workspace:4.4.4
         version: link:../trigger-sdk
       '@types/node':
-        specifier: 20.14.14
-        version: 20.14.14
+        specifier: 20.19.39
+        version: 20.19.39
       esbuild:
         specifier: ^0.23.0
         version: 0.23.0
@@ -2021,8 +2024,8 @@ importers:
         specifier: workspace:^4.4.4
         version: link:../build
       '@types/node':
-        specifier: 20.14.14
-        version: 20.14.14
+        specifier: 20.19.39
+        version: 20.19.39
       '@types/react':
         specifier: '*'
         version: 18.3.1
@@ -2283,8 +2286,8 @@ importers:
         specifier: ^4.0.3
         version: 4.0.8
       '@types/node':
-        specifier: 20.14.14
-        version: 20.14.14
+        specifier: 20.19.39
+        version: 20.19.39
       '@types/react':
         specifier: ^19
         version: 19.0.12
@@ -2365,8 +2368,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/build
       '@types/node':
-        specifier: 20.14.14
-        version: 20.14.14
+        specifier: 20.19.39
+        version: 20.19.39
       '@types/react':
         specifier: ^19
         version: 19.0.12
@@ -2752,8 +2755,8 @@ importers:
         specifier: ^4
         version: 4.0.17
       '@types/node':
-        specifier: 20.14.14
-        version: 20.14.14
+        specifier: 20.19.39
+        version: 20.19.39
       '@types/react':
         specifier: ^19
         version: 19.0.12
@@ -2807,8 +2810,8 @@ importers:
         specifier: ^4
         version: 4.0.17
       '@types/node':
-        specifier: 20.14.14
-        version: 20.14.14
+        specifier: 20.19.39
+        version: 20.19.39
       '@types/react':
         specifier: ^19
         version: 19.0.12
@@ -2869,8 +2872,8 @@ importers:
         version: link:../../packages/trigger-sdk
     devDependencies:
       '@types/node':
-        specifier: 20.14.14
-        version: 20.14.14
+        specifier: 20.19.39
+        version: 20.19.39
       trigger.dev:
         specifier: workspace:*
         version: link:../../packages/cli-v3
@@ -8464,189 +8467,221 @@ packages:
 
   '@react-email/body@0.0.7':
     resolution: {integrity: sha512-vjJ5P1MUNWV0KNivaEWA6MGj/I3c764qQJMsKjCHlW6mkFJ4SXbm2OlQFtKAb++Bj8LDqBlnE6oW77bWcMc0NA==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/body@0.0.8':
     resolution: {integrity: sha512-gqdkNYlIaIw0OdpWu8KjIcQSIFvx7t2bZpXVxMMvBS859Ia1+1X3b5RNbjI3S1ZqLddUf7owOHkO4MiXGE+nxg==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
   '@react-email/button@0.0.14':
     resolution: {integrity: sha512-SMk40moGcAvkHIALX4XercQlK0PNeeEIam6OXHw68ea9WtzzqVwiK4pzLY0iiMI9B4xWHcaS2lCPf3cKbQBf1Q==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/button@0.0.15':
     resolution: {integrity: sha512-9Zi6SO3E8PoHYDfcJTecImiHLyitYWmIRs0HE3Ogra60ZzlWP2EXu+AZqwQnhXuq+9pbgwBWNWxB5YPetNPTNA==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
   '@react-email/code-block@0.0.3':
     resolution: {integrity: sha512-nxhl7WjjM2cOYtl0boBZfSObTrUCz2LbarcMyHkTVAsA9rbjbtWAQF7jmlefXJusk3Uol5l2c8hTh2lHLlHTRQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/code-block@0.0.4':
     resolution: {integrity: sha512-xjVLi/9dFNJ70N7hYme+21eQWa3b9/kgp4V+FKQJkQCuIMobxPRCIGM5jKD/0Vo2OqrE5chYv/dkg/aP8a8sPg==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
   '@react-email/code-inline@0.0.1':
     resolution: {integrity: sha512-SeZKTB9Q4+TUafzeUm/8tGK3dFgywUHb1od/BrAiJCo/im65aT+oJfggJLjK2jCdSsus8odcK2kReeM3/FCNTQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/code-inline@0.0.2':
     resolution: {integrity: sha512-0cmgbbibFeOJl0q04K9jJlPDuJ+SEiX/OG6m3Ko7UOkG3TqjRD8Dtvkij6jNDVfUh/zESpqJCP2CxrCLLMUjdA==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
   '@react-email/column@0.0.10':
     resolution: {integrity: sha512-MnP8Mnwipr0X3XtdD6jMLckb0sI5/IlS6Kl/2F6/rsSWBJy5Gg6nizlekTdkwDmy0kNSe3/1nGU0Zqo98pl63Q==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
   '@react-email/column@0.0.9':
     resolution: {integrity: sha512-1ekqNBgmbS6m97/sUFOnVvQtLYljUWamw8Y44VId95v6SjiJ4ca+hMcdOteHWBH67xkRofEOWTvqDRea5SBV8w==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/components@0.0.16':
     resolution: {integrity: sha512-1WATpMSH03cRvhfNjGl/Up3seZJOzN9KLzlk3Q9g/cqNhZEJ7HYxoZM4AQKAI0V3ttXzzxKv8Oj+AZQLHDiICA==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/components@0.0.17':
     resolution: {integrity: sha512-x5gGQaK0QchbwHvUrCBVnE8GCWdO5osTVuTSA54Fwzels6ZDeNTHEYRx9gI3Nwcf/dkoVYkVH4rzWST0SF0MLA==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
   '@react-email/container@0.0.11':
     resolution: {integrity: sha512-jzl/EHs0ClXIRFamfH+NR/cqv4GsJJscqRhdYtnWYuRAsWpKBM1muycrrPqIVhWvWi6sFHInWTt07jX+bDc3SQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/container@0.0.12':
     resolution: {integrity: sha512-HFu8Pu5COPFfeZxSL+wKv/TV5uO/sp4zQ0XkRCdnGkj/xoq0lqOHVDL4yC2Pu6fxXF/9C3PHDA++5uEYV5WVJw==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
   '@react-email/font@0.0.5':
     resolution: {integrity: sha512-if/qKYmH3rJ2egQJoKbV8SfKCPavu+ikUq/naT/UkCr8Q0lkk309tRA0x7fXG/WeIrmcipjMzFRGTm2TxTecDw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/font@0.0.6':
     resolution: {integrity: sha512-sZZFvEZ4U3vNCAZ8wXqIO3DuGJR2qE/8m2fEH+tdqwa532zGO3zW+UlCTg0b9455wkJSzEBeaWik0IkNvjXzxw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
   '@react-email/head@0.0.7':
     resolution: {integrity: sha512-IcXL4jc0H1qzAXJCD9ajcRFBQdbUHkjKJyiUeogpaYSVZSq6cVDWQuGaI23TA9k+pI2TFeQimogUFb3Kgeeudw==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/head@0.0.8':
     resolution: {integrity: sha512-8/NI0gtQmLIilAe6rebK1TWw3IXHxtrR02rInkQq8yQ7zKbYbzx7Q/FhmsJgAk+uYh2Er/KhgYJ0sHZyDhfMTQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
   '@react-email/heading@0.0.11':
     resolution: {integrity: sha512-EF5ZtRCxhHPw3m+8iibKKg0RAvAeHj1AP68sjU7s6+J+kvRgllr/E972Wi5Y8UvcIGossCvpX1WrSMDzeB4puA==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/heading@0.0.12':
     resolution: {integrity: sha512-eB7mpnAvDmwvQLoPuwEiPRH4fPXWe6ltz6Ptbry2BlI88F0a2k11Ghb4+sZHBqg7vVw/MKbqEgtLqr3QJ/KfCQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
   '@react-email/hr@0.0.7':
     resolution: {integrity: sha512-8suK0M/deXHt0DBSeKhSC4bnCBCBm37xk6KJh9M0/FIKlvdltQBem52YUiuqVl1XLB87Y6v6tvspn3SZ9fuxEA==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/hr@0.0.8':
     resolution: {integrity: sha512-JLVvpCg2wYKEB+n/PGCggWG9fRU5e4lxsGdpK5SDLsCL0ic3OLKSpHMfeE+ZSuw0GixAVVQN7F64PVJHQkd4MQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
   '@react-email/html@0.0.7':
     resolution: {integrity: sha512-oy7OoRtoOKApVI/5Lz1OZptMKmMYJu9Xn6+lOmdBQchAuSdQtWJqxhrSj/iI/mm8HZWo6MZEQ6SFpfOuf8/P6Q==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/html@0.0.8':
     resolution: {integrity: sha512-arII3wBNLpeJtwyIJXPaILm5BPKhA+nvdC1F9QkuKcOBJv2zXctn8XzPqyGqDfdplV692ulNJP7XY55YqbKp6w==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
   '@react-email/img@0.0.7':
     resolution: {integrity: sha512-up9tM2/dJ24u/CFjcvioKbyGuPw1yeJg605QA7VkrygEhd0CoQEjjgumfugpJ+VJgIt4ZjT9xMVCK5QWTIWoaA==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/img@0.0.8':
     resolution: {integrity: sha512-jx/rPuKo31tV18fu7P5rRqelaH5wkhg83Dq7uLwJpfqhbi4KFBGeBfD0Y3PiLPPoh+WvYf+Adv9W2ghNW8nOMQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
   '@react-email/link@0.0.7':
     resolution: {integrity: sha512-hXPChT3ZMyKnUSA60BLEMD2maEgyB2A37yg5bASbLMrXmsExHi6/IS1h2XiUPLDK4KqH5KFaFxi2cdNo1JOKwA==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/link@0.0.8':
     resolution: {integrity: sha512-nVikuTi8WJHa6Baad4VuRUbUCa/7EtZ1Qy73TRejaCHn+vhetc39XGqHzKLNh+Z/JFL8Hv9g+4AgG16o2R0ogQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
   '@react-email/markdown@0.0.10':
     resolution: {integrity: sha512-MH0xO+NJ4IuJcx9nyxbgGKAMXyudFjCZ0A2GQvuWajemW9qy2hgnJ3mW3/z5lwcenG+JPn7JyO/iZpizQ7u1tA==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
   '@react-email/markdown@0.0.9':
     resolution: {integrity: sha512-t//19Zz+W5svKqrSrqoOLpf6dq70jbwYxX8Z+NEMi4LqylklccOaYAyKrkYyulfZwhW7KDH9d2wjVk5jfUABxQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/preview@0.0.8':
     resolution: {integrity: sha512-Jm0KUYBZQd2w0s2QRMQy0zfHdo3Ns+9bYSE1OybjknlvhANirjuZw9E5KfWgdzO7PyrRtB1OBOQD8//Obc4uIQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/preview@0.0.9':
     resolution: {integrity: sha512-2fyAA/zzZYfYmxfyn3p2YOIU30klyA6Dq4ytyWq4nfzQWWglt5hNDE0cMhObvRtfjM9ghMSVtoELAb0MWiF/kw==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
@@ -8661,48 +8696,56 @@ packages:
   '@react-email/row@0.0.7':
     resolution: {integrity: sha512-h7pwrLVGk5CIx7Ai/oPxBgCCAGY7BEpCUQ7FCzi4+eThcs5IdjSwDPefLEkwaFS8KZc56UNwTAH92kNq5B7blg==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/row@0.0.8':
     resolution: {integrity: sha512-JsB6pxs/ZyjYpEML3nbwJRGAerjcN/Pa/QG48XUwnT/MioDWrUuyQuefw+CwCrSUZ2P1IDrv2tUD3/E3xzcoKw==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
   '@react-email/section@0.0.11':
     resolution: {integrity: sha512-3bZ/DuvX1julATI7oqYza6pOtWZgLJDBaa62LFFEvYjisyN+k6lrP2KOucPsDKu2DOkUzlQgK0FOm6VQJX+C0w==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/section@0.0.12':
     resolution: {integrity: sha512-UCD/N/BeOTN4h3VZBUaFdiSem6HnpuxD1Q51TdBFnqeNqS5hBomp8LWJJ9s4gzwHWk1XPdNfLA3I/fJwulJshg==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
   '@react-email/tailwind@0.0.15':
     resolution: {integrity: sha512-TE3NQ7VKhhvv3Zv0Z1NtoV6AF7aOWiG4juVezMZw1hZCG0mkN6iXC63u23vPQi12y6xCp20ZUHfg67kQeDSP/g==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/tailwind@0.0.16':
     resolution: {integrity: sha512-uMifPxCEHaHLhpS1kVCMGyTeEL+aMYzHT4bgj8CkgCiBoF9wNNfIVMUlHGzHUTv4ZTEPaMfZgC/Hi8RqzL/Ogw==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
   '@react-email/text@0.0.7':
     resolution: {integrity: sha512-eHCx0mdllGcgK9X7wiLKjNZCBRfxRVNjD3NNYRmOc3Icbl8M9JHriJIfxBuGCmGg2UAORK5P3KmaLQ8b99/pbA==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: 18.2.0
 
   '@react-email/text@0.0.8':
     resolution: {integrity: sha512-uvN2TNWMrfC9wv/LLmMLbbEN1GrMWZb9dBK14eYxHHAEHCeyvGb5ePZZ2MPyzO7Y5yTC+vFEnCEr76V+hWMxCQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.2.0
 
@@ -10494,6 +10537,7 @@ packages:
 
   '@team-plain/typescript-sdk@3.5.0':
     resolution: {integrity: sha512-9kweiSlYAN31VI7yzILGxdlZqsGJ+FmCEfXyEZ/0/i3r6vOwq45FDqtjadnQJVtFm+rf/8vCFRN+wEYMIEv6Aw==}
+    deprecated: This package is now deprecated. Please use @team-plain/graphql, @team-plain/webhooks and @team-plain/ui-components (https://github.com/team-plain/sdk)
 
   '@testcontainers/postgresql@10.28.0':
     resolution: {integrity: sha512-NN25rruG5D4Q7pCNIJuHwB+G85OSeJ3xHZ2fWx0O6sPoPEfCYwvpj8mq99cyn68nxFkFYZeyrZJtSFO+FnydiA==}
@@ -10832,8 +10876,8 @@ packages:
   '@types/node-fetch@2.6.4':
     resolution: {integrity: sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==}
 
-  '@types/node@20.14.14':
-    resolution: {integrity: sha512-d64f00982fS9YoOgJkAMolK7MN8Iq3TDdVjchbYHdEmjth/DHowx82GnoA+tVUAN+7vxfYUgAzi+JXbKNd2SDQ==}
+  '@types/node@20.19.39':
+    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
 
   '@types/nodemailer@7.0.4':
     resolution: {integrity: sha512-ee8fxWqOchH+Hv6MDDNNy028kwvVnLplrStm4Zf/3uHWw5zzo8FoYYeffpJtGs2wWysEumMH0ZIdMGMY1eMAow==}
@@ -11072,6 +11116,45 @@ packages:
   '@typescript-eslint/visitor-keys@5.59.6':
     resolution: {integrity: sha512-zEfbFLzB9ETcEJ4HZEEsCR9HHeNku5/Qw1jSS5McYJv5BR+ftYXwFFAH5Al+xkGaZEqowMwl7uoJjQb1YSPF8Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww==}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg==}
+    hasBin: true
 
   '@uiw/codemirror-extensions-basic-setup@4.19.5':
     resolution: {integrity: sha512-1zt7ZPJ01xKkSW/KDy0FZNga0bngN1fC594wCVG7FBi60ehfcAucpooQ+JSPScKXopxcb+ugPKZvVLzr9/OfzA==}
@@ -11828,7 +11911,7 @@ packages:
   basic-ftp@5.0.3:
     resolution: {integrity: sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
@@ -19483,8 +19566,8 @@ packages:
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici@5.29.0:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
@@ -19782,7 +19865,7 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
@@ -19810,7 +19893,7 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
@@ -19843,7 +19926,7 @@ packages:
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       '@vitest/browser': 3.1.4
       '@vitest/ui': 3.1.4
       happy-dom: '*'
@@ -24193,7 +24276,7 @@ snapshots:
   '@kubernetes/client-node@0.20.0(bufferutil@4.0.9)':
     dependencies:
       '@types/js-yaml': 4.0.9
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       '@types/request': 2.48.12
       '@types/ws': 8.5.10
       byline: 5.0.0
@@ -24215,7 +24298,7 @@ snapshots:
   '@kubernetes/client-node@1.0.0(patch_hash=ba1a06f46256cdb8d6faf7167246692c0de2e7cd846a9dc0f13be0137e1c3745)(bufferutil@4.0.9)(encoding@0.1.13)':
     dependencies:
       '@types/js-yaml': 4.0.9
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       '@types/node-fetch': 2.6.12
       '@types/stream-buffers': 3.0.7
       '@types/tar': 6.1.4
@@ -24285,7 +24368,7 @@ snapshots:
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       find-up: 4.1.0
       fs-extra: 8.1.0
 
@@ -25375,7 +25458,7 @@ snapshots:
 
   '@playwright/test@1.37.0':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       playwright-core: 1.37.0
     optionalDependencies:
       fsevents: 2.3.2
@@ -29022,7 +29105,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@remix-run/dev@2.17.4(@remix-run/react@2.17.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4))(@remix-run/serve@2.17.4(typescript@5.5.4))(@types/node@20.14.14)(bufferutil@4.0.9)(lightningcss@1.29.2)(terser@5.44.1)(typescript@5.5.4)(vite@5.4.21(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1))':
+  '@remix-run/dev@2.17.4(@remix-run/react@2.17.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4))(@remix-run/serve@2.17.4(typescript@5.5.4))(@types/node@20.19.39)(bufferutil@4.0.9)(lightningcss@1.29.2)(terser@5.44.1)(typescript@5.5.4)(vite@5.4.21(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1))':
     dependencies:
       '@babel/core': 7.22.17
       '@babel/generator': 7.24.7
@@ -29039,7 +29122,7 @@ snapshots:
       '@remix-run/router': 1.23.2
       '@remix-run/server-runtime': 2.17.4(typescript@5.5.4)
       '@types/mdx': 2.0.5
-      '@vanilla-extract/integration': 6.2.1(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1)
+      '@vanilla-extract/integration': 6.2.1(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1)
       arg: 5.0.2
       cacache: 17.1.4
       chalk: 4.1.2
@@ -29079,12 +29162,12 @@ snapshots:
       tar-fs: 2.1.4
       tsconfig-paths: 4.2.0
       valibot: 1.3.1(typescript@5.5.4)
-      vite-node: 3.1.4(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1)
+      vite-node: 3.1.4(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1)
       ws: 7.5.10(bufferutil@4.0.9)
     optionalDependencies:
       '@remix-run/serve': 2.17.4(typescript@5.5.4)
       typescript: 5.5.4
-      vite: 5.4.21(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1)
+      vite: 5.4.21(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1)
     transitivePeerDependencies:
       - '@types/node'
       - bluebird
@@ -29522,7 +29605,7 @@ snapshots:
 
   '@slack/logger@4.0.0':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@slack/types@2.14.0': {}
 
@@ -29530,7 +29613,7 @@ snapshots:
     dependencies:
       '@slack/logger': 4.0.0
       '@slack/types': 2.14.0
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       '@types/retry': 0.12.0
       axios: 1.12.2
       eventemitter3: 5.0.1
@@ -30780,7 +30863,7 @@ snapshots:
   '@types/body-parser@1.19.2':
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/btoa-lite@1.0.2': {}
 
@@ -30796,11 +30879,11 @@ snapshots:
 
   '@types/connect@3.4.35':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/cookie@0.4.1': {}
 
@@ -30810,11 +30893,11 @@ snapshots:
 
   '@types/cors@2.8.17':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/cross-spawn@6.0.2':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/d3-array@3.0.8': {}
 
@@ -30953,13 +31036,13 @@ snapshots:
 
   '@types/docker-modem@3.0.6':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       '@types/ssh2': 1.15.1
 
   '@types/dockerode@3.3.35':
     dependencies:
       '@types/docker-modem': 3.0.6
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       '@types/ssh2': 1.15.1
 
   '@types/dompurify@3.2.0':
@@ -31000,7 +31083,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.17.32':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
 
@@ -31031,7 +31114,7 @@ snapshots:
 
   '@types/interpret@1.1.3':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/invariant@2.2.37': {}
 
@@ -31056,13 +31139,13 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 0.7.31
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/katex@0.16.7': {}
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/lodash.get@4.4.9':
     dependencies:
@@ -31094,37 +31177,37 @@ snapshots:
 
   '@types/morgan@1.9.4':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/ms@0.7.31': {}
 
   '@types/mysql@2.15.26':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/node-fetch@2.6.12':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       form-data: 4.0.4
 
   '@types/node-fetch@2.6.2':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       form-data: 3.0.4
 
   '@types/node-fetch@2.6.4':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       form-data: 3.0.4
 
-  '@types/node@20.14.14':
+  '@types/node@20.19.39':
     dependencies:
-      undici-types: 5.26.5
+      undici-types: 6.21.0
 
   '@types/nodemailer@7.0.4':
     dependencies:
       '@aws-sdk/client-sesv2': 3.940.0
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
     transitivePeerDependencies:
       - aws-crt
 
@@ -31138,25 +31221,25 @@ snapshots:
 
   '@types/pg@8.11.14':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       pg-protocol: 1.9.5
       pg-types: 4.0.2
 
   '@types/pg@8.11.6':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       pg-protocol: 1.10.3
       pg-types: 4.0.2
 
   '@types/pg@8.6.1':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       pg-protocol: 1.10.3
       pg-types: 2.2.0
 
   '@types/pg@8.6.6':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       pg-protocol: 1.6.1
       pg-types: 2.2.0
 
@@ -31164,7 +31247,7 @@ snapshots:
     dependencies:
       '@types/express': 4.17.15
       '@types/express-serve-static-core': 4.17.32
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       '@types/trouter': 3.1.4
 
   '@types/prismjs@1.26.0': {}
@@ -31214,7 +31297,7 @@ snapshots:
 
   '@types/readable-stream@4.0.14':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       safe-buffer: 5.1.2
 
   '@types/regression@2.0.6': {}
@@ -31222,7 +31305,7 @@ snapshots:
   '@types/request@2.48.12':
     dependencies:
       '@types/caseless': 0.12.5
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.4
 
@@ -31230,7 +31313,7 @@ snapshots:
 
   '@types/responselike@1.0.0':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/retry@0.12.0': {}
 
@@ -31251,7 +31334,7 @@ snapshots:
   '@types/serve-static@1.15.0':
     dependencies:
       '@types/mime': 3.0.1
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/shimmer@1.2.0': {}
 
@@ -31265,26 +31348,26 @@ snapshots:
 
   '@types/ssh2-streams@0.1.12':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/ssh2@0.5.52':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       '@types/ssh2-streams': 0.1.12
 
   '@types/ssh2@1.15.1':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/stream-buffers@3.0.7':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/superagent@8.1.9':
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       form-data: 4.0.4
 
   '@types/supertest@6.0.2':
@@ -31294,12 +31377,12 @@ snapshots:
 
   '@types/tar@6.1.4':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       minipass: 4.0.0
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/tinycolor2@1.4.3': {}
 
@@ -31320,7 +31403,7 @@ snapshots:
 
   '@types/webpack@5.28.5(@swc/core@1.3.101(@swc/helpers@0.5.15))(esbuild@0.19.11)':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       tapable: 2.3.0
       webpack: 5.88.2(@swc/core@1.3.101(@swc/helpers@0.5.15))(esbuild@0.19.11)
     transitivePeerDependencies:
@@ -31331,19 +31414,19 @@ snapshots:
 
   '@types/ws@8.5.10':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/ws@8.5.12':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/ws@8.5.4':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
     optional: true
 
   '@typescript-eslint/eslint-plugin@5.59.6(@typescript-eslint/parser@5.59.6(eslint@8.31.0)(typescript@5.5.4))(eslint@8.31.0)(typescript@5.5.4)':
@@ -31429,6 +31512,37 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.59.6
       eslint-visitor-keys: 3.4.2
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260421.2':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260421.2
 
   '@uiw/codemirror-extensions-basic-setup@4.19.5(@codemirror/autocomplete@6.4.0(@codemirror/language@6.3.2)(@codemirror/state@6.2.0)(@codemirror/view@6.7.2)(@lezer/common@1.3.0))(@codemirror/commands@6.1.3)(@codemirror/language@6.3.2)(@codemirror/lint@6.4.2)(@codemirror/search@6.2.3)(@codemirror/state@6.2.0)(@codemirror/view@6.7.2)':
     dependencies:
@@ -31518,7 +31632,7 @@ snapshots:
       media-query-parser: 2.0.2
       outdent: 0.8.0
 
-  '@vanilla-extract/integration@6.2.1(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1)':
+  '@vanilla-extract/integration@6.2.1(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1)':
     dependencies:
       '@babel/core': 7.22.17
       '@babel/plugin-syntax-typescript': 7.21.4(@babel/core@7.22.17)
@@ -31531,8 +31645,8 @@ snapshots:
       lodash: 4.17.23
       mlly: 1.7.4
       outdent: 0.8.0
-      vite: 4.4.9(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1)
-      vite-node: 0.28.5(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1)
+      vite: 4.4.9(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1)
+      vite-node: 0.28.5(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -31577,7 +31691,7 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@vitest/coverage-v8@3.1.4(vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1))':
+  '@vitest/coverage-v8@3.1.4(vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -31591,7 +31705,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.4(@types/debug@4.1.12)(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1)
+      vitest: 3.1.4(@types/debug@4.1.12)(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -31602,13 +31716,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.4(vite@5.4.21(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1))':
+  '@vitest/mocker@3.1.4(vite@5.4.21(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1))':
     dependencies:
       '@vitest/spy': 3.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1)
+      vite: 5.4.21(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -32506,7 +32620,7 @@ snapshots:
 
   bun-types@1.1.17:
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       '@types/ws': 8.5.10
 
   bundle-name@4.1.0:
@@ -33762,7 +33876,7 @@ snapshots:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.17
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -35349,7 +35463,7 @@ snapshots:
   graphile-config@0.0.1-beta.8:
     dependencies:
       '@types/interpret': 1.1.3
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       '@types/semver': 7.5.1
       chalk: 4.1.2
       debug: 4.4.3(supports-color@10.0.0)
@@ -36058,7 +36172,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -38029,7 +38143,7 @@ snapshots:
 
   openai@4.33.1(encoding@0.1.13):
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       '@types/node-fetch': 2.6.4
       abort-controller: 3.0.0
       agentkeepalive: 4.5.0
@@ -38042,7 +38156,7 @@ snapshots:
 
   openai@4.68.4(encoding@0.1.13)(zod@3.25.76):
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       '@types/node-fetch': 2.6.4
       abort-controller: 3.0.0
       agentkeepalive: 4.5.0
@@ -38056,7 +38170,7 @@ snapshots:
 
   openai@4.97.0(encoding@0.1.13)(ws@8.12.0(bufferutil@4.0.9))(zod@3.25.76):
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       '@types/node-fetch': 2.6.12
       abort-controller: 3.0.0
       agentkeepalive: 4.5.0
@@ -38071,7 +38185,7 @@ snapshots:
 
   openai@4.97.0(encoding@0.1.13)(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.76):
     dependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       '@types/node-fetch': 2.6.12
       abort-controller: 3.0.0
       agentkeepalive: 4.5.0
@@ -38967,7 +39081,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       long: 5.2.3
 
   proxy-addr@2.0.7:
@@ -39233,7 +39347,7 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  react-email@2.1.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.15)(bufferutil@4.0.9)(eslint@8.31.0):
+  react-email@2.1.2(@opentelemetry/api@1.9.0)(@swc/helpers@0.5.15)(eslint@8.31.0):
     dependencies:
       '@babel/parser': 7.24.1
       '@radix-ui/colors': 1.0.1
@@ -39270,8 +39384,8 @@ snapshots:
       react: 18.3.1
       react-dom: 18.2.0(react@18.3.1)
       shelljs: 0.8.5
-      socket.io: 4.7.3(bufferutil@4.0.9)
-      socket.io-client: 4.7.3(bufferutil@4.0.9)
+      socket.io: 4.7.3
+      socket.io-client: 4.7.3
       sonner: 1.3.1(react-dom@18.2.0(react@18.3.1))(react@18.3.1)
       source-map-js: 1.0.2
       stacktrace-parser: 0.1.10
@@ -40496,7 +40610,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  socket.io-client@4.7.3(bufferutil@4.0.9):
+  socket.io-client@4.7.3:
     dependencies:
       '@socket.io/component-emitter': 3.1.0
       debug: 4.3.7(supports-color@10.0.0)
@@ -40525,7 +40639,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  socket.io@4.7.3(bufferutil@4.0.9):
+  socket.io@4.7.3:
     dependencies:
       accepts: 1.3.8
       base64id: 2.0.0
@@ -41735,7 +41849,7 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
-  undici-types@5.26.5: {}
+  undici-types@6.21.0: {}
 
   undici@5.29.0:
     dependencies:
@@ -42077,7 +42191,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-node@0.28.5(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1):
+  vite-node@0.28.5(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@10.0.0)
@@ -42086,7 +42200,7 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.6.1
       source-map-support: 0.5.21
-      vite: 4.4.9(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1)
+      vite: 4.4.9(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -42097,13 +42211,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.1.4(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1):
+  vite-node@3.1.4(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@10.0.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.21(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1)
+      vite: 5.4.21(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -42124,32 +42238,32 @@ snapshots:
       - supports-color
       - typescript
 
-  vite@4.4.9(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1):
+  vite@4.4.9(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1):
     dependencies:
       esbuild: 0.18.11
       postcss: 8.5.6
       rollup: 3.29.1
     optionalDependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       fsevents: 2.3.3
       lightningcss: 1.29.2
       terser: 5.44.1
 
-  vite@5.4.21(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1):
+  vite@5.4.21(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.36.0
     optionalDependencies:
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
       fsevents: 2.3.3
       lightningcss: 1.29.2
       terser: 5.44.1
 
-  vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1):
+  vitest@3.1.4(@types/debug@4.1.12)(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1):
     dependencies:
       '@vitest/expect': 3.1.4
-      '@vitest/mocker': 3.1.4(vite@5.4.21(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1))
+      '@vitest/mocker': 3.1.4(vite@5.4.21(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1))
       '@vitest/pretty-format': 3.1.4
       '@vitest/runner': 3.1.4
       '@vitest/snapshot': 3.1.4
@@ -42166,12 +42280,12 @@ snapshots:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 5.4.21(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1)
-      vite-node: 3.1.4(@types/node@20.14.14)(lightningcss@1.29.2)(terser@5.44.1)
+      vite: 5.4.21(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1)
+      vite-node: 3.1.4(@types/node@20.19.39)(lightningcss@1.29.2)(terser@5.44.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 20.14.14
+      '@types/node': 20.19.39
     transitivePeerDependencies:
       - less
       - lightningcss

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,8 @@ minimumReleaseAgeExclude:
   - "next"
   - "@next/*"
   - "agentcrumbs"
+  - "@typescript/native-preview"
+  - "@typescript/native-preview-*"
 preferOffline: true
 
 linkWorkspacePackages: false


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Ran the full workspace typecheck with the native-preview compiler on every app and package:

```
pnpm run typecheck --force
# Tasks:    45 successful, 45 total
# Cached:    0 cached, 45 total
# Time:     4m35.832s   (cold — no Turbo cache for typecheck tasks)
```

```
pnpm run typecheck          # re-run, cache fully warm
# Tasks:    45 successful, 45 total
# Cached:   45 cached, 45 total
# Time:     1.268s >>> FULL TURBO
```

This also builds every package whose typecheck depends on emitted outputs (core, sdk, cli-v3, database, clickhouse, run-engine, schedule-engine, replication, compute, redis-worker, react-hooks, rsc, build, schema-to-json, python), all with `tsc` 5.5.4 — so both pipelines are exercised.

---

## Benchmarks: tsgo 7.0 beta vs tsc 5.5.4

Measured on the development VM (AMD x86_64, **2 physical cores**, 8 GB RAM, Linux 6.x, Node.js 20.20.0). Numbers are `bash time` wall clock, over the same source tree, with `node_modules` already installed, upstream package `build` outputs already produced and cached in Turbo (so the typecheck task is the only thing being re-run). The `tsc` column was produced by `sed`-swapping `tsgo` → `tsc` in every `typecheck` script, running the same commands, then reverting — no config differences.

### Full monorepo (45 workspaces via Turbo)

| Scenario | `tsgo` (TS 7.0 beta) | `tsc` 5.5.4 | Speed-up |
| --- | --- | --- | --- |
| **Cold** — `pnpm run typecheck --force` (typecheck cache cleared, `^build` outputs cached) | **4 m 35.8 s** (user 8 m 01 s) | **7 m 46.8 s** (user 14 m 08 s) | **~1.7×** |
| **Warm** — `pnpm run typecheck` (full Turbo cache hit, no compiler runs) | **1.3 s** | **1.3 s** | — |

### Single workspace — `apps/webapp` (pure compiler, no Turbo)

Runs `<compiler> --noEmit` directly from `apps/webapp/`, filesystem cache pre-warmed.

| Run | `tsgo` | `tsc` 5.5.4 | Notes |
| --- | --- | --- | --- |
| Run 1 | 43.9 s (user 69.2 s) | 111.4 s (user 150.7 s) | `tsc` needs `NODE_OPTIONS=--max-old-space-size=6144`; at the default 2 GB heap it aborts with `v8 OrderedHashTable/Mark-Compact allocation failure` after ~52 s. |
| Run 2 | 46.2 s (user 73.9 s) | 103.2 s (user 138.8 s) | |
| **Avg** | **45.0 s** | **107.3 s** | **~2.4× speed-up; no OOM** |

### Takeaways

- **Cold cache is meaningfully faster**: ~3 min saved on the full repo, ~1 min saved on just the webapp. That's the cost your editor / lint-on-save / CI cold boot all see.
- **Warm cache is unchanged**: once Turbo has cached a `typecheck` task, both compilers are equivalent (because neither runs). This PR does not speed up the `>>> FULL TURBO` green path.
- **Memory footprint is dramatically smaller**: the native Go binary doesn't inherit V8's 2 GB heap cap. `tsc --noEmit` on `apps/webapp` OOMs at the default Node heap size; `tsgo` finishes well below 1 GB RSS.
- **Parallelism is CPU-limited on this VM**: `tsgo`'s user-CPU / wall-clock ratio is ~1.6× (close to 2 cores saturated). On dev machines with more cores the speedup should widen closer to the ~10× the [TS 7 launch post](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-beta/) measured.
- **Diagnostic output is equivalent**: every error `tsc` surfaced in the benchmark runs (`TS2550`, `TS2578`, `TS2339`, `TS18048`, etc.) was also surfaced by `tsgo`. No silent false negatives were observed.

### Reproducing

```bash
# tsgo (current state of this branch)
pnpm run typecheck --force          # cold
pnpm run typecheck                  # warm

# tsc 5.5.4 (sed-swap, then revert)
find apps internal-packages packages -name package.json -not -path "*/node_modules/*" -print0 \
  | xargs -0 grep -l '"tsgo' \
  | while read f; do cp "$f" "$f.bak"; sed -i 's/tsgo/tsc/g' "$f"; done

NODE_OPTIONS="--max-old-space-size=6144" pnpm run typecheck --force   # cold
NODE_OPTIONS="--max-old-space-size=6144" pnpm run typecheck           # warm

find apps internal-packages packages -name '*.bak' -not -path "*/node_modules/*" \
  | while read f; do mv "$f" "${f%.bak}"; done
```

---

## Changelog

Adopts the newly-announced [TypeScript 7.0 beta](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-beta/) (the Go-native `tsgo` compiler) for type-checking across the monorepo. The TypeScript 5.5.4 `tsc` is retained for emit (package builds), so published artifacts are byte-for-byte identical to `main`.

### Approach

- Add `@typescript/native-preview@7.0.0-dev.20260421.2` to the root `devDependencies`. This pulls in the `tsgo` binary and the platform-specific native packages (`@typescript/native-preview-linux-x64`, etc.).
- Add it (and the `@typescript/native-preview-*` platform packages) to `pnpm-workspace.yaml`'s `minimumReleaseAgeExclude` so pnpm doesn't block the nightly beta on the 3-day release-age rule.
- Replace `tsc` with `tsgo` **only** in `typecheck` scripts across 30 `package.json` files (43 occurrences). `build` and `dev` scripts that actually emit (`apps/supervisor`, `internal-packages/{database,compute,clickhouse,replication,run-engine,schedule-engine}`) continue to use `tsc` to avoid any runtime surprises from the beta emitter.
- Keep `"typescript": "5.5.4"` as a pnpm override so every programmatic TS consumer (typescript-eslint, vite, remix, tshy, ts-proto, etc.) continues to run against a known-stable compiler.

### Config changes required by TS 7.0 (= TS 6.0 semantics)

TS 6.0 removed several long-deprecated `tsconfig` options. The following edits make existing configs forward-compatible while staying valid for `tsc` 5.5.4:

- `apps/webapp/tsconfig.json`: dropped `baseUrl` (removed in TS 6.0; `paths` alone is sufficient).
- `.configs/tsconfig.base.json`: dropped `downlevelIteration` (removed in TS 6.0; modern targets don't need it).
- `moduleResolution: "node"` / `"Node"` → `"bundler"` in the five packages that still used the legacy value: `internal-packages/{tsql,zod-worker,testcontainers,emails}`. Those packages are typecheck-only (`--noEmit`), so `bundler` is the least-invasive choice; I bumped `module` to `ESNext` in `zod-worker`/`testcontainers` to satisfy the bundler-resolution constraint.
- `internal-packages/database` still emits with `tsc`, so `tsconfig.json` keeps `moduleResolution: "node"` for the build. Typecheck goes through a new `tsconfig.typecheck.json` that extends it and sets `moduleResolution: "bundler"` / `module: "ESNext"`.
- `internal-packages/otlp-importer/tsconfig.json`: added `"types": ["node"]`. tsgo doesn't auto-include `@types/node` as eagerly as tsc when `lib` already pulls in DOM.

### Dependency bump

- `@types/node`: `20.14.14` → `20.19.39` (direct dep and pnpm override, plus `packages/python`). TS 7's lib.d.ts tightens `Uint8Array<TArrayBuffer extends ArrayBufferLike>`, so the older types drove ~30 genuine `Buffer` vs `Uint8Array` mismatches in `otlp-importer` generated code and webapp routes. The bump reconciles them.

### Source-level fixes flushed out by the stricter checker

All minimal, bug-for-bug equivalent:

- `apps/webapp/app/routes/otel.v1.{logs,metrics,traces}.ts`: `new Response(buf)` with a protobuf `Uint8Array` now needs an explicit `as BodyInit` cast (DOM's `BodyInit` union vs. node's generic `Uint8Array`).
- `apps/webapp/app/services/realtime/redisRealtimeStreams.server.ts`: cast `new TextDecoderStream()` through `ReadableWritablePair<string, Uint8Array>` for the same reason.
- `apps/webapp/test/setup-test-env.ts`: removed a dangling `import "@testing-library/jest-dom/extend-expect"` — the package isn't in the dep tree and this file isn't wired into the vitest setup, so the import was dead.
- `internal-packages/clickhouse/src/client/client.ts`: typed `row.json<Record<number, unknown>>()` so subsequent index access type-checks (previously inferred `unknown`).
- `packages/cli-v3/src/apiClient.ts`: pre-existing bug — `onConnectionError` was reading `error.status`, but the `eventsource@3` `ErrorEvent` field is `error.code`. User-visible in the `trigger.dev deploy` error message for SSE connection failures.

### What this does not do

- Does not switch `build`/`dev` emission to tsgo. tsgo still has rough edges around `--watch` and some emit options, and switching would change shipped artifacts. This PR is pure typechecker swap.
- Does not change the pinned `typescript` version (5.5.4). tsgo implements TS 6.0 semantics today; the JS `tsc` stays put until TS 6.x / 7.x ships stable.
- Does not upgrade `@types/node` past the 20.x line (pinned because the runtime is Node 20.20.0).

---

## Screenshots

n/a — dev tooling only.


Link to Devin session: https://app.devin.ai/sessions/89038603ea414395a95cc8681a9d0a5a
Requested by: @ericallam