### PR TITLE
feat(webapp): errors page polish and GA rollout

### DIFF
--- a/.server-changes/errors-page-polish-and-ga.md
+++ b/.server-changes/errors-page-polish-and-ga.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: feature
+---
+
+Ship the Errors page to all users, with a polish + bug-fix pass: pinned "No channel" item in the Slack alert channel picker, viewer-timezone alert timestamps via Slack's `<!date^>` token, Activity sparkline peak tooltip, centered loading spinner and bug-icon empty state on the error detail page, ellipsis on the Configure alerts trigger.

--- a/apps/webapp/app/components/errors/ConfigureErrorAlerts.tsx
+++ b/apps/webapp/app/components/errors/ConfigureErrorAlerts.tsx
@@ -9,7 +9,8 @@ import {
 } from "@heroicons/react/20/solid";
 import { useFetcher, useNavigate } from "@remix-run/react";
 import { SlackIcon } from "@trigger.dev/companyicons";
-import { Fragment, useEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import stableStringify from "json-stable-stringify";
 import { z } from "zod";
 import { Button, LinkButton } from "~/components/primitives/Buttons";
 import { Callout, variantClasses } from "~/components/primitives/Callout";
@@ -104,6 +105,35 @@ export function ConfigureErrorAlerts({
     existingWebhooks.length > 0 ? [...existingWebhooks.map((w) => w.url), ""] : [""]
   );
 
+  const [formChangeTick, setFormChangeTick] = useState(0);
+  const bumpFormChange = () => setFormChangeTick((n) => n + 1);
+
+  const isDirty = useMemo(() => {
+    const initialSlackValue = existingSlackChannel
+      ? `${existingSlackChannel.channelId}/${existingSlackChannel.channelName}`
+      : "";
+    if ((selectedSlackChannelValue ?? "") !== initialSlackValue) return true;
+    const currentEmails = emailFieldValues.current.filter((v) => v !== "");
+    if (
+      stableStringify(currentEmails) !==
+      stableStringify(existingEmails.map((e) => e.email))
+    )
+      return true;
+    const currentWebhooks = webhookFieldValues.current.filter((v) => v !== "");
+    if (
+      stableStringify(currentWebhooks) !==
+      stableStringify(existingWebhooks.map((w) => w.url))
+    )
+      return true;
+    return false;
+  }, [
+    selectedSlackChannelValue,
+    existingSlackChannel,
+    existingEmails,
+    existingWebhooks,
+    formChangeTick,
+  ]);
+
   const [form, { emails, webhooks, slackChannel, slackIntegrationId }] = useForm({
     id: "configure-error-alerts",
     onValidate({ formData }) {
@@ -165,6 +195,7 @@ export function ConfigureErrorAlerts({
                         icon={EnvelopeIcon}
                         onChange={(e) => {
                           emailFieldValues.current[index] = e.target.value;
+                          bumpFormChange();
                           if (
                             emailFields.length === emailFieldValues.current.length &&
                             emailFieldValues.current.every((v) => v !== "")
@@ -218,6 +249,15 @@ export function ConfigureErrorAlerts({
                     >
                       {(matches) => (
                         <>
+                          <SelectItem
+                            value=""
+                            className="border-b border-grid-bright text-text-dimmed"
+                          >
+                            <div className="flex items-center gap-1.5">
+                              <XMarkIcon className="size-4" />
+                              <span>No channel</span>
+                            </div>
+                          </SelectItem>
                           {matches?.map((channel) => (
                             <SelectItem
                               key={channel.id}
@@ -243,15 +283,6 @@ export function ConfigureErrorAlerts({
                       </Callout>
                     )}
                     <Hint>
-                      {selectedSlackChannelValue ? (
-                        <button
-                          type="button"
-                          onClick={() => setSelectedSlackChannelValue("")}
-                          className="mr-3 text-indigo-500 transition hover:text-indigo-400 focus-visible:focus-custom"
-                        >
-                          Remove channel
-                        </button>
-                      ) : null}
                       <TextLink to={organizationSlackIntegrationPath(organization)}>
                         Manage Slack connection
                       </TextLink>
@@ -327,6 +358,7 @@ export function ConfigureErrorAlerts({
                       icon={GlobeAltIcon}
                       onChange={(e) => {
                         webhookFieldValues.current[index] = e.target.value;
+                        bumpFormChange();
                         if (
                           webhookFields.length === webhookFieldValues.current.length &&
                           webhookFieldValues.current.every((v) => v !== "")
@@ -353,7 +385,7 @@ export function ConfigureErrorAlerts({
           <Button
             variant="primary/medium"
             type="submit"
-            disabled={isSubmitting}
+            disabled={!isDirty || isSubmitting}
             isLoading={isSubmitting}
           >
             {isSubmitting ? "Saving…" : "Save"}

--- a/apps/webapp/app/components/errors/ConfigureErrorAlerts.tsx
+++ b/apps/webapp/app/components/errors/ConfigureErrorAlerts.tsx
@@ -196,7 +196,7 @@ export function ConfigureErrorAlerts({
                       name={slackChannel.name}
                       placeholder={<span className="text-text-dimmed">Select a Slack channel</span>}
                       heading="Filter channels…"
-                      defaultValue={selectedSlackChannelValue}
+                      value={selectedSlackChannelValue ?? ""}
                       dropdownIcon
                       variant="tertiary/medium"
                       items={slack.channels}
@@ -243,6 +243,15 @@ export function ConfigureErrorAlerts({
                       </Callout>
                     )}
                     <Hint>
+                      {selectedSlackChannelValue ? (
+                        <button
+                          type="button"
+                          onClick={() => setSelectedSlackChannelValue("")}
+                          className="mr-3 text-indigo-500 transition hover:text-indigo-400 focus-visible:focus-custom"
+                        >
+                          Remove channel
+                        </button>
+                      ) : null}
                       <TextLink to={organizationSlackIntegrationPath(organization)}>
                         Manage Slack connection
                       </TextLink>

--- a/apps/webapp/app/components/errors/ConfigureErrorAlerts.tsx
+++ b/apps/webapp/app/components/errors/ConfigureErrorAlerts.tsx
@@ -9,8 +9,7 @@ import {
 } from "@heroicons/react/20/solid";
 import { useFetcher, useNavigate } from "@remix-run/react";
 import { SlackIcon } from "@trigger.dev/companyicons";
-import { Fragment, useEffect, useMemo, useRef, useState } from "react";
-import stableStringify from "json-stable-stringify";
+import { Fragment, useEffect, useRef, useState } from "react";
 import { z } from "zod";
 import { Button, LinkButton } from "~/components/primitives/Buttons";
 import { Callout, variantClasses } from "~/components/primitives/Callout";
@@ -105,35 +104,6 @@ export function ConfigureErrorAlerts({
     existingWebhooks.length > 0 ? [...existingWebhooks.map((w) => w.url), ""] : [""]
   );
 
-  const [formChangeTick, setFormChangeTick] = useState(0);
-  const bumpFormChange = () => setFormChangeTick((n) => n + 1);
-
-  const isDirty = useMemo(() => {
-    const initialSlackValue = existingSlackChannel
-      ? `${existingSlackChannel.channelId}/${existingSlackChannel.channelName}`
-      : "";
-    if ((selectedSlackChannelValue ?? "") !== initialSlackValue) return true;
-    const currentEmails = emailFieldValues.current.filter((v) => v !== "");
-    if (
-      stableStringify(currentEmails) !==
-      stableStringify(existingEmails.map((e) => e.email))
-    )
-      return true;
-    const currentWebhooks = webhookFieldValues.current.filter((v) => v !== "");
-    if (
-      stableStringify(currentWebhooks) !==
-      stableStringify(existingWebhooks.map((w) => w.url))
-    )
-      return true;
-    return false;
-  }, [
-    selectedSlackChannelValue,
-    existingSlackChannel,
-    existingEmails,
-    existingWebhooks,
-    formChangeTick,
-  ]);
-
   const [form, { emails, webhooks, slackChannel, slackIntegrationId }] = useForm({
     id: "configure-error-alerts",
     onValidate({ formData }) {
@@ -195,7 +165,6 @@ export function ConfigureErrorAlerts({
                         icon={EnvelopeIcon}
                         onChange={(e) => {
                           emailFieldValues.current[index] = e.target.value;
-                          bumpFormChange();
                           if (
                             emailFields.length === emailFieldValues.current.length &&
                             emailFieldValues.current.every((v) => v !== "")
@@ -358,7 +327,6 @@ export function ConfigureErrorAlerts({
                       icon={GlobeAltIcon}
                       onChange={(e) => {
                         webhookFieldValues.current[index] = e.target.value;
-                        bumpFormChange();
                         if (
                           webhookFields.length === webhookFieldValues.current.length &&
                           webhookFieldValues.current.every((v) => v !== "")
@@ -385,7 +353,7 @@ export function ConfigureErrorAlerts({
           <Button
             variant="primary/medium"
             type="submit"
-            disabled={!isDirty || isSubmitting}
+            disabled={isSubmitting}
             isLoading={isSubmitting}
           >
             {isSubmitting ? "Saving…" : "Save"}

--- a/apps/webapp/app/components/navigation/SideMenu.tsx
+++ b/apps/webapp/app/components/navigation/SideMenu.tsx
@@ -524,17 +524,15 @@ export function SideMenu({
                     isCollapsed={isCollapsed}
                   />
                 )}
-                {(user.admin || user.isImpersonating) && (
-                  <SideMenuItem
-                    name="Errors"
-                    icon={IconBugFilled}
-                    activeIconColor="text-errors"
-                    inactiveIconColor="text-errors"
-                    to={v3ErrorsPath(organization, project, environment)}
-                    data-action="errors"
-                    isCollapsed={isCollapsed}
-                  />
-                )}
+                <SideMenuItem
+                  name="Errors"
+                  icon={IconBugFilled}
+                  activeIconColor="text-errors"
+                  inactiveIconColor="text-errors"
+                  to={v3ErrorsPath(organization, project, environment)}
+                  data-action="errors"
+                  isCollapsed={isCollapsed}
+                />
                 <SideMenuItem
                   name="Query"
                   icon={TableCellsIcon}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.errors.$fingerprint/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.errors.$fingerprint/route.tsx
@@ -1,7 +1,11 @@
 import { type LoaderFunctionArgs, type ActionFunctionArgs, json } from "@remix-run/server-runtime";
 import { type MetaFunction, useFetcher, useRevalidator } from "@remix-run/react";
 import { BellAlertIcon } from "@heroicons/react/20/solid";
-import { IconAlarmSnooze as IconAlarmSnoozeBase, IconCircleDotted } from "@tabler/icons-react";
+import {
+  IconAlarmSnooze as IconAlarmSnoozeBase,
+  IconBugFilled,
+  IconCircleDotted,
+} from "@tabler/icons-react";
 import { parse } from "@conform-to/zod";
 import { z } from "zod";
 import { ErrorStatusBadge } from "~/components/errors/ErrorStatusBadge";
@@ -506,9 +510,12 @@ function ErrorGroupDetail({
                 additionalTableState={{ errorId: ErrorId.toFriendlyId(fingerprint) }}
               />
             ) : (
-              <Paragraph variant="small" className="p-4 text-text-dimmed">
-                No runs found for this error.
-              </Paragraph>
+              <div className="flex flex-1 flex-col items-center justify-center gap-3">
+                <IconBugFilled className="size-16 text-charcoal-650" />
+                <Paragraph className="max-w-32 text-center text-text-dimmed">
+                  No runs found for this error.
+                </Paragraph>
+              </div>
             )}
           </div>
         </div>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.errors.$fingerprint/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.errors.$fingerprint/route.tsx
@@ -331,7 +331,7 @@ export default function Page() {
             LeadingIcon={BellAlertIcon}
             leadingIconClassName="text-alerts"
           >
-            Configure alerts
+            Configure alerts…
           </LinkButton>
         </PageAccessories>
       </NavBar>
@@ -339,8 +339,8 @@ export default function Page() {
       <PageBody scrollable={false}>
         <Suspense
           fallback={
-            <div className="my-2 flex items-center justify-center">
-              <div className="mx-auto flex items-center gap-2">
+            <div className="flex h-full items-center justify-center">
+              <div className="flex items-center gap-2">
                 <Spinner />
                 <Paragraph variant="small">Loading error details…</Paragraph>
               </div>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.errors.$fingerprint/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.errors.$fingerprint/route.tsx
@@ -27,7 +27,7 @@ import {
 import { type NextRunList } from "~/presenters/v3/NextRunListPresenter.server";
 import { $replica } from "~/db.server";
 import { logsClickhouseClient, clickhouseClient } from "~/services/clickhouseInstance.server";
-import { NavBar, PageTitle } from "~/components/primitives/PageHeader";
+import { NavBar, PageAccessories, PageTitle } from "~/components/primitives/PageHeader";
 import { PageBody } from "~/components/layout/AppLayout";
 import {
   ResizableHandle,
@@ -324,6 +324,16 @@ export default function Page() {
           }}
           title={<span className="font-mono text-xs">{ErrorId.toFriendlyId(fingerprint)}</span>}
         />
+        <PageAccessories>
+          <LinkButton
+            to={alertsHref}
+            variant="secondary/small"
+            LeadingIcon={BellAlertIcon}
+            leadingIconClassName="text-alerts"
+          >
+            Configure alerts
+          </LinkButton>
+        </PageAccessories>
       </NavBar>
 
       <PageBody scrollable={false}>
@@ -366,7 +376,6 @@ export default function Page() {
                   projectParam={projectParam}
                   envParam={envParam}
                   fingerprint={fingerprint}
-                  alertsHref={alertsHref}
                 />
               );
             }}
@@ -385,7 +394,6 @@ function ErrorGroupDetail({
   projectParam,
   envParam,
   fingerprint,
-  alertsHref,
 }: {
   errorGroup: ErrorGroupSummary | undefined;
   runList: NextRunList | undefined;
@@ -394,7 +402,6 @@ function ErrorGroupDetail({
   projectParam: string;
   envParam: string;
   fingerprint: string;
-  alertsHref: string;
 }) {
   const { value, values } = useSearchParams();
   const organization = useOrganization();
@@ -510,11 +517,7 @@ function ErrorGroupDetail({
       {/* Right-hand detail sidebar */}
       <ResizableHandle id="error-detail-handle" />
       <ResizablePanel id="error-detail" min="280px" default="380px" max="500px" isStaticAtRest>
-        <ErrorDetailSidebar
-          errorGroup={errorGroup}
-          fingerprint={fingerprint}
-          alertsHref={alertsHref}
-        />
+        <ErrorDetailSidebar errorGroup={errorGroup} fingerprint={fingerprint} />
       </ResizablePanel>
     </ResizablePanelGroup>
   );
@@ -523,24 +526,14 @@ function ErrorGroupDetail({
 function ErrorDetailSidebar({
   errorGroup,
   fingerprint,
-  alertsHref,
 }: {
   errorGroup: ErrorGroupSummary;
   fingerprint: string;
-  alertsHref: string;
 }) {
   return (
     <div className="grid h-full grid-rows-[auto_1fr] overflow-hidden bg-background-bright">
-      <div className="flex items-center justify-between border-b border-grid-dimmed py-2 pl-3 pr-2">
+      <div className="border-b border-grid-dimmed px-3 py-2">
         <Header2 className="truncate">Details</Header2>
-        <LinkButton
-          to={alertsHref}
-          variant="secondary/small"
-          LeadingIcon={BellAlertIcon}
-          leadingIconClassName="text-alerts"
-        >
-          Configure alerts
-        </LinkButton>
       </div>
       <div className="overflow-y-auto px-3 py-3 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600">
         <div className="flex flex-col gap-4">

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.errors._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.errors._index/route.tsx
@@ -55,6 +55,7 @@ import {
   statusActionToastMessage,
 } from "~/components/errors/ErrorStatusMenu";
 import { useToast } from "~/components/primitives/Toast";
+import { SimpleTooltip } from "~/components/primitives/Tooltip";
 import TooltipPortal from "~/components/primitives/TooltipPortal";
 import { appliedSummary, FilterMenuProvider, TimeFilter } from "~/components/runs/v3/SharedFilters";
 import { $replica } from "~/db.server";
@@ -706,9 +707,14 @@ function ErrorActivityGraph({ activity }: { activity: ErrorOccurrenceActivity })
           </BarChart>
         </ResponsiveContainer>
       </div>
-      <span className="-mt-1 text-xxs tabular-nums text-text-dimmed">
-        {formatNumberCompact(maxCount)}
-      </span>
+      <SimpleTooltip
+        button={
+          <span className="-mt-1 text-xxs tabular-nums text-text-dimmed">
+            {formatNumberCompact(maxCount)}
+          </span>
+        }
+        content="Peak occurrences in a single time bucket"
+      />
     </div>
   );
 }

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.errors._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.errors._index/route.tsx
@@ -464,7 +464,7 @@ function FiltersBar({
           LeadingIcon={BellAlertIcon}
           leadingIconClassName="text-alerts"
         >
-          Configure alerts
+          Configure alerts…
         </LinkButton>
         {list && <ListPagination list={list} />}
       </div>

--- a/apps/webapp/app/v3/services/alerts/deliverAlert.server.ts
+++ b/apps/webapp/app/v3/services/alerts/deliverAlert.server.ts
@@ -1182,15 +1182,19 @@ export class DeliverAlertService extends BaseService {
   }
 
   #formatTimestamp(date: Date): string {
-    return new Intl.DateTimeFormat("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: true,
-    }).format(date);
+    const unix = Math.floor(date.getTime() / 1000);
+    const fallback =
+      new Intl.DateTimeFormat("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: true,
+        timeZone: "UTC",
+      }).format(date) + " UTC";
+    return `<!date^${unix}^{date_short_pretty} {time_secs}|${fallback}>`;
   }
 
   #buildWebhookGitObject(git: GitMetaLinks | null) {

--- a/apps/webapp/app/v3/services/alerts/deliverErrorGroupAlert.server.ts
+++ b/apps/webapp/app/v3/services/alerts/deliverErrorGroupAlert.server.ts
@@ -383,15 +383,19 @@ export class DeliverErrorGroupAlertService {
   }
 
   #formatTimestamp(date: Date): string {
-    return new Intl.DateTimeFormat("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: true,
-    }).format(date);
+    const unix = Math.floor(date.getTime() / 1000);
+    const fallback =
+      new Intl.DateTimeFormat("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: true,
+        timeZone: "UTC",
+      }).format(date) + " UTC";
+    return `<!date^${unix}^{date_short_pretty} {time_secs}|${fallback}>`;
   }
 }
 


### PR DESCRIPTION
## What this does

Polish + bug-fix pass on the Errors page so it can ship to everyone. Touches the Slack alert config UX, errors list, error detail page, and unhides the SideMenu entry for non-admins. 
## Decisions

**"No channel" item over standalone Remove button**
Chose pinning a `<XMarkIcon /> No channel` `SelectItem` above the channel list. Rejected the standalone "Remove channel" link in a `<Hint>` — color/hover behaviour clashed with the sibling `<TextLink>`, and "channel selection" is the right context for clearing. Server action already deletes the channel when `slackChannel=""` is submitted.

**Slack `<!date^>` token over per-user TZ field for alerts**
Chose Slack's native `<!date^TS^…>` token so each viewer sees timestamps in their own timezone (UTC fallback). Rejected per-user/per-org TZ schema work — works for multi-region channels for free. Email/dashboard TZ source-of-truth filed as TRI-8885 / TRI-8886.

**Make errors GA**
