### PR TITLE
ci: skip privileged PR jobs on fork PRs

### DIFF
--- a/.github/workflows/claude-md-audit.yml
+++ b/.github/workflows/claude-md-audit.yml
@@ -16,7 +16,9 @@ concurrency:
 
 jobs:
   audit:
-    if: github.event.pull_request.draft == false
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/helm-pr-prerelease.yml
+++ b/.github/workflows/helm-pr-prerelease.yml
@@ -54,6 +54,7 @@ jobs:
 
   prerelease:
     needs: lint-and-test
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Fork PRs can't access org secrets or push to GHCR, so these two `pull_request` jobs hard-fail with no path to passing:

- `claude-md-audit` - needs `CLAUDE_CODE_OAUTH_TOKEN`
- `helm-pr-prerelease` `prerelease` job - needs `packages: write` to push the chart

Hit this on #3449. Approving the run didn't help; the jobs ran and failed at the privileged step. The chart-validation `lint-and-test` job is fork-safe and stays untouched - that remains the merge gate for Helm changes.

Gate both jobs on same-repo head:

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

Other PR workflows already handle forks fine: `pr_checks` (typecheck/units/e2e/sdk-compat) falls back to anonymous DockerHub pulls when secrets are missing.