### PR TITLE
ci: swap buildjet/setup-node for actions/setup-node v6.4.0

### DIFF
--- a/.github/workflows/changesets-pr.yml
+++ b/.github/workflows/changesets-pr.yml
@@ -33,7 +33,7 @@ jobs:
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup node
-        uses: buildjet/setup-node@6131e76b005f1e3f5c721e0ca2d8279eb577c3a8 # v4.0.4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.20.0
           cache: "pnpm"
@@ -91,7 +91,7 @@ jobs:
           version: 10.23.0
 
       - name: Setup node
-        uses: buildjet/setup-node@6131e76b005f1e3f5c721e0ca2d8279eb577c3a8 # v4.0.4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.20.0
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ jobs:
           version: 10.23.0
 
       - name: ⎔ Setup node
-        uses: buildjet/setup-node@6131e76b005f1e3f5c721e0ca2d8279eb577c3a8 # v4.0.4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.20.0
           cache: "pnpm"

--- a/.github/workflows/e2e-webapp.yml
+++ b/.github/workflows/e2e-webapp.yml
@@ -51,7 +51,7 @@ jobs:
           version: 10.23.0
 
       - name: ⎔ Setup node
-        uses: buildjet/setup-node@6131e76b005f1e3f5c721e0ca2d8279eb577c3a8 # v4.0.4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.20.0
           cache: "pnpm"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,7 +34,7 @@ jobs:
           version: 10.23.0
 
       - name: ⎔ Setup node
-        uses: buildjet/setup-node@6131e76b005f1e3f5c721e0ca2d8279eb577c3a8 # v4.0.4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.20.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
           version: 10.23.0
 
       - name: Setup node
-        uses: buildjet/setup-node@6131e76b005f1e3f5c721e0ca2d8279eb577c3a8 # v4.0.4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.20.0
           cache: "pnpm"
@@ -253,7 +253,7 @@ jobs:
           version: 10.23.0
 
       - name: Setup node
-        uses: buildjet/setup-node@6131e76b005f1e3f5c721e0ca2d8279eb577c3a8 # v4.0.4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.20.0
           cache: "pnpm"

--- a/.github/workflows/sdk-compat.yml
+++ b/.github/workflows/sdk-compat.yml
@@ -28,7 +28,7 @@ jobs:
           version: 10.23.0
 
       - name: ⎔ Setup node
-        uses: buildjet/setup-node@6131e76b005f1e3f5c721e0ca2d8279eb577c3a8 # v4.0.4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
           cache: "pnpm"
@@ -66,7 +66,7 @@ jobs:
           version: 10.23.0
 
       - name: ⎔ Setup node
-        uses: buildjet/setup-node@6131e76b005f1e3f5c721e0ca2d8279eb577c3a8 # v4.0.4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.20.0
           cache: "pnpm"
@@ -107,7 +107,7 @@ jobs:
           version: 10.23.0
 
       - name: ⎔ Setup node
-        uses: buildjet/setup-node@6131e76b005f1e3f5c721e0ca2d8279eb577c3a8 # v4.0.4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.20.0
           cache: "pnpm"
@@ -152,7 +152,7 @@ jobs:
           version: 10.23.0
 
       - name: ⎔ Setup node
-        uses: buildjet/setup-node@6131e76b005f1e3f5c721e0ca2d8279eb577c3a8 # v4.0.4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.20.0
           cache: "pnpm"

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -22,7 +22,7 @@ jobs:
           version: 10.23.0
 
       - name: ⎔ Setup node
-        uses: buildjet/setup-node@6131e76b005f1e3f5c721e0ca2d8279eb577c3a8 # v4.0.4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.20.0
           cache: "pnpm"

--- a/.github/workflows/unit-tests-internal.yml
+++ b/.github/workflows/unit-tests-internal.yml
@@ -56,7 +56,7 @@ jobs:
           version: 10.23.0
 
       - name: ⎔ Setup node
-        uses: buildjet/setup-node@6131e76b005f1e3f5c721e0ca2d8279eb577c3a8 # v4.0.4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.20.0
           cache: "pnpm"
@@ -125,7 +125,7 @@ jobs:
           version: 10.23.0
 
       - name: ⎔ Setup node
-        uses: buildjet/setup-node@6131e76b005f1e3f5c721e0ca2d8279eb577c3a8 # v4.0.4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.20.0
           # no cache enabled, we're not installing deps

--- a/.github/workflows/unit-tests-packages.yml
+++ b/.github/workflows/unit-tests-packages.yml
@@ -56,7 +56,7 @@ jobs:
           version: 10.23.0
 
       - name: ⎔ Setup node
-        uses: buildjet/setup-node@6131e76b005f1e3f5c721e0ca2d8279eb577c3a8 # v4.0.4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.20.0
           cache: "pnpm"
@@ -125,7 +125,7 @@ jobs:
           version: 10.23.0
 
       - name: ⎔ Setup node
-        uses: buildjet/setup-node@6131e76b005f1e3f5c721e0ca2d8279eb577c3a8 # v4.0.4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.20.0
           # no cache enabled, we're not installing deps

--- a/.github/workflows/unit-tests-webapp.yml
+++ b/.github/workflows/unit-tests-webapp.yml
@@ -56,7 +56,7 @@ jobs:
           version: 10.23.0
 
       - name: ⎔ Setup node
-        uses: buildjet/setup-node@6131e76b005f1e3f5c721e0ca2d8279eb577c3a8 # v4.0.4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.20.0
           cache: "pnpm"
@@ -133,7 +133,7 @@ jobs:
           version: 10.23.0
 
       - name: ⎔ Setup node
-        uses: buildjet/setup-node@6131e76b005f1e3f5c721e0ca2d8279eb577c3a8 # v4.0.4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.20.0
           # no cache enabled, we're not installing deps


### PR DESCRIPTION
Last action still firing the Node 20 deprecation warning after #3494. `buildjet/setup-node@v4.0.4` (the latest tag) declares `runs: using: 'node20'` and the repo hasn't shipped a node24 update.

Workflows here run on `ubuntu-latest` (not buildjet runners), so the buildjet fork wasn't giving us anything we don't get from `actions/setup-node` directly. Swapping to `actions/setup-node@v6.4.0` (node24 runtime) silences the warning.