### PR TITLE
ci: vouch dependabot[bot]

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -13,6 +13,7 @@ samejr
 isshaddad
 # Bots
 devin-ai-integration[bot]
+dependabot[bot]
 # Outside contributors
 gautamsi
 capaj

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -28,7 +28,8 @@ jobs:
       github.event.pull_request.author_association != 'MEMBER' &&
       github.event.pull_request.author_association != 'OWNER' &&
       github.event.pull_request.author_association != 'COLLABORATOR' &&
-      github.event.pull_request.user.login != 'devin-ai-integration[bot]'
+      github.event.pull_request.user.login != 'devin-ai-integration[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Close non-draft PR


### PR DESCRIPTION
Dependabot's first auto-bump PR (#3495) was auto-closed because `dependabot[bot]` isn't in the vouch list and isn't exempt from the require-draft check.

Two changes:

- Add `dependabot[bot]` to `.github/VOUCHED.td` so the vouch check passes.
- Add `dependabot[bot]` to the require-draft exception in `vouch-check-pr.yml` (alongside `devin-ai-integration[bot]`) so its PRs aren't closed for being non-draft.

Without both, dependabot bumps will keep getting closed and we lose the weekly action update flow that #3494 set up.