### PR TITLE
Don't log waitpoint output when resolving

### DIFF
--- a/.changeset/redact-resolve-waitpoint-log.md
+++ b/.changeset/redact-resolve-waitpoint-log.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Redact the `resolveWaitpoint` runtime log so it only emits `id` and `type` instead of the full completed waitpoint. Previously the log printed the entire waitpoint (including `output`) to stdout in production runs, which could leak sensitive payloads. The value returned by `wait.forToken()` is unchanged.

--- a/packages/core/src/v3/runtime/sharedRuntimeManager.ts
+++ b/packages/core/src/v3/runtime/sharedRuntimeManager.ts
@@ -219,7 +219,7 @@ export class SharedRuntimeManager implements RuntimeManager {
 
   private resolveWaitpoint(waitpoint: CompletedWaitpoint, resolverId?: ResolverId | null): void {
     // This is spammy, don't make this a debug log
-    this.log("resolveWaitpoint", waitpoint);
+    this.log("resolveWaitpoint", { id: waitpoint.id, type: waitpoint.type });
 
     if (waitpoint.type === "BATCH") {
       // We currently ignore these, they're not required to resume after a batch completes


### PR DESCRIPTION
 Redact the `resolveWaitpoint` runtime log so it only emits `id` and `type` instead of the full completed waitpoint. Previously the log printed the entire waitpoint (including `output`) to stdout in production runs, which could leak sensitive payloads. The value returned by `wait.forToken()` is unchanged.
