### PR TITLE
feat(webapp): admin Coupon Deals tool

### DIFF
--- a/apps/webapp/app/components/admin/ApplyCouponDialog.tsx
+++ b/apps/webapp/app/components/admin/ApplyCouponDialog.tsx
@@ -73,7 +73,7 @@ export function ApplyCouponDialog({ target, open, onOpenChange }: ApplyCouponDia
               </Property.Item>
             </Property.Table>
 
-            <Form method="post" className="flex flex-col gap-3" reloadDocument>
+            <Form method="post" className="flex flex-col gap-3">
               <input type="hidden" name="intent" value="apply" />
               <input type="hidden" name="orgId" value={target.orgId} />
               <input type="hidden" name="dealKey" value={target.dealKey} />

--- a/apps/webapp/app/components/admin/ApplyCouponDialog.tsx
+++ b/apps/webapp/app/components/admin/ApplyCouponDialog.tsx
@@ -1,0 +1,104 @@
+import { Form, useNavigation } from "@remix-run/react";
+import { Button } from "~/components/primitives/Buttons";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+} from "~/components/primitives/Dialog";
+import { Paragraph } from "~/components/primitives/Paragraph";
+import * as Property from "~/components/primitives/PropertyTable";
+
+export type ApplyCouponTarget = {
+  orgId: string;
+  orgSlug: string;
+  orgTitle: string;
+  planCode: string | null;
+  subscriptionId: string | null;
+  stripeCustomerId: string;
+  stripeCustomerEmail: string;
+  dealKey: string;
+  dealLabel: string;
+  dealCategory: string;
+};
+
+type ApplyCouponDialogProps = {
+  target: ApplyCouponTarget | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function ApplyCouponDialog({ target, open, onOpenChange }: ApplyCouponDialogProps) {
+  const navigation = useNavigation();
+  const isSubmitting = navigation.state !== "idle";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          {target
+            ? `Apply ${target.dealLabel} to ${target.orgTitle}?`
+            : "Apply coupon deal"}
+        </DialogHeader>
+
+        {target && (
+          <>
+            <Paragraph variant="small" className="text-text-dimmed">
+              Re-read the org and Stripe customer below before applying. The
+              coupon will be added to the org's active Stripe subscription.
+            </Paragraph>
+
+            <Property.Table>
+              <Property.Item>
+                <Property.Label>Org</Property.Label>
+                <Property.Value>
+                  {target.orgSlug} · {target.planCode ?? "Free"}
+                </Property.Value>
+              </Property.Item>
+              <Property.Item>
+                <Property.Label>Stripe customer</Property.Label>
+                <Property.Value>
+                  {target.stripeCustomerId} ({target.stripeCustomerEmail})
+                </Property.Value>
+              </Property.Item>
+              <Property.Item>
+                <Property.Label>Stripe sub</Property.Label>
+                <Property.Value>{target.subscriptionId ?? "—"}</Property.Value>
+              </Property.Item>
+              <Property.Item>
+                <Property.Label>Coupon</Property.Label>
+                <Property.Value>
+                  {target.dealKey} · {target.dealCategory}
+                </Property.Value>
+              </Property.Item>
+            </Property.Table>
+
+            <Form method="post" className="flex flex-col gap-3" reloadDocument>
+              <input type="hidden" name="intent" value="apply" />
+              <input type="hidden" name="orgId" value={target.orgId} />
+              <input type="hidden" name="dealKey" value={target.dealKey} />
+
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="tertiary/medium"
+                  onClick={() => onOpenChange(false)}
+                  disabled={isSubmitting}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  variant="primary/medium"
+                  disabled={isSubmitting || !target.subscriptionId}
+                >
+                  Apply
+                </Button>
+              </DialogFooter>
+            </Form>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/webapp/app/routes/admin.back-office.coupons.tsx
+++ b/apps/webapp/app/routes/admin.back-office.coupons.tsx
@@ -1,6 +1,6 @@
 import { Form } from "@remix-run/react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/server-runtime";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { redirect, typedjson, useTypedActionData, useTypedLoaderData } from "remix-typedjson";
 import { z } from "zod";
 import {
@@ -197,6 +197,13 @@ export default function CouponsPage() {
     setDialogTarget(target);
     setDialogOpen(true);
   };
+
+  // Close the dialog after a successful apply: the action redirects with
+  // ?applied=<dealKey>, the loader echoes that as appliedDealKey, and we
+  // dismiss the modal so the success banner underneath is visible.
+  useEffect(() => {
+    if (appliedDealKey) setDialogOpen(false);
+  }, [appliedDealKey]);
 
   const appliedDeal = appliedDealKey ? dealsByKey.get(appliedDealKey) : null;
 

--- a/apps/webapp/app/routes/admin.back-office.coupons.tsx
+++ b/apps/webapp/app/routes/admin.back-office.coupons.tsx
@@ -7,12 +7,6 @@ import {
   ApplyCouponDialog,
   type ApplyCouponTarget,
 } from "~/components/admin/ApplyCouponDialog";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "~/components/primitives/Accordion";
 import { Button } from "~/components/primitives/Buttons";
 import { CopyableText } from "~/components/primitives/CopyableText";
 import { Header1, Header2 } from "~/components/primitives/Headers";
@@ -29,10 +23,8 @@ import {
   TableRow,
 } from "~/components/primitives/Table";
 import { SimpleTooltip } from "~/components/primitives/Tooltip";
-import { logger } from "~/services/logger.server";
 import {
   applyCouponDeal,
-  getCouponDiagnostics,
   listCouponDeals,
   refreshCouponDeals,
   resolveCouponCustomer,
@@ -58,17 +50,10 @@ type CouponMatch = {
   primaryUserEmail: string | null;
 };
 
-type CouponDiagnostic = {
-  id: string;
-  name: string | null;
-  metadata: Record<string, string>;
-};
-
 type LoaderData = {
   email: string | null;
   deals: CouponDeal[];
   matches: CouponMatch[] | null;
-  diagnostics: CouponDiagnostic[];
   appliedDealKey: string | null;
 };
 
@@ -83,10 +68,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const email = emailParam && emailParam.trim().length > 0 ? emailParam.trim() : null;
   const appliedDealKey = url.searchParams.get("applied");
 
-  const [dealsResult, diagnostics] = await Promise.all([
-    listCouponDeals(),
-    safeDiagnostics(),
-  ]);
+  const dealsResult = await listCouponDeals();
 
   let matches: CouponMatch[] | null = null;
   if (email) {
@@ -98,25 +80,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
     email,
     deals: dealsResult.deals as CouponDeal[],
     matches,
-    diagnostics,
     appliedDealKey,
   };
   return typedjson(data);
-}
-
-// Diagnostics is a nice-to-have panel; if billing has a transient issue with
-// it, the rest of the page should still work. The other calls remain hard
-// failures because the page is useless without them.
-async function safeDiagnostics(): Promise<CouponDiagnostic[]> {
-  try {
-    const result = await getCouponDiagnostics();
-    return result.unregisteredCoupons as CouponDiagnostic[];
-  } catch (error) {
-    logger.warn("Coupon diagnostics fetch failed; rendering page without panel", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return [];
-  }
 }
 
 const ApplySchema = z.object({
@@ -217,7 +183,7 @@ function groupDealsByCategory(deals: CouponDeal[]): Array<[string, CouponDeal[]]
 }
 
 export default function CouponsPage() {
-  const { email, deals, matches, diagnostics, appliedDealKey } =
+  const { email, deals, matches, appliedDealKey } =
     useTypedLoaderData<typeof loader>();
   const actionData = useTypedActionData<typeof action>();
 
@@ -301,40 +267,6 @@ export default function CouponsPage() {
           Find orgs
         </Button>
       </Form>
-
-      {diagnostics.length > 0 && (
-        <Accordion type="single" collapsible>
-          <AccordionItem value="diagnostics">
-            <AccordionTrigger>
-              {diagnostics.length} Stripe coupon{diagnostics.length === 1 ? "" : "s"} aren&apos;t
-              tagged as deals
-            </AccordionTrigger>
-            <AccordionContent>
-              <Paragraph variant="small" className="text-text-dimmed pb-2">
-                These coupons are valid in Stripe but missing the{" "}
-                <code className="rounded bg-charcoal-700 px-1">trigger_deal_key</code>{" "}
-                metadata field, so they don&apos;t appear in the apply controls
-                below. Common causes: typo in the metadata field name, or the
-                coupon was never tagged.
-              </Paragraph>
-              <ul className="flex flex-col gap-1 text-sm">
-                {diagnostics.map((c) => (
-                  <li key={c.id} className="font-mono text-text-dimmed">
-                    {c.id}
-                    {c.name ? ` — ${c.name}` : ""}
-                    {Object.keys(c.metadata).length > 0 ? (
-                      <span className="text-text-dimmed/70">
-                        {" "}
-                        · {JSON.stringify(c.metadata)}
-                      </span>
-                    ) : null}
-                  </li>
-                ))}
-              </ul>
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
-      )}
 
       {matches === null ? (
         <Paragraph variant="small" className="text-text-dimmed">

--- a/apps/webapp/app/routes/admin.back-office.coupons.tsx
+++ b/apps/webapp/app/routes/admin.back-office.coupons.tsx
@@ -202,28 +202,15 @@ export default function CouponsPage() {
 
   return (
     <div className="flex flex-col gap-6 py-4">
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex flex-col gap-1">
-          <Header1>Coupon Deals</Header1>
-          <Paragraph variant="small" className="text-text-dimmed max-w-prose">
-            Apply a Stripe-tagged coupon to a customer's subscription. Lookup is
-            by Stripe customer email — often different from the user's
-            Trigger.dev email. Catalog is built from coupons in Stripe whose
-            metadata carries{" "}
-            <code className="rounded bg-charcoal-700 px-1">trigger_deal_key</code>.
-          </Paragraph>
-        </div>
-        <Form method="post" reloadDocument>
-          <input type="hidden" name="intent" value="refresh" />
-          <SimpleTooltip
-            button={
-              <Button type="submit" variant="tertiary/small">
-                Refresh deals
-              </Button>
-            }
-            content="Pull the latest tagged coupons from Stripe."
-          />
-        </Form>
+      <div className="flex flex-col gap-1">
+        <Header1>Coupon Deals</Header1>
+        <Paragraph variant="small" className="text-text-dimmed max-w-prose">
+          Apply a Stripe-tagged coupon to a customer's subscription. Lookup is
+          by Stripe customer email — often different from the user's
+          Trigger.dev email. Catalog is built from coupons in Stripe whose
+          metadata carries{" "}
+          <code className="rounded bg-charcoal-700 px-1">trigger_deal_key</code>.
+        </Paragraph>
       </div>
 
       {appliedDeal && (
@@ -248,24 +235,26 @@ export default function CouponsPage() {
         </div>
       )}
 
-      <Form method="get" className="flex items-end gap-3">
-        <div className="flex flex-1 flex-col gap-1">
-          <Label>Stripe customer email</Label>
-          <Input
-            type="email"
-            name="email"
-            defaultValue={email ?? ""}
-            placeholder="customer@example.com"
-            autoFocus={!email}
-          />
-          <Hint>
-            This is the email on the Stripe customer record, not necessarily the
-            user's Trigger.dev email.
-          </Hint>
+      <Form method="get" className="flex flex-col gap-1">
+        <Label>Stripe customer email</Label>
+        <div className="flex items-center gap-3">
+          <div className="flex-1">
+            <Input
+              type="email"
+              name="email"
+              defaultValue={email ?? ""}
+              placeholder="customer@example.com"
+              autoFocus={!email}
+            />
+          </div>
+          <Button type="submit" variant="primary/medium">
+            Find orgs
+          </Button>
         </div>
-        <Button type="submit" variant="primary/medium">
-          Find orgs
-        </Button>
+        <Hint>
+          This is the email on the Stripe customer record, not necessarily the
+          user's Trigger.dev email.
+        </Hint>
       </Form>
 
       {matches === null ? (

--- a/apps/webapp/app/routes/admin.back-office.coupons.tsx
+++ b/apps/webapp/app/routes/admin.back-office.coupons.tsx
@@ -165,11 +165,23 @@ export async function action({ request }: ActionFunctionArgs) {
     try {
       const result = await applyCouponDeal({ orgId, dealKey });
       if (!result.success) {
+        // Cast to read `code` and `currentDealKey` from the wire body. The
+        // platform's generic ErrorSchema currently strips these to `error`
+        // only, so they arrive as undefined for now; the cast keeps the route
+        // forward-compatible with a future schema loosening that preserves
+        // them, at which point the precise UI messages will start rendering
+        // automatically.
+        const err = result as {
+          success: false;
+          error: string;
+          code?: string;
+          currentDealKey?: string;
+        };
         return typedjson<ActionResponse>(
           {
-            error: result.error ?? "Failed to apply coupon deal.",
-            code: result.code,
-            currentDealKey: result.currentDealKey ?? null,
+            error: err.error,
+            code: err.code,
+            currentDealKey: err.currentDealKey ?? null,
           },
           { status: 400 }
         );

--- a/apps/webapp/app/routes/admin.back-office.coupons.tsx
+++ b/apps/webapp/app/routes/admin.back-office.coupons.tsx
@@ -1,0 +1,454 @@
+import { Form } from "@remix-run/react";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/server-runtime";
+import { useState } from "react";
+import { redirect, typedjson, useTypedActionData, useTypedLoaderData } from "remix-typedjson";
+import { z } from "zod";
+import {
+  ApplyCouponDialog,
+  type ApplyCouponTarget,
+} from "~/components/admin/ApplyCouponDialog";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "~/components/primitives/Accordion";
+import { Button } from "~/components/primitives/Buttons";
+import { CopyableText } from "~/components/primitives/CopyableText";
+import { Header1, Header2 } from "~/components/primitives/Headers";
+import { Hint } from "~/components/primitives/Hint";
+import { Input } from "~/components/primitives/Input";
+import { Label } from "~/components/primitives/Label";
+import { Paragraph } from "~/components/primitives/Paragraph";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+} from "~/components/primitives/Table";
+import { SimpleTooltip } from "~/components/primitives/Tooltip";
+import { logger } from "~/services/logger.server";
+import {
+  applyCouponDeal,
+  getCouponDiagnostics,
+  listCouponDeals,
+  refreshCouponDeals,
+  resolveCouponCustomer,
+} from "~/services/platform.v3.server";
+import { requireUser } from "~/services/session.server";
+
+type CouponDeal = {
+  key: string;
+  label: string;
+  category: string;
+  couponId: string;
+};
+
+type CouponMatch = {
+  orgId: string;
+  slug: string;
+  title: string;
+  planCode: string | null;
+  subscriptionId: string | null;
+  activeDealKey: string | null;
+  stripeCustomerId: string;
+  stripeCustomerEmail: string;
+  primaryUserEmail: string | null;
+};
+
+type CouponDiagnostic = {
+  id: string;
+  name: string | null;
+  metadata: Record<string, string>;
+};
+
+type LoaderData = {
+  email: string | null;
+  deals: CouponDeal[];
+  matches: CouponMatch[] | null;
+  diagnostics: CouponDiagnostic[];
+  appliedDealKey: string | null;
+};
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await requireUser(request);
+  if (!user.admin) {
+    return redirect("/");
+  }
+
+  const url = new URL(request.url);
+  const emailParam = url.searchParams.get("email");
+  const email = emailParam && emailParam.trim().length > 0 ? emailParam.trim() : null;
+  const appliedDealKey = url.searchParams.get("applied");
+
+  const [dealsResult, diagnostics] = await Promise.all([
+    listCouponDeals(),
+    safeDiagnostics(),
+  ]);
+
+  let matches: CouponMatch[] | null = null;
+  if (email) {
+    const resolveResult = await resolveCouponCustomer(email);
+    matches = resolveResult.matches as CouponMatch[];
+  }
+
+  const data: LoaderData = {
+    email,
+    deals: dealsResult.deals as CouponDeal[],
+    matches,
+    diagnostics,
+    appliedDealKey,
+  };
+  return typedjson(data);
+}
+
+// Diagnostics is a nice-to-have panel; if billing has a transient issue with
+// it, the rest of the page should still work. The other calls remain hard
+// failures because the page is useless without them.
+async function safeDiagnostics(): Promise<CouponDiagnostic[]> {
+  try {
+    const result = await getCouponDiagnostics();
+    return result.unregisteredCoupons as CouponDiagnostic[];
+  } catch (error) {
+    logger.warn("Coupon diagnostics fetch failed; rendering page without panel", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
+}
+
+const ApplySchema = z.object({
+  intent: z.literal("apply"),
+  orgId: z.string().min(1),
+  dealKey: z.string().min(1),
+});
+
+const RefreshSchema = z.object({
+  intent: z.literal("refresh"),
+});
+
+type ActionResponse =
+  | {
+      error: string;
+      code?: string;
+      currentDealKey?: string | null;
+    }
+  | undefined;
+
+export async function action({ request }: ActionFunctionArgs) {
+  const user = await requireUser(request);
+  if (!user.admin) {
+    return redirect("/");
+  }
+
+  const payload = Object.fromEntries(await request.formData());
+
+  const refreshAttempt = RefreshSchema.safeParse(payload);
+  if (refreshAttempt.success) {
+    try {
+      await refreshCouponDeals();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to refresh deals.";
+      return typedjson<ActionResponse>({ error: message }, { status: 500 });
+    }
+
+    const url = new URL(request.url);
+    return redirect(`${url.pathname}${url.search}`);
+  }
+
+  const applyAttempt = ApplySchema.safeParse(payload);
+  if (applyAttempt.success) {
+    const { orgId, dealKey } = applyAttempt.data;
+
+    try {
+      const result = await applyCouponDeal({ orgId, dealKey });
+      if (!result.success) {
+        return typedjson<ActionResponse>(
+          {
+            error: result.error ?? "Failed to apply coupon deal.",
+            code: result.code,
+            currentDealKey: result.currentDealKey ?? null,
+          },
+          { status: 400 }
+        );
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to apply coupon deal.";
+      return typedjson<ActionResponse>({ error: message }, { status: 500 });
+    }
+
+    const url = new URL(request.url);
+    const search = new URLSearchParams(url.search);
+    search.set("applied", dealKey);
+    return redirect(`${url.pathname}?${search.toString()}`);
+  }
+
+  return typedjson<ActionResponse>(
+    { error: "Unrecognized form submission." },
+    { status: 400 }
+  );
+}
+
+function groupDealsByCategory(deals: CouponDeal[]): Array<[string, CouponDeal[]]> {
+  const groups = new Map<string, CouponDeal[]>();
+  for (const deal of deals) {
+    const existing = groups.get(deal.category);
+    if (existing) {
+      existing.push(deal);
+    } else {
+      groups.set(deal.category, [deal]);
+    }
+  }
+  return Array.from(groups.entries());
+}
+
+export default function CouponsPage() {
+  const { email, deals, matches, diagnostics, appliedDealKey } =
+    useTypedLoaderData<typeof loader>();
+  const actionData = useTypedActionData<typeof action>();
+
+  const dealsByKey = new Map(deals.map((d) => [d.key, d]));
+  const dealGroups = groupDealsByCategory(deals);
+
+  const [dialogTarget, setDialogTarget] = useState<ApplyCouponTarget | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const openDialog = (target: ApplyCouponTarget) => {
+    setDialogTarget(target);
+    setDialogOpen(true);
+  };
+
+  const appliedDeal = appliedDealKey ? dealsByKey.get(appliedDealKey) : null;
+
+  return (
+    <div className="flex flex-col gap-6 py-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <Header1>Coupon Deals</Header1>
+          <Paragraph variant="small" className="text-text-dimmed max-w-prose">
+            Apply a Stripe-tagged coupon to a customer's subscription. Lookup is
+            by Stripe customer email — often different from the user's
+            Trigger.dev email. Catalog is built from coupons in Stripe whose
+            metadata carries{" "}
+            <code className="rounded bg-charcoal-700 px-1">trigger_deal_key</code>.
+          </Paragraph>
+        </div>
+        <Form method="post" reloadDocument>
+          <input type="hidden" name="intent" value="refresh" />
+          <SimpleTooltip
+            button={
+              <Button type="submit" variant="tertiary/small">
+                Refresh deals
+              </Button>
+            }
+            content="Pull the latest tagged coupons from Stripe."
+          />
+        </Form>
+      </div>
+
+      {appliedDeal && (
+        <div className="rounded-md border border-green-600/40 bg-green-600/10 px-3 py-2">
+          <Paragraph variant="small" className="text-green-500">
+            Applied: {appliedDeal.label}.
+          </Paragraph>
+        </div>
+      )}
+
+      {actionData && "error" in actionData && actionData.error && (
+        <div className="rounded-md border border-red-600/40 bg-red-600/10 px-3 py-2">
+          <Paragraph variant="small" className="text-red-500">
+            {actionData.error}
+            {actionData.code === "already_applied" && actionData.currentDealKey
+              ? ` (currently has: ${
+                  dealsByKey.get(actionData.currentDealKey)?.label ??
+                  actionData.currentDealKey
+                })`
+              : null}
+          </Paragraph>
+        </div>
+      )}
+
+      <Form method="get" className="flex items-end gap-3">
+        <div className="flex flex-1 flex-col gap-1">
+          <Label>Stripe customer email</Label>
+          <Input
+            type="email"
+            name="email"
+            defaultValue={email ?? ""}
+            placeholder="customer@example.com"
+            autoFocus={!email}
+          />
+          <Hint>
+            This is the email on the Stripe customer record, not necessarily the
+            user's Trigger.dev email.
+          </Hint>
+        </div>
+        <Button type="submit" variant="primary/medium">
+          Find orgs
+        </Button>
+      </Form>
+
+      {diagnostics.length > 0 && (
+        <Accordion type="single" collapsible>
+          <AccordionItem value="diagnostics">
+            <AccordionTrigger>
+              {diagnostics.length} Stripe coupon{diagnostics.length === 1 ? "" : "s"} aren&apos;t
+              tagged as deals
+            </AccordionTrigger>
+            <AccordionContent>
+              <Paragraph variant="small" className="text-text-dimmed pb-2">
+                These coupons are valid in Stripe but missing the{" "}
+                <code className="rounded bg-charcoal-700 px-1">trigger_deal_key</code>{" "}
+                metadata field, so they don&apos;t appear in the apply controls
+                below. Common causes: typo in the metadata field name, or the
+                coupon was never tagged.
+              </Paragraph>
+              <ul className="flex flex-col gap-1 text-sm">
+                {diagnostics.map((c) => (
+                  <li key={c.id} className="font-mono text-text-dimmed">
+                    {c.id}
+                    {c.name ? ` — ${c.name}` : ""}
+                    {Object.keys(c.metadata).length > 0 ? (
+                      <span className="text-text-dimmed/70">
+                        {" "}
+                        · {JSON.stringify(c.metadata)}
+                      </span>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      )}
+
+      {matches === null ? (
+        <Paragraph variant="small" className="text-text-dimmed">
+          Enter a Stripe customer email above to find matching Trigger.dev orgs.
+        </Paragraph>
+      ) : matches.length === 0 ? (
+        <Paragraph variant="base">No Trigger.dev orgs found for this Stripe email.</Paragraph>
+      ) : (
+        <>
+          {matches.length > 1 && (
+            <div className="rounded-md border border-amber-600/40 bg-amber-600/10 px-3 py-2">
+              <Paragraph variant="small" className="text-amber-500">
+                Multiple Stripe customers share this email. Verify the org by
+                Stripe customer ID before applying.
+              </Paragraph>
+            </div>
+          )}
+
+          <div className="flex flex-col gap-2">
+            <Header2>{matches.length} match{matches.length === 1 ? "" : "es"}</Header2>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHeaderCell>Org</TableHeaderCell>
+                  <TableHeaderCell>Stripe customer</TableHeaderCell>
+                  <TableHeaderCell>Trigger.dev user</TableHeaderCell>
+                  <TableHeaderCell>Plan</TableHeaderCell>
+                  <TableHeaderCell>Active deal</TableHeaderCell>
+                  <TableHeaderCell>Apply</TableHeaderCell>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {matches.map((match) => {
+                  const activeDeal = match.activeDealKey
+                    ? dealsByKey.get(match.activeDealKey)
+                    : null;
+                  const isFree = match.subscriptionId === null;
+                  const hasActive = match.activeDealKey !== null;
+                  const disabledReason = isFree
+                    ? "Org is on free plan — no subscription to discount."
+                    : hasActive
+                    ? `Already has: ${activeDeal?.label ?? match.activeDealKey}`
+                    : null;
+
+                  return (
+                    <TableRow key={match.orgId}>
+                      <TableCell>
+                        <div className="flex flex-col">
+                          <span className="font-medium">{match.title}</span>
+                          <span className="text-text-dimmed text-xs">
+                            <CopyableText value={match.slug} />
+                          </span>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-col">
+                          <CopyableText value={match.stripeCustomerId} />
+                          <span className="text-text-dimmed text-xs">
+                            {match.stripeCustomerEmail}
+                          </span>
+                        </div>
+                      </TableCell>
+                      <TableCell>{match.primaryUserEmail ?? "—"}</TableCell>
+                      <TableCell>{match.planCode ?? "Free"}</TableCell>
+                      <TableCell>{activeDeal?.label ?? "None"}</TableCell>
+                      <TableCell>
+                        <div className="flex flex-col gap-2">
+                          {dealGroups.map(([category, dealsInCategory]) => (
+                            <div key={category} className="flex flex-col gap-1">
+                              <span className="text-text-dimmed text-xs uppercase tracking-wide">
+                                {category}
+                              </span>
+                              <div className="flex flex-wrap gap-1">
+                                {dealsInCategory.map((deal) => {
+                                  const button = (
+                                    <Button
+                                      type="button"
+                                      variant="tertiary/small"
+                                      disabled={disabledReason !== null}
+                                      onClick={() =>
+                                        openDialog({
+                                          orgId: match.orgId,
+                                          orgSlug: match.slug,
+                                          orgTitle: match.title,
+                                          planCode: match.planCode,
+                                          subscriptionId: match.subscriptionId,
+                                          stripeCustomerId: match.stripeCustomerId,
+                                          stripeCustomerEmail: match.stripeCustomerEmail,
+                                          dealKey: deal.key,
+                                          dealLabel: deal.label,
+                                          dealCategory: deal.category,
+                                        })
+                                      }
+                                    >
+                                      {deal.label}
+                                    </Button>
+                                  );
+                                  return disabledReason ? (
+                                    <SimpleTooltip
+                                      key={deal.key}
+                                      button={button}
+                                      content={disabledReason}
+                                    />
+                                  ) : (
+                                    <span key={deal.key}>{button}</span>
+                                  );
+                                })}
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        </>
+      )}
+
+      <ApplyCouponDialog
+        target={dialogTarget}
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+      />
+    </div>
+  );
+}

--- a/apps/webapp/app/routes/admin.back-office.tsx
+++ b/apps/webapp/app/routes/admin.back-office.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from "@remix-run/react";
 import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { redirect, typedjson } from "remix-typedjson";
+import { Tabs } from "~/components/primitives/Tabs";
 import { requireUser } from "~/services/session.server";
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -17,6 +18,17 @@ export default function BackOfficeLayout() {
       aria-labelledby="primary-heading"
       className="flex h-full min-w-0 flex-1 flex-col overflow-y-auto px-4 pb-4 lg:order-last"
     >
+      <div className="flex items-center pt-2">
+        <Tabs
+          tabs={[
+            {
+              label: "Coupon Deals",
+              to: "/admin/back-office/coupons",
+            },
+          ]}
+          layoutId="admin-back-office"
+        />
+      </div>
       <Outlet />
     </main>
   );

--- a/apps/webapp/app/services/platform.v3.server.ts
+++ b/apps/webapp/app/services/platform.v3.server.ts
@@ -17,7 +17,7 @@ import {
   type UsageResult,
   type UsageSeriesParams,
   type CurrentPlan,
-  type ApplyCouponDealResponse,
+  type ApplyCouponDealResult,
   type CouponDiagnosticsResponse,
   type ListCouponDealsResponse,
   type ResolveCouponCustomerResponse,
@@ -844,7 +844,7 @@ export async function resolveCouponCustomer(
 export async function applyCouponDeal(input: {
   orgId: string;
   dealKey: string;
-}): Promise<ApplyCouponDealResponse> {
+}): Promise<ApplyCouponDealResult> {
   if (!client) throw new Error("Platform client not configured");
 
   const [error, result] = await tryCatch(client.applyCouponDeal(input));

--- a/apps/webapp/app/services/platform.v3.server.ts
+++ b/apps/webapp/app/services/platform.v3.server.ts
@@ -17,6 +17,10 @@ import {
   type UsageResult,
   type UsageSeriesParams,
   type CurrentPlan,
+  type ApplyCouponDealResponse,
+  type CouponDiagnosticsResponse,
+  type ListCouponDealsResponse,
+  type ResolveCouponCustomerResponse,
 } from "@trigger.dev/platform";
 import { createCache, DefaultStatefulContext, Namespace } from "@unkey/cache";
 import { createLRUMemoryStore } from "@internal/cache";
@@ -776,6 +780,103 @@ export async function triggerInitialDeployment(
       error: result.error,
     });
   }
+}
+
+export async function listCouponDeals(): Promise<ListCouponDealsResponse> {
+  if (!client) throw new Error("Platform client not configured");
+
+  const [error, result] = await tryCatch(client.listCouponDeals());
+
+  if (error) {
+    logger.error("Error listing coupon deals", { error });
+    throw error;
+  }
+
+  if (!result.success) {
+    logger.error("Error listing coupon deals - no success", { error: result.error });
+    throw new Error(result.error ?? "Failed to list coupon deals");
+  }
+
+  return result;
+}
+
+export async function refreshCouponDeals(): Promise<ListCouponDealsResponse> {
+  if (!client) throw new Error("Platform client not configured");
+
+  const [error, result] = await tryCatch(client.refreshCouponDeals());
+
+  if (error) {
+    logger.error("Error refreshing coupon deals", { error });
+    throw error;
+  }
+
+  if (!result.success) {
+    logger.error("Error refreshing coupon deals - no success", { error: result.error });
+    throw new Error(result.error ?? "Failed to refresh coupon deals");
+  }
+
+  return result;
+}
+
+export async function resolveCouponCustomer(
+  stripeEmail: string
+): Promise<ResolveCouponCustomerResponse> {
+  if (!client) throw new Error("Platform client not configured");
+
+  const [error, result] = await tryCatch(client.resolveCouponCustomer(stripeEmail));
+
+  if (error) {
+    logger.error("Error resolving coupon customer", { error });
+    throw error;
+  }
+
+  if (!result.success) {
+    logger.error("Error resolving coupon customer - no success", { error: result.error });
+    throw new Error(result.error ?? "Failed to resolve coupon customer");
+  }
+
+  return result;
+}
+
+// Returns the full discriminated result rather than throwing on !success so the
+// admin route can branch on `code` ("already_applied", "no_subscription",
+// "unknown_deal", etc.) and surface precise UI messages.
+export async function applyCouponDeal(input: {
+  orgId: string;
+  dealKey: string;
+}): Promise<ApplyCouponDealResponse> {
+  if (!client) throw new Error("Platform client not configured");
+
+  const [error, result] = await tryCatch(client.applyCouponDeal(input));
+
+  if (error) {
+    logger.error("Error applying coupon deal", { input, error });
+    throw error;
+  }
+
+  if (!result.success) {
+    logger.warn("Coupon deal apply unsuccessful", { input, error: result.error });
+  }
+
+  return result;
+}
+
+export async function getCouponDiagnostics(): Promise<CouponDiagnosticsResponse> {
+  if (!client) throw new Error("Platform client not configured");
+
+  const [error, result] = await tryCatch(client.getCouponDiagnostics());
+
+  if (error) {
+    logger.error("Error getting coupon diagnostics", { error });
+    throw error;
+  }
+
+  if (!result.success) {
+    logger.error("Error getting coupon diagnostics - no success", { error: result.error });
+    throw new Error(result.error ?? "Failed to get coupon diagnostics");
+  }
+
+  return result;
 }
 
 function isCloud(): boolean {


### PR DESCRIPTION
## Summary

Adds a Coupon Deals tool to the Back office admin area. Admins can look up an org by Stripe customer email and apply any Stripe coupon tagged with `trigger_deal_key` / `trigger_deal_label` / `trigger_deal_category` metadata to that org's subscription. The catalog is built dynamically from Stripe — no env vars per deal, no code change, no redeploy when a new deal is added; just tag a coupon in the Stripe dashboard.

## What's in here

- New `Coupon Deals` sub-tab under `/admin/back-office`.
- New route `admin.back-office.coupons.tsx` — search by Stripe customer email, multi-match banner, per-row apply buttons grouped by category, confirmation modal, disabled states for free-plan and already-applied orgs.
- New `ApplyCouponDialog` confirmation modal — re-states the org / Stripe customer / Stripe sub / coupon before submit.
- Five new wrappers in `services/platform.v3.server.ts` around `BillingClient` (`listCouponDeals`, `refreshCouponDeals`, `resolveCouponCustomer`, `applyCouponDeal`, `getCouponDiagnostics`) — modeled on the `deleteUser` pattern from the admin user-delete PR.

## Merge-order gate (read before reviewing CI)

Depends on the matching cloud-side branch landing first:

- `cloud/billing` adds the five `/api/admin/coupons/*` endpoints + Stripe-backed registry.
- `@trigger.dev/platform` minor releases with the new `BillingClient` methods and Zod schemas.

**This PR's typecheck WILL fail in CI** on `listCouponDeals`, `applyCouponDeal`, `ApplyCouponDealResult`, etc. until that minor is published. The pin in `apps/webapp/package.json` is intentionally **not** bumped here — bumping is a follow-up after the platform release. Same shape as the recent admin user-delete PR.

## Test plan (after platform publish)

- [ ] Tag a Stripe test-mode coupon with `trigger_deal_key` / `trigger_deal_label` / `trigger_deal_category`.
- [ ] Visit `/admin/back-office/coupons` as admin.
- [ ] Search by Stripe customer email → matching orgs render in the table.
- [ ] Click Apply → confirmation modal → submit → green "Applied: …" banner; verify the discount on the subscription in the Stripe dashboard.
- [ ] Re-apply on the same org → buttons disabled with "Already has: …" tooltip.
- [ ] Search an org on Free plan → buttons disabled with "Org is on free plan…" tooltip.
- [ ] Multi-match: two Stripe customers sharing one email → amber banner above the table.

## Known gaps (intentional v1)

- **Apply error UX is degraded** when re-applying a registered deal. The `409 already_applied` response carries `code` and `currentDealKey` on the wire, but the platform's generic `ErrorSchema` strips them, so the inline banner shows the generic error string rather than `(currently has: <label>)`. Cloud-side fix is small (loosen `ErrorSchema` to passthrough extras); the route is forward-compatible — once that lands, the precise UI starts rendering with no webapp change.
- **Untagged Stripe-applied coupons** show as "Active deal: None" even when the subscription has a discount. Spec deferred ("future enhancement: surface unknown discounts inline"). Workaround for support: always cross-check the Stripe subscription before applying.
- **5-minute catalog cache** on the cloud side. Editing a coupon's metadata in Stripe propagates to the admin tool within ≤5 min

## Out of scope

- Removing or swapping an already-applied deal (manual via Stripe dashboard for v1).
- Audit log of admin applications (Stripe's subscription/discount history is sufficient for MVP).
- Diagnostics panel for untagged coupons (was prototyped, removed for launch).
