### PR TITLE
fix(webapp): preserve filters on queues page action redirects

### DIFF
--- a/.server-changes/queues-preserve-filters-on-action.md
+++ b/.server-changes/queues-preserve-filters-on-action.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Preserve filters on the queues page when submitting modal actions.

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -176,9 +176,7 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
   const action = formData.get("action");
 
   const url = new URL(request.url);
-  const { page } = SearchParamsSchema.parse(Object.fromEntries(url.searchParams));
-
-  const redirectPath = `/orgs/${organizationSlug}/projects/${projectParam}/env/${envParam}/queues?page=${page}`;
+  const redirectPath = `/orgs/${organizationSlug}/projects/${projectParam}/env/${envParam}/queues${url.search}`;
 
   if (environment.archivedAt) {
     return redirectWithErrorMessage(redirectPath, request, "This branch is archived");


### PR DESCRIPTION
Queues page action handler was rebuilding the redirect URL with only `?page=`, so any pause/resume/override modal confirmation wiped the user's search query. With hundreds of queues filtered down to a handful, every confirmation dropped you back to the unfiltered list - and pagination still pointed at the previous numeric page, so you'd land on a different slice than you came from.

Swap the manual rebuild for `url.search` so the full querystring (including any future filter params) flows through. Drops the now-unused `SearchParamsSchema.parse` call inside `action`; the loader still validates on the way back.