### PR TITLE
ci: automate helm chart release alongside package release

### DIFF
--- a/.github/workflows/changesets-pr.yml
+++ b/.github/workflows/changesets-pr.yml
@@ -121,3 +121,35 @@ jobs:
           else
             echo "No changes to commit"
           fi
+
+  bump-chart-version:
+    name: Bump Helm chart version on release PR
+    runs-on: ubuntu-latest
+    needs: update-lockfile
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref: changeset-release/main
+
+      - name: Bump Chart.yaml
+        run: |
+          set -e
+          VERSION=$(jq -r '.version' packages/cli-v3/package.json)
+          sed -i "s/^version:.*/version: ${VERSION}/" ./hosting/k8s/helm/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: v${VERSION}/" ./hosting/k8s/helm/Chart.yaml
+
+      - name: Commit and push Chart.yaml bump
+        run: |
+          set -e
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add hosting/k8s/helm/Chart.yaml
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: bump helm chart version for release"
+            git push origin changeset-release/main
+          else
+            echo "Chart.yaml already at target version, no-op"
+          fi

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'helm-v*'
+  workflow_call:
+    inputs:
+      chart_version:
+        description: 'Chart version to release'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       chart_version:
@@ -86,8 +92,8 @@ jobs:
       - name: Extract version from tag or input
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.chart_version }}"
+          if [ -n "${{ inputs.chart_version }}" ]; then
+            VERSION="${{ inputs.chart_version }}"
           else
             VERSION="${{ github.ref_name }}"
             VERSION="${VERSION#helm-v}"
@@ -122,9 +128,8 @@ jobs:
       - name: Create GitHub Release
         id: release
         uses: softprops/action-gh-release@v1
-        if: github.event_name == 'push'
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: helm-v${{ steps.version.outputs.version }}
           name: "Helm Chart ${{ steps.version.outputs.version }}"
           body: |
             ### Installation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,13 @@ jobs:
           git tag "v.docker.${{ steps.get_version.outputs.package_version }}"
           git push origin "v.docker.${{ steps.get_version.outputs.package_version }}"
 
+      - name: Create and push Helm chart tag
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          set -e
+          git tag "helm-v${{ steps.get_version.outputs.package_version }}"
+          git push origin "helm-v${{ steps.get_version.outputs.package_version }}"
+
   # Trigger Docker builds directly via workflow_call since tags pushed with
   # GITHUB_TOKEN don't trigger other workflows (GitHub Actions limitation).
   publish-docker:
@@ -152,6 +159,18 @@ jobs:
     secrets: inherit
     with:
       image_tag: v${{ needs.release.outputs.published_package_version }}
+
+  # Trigger Helm chart release directly via workflow_call (same GITHUB_TOKEN
+  # limitation as the Docker path). Runs after Docker images are published so
+  # the chart never references images that don't exist yet.
+  publish-helm:
+    name: 🧭 Publish Helm chart
+    needs: [release, publish-docker]
+    if: needs.release.outputs.published == 'true'
+    uses: ./.github/workflows/release-helm.yml
+    secrets: inherit
+    with:
+      chart_version: ${{ needs.release.outputs.published_package_version }}
 
   # After Docker images are published, update the GitHub release with the exact GHCR tag URL.
   # The GHCR package version ID is only known after the image is pushed, so we query for it here.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,9 @@ jobs:
     name: 🧭 Publish Helm chart
     needs: [release, publish-docker]
     if: needs.release.outputs.published == 'true'
+    permissions:
+      contents: write
+      packages: write
     uses: ./.github/workflows/release-helm.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Wires up automatic Helm chart releases to ride along with the existing changeset-driven package release flow.

Today `Chart.yaml` is bumped by hand and `release-helm.yml` fires only when a human pushes a `helm-v*` tag. With this, the changeset release PR also carries a `Chart.yaml` bump so main always matches the published version, and `release.yml` invokes `release-helm.yml` via `workflow_call` after Docker images are published.

`helm-v${VERSION}` tag is pushed as a marker (same GITHUB_TOKEN trick as `v.docker.*`). Manual `helm-v*` tag flow still works. Chart.yaml consistency check in `release-helm.yml` is the safety net if the bump job ever drifts.

First rollout: the open `changeset-release/main` PR has stale Chart.yaml. Bump it manually on that branch before merging, otherwise the first automated helm release fails at the consistency check.