### PR TITLE
Fix/orphaned worker processes

### DIFF
--- a/.changeset/silly-planes-march.md
+++ b/.changeset/silly-planes-march.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": major
+---
+
+Kill orphaned trigger-dev-run-worker processes when CLI is killed with SIGKILL

--- a/packages/cli-v3/src/dev/devSupervisor.ts
+++ b/packages/cli-v3/src/dev/devSupervisor.ts
@@ -80,6 +80,9 @@ class DevSupervisor implements WorkerRuntime {
   private activeRunsPath?: string;
   private watchdogPidPath?: string;
 
+  private activeRunsUpdateInterval?: NodeJS.Timeout;
+
+
   constructor(public readonly options: WorkerRuntimeOptions) { }
 
   async init(): Promise<void> {
@@ -153,6 +156,10 @@ class DevSupervisor implements WorkerRuntime {
 
     // Spawn detached watchdog to cancel runs if CLI is killed (e.g. pnpm SIGKILL)
     this.#spawnWatchdog();
+    // Keep active-runs.json current with latest worker PIDs
+    this.activeRunsUpdateInterval = setInterval(() => {
+      this.#updateActiveRunsFile();
+    }, 2_000);
 
     //start dequeuing
     await this.#dequeueRuns();
@@ -197,6 +204,10 @@ class DevSupervisor implements WorkerRuntime {
           error: shutdownError,
         });
       }
+    }
+
+    if (this.activeRunsUpdateInterval) {
+      clearInterval(this.activeRunsUpdateInterval);
     }
   }
 
@@ -292,6 +303,7 @@ class DevSupervisor implements WorkerRuntime {
       const data = {
         parentPid: process.pid,
         runFriendlyIds: Array.from(this.runControllers.keys()),
+        workerPids: this.taskRunProcessPool?.getAllPids() ?? [],
       };
       // Atomic write: write to temp file then rename to avoid corrupt reads
       const tmpPath = this.activeRunsPath + ".tmp";

--- a/packages/cli-v3/src/dev/devWatchdog.ts
+++ b/packages/cli-v3/src/dev/devWatchdog.ts
@@ -71,10 +71,10 @@ writeFileSync(pidFilePath, `${PID_FILE_PREFIX}${process.pid}`);
 function cleanup() {
   try {
     unlinkSync(pidFilePath);
-  } catch {}
+  } catch { }
   try {
     unlinkSync(activeRunsPath);
-  } catch {}
+  } catch { }
 }
 
 function cleanupTmpDir() {
@@ -95,12 +95,39 @@ function isParentAlive(): boolean {
   }
 }
 
-function readActiveRuns(): string[] {
+function readActiveRuns(): { runFriendlyIds: string[]; workerPids: number[] } {
   try {
     const data = JSON.parse(readFileSync(activeRunsPath, "utf8"));
-    return data.runFriendlyIds ?? [];
+    return {
+      runFriendlyIds: data.runFriendlyIds ?? [],
+      workerPids: data.workerPids ?? [],
+    };
   } catch {
-    return [];
+    return { runFriendlyIds: [], workerPids: [] };
+  }
+}
+
+async function killWorkerProcesses(pids: number[]): Promise<void> {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      // Already dead
+    }
+  }
+
+  if (pids.length === 0) return;
+
+  // Give processes a moment to exit cleanly before SIGKILL
+  await new Promise((resolve) => setTimeout(resolve, 3_000));
+
+  for (const pid of pids) {
+    try {
+      process.kill(pid, 0); // Check if still alive
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Already dead — good
+    }
   }
 }
 
@@ -124,7 +151,10 @@ const MAX_DISCONNECT_ATTEMPTS = 5;
 const INITIAL_BACKOFF_MS = 500;
 
 async function onParentDied(): Promise<void> {
-  const runFriendlyIds = readActiveRuns();
+  const { runFriendlyIds, workerPids } = readActiveRuns();
+
+  //kill orphaned worker processes first
+  await killWorkerProcesses(workerPids);
 
   if (runFriendlyIds.length > 0) {
     for (let attempt = 0; attempt < MAX_DISCONNECT_ATTEMPTS; attempt++) {

--- a/packages/cli-v3/src/dev/taskRunProcessPool.test.ts
+++ b/packages/cli-v3/src/dev/taskRunProcessPool.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { TaskRunProcessPool } from "./taskRunProcessPool.js";
+
+describe("TaskRunProcessPool", () => {
+  it("getAllPids returns empty array when pool is empty", () => {
+    const pool = new TaskRunProcessPool({
+      env: {},
+      cwd: "/tmp",
+      enableProcessReuse: false,
+    });
+
+    expect(pool.getAllPids()).toEqual([]);
+  });
+
+  it("getAllPids returns no undefined values", () => {
+    const pool = new TaskRunProcessPool({
+      env: {},
+      cwd: "/tmp",
+      enableProcessReuse: false,
+    });
+
+    const pids = pool.getAllPids();
+    expect(pids.every((pid) => typeof pid === "number")).toBe(true);
+  });
+});

--- a/packages/cli-v3/src/dev/taskRunProcessPool.ts
+++ b/packages/cli-v3/src/dev/taskRunProcessPool.ts
@@ -271,6 +271,24 @@ export class TaskRunProcessPool {
     }
   }
 
+  getAllPids(): number[] {
+    const pids: number[] = [];
+
+    for (const processes of this.availableProcessesByVersion.values()) {
+      for (const process of processes) {
+        if (process.pid !== undefined) pids.push(process.pid);
+      }
+    }
+
+    for (const processSet of this.busyProcessesByVersion.values()) {
+      for (const process of processSet) {
+        if (process.pid !== undefined) pids.push(process.pid);
+      }
+    }
+
+    return pids;
+  }
+
   async shutdown(): Promise<void> {
     const totalAvailable = Array.from(this.availableProcessesByVersion.values()).reduce(
       (sum, processes) => sum + processes.length,


### PR DESCRIPTION
Closes #2909 

## ✅ Checklist

- [x] I have followed every step in the contributing guide
- [x] The PR title follows the convention
- [x] I ran and tested the code works

---

## Testing

- Ran existing `taskRunProcess.test.ts` suite, passes clean
- Added `taskRunProcessPool.test.ts` covering `getAllPids()` on a fresh pool
- Integration test against local self-hosted instance:
  1. Started CLI with locally built binary against `http://localhost:3030`
  2. Triggered a 60-second sleep task to force worker processes to spawn
  3. Confirmed `active-runs.json` contained real PIDs in `workerPids`
  4. Sent `kill -9 <CLI_PID>`, bypassing all signal handlers, exactly what pnpm does
  5. Waited 5 seconds for watchdog poll cycle
  6. `ps -p <pid1>,<pid2>,<pid3>` -> All dead ✔️

---

## Changelog

Fix orphaned trigger-dev-run-worker processes that accumulate and consume significant CPU when the CLI is killed ungracefully via SIGKILL. The watchdog now reads worker PIDs from active-runs.json and kills them when the parent CLI process dies.

---

## Screenshots

---

## Fix: Kill orphaned worker processes when the CLI is killed ungracefully

### Problem

When running `trigger.dev dev` through pnpm and the session is stopped, `trigger-dev-run-worker` child processes are left alive on the machine, consuming significant CPU, up to 450%+ combined after several restarts.

The root cause is how pnpm handles process termination. When you do Ctrl+C, pnpm sends **SIGKILL** directly to the CLI process, not SIGTERM. SIGKILL cannot be caught or handled. Node.js signal handlers (`process.on("SIGINT", ...)`, `process.on("SIGTERM", ...)`) never run. The graceful `shutdown()` path, which calls `taskRunProcessPool.shutdown()` and kills all tracked worker processes, is bypassed entirely.

On Linux and macOS, child processes are not automatically killed when their parent dies. So the `trigger-dev-run-worker` processes spawned by `TaskRunProcess.initialize()` via `fork()` continue running indefinitely, orphaned, with no parent to report to and no work to do.

### What already existed

PR #3191 introduced a detached watchdog process (`devWatchdog.ts`) that survives SIGKILL and handles server-side cleanup. It polls for parent death, then calls `/engine/v1/dev/disconnect` to cancel in-flight runs on the server. This is correct and important.

However, the watchdog only addresses the server's view of those runs. It does not kill the actual OS-level worker processes on the user's machine. Those processes keep running regardless of what the API call does.

### How I found it

Tracing the codebase from the issue report:

1. `DevSupervisor.init()` registers SIGINT/SIGTERM handlers and spawns the watchdog, but those handlers are unreachable under SIGKILL.
2. `TaskRunProcessPool` manages two maps: `availableProcessesByVersion` (idle, reusable processes) and `busyProcessesByVersion` (actively executing). Both are populated with `TaskRunProcess` instances, each wrapping a forked child process with a known PID.
3. `DevSupervisor.#updateActiveRunsFile()` writes `active-runs.json` to `.trigger/` in the user's project directory, the file the watchdog reads on parent death. It contained `parentPid` and `runFriendlyIds` but not the worker PIDs.
4. `devWatchdog.ts` reads that file in `onParentDied()`, calls disconnect, and exits. No process killing.

The gap: the watchdog had everything it needed to cancel runs on the server, but no information about which OS processes to kill locally.

### What I changed

**Three files, one new test file.**

#### 1. `packages/cli-v3/src/dev/taskRunProcessPool.ts`

Added `getAllPids()`, which collects PIDs from both the available and busy process maps:

```typescript
getAllPids(): number[] {
  const pids: number[] = [];
  for (const processes of this.availableProcessesByVersion.values()) {
    for (const process of processes) {
      if (process.pid !== undefined) pids.push(process.pid);
    }
  }
  for (const processSet of this.busyProcessesByVersion.values()) {
    for (const process of processSet) {
      if (process.pid !== undefined) pids.push(process.pid);
    }
  }
  return pids;
}
```

This includes both idle pooled processes and actively executing ones; both are orphaned under SIGKILL.

#### 2. `packages/cli-v3/src/dev/devSupervisor.ts`

Two changes here:

**`#updateActiveRunsFile()`**, now includes `workerPids` alongside the existing fields:

```typescript
const data = {
  parentPid: process.pid,
  runFriendlyIds: Array.from(this.runControllers.keys()),
  workerPids: this.taskRunProcessPool?.getAllPids() ?? [],
};
```

**Periodic refresh interval**, I discovered during testing that a timing issue exists: worker processes are spawned *after* `#updateActiveRunsFile()` is first called when a run is dequeued, so the file would be written before the PID existed, leaving `workerPids` empty. A 2-second refresh interval keeps the file current as processes enter and leave the pool:

```typescript
// In init():
this.activeRunsUpdateInterval = setInterval(() => {
  this.#updateActiveRunsFile();
}, 2_000);

// In shutdown():
if (this.activeRunsUpdateInterval) {
  clearInterval(this.activeRunsUpdateInterval);
}
```

The interval is cleared on clean shutdown, so it doesn't interfere with the normal Ctrl+C exit path.

#### 3. `packages/cli-v3/src/dev/devWatchdog.ts`

Updated `readActiveRuns()` to return the new `workerPids` field, and added `killWorkerProcesses()` called at the start of `onParentDied()`:

```typescript
async function killWorkerProcesses(pids: number[]): Promise<void> {
  for (const pid of pids) {
    try { process.kill(pid, "SIGTERM"); } catch { /* Already dead */ }
  }

  if (pids.length === 0) return;

  await new Promise((resolve) => setTimeout(resolve, 3_000));

  for (const pid of pids) {
    try {
      process.kill(pid, 0);
      process.kill(pid, "SIGKILL");
    } catch { /* Already dead, good */ }
  }
}
```

Worker processes are killed before the disconnect API call; there's no dependency between the two, but it makes sense to handle the local machine first.

### How I tested it

**Unit tests**: ran the existing `taskRunProcess.test.ts` suite (passes clean) and added `taskRunProcessPool.test.ts` covering `getAllPids()` returning an empty array on a fresh pool and returning only defined numeric values.

**Integration test against a local self-hosted instance**: ran the full Docker stack and webapp locally, then:

1. Started the CLI with the locally built binary pointed at `http://localhost:3030`
2. Triggered a long-running task (60-second sleep) to force worker processes to spawn
3. Confirmed `active-runs.json` contained real PIDs in `workerPids`
4. Sent SIGKILL to the CLI process (`kill -9 <pid>`) — bypassing all signal handlers, exactly what pnpm does
5. Waited 5 seconds for the watchdog's poll cycle to detect parent death
6. Checked all worker PIDs: `ps -p <pid1>,<pid2>,<pid3>` → **All dead ✓**

Before this fix, the same sequence left all worker processes running indefinitely. After, they're gone within the watchdog's poll interval.

### Backward compatibility

The change to `active-runs.json` is additive; `workerPids` defaults to `[]` if the field is missing, so any existing watchdog reading an old-format file degrades gracefully. The periodic interval only runs during an active dev session and is always cleared on clean shutdown, leaving the normal Ctrl+C path completely unaffected.

Fixes #2909 

---
