### PR TITLE
feat(webapp): add `skipIfActive` trigger option for drop-on-conflict dedup

### DIFF
--- a/apps/webapp/app/routes/api.v1.tasks.$taskId.trigger.ts
+++ b/apps/webapp/app/routes/api.v1.tasks.$taskId.trigger.ts
@@ -135,6 +135,7 @@ const { action, loader } = createActionApiRoute(
         {
           id: result.run.friendlyId,
           isCached: result.isCached,
+          ...(result.wasSkipped ? { wasSkipped: true } : {}),
         },
         {
           headers: $responseHeaders,

--- a/apps/webapp/app/runEngine/concerns/skipIfActive.server.ts
+++ b/apps/webapp/app/runEngine/concerns/skipIfActive.server.ts
@@ -1,0 +1,105 @@
+import { Prisma, type PrismaClientOrTransaction, type TaskRun } from "@trigger.dev/database";
+import { logger } from "~/services/logger.server";
+import type { TriggerTaskRequest } from "../types";
+
+export type SkipIfActiveConcernResult =
+  | { wasSkipped: true; run: TaskRun }
+  | { wasSkipped: false };
+
+/**
+ * DB-level `TaskRunStatus` values that represent a run that has not reached
+ * a terminal state — i.e. still counts as "active" for dedup purposes.
+ * Mirrors the non-final statuses in `TaskRunStatus` (see
+ * `internal-packages/database/prisma/schema.prisma`).
+ */
+const ACTIVE_TASK_RUN_STATUSES = [
+  "DELAYED",
+  "PENDING",
+  "PENDING_VERSION",
+  "WAITING_FOR_DEPLOY",
+  "DEQUEUED",
+  "EXECUTING",
+  "WAITING_TO_RESUME",
+  "RETRYING_AFTER_FAILURE",
+  "PAUSED",
+] as const;
+
+/**
+ * Implements the `skipIfActive` trigger option.
+ *
+ * When `body.options.skipIfActive === true` and at least one tag is set, the
+ * concern looks for any in-flight TaskRun with:
+ *
+ *   runtimeEnvironmentId = <env>
+ *   taskIdentifier       = <task>
+ *   status IN (non-terminal)
+ *   runTags           @> <supplied tags>
+ *
+ * If found, the existing run is returned and the trigger is short-circuited.
+ * If not found, the caller proceeds to create a new run as usual.
+ *
+ * Intended use case: cron-style scanners that poll at a fixed cadence but
+ * should drop duplicate triggers while a prior invocation is still running —
+ * without generating queue backlog (`concurrencyKey`) or caching successful
+ * completions (`idempotencyKey`).
+ */
+export class SkipIfActiveConcern {
+  constructor(private readonly prisma: PrismaClientOrTransaction) {}
+
+  async handleTriggerRequest(request: TriggerTaskRequest): Promise<SkipIfActiveConcernResult> {
+    if (request.body.options?.skipIfActive !== true) {
+      return { wasSkipped: false };
+    }
+
+    const rawTags = request.body.options?.tags;
+    const tags = Array.isArray(rawTags) ? rawTags : rawTags ? [rawTags] : [];
+
+    if (tags.length === 0) {
+      // `skipIfActive` requires a tag scope — without tags, every run of this
+      // task would dedup against every other, which is rarely the intent.
+      // Treat as no-op rather than silently matching.
+      logger.debug("[SkipIfActiveConcern] skipIfActive=true with no tags — skipping the check", {
+        taskIdentifier: request.taskId,
+      });
+      return { wasSkipped: false };
+    }
+
+    // `runTags @> ARRAY[...]::text[]` hits the GIN ArrayOps index on
+    // `TaskRun.runTags` and AND-matches every supplied tag. Bounded by
+    // runtimeEnvironmentId + taskIdentifier + status via existing indexes.
+    const statusArray = Prisma.sql`ARRAY[${Prisma.join(
+      ACTIVE_TASK_RUN_STATUSES.map((s) => Prisma.sql`${s}`)
+    )}]::"TaskRunStatus"[]`;
+
+    const existing = await this.prisma.$queryRaw<Array<{ id: string }>>`
+      SELECT id
+      FROM "TaskRun"
+      WHERE "runtimeEnvironmentId" = ${request.environment.id}
+        AND "taskIdentifier" = ${request.taskId}
+        AND status = ANY(${statusArray})
+        AND "runTags" @> ${tags}::text[]
+      LIMIT 1
+    `;
+
+    if (existing.length === 0) {
+      return { wasSkipped: false };
+    }
+
+    const run = await this.prisma.taskRun.findUnique({ where: { id: existing[0].id } });
+    if (!run) {
+      // Row disappeared between the existence probe and the fetch (e.g.
+      // completed + deleted mid-query). Treat as "no active run" so the
+      // caller creates a fresh one instead of failing.
+      return { wasSkipped: false };
+    }
+
+    logger.debug("[SkipIfActiveConcern] active run matched, skipping new trigger", {
+      runId: run.id,
+      taskIdentifier: request.taskId,
+      environmentId: request.environment.id,
+      tags,
+    });
+
+    return { wasSkipped: true, run };
+  }
+}

--- a/apps/webapp/app/runEngine/services/triggerTask.server.ts
+++ b/apps/webapp/app/runEngine/services/triggerTask.server.ts
@@ -31,6 +31,7 @@ import type {
 } from "../../v3/services/triggerTask.server";
 import { clampMaxDuration } from "../../v3/utils/maxDuration";
 import { IdempotencyKeyConcern } from "../concerns/idempotencyKeys.server";
+import { SkipIfActiveConcern } from "../concerns/skipIfActive.server";
 import type {
   PayloadProcessor,
   QueueManager,
@@ -54,6 +55,7 @@ export class RunEngineTriggerTaskService {
   private readonly validator: TriggerTaskValidator;
   private readonly payloadProcessor: PayloadProcessor;
   private readonly idempotencyKeyConcern: IdempotencyKeyConcern;
+  private readonly skipIfActiveConcern: SkipIfActiveConcern;
   private readonly runNumberIncrementer: RunNumberIncrementer;
   private readonly prisma: PrismaClientOrTransaction;
   private readonly engine: RunEngine;
@@ -69,6 +71,7 @@ export class RunEngineTriggerTaskService {
     validator: TriggerTaskValidator;
     payloadProcessor: PayloadProcessor;
     idempotencyKeyConcern: IdempotencyKeyConcern;
+    skipIfActiveConcern?: SkipIfActiveConcern;
     runNumberIncrementer: RunNumberIncrementer;
     traceEventConcern: TraceEventConcern;
     tracer: Tracer;
@@ -81,6 +84,7 @@ export class RunEngineTriggerTaskService {
     this.validator = opts.validator;
     this.payloadProcessor = opts.payloadProcessor;
     this.idempotencyKeyConcern = opts.idempotencyKeyConcern;
+    this.skipIfActiveConcern = opts.skipIfActiveConcern ?? new SkipIfActiveConcern(opts.prisma);
     this.runNumberIncrementer = opts.runNumberIncrementer;
     this.tracer = opts.tracer;
     this.traceEventConcern = opts.traceEventConcern;
@@ -206,6 +210,14 @@ export class RunEngineTriggerTaskService {
       }
 
       const { idempotencyKey, idempotencyKeyExpiresAt } = idempotencyKeyConcernResult;
+
+      // `skipIfActive` — drop-on-conflict. Runs *after* idempotency so a
+      // deliberate idempotency cache-hit wins, but *before* run creation so
+      // we never touch the queue for a skipped trigger.
+      const skipIfActiveResult = await this.skipIfActiveConcern.handleTriggerRequest(triggerRequest);
+      if (skipIfActiveResult.wasSkipped) {
+        return { run: skipIfActiveResult.run, isCached: true, wasSkipped: true };
+      }
 
       if (idempotencyKey) {
         await this.triggerRacepointSystem.waitForRacepoint({

--- a/apps/webapp/app/v3/services/triggerTask.server.ts
+++ b/apps/webapp/app/v3/services/triggerTask.server.ts
@@ -45,6 +45,12 @@ export class OutOfEntitlementError extends Error {
 export type TriggerTaskServiceResult = {
   run: TaskRun;
   isCached: boolean;
+  /**
+   * True when the run returned was matched by the `skipIfActive` option and
+   * no new run was created. Always false/undefined for idempotency-cached
+   * runs — `isCached` distinguishes those.
+   */
+  wasSkipped?: boolean;
 };
 
 export const MAX_ATTEMPTS = 2;

--- a/apps/webapp/test/engine/skipIfActiveConcern.test.ts
+++ b/apps/webapp/test/engine/skipIfActiveConcern.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("~/services/logger.server", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { SkipIfActiveConcern } from "../../app/runEngine/concerns/skipIfActive.server";
+import type { TriggerTaskRequest } from "../../app/runEngine/types";
+
+type MockPrisma = {
+  $queryRaw: ReturnType<typeof vi.fn>;
+  taskRun: { findUnique: ReturnType<typeof vi.fn> };
+};
+
+function buildRequest(overrides: {
+  skipIfActive?: boolean;
+  tags?: string | string[];
+  taskId?: string;
+  environmentId?: string;
+}): TriggerTaskRequest {
+  return {
+    taskId: overrides.taskId ?? "ezderm-notes-fetch",
+    friendlyId: "run_test",
+    environment: {
+      id: overrides.environmentId ?? "env_123",
+      organizationId: "org_1",
+      projectId: "proj_1",
+    } as TriggerTaskRequest["environment"],
+    body: {
+      payload: {},
+      options: {
+        skipIfActive: overrides.skipIfActive,
+        tags: overrides.tags,
+      },
+    },
+    options: {},
+  } as TriggerTaskRequest;
+}
+
+function mockPrisma(initial?: {
+  existing?: Array<{ id: string }>;
+  run?: { id: string } | null;
+}): MockPrisma {
+  return {
+    $queryRaw: vi.fn().mockResolvedValue(initial?.existing ?? []),
+    taskRun: { findUnique: vi.fn().mockResolvedValue(initial?.run ?? null) },
+  };
+}
+
+describe("SkipIfActiveConcern", () => {
+  it("returns wasSkipped=false when the flag is not set", async () => {
+    const prisma = mockPrisma();
+    const concern = new SkipIfActiveConcern(prisma as never);
+
+    const result = await concern.handleTriggerRequest(
+      buildRequest({ skipIfActive: undefined, tags: ["connector:abc"] })
+    );
+
+    expect(result).toEqual({ wasSkipped: false });
+    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("returns wasSkipped=false when skipIfActive=false", async () => {
+    const prisma = mockPrisma();
+    const concern = new SkipIfActiveConcern(prisma as never);
+
+    const result = await concern.handleTriggerRequest(
+      buildRequest({ skipIfActive: false, tags: ["connector:abc"] })
+    );
+
+    expect(result).toEqual({ wasSkipped: false });
+    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("returns wasSkipped=false when no tags are supplied (tag scope required)", async () => {
+    const prisma = mockPrisma();
+    const concern = new SkipIfActiveConcern(prisma as never);
+
+    const result = await concern.handleTriggerRequest(
+      buildRequest({ skipIfActive: true, tags: undefined })
+    );
+
+    expect(result).toEqual({ wasSkipped: false });
+    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("returns wasSkipped=false when no active run matches", async () => {
+    const prisma = mockPrisma({ existing: [] });
+    const concern = new SkipIfActiveConcern(prisma as never);
+
+    const result = await concern.handleTriggerRequest(
+      buildRequest({ skipIfActive: true, tags: ["connector:abc"] })
+    );
+
+    expect(result).toEqual({ wasSkipped: false });
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(prisma.taskRun.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns wasSkipped=true with the existing run when an active run matches all tags", async () => {
+    const existingRun = { id: "run_existing", status: "EXECUTING", runTags: ["connector:abc"] };
+    const prisma = mockPrisma({ existing: [{ id: existingRun.id }], run: existingRun });
+    const concern = new SkipIfActiveConcern(prisma as never);
+
+    const result = await concern.handleTriggerRequest(
+      buildRequest({ skipIfActive: true, tags: ["connector:abc"] })
+    );
+
+    expect(result).toMatchObject({ wasSkipped: true, run: existingRun });
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(prisma.taskRun.findUnique).toHaveBeenCalledWith({ where: { id: "run_existing" } });
+  });
+
+  it("normalizes a single tag string into an array", async () => {
+    const prisma = mockPrisma({
+      existing: [{ id: "run_x" }],
+      run: { id: "run_x", status: "PENDING", runTags: ["connector:abc"] },
+    });
+    const concern = new SkipIfActiveConcern(prisma as never);
+
+    const result = await concern.handleTriggerRequest(
+      // @ts-expect-error Zod allows both string and string[] for tags
+      buildRequest({ skipIfActive: true, tags: "connector:abc" })
+    );
+
+    expect(result.wasSkipped).toBe(true);
+  });
+
+  it("recovers gracefully when the row disappears between the probe and the fetch", async () => {
+    const prisma = mockPrisma({ existing: [{ id: "run_gone" }], run: null });
+    const concern = new SkipIfActiveConcern(prisma as never);
+
+    const result = await concern.handleTriggerRequest(
+      buildRequest({ skipIfActive: true, tags: ["connector:abc"] })
+    );
+
+    expect(result).toEqual({ wasSkipped: false });
+  });
+});

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -70,6 +70,7 @@
               "versioning",
               "machines",
               "idempotency",
+              "skip-if-active",
               "runs/max-duration",
               "tags",
               "runs/metadata",

--- a/docs/skip-if-active.mdx
+++ b/docs/skip-if-active.mdx
@@ -1,0 +1,81 @@
+---
+title: "Skip-if-active"
+description: "Drop a trigger request when a matching run is already in flight — built for cron-style scanners that should dedup without queueing."
+---
+
+## When to use `skipIfActive`
+
+`skipIfActive` is a trigger option that **drops** the request if an in-flight run with the same `taskIdentifier` and tag set already exists in the same environment. No new run is created, no queue entry is added, and the caller gets back the existing run with `wasSkipped: true`.
+
+Typical use case: a **cron-style orchestrator** that polls every minute and should start a sync if one isn't already running — but should **not** build up a backlog when the previous sync is still working.
+
+### `idempotencyKey` vs `concurrencyKey` vs `skipIfActive`
+
+| Option           | Behavior when a matching run exists            | Use when                                                 |
+|------------------|-------------------------------------------------|----------------------------------------------------------|
+| `idempotencyKey` | Returns the existing run (including completed!) | Webhook retries, "run this exactly once ever"            |
+| `concurrencyKey` | Queues the new run FIFO behind the existing one | Every request is real work that must eventually execute  |
+| `skipIfActive`   | Drops the new trigger, returns the in-flight run | Cron polling; duplicate triggers are redundant work     |
+
+`skipIfActive` differs from `idempotencyKey` because it **does not** cache completed runs — once the run reaches a terminal state the dedup window ends automatically. It differs from `concurrencyKey` because it does not queue — excess triggers are discarded, not delayed.
+
+## Example
+
+```ts
+import { tasks } from "@trigger.dev/sdk/v3";
+
+// Orchestrator fires every minute for each connector.
+for (const connector of connectors) {
+  await tasks.trigger(
+    "ezderm-notes-fetch",
+    { connectorId: connector.id },
+    {
+      tags: [`connector:${connector.id}`],
+      skipIfActive: true,
+    }
+  );
+}
+```
+
+If `ezderm-notes-fetch` is already running (PENDING / DEQUEUED / EXECUTING / WAITING_TO_RESUME / …) with `connector:<id>` in its `runTags`, the second call is a no-op.
+
+## Required: at least one tag
+
+`skipIfActive` is a no-op without a `tags` scope. Without tags every run of the task would dedup against every other, which is rarely what you want. Supply one or more tags:
+
+```ts
+await tasks.trigger("sync-patient", payload, {
+  tags: [`patient:${patientId}`],
+  skipIfActive: true,
+});
+```
+
+All supplied tags must be present on the existing run (AND semantics, powered by PostgreSQL's `array @> array` operator + the `runTags` GIN index).
+
+## Response shape
+
+```ts
+// Fresh trigger — no conflict
+{ id: "run_abc", isCached: false }
+
+// Dropped because an in-flight match was found
+{ id: "run_existing", isCached: true, wasSkipped: true }
+```
+
+`isCached: true` is reused for parity with `idempotencyKey`-matched responses. The additional `wasSkipped: true` flag distinguishes drop-on-active from idempotency reuse when the caller needs to tell them apart.
+
+## Interaction with other options
+
+| Combined with            | Behavior                                                                                 |
+|--------------------------|------------------------------------------------------------------------------------------|
+| `idempotencyKey`         | Idempotency check runs first. A match wins and skipIfActive never fires.                  |
+| `concurrencyKey`         | skipIfActive runs before queue admission. A match drops — queue is not touched.           |
+| `delay`                  | A skipped trigger never creates a delayed run. The existing in-flight run is returned.    |
+| `ttl`                    | Irrelevant for skipped triggers — no new run is created.                                  |
+| `batchTrigger`           | Applied per item. Some items may be skipped while others enqueue normally.                |
+
+## When *not* to use it
+
+- Webhooks where the duplicate represents real, distinct work that must be processed. Use `idempotencyKey` to dedup by event id, or `concurrencyKey` to serialize.
+- Workflows where losing a trigger is a data-loss bug. skipIfActive is drop-on-conflict — silently discarded triggers are the intended outcome.
+- Anywhere you want visibility of queued work on the dashboard; skipped triggers leave no trace beyond the returned `wasSkipped: true` response.

--- a/packages/core/src/v3/schemas/api.ts
+++ b/packages/core/src/v3/schemas/api.ts
@@ -191,6 +191,19 @@ export const TriggerTaskRequestBody = z.object({
       delay: z.string().or(z.coerce.date()).optional(),
       idempotencyKey: z.string().optional(),
       idempotencyKeyTTL: z.string().optional(),
+      /**
+       * When true, the request is a no-op if an in-flight (non-terminal) run
+       * for the same `taskIdentifier` already exists in the same runtime
+       * environment AND contains all of the supplied `tags`. The existing run
+       * is returned with `wasSkipped: true` and no new run is created.
+       *
+       * Designed for cron-style scanners that poll repeatedly but should drop
+       * duplicate work when a previous invocation is still running — unlike
+       * `idempotencyKey` (which also caches successful completions) and
+       * unlike `concurrencyKey` (which queues duplicates). Requires at least
+       * one tag to scope the check.
+       */
+      skipIfActive: z.boolean().optional(),
       machine: MachinePresetName.optional(),
       maxAttempts: z.number().int().optional(),
       maxDuration: z.number().optional(),
@@ -212,6 +225,11 @@ export type TriggerTaskRequestBody = z.infer<typeof TriggerTaskRequestBody>;
 export const TriggerTaskResponse = z.object({
   id: z.string(),
   isCached: z.boolean().optional(),
+  /**
+   * When true, the request matched an existing in-flight run via
+   * `skipIfActive` and no new run was created.
+   */
+  wasSkipped: z.boolean().optional(),
 });
 
 export type TriggerTaskResponse = z.infer<typeof TriggerTaskResponse>;
@@ -233,6 +251,8 @@ export const BatchTriggerTaskItem = z.object({
       delay: z.string().or(z.coerce.date()).optional(),
       idempotencyKey: z.string().optional(),
       idempotencyKeyTTL: z.string().optional(),
+      /** See `TriggerTaskRequestBody.options.skipIfActive`. */
+      skipIfActive: z.boolean().optional(),
       lockToVersion: z.string().optional(),
       machine: MachinePresetName.optional(),
       maxAttempts: z.number().int().optional(),


### PR DESCRIPTION
Refs #3428
Closes (none — filed alongside this PR; happy to open a tracking issue if you'd prefer)

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works
- [x] Changeset added (`.changeset/skip-if-active.md` — `@trigger.dev/core` minor)
- [x] "Allow edits from maintainers" enabled on the fork

---

## Testing

Unit tests added at `apps/webapp/test/engine/skipIfActiveConcern.test.ts` (no DB, mocks Prisma). Covers:

1. Flag unset → no-op, no query executed.
2. Flag `false` → no-op, no query executed.
3. Flag `true` but no tags → no-op (documented: tag scope required).
4. Flag `true` + tags + no match → proceed to normal run creation.
5. Flag `true` + tags + match → return existing run, `wasSkipped: true`, no new run.
6. Single-string tag (`tags: "foo"`) normalizes to array correctly.
7. Row-disappeared-mid-query race (probe returns id, subsequent fetch returns null) → falls back to creating instead of failing.

Local end-to-end verification against prod-like Postgres (maxcare's self-hosted Trigger.dev v4 instance running this patch):

- `skipIfActive=true` with matching in-flight run → response `{ id, isCached: true, wasSkipped: true }`, no new row in `"TaskRun"`.
- `skipIfActive=true` with no match → new run created normally.
- `skipIfActive=true` combined with `idempotencyKey` → idempotency match wins, the skip-check never fires.
- `skipIfActive=true` with `tags: []` → no-op (proceeds to create).
- Query plan: `Bitmap Heap Scan` on `TaskRun_runTags_idx` + `TaskRun_status_runtimeEnvironmentId_createdAt_id_idx`, Execution Time <100ms against a 12M-row production `TaskRun` table.

No DB schema change — uses existing indexes.

---

## Changelog

**New:** `skipIfActive: boolean` option on `tasks.trigger()` and batch items.

When set, and at least one `tag` is supplied, the server short-circuits the trigger if an in-flight (non-terminal) TaskRun with the same `taskIdentifier` + environment + all of the supplied tags already exists. Returns the existing run with `isCached: true` + new `wasSkipped: true` flag. No new run is created. No queue entry. No trace span for the would-be new run.

**Why a new option?** Existing options each miss the "cron scanner drops duplicates" case:

| Option | Behavior on match | Cron-scanner fit |
|---|---|---|
| `idempotencyKey` | Returns existing run, **including completed** runs, until TTL expires | Blocks scheduled re-runs after success |
| `concurrencyKey` | Queues FIFO behind the existing run | Backlog grows unboundedly when a sync hangs |
| `runs.list()` in user code | ✅ correct semantics | Expensive: `task_runs_v2 FINAL + hasAny(tags)` in ClickHouse. On our self-hosted v4 instance we observed 59+ concurrent pile-up pegging CH at 100% CPU. See issue #3426 for background. |

`skipIfActive` gives a first-class drop-on-conflict primitive that lets the server do the dedup with one indexed Postgres lookup.

## Implementation

Mirrors the existing `IdempotencyKeyConcern` pattern end-to-end.

- **Schema** (`packages/core/src/v3/schemas/api.ts`): adds the optional field to `TriggerTaskRequestBody.options` and `BatchTriggerTaskItem.options`. Adds optional `wasSkipped: boolean` to `TriggerTaskResponse`.
- **New concern** (`apps/webapp/app/runEngine/concerns/skipIfActive.server.ts`): one indexed SELECT on `"TaskRun"` scoped to non-terminal statuses. `runTags @> ARRAY[...]::text[]` for AND-match on tags. Returns `{ wasSkipped: true, run }` on match.
- **Wire-in** (`apps/webapp/app/runEngine/services/triggerTask.server.ts`): invoked from `RunEngineTriggerTaskService.call()` **after** idempotency (so explicit idempotency cache-hits win) and **before** run creation (so skipped triggers never touch the queue).
- **Route** (`apps/webapp/app/routes/api.v1.tasks.$taskId.trigger.ts`): surfaces `wasSkipped` in the JSON response.
- **`TriggerTaskServiceResult`** gains optional `wasSkipped?: boolean`.

### Scope

- Engine v2 only. `TriggerTaskServiceV1` is intentionally untouched — v1 is frozen.
- Batch: per-item. Each `BatchTriggerTaskItem` can carry its own `skipIfActive`; the same concern fires per item.
- No migration. Uses existing `TaskRun_runTags_idx` + composite status/env index.
- Requires ≥1 tag — `skipIfActive: true` with no tags is a documented no-op (prevents surprising global dedup).
- Interaction with `idempotencyKey` / `concurrencyKey` / `delay` / `ttl` / `batchTrigger` documented in `docs/skip-if-active.mdx`.

### Out of scope (follow-ups)

- V1 parity (v1 freeze).
- Metrics counter for skipped triggers.
- SDK convenience wrapper (the raw option works today; SDK devs may want a typed helper).

## Docs

- New page: `docs/skip-if-active.mdx` — compares with `idempotencyKey` and `concurrencyKey`, walks through the cron-scanner example, lists interaction matrix.
- Registered in `docs/docs.json` under the existing idempotency entry.

## Screenshots

N/A — server-side feature, no UI.

---

💯