### PR TITLE
fix(webapp): invalid HTML nesting in errors Activity tooltip

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.errors._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.errors._index/route.tsx
@@ -708,6 +708,7 @@ function ErrorActivityGraph({ activity }: { activity: ErrorOccurrenceActivity })
         </ResponsiveContainer>
       </div>
       <SimpleTooltip
+        asChild
         button={
           <span className="-mt-1 text-xxs tabular-nums text-text-dimmed">
             {formatNumberCompact(maxCount)}


### PR DESCRIPTION
The Activity peak count tooltip in the errors list rendered a `<button>` (from `SimpleTooltip`'s default `TooltipTrigger`) inside the row's `<a>` link (`TableCell to={errorPath}`). Interactive content nested inside other interactive content is invalid HTML and triggers accessibility warnings. Adding `asChild` to `SimpleTooltip` makes the existing `<span>` the trigger directly, removing the nested `<button>`.