### PR TITLE
chore: bump helm chart version to 4.4.5

### DIFF
--- a/hosting/k8s/helm/Chart.yaml
+++ b/hosting/k8s/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: trigger
 description: The official Trigger.dev Helm chart
 type: application
-version: 4.4.4
-appVersion: v4.4.4
+version: 4.4.5
+appVersion: v4.4.5
 home: https://trigger.dev
 sources:
   - https://github.com/triggerdotdev/trigger.dev


### PR DESCRIPTION
Follow-up to v4.4.5 release. The `bump-chart-version` job on the release PR was cancelled before it could run, so Chart.yaml was merged still pointing at 4.4.4. The helm release job ([failed run](https://github.com/triggerdotdev/trigger.dev/actions/runs/25218553990/job/73947054128)) caught it via its version-match guard.

Once this merges I'll re-run the helm release workflow manually.