### PR TITLE
docs: add compute private beta page

### DIFF
--- a/docs/compute-private-beta.mdx
+++ b/docs/compute-private-beta.mdx
@@ -1,0 +1,62 @@
+---
+title: "Compute private beta"
+description: "Early access to the new microVM-based compute runtime."
+sidebarTitle: "Compute private beta"
+hidden: true
+---
+
+<Warning>
+  MicroVM compute is in private beta. Use it in staging only - do not run production traffic on it
+  yet, and expect bugs.
+</Warning>
+
+## What it is
+
+MicroVM compute is a new runtime for your tasks, designed for fast cold starts via boot snapshots. For most tasks the migration is transparent - the same task code runs unchanged.
+
+## Getting access
+
+You can't opt in yourself. Once we've enabled the private beta for your org, the `us-east-1-next` region becomes available on the **Regions** page in the dashboard. If you'd like access, ping us on Slack.
+
+## Routing runs to microVM compute
+
+MicroVM compute is exposed as a region: `us-east-1-next`. The region is tagged with a **microVM** badge on the **Regions** page.
+
+### Per-trigger override (recommended)
+
+The `region` option is part of `TriggerOptions`, accepted by most triggering functions.
+
+```typescript
+import { yourTask } from "./trigger/your-task";
+
+await yourTask.trigger(payload, { region: "us-east-1-next" });
+```
+
+This is the safest way to opt in during the beta - you control exactly which runs land on microVM compute.
+
+To gate it on an environment variable so prod isn't affected, define one constant and reuse it at every call site:
+
+```typescript
+const defaultRegion = process.env.USE_COMPUTE_BETA === "1" ? "us-east-1-next" : undefined;
+
+await yourTask.trigger(payload, { region: defaultRegion });
+```
+
+Set `USE_COMPUTE_BETA=1` in the staging environment of the app that calls `trigger()` (typically Vercel, or wherever you deploy your app).
+
+### Set it as your project default
+
+Open the **Regions** page in the dashboard and set `us-east-1-next` as the project-wide default. This applies to **all environments in the project**, so only do this on a project that is running staging traffic only.
+
+## Cold start expectations
+
+A few things to be aware of during the beta:
+
+- **`small-1x` is the default and what we've optimized for.** Boot snapshots are precreated for `small-1x` only. Other machine sizes will have a slower first run after each deploy while we generate the snapshot - subsequent runs use it.
+- **Avoid `micro` during the beta.** Cold starts on `micro` are noticeably slower than other sizes.
+
+We'll be shipping CLI and SDK changes during the beta to make cold start times more consistent across machine sizes. Compute-specific prereleases will be announced on this page as we go, and we'll also reach out on Slack.
+
+## Reporting issues
+
+Send anything weird (errors, slow runs, restore failures, anything that surprises you) over Slack with the run ID. The more reproductions we get during the beta, the faster we harden it for public beta.


### PR DESCRIPTION
Compute page for private beta onboarding (not added to nav).