### PR TITLE
ci: add actionlint workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,33 @@
+name: Actionlint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667

--- a/.github/workflows/helm-prerelease.yml
+++ b/.github/workflows/helm-prerelease.yml
@@ -118,7 +118,7 @@ jobs:
             fi
             PRERELEASE_VERSION="${BASE_VERSION}-${REF_SLUG}.${SHORT_SHA}"
           fi
-          echo "version=$PRERELEASE_VERSION" >> $GITHUB_OUTPUT
+          echo "version=$PRERELEASE_VERSION" >> "$GITHUB_OUTPUT"
           echo "Prerelease version: $PRERELEASE_VERSION"
 
       - name: Update Chart.yaml with prerelease version

--- a/.github/workflows/publish-webapp.yml
+++ b/.github/workflows/publish-webapp.yml
@@ -59,13 +59,15 @@ jobs:
       - name: 📝 Set the build info
         id: set_build_info
         run: |
-          tag=${{ steps.get_tag.outputs.tag }}
-          if [[ "${{ steps.get_tag.outputs.is_semver }}" == true ]]; then
-            echo "BUILD_APP_VERSION=${tag}" >> "$GITHUB_OUTPUT"
-          fi
-          echo "BUILD_GIT_SHA=${{ github.sha }}" >> "$GITHUB_OUTPUT"
-          echo "BUILD_GIT_REF_NAME=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-          echo "BUILD_TIMESTAMP_SECONDS=$(date +%s)" >> "$GITHUB_OUTPUT"
+          {
+            tag="${{ steps.get_tag.outputs.tag }}"
+            if [[ "${{ steps.get_tag.outputs.is_semver }}" == true ]]; then
+              echo "BUILD_APP_VERSION=${tag}"
+            fi
+            echo "BUILD_GIT_SHA=${{ github.sha }}"
+            echo "BUILD_GIT_REF_NAME=${{ github.ref_name }}"
+            echo "BUILD_TIMESTAMP_SECONDS=$(date +%s)"
+          } >> "$GITHUB_OUTPUT"
 
       - name: 🐙 Login to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/publish-worker-v4.yml
+++ b/.github/workflows/publish-worker-v4.yml
@@ -44,12 +44,13 @@ jobs:
 
       - name: 📦 Get image repo
         id: get_repository
+        env:
+          PACKAGE: ${{ matrix.package }}
         run: |
-          if [[ "${{ matrix.package }}" == *-provider ]]; then
-            provider_type=$(echo "${{ matrix.package }}" | cut -d- -f1)
-            repo=provider/${provider_type}
+          if [[ "$PACKAGE" == *-provider ]]; then
+            repo="provider/${PACKAGE%-provider}"
           else
-            repo="${{ matrix.package }}"
+            repo="$PACKAGE"
           fi
           echo "repo=${repo}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish-worker.yml
+++ b/.github/workflows/publish-worker.yml
@@ -32,12 +32,13 @@ jobs:
 
       - name: 📦 Get image repo
         id: get_repository
+        env:
+          PACKAGE: ${{ matrix.package }}
         run: |
-          if [[ "${{ matrix.package }}" == *-provider ]]; then
-            provider_type=$(echo "${{ matrix.package }}" | cut -d- -f1)
-            repo=provider/${provider_type}
+          if [[ "$PACKAGE" == *-provider ]]; then
+            repo="provider/${PACKAGE%-provider}"
           else
-            repo="${{ matrix.package }}"
+            repo="$PACKAGE"
           fi
           echo "repo=${repo}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -98,7 +98,7 @@ jobs:
             VERSION="${{ github.ref_name }}"
             VERSION="${VERSION#helm-v}"
           fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Releasing version: $VERSION"
 
       - name: Check Chart.yaml version matches release version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          echo "$PR_BODY" | sed -n '/^# Releases/,$p' >> $GITHUB_STEP_SUMMARY
+          echo "$PR_BODY" | sed -n '/^# Releases/,$p' >> "$GITHUB_STEP_SUMMARY"
 
   release:
     name: 🚀 Release npm packages


### PR DESCRIPTION
Adds an `actionlint` job that runs on changes to `.github/workflows/**` and `.github/actions/**`. Catches workflow bugs at PR time — expression typos, deprecated runner labels, broken matrices, and shellcheck issues in `run:` blocks.

Run from the official `docker://rhysd/actionlint` image, digest-pinned alongside everything else.

Existing workflows had 6 shellcheck findings — fixed inline:

- 3× SC2086 (`>> $GITHUB_OUTPUT` → `>> "$GITHUB_OUTPUT"`) in `helm-prerelease.yml`, `release-helm.yml`, `release.yml`
- 1× SC2129 in `publish-webapp.yml` (grouped repeated redirects under one `{ ... } >> "$GITHUB_OUTPUT"`)
- 2× SC2193 false-positive in `publish-worker.yml` and `publish-worker-v4.yml` (the `[[ "${{ matrix.package }}" == *-provider ]]` pattern). Refactored to pass `matrix.package` via `env:` and use bash parameter expansion - cleaner and dodges the warning.