### PR TITLE
fix: prevent nanosecond timestamp overflow in OTLP conversion

### DIFF
--- a/apps/webapp/app/v3/eventRepository/common.server.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.ts
@@ -21,7 +21,7 @@ export function extractContextFromCarrier(carrier: Record<string, unknown>) {
 }
 
 export function getNowInNanoseconds(): bigint {
-  return BigInt(new Date().getTime() * 1_000_000);
+  return convertDateToNanoseconds(new Date());
 }
 
 export function getDateFromNanoseconds(nanoseconds: bigint): Date {
@@ -35,7 +35,7 @@ export function calculateDurationFromStart(
 ) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  const duration = Number(BigInt($endtime.getTime() * 1_000_000) - startTime);
+  const duration = Number(BigInt($endtime.getTime()) * BigInt(1_000_000) - startTime);
 
   if (minimumDuration && duration < minimumDuration) {
     return minimumDuration;

--- a/apps/webapp/app/v3/eventRepository/index.server.ts
+++ b/apps/webapp/app/v3/eventRepository/index.server.ts
@@ -10,6 +10,7 @@ import { logger } from "~/services/logger.server";
 import { FEATURE_FLAG } from "../featureFlags";
 import { flag } from "../featureFlags.server";
 import { getTaskEventStore } from "../taskEventStore.server";
+import { convertDateToNanoseconds } from "./common.server";
 
 export function resolveEventRepositoryForStore(store: string | undefined): IEventRepository {
   const taskEventStore = store ?? env.EVENT_REPOSITORY_DEFAULT_STORE;
@@ -215,7 +216,7 @@ async function recordRunEvent(
         runId: foundRun.friendlyId,
         ...attributes,
       },
-      startTime: BigInt((startTime?.getTime() ?? Date.now()) * 1_000_000),
+      startTime: convertDateToNanoseconds(startTime ?? new Date()),
       ...optionsRest,
     });
 

--- a/apps/webapp/app/v3/runEngineHandlers.server.ts
+++ b/apps/webapp/app/v3/runEngineHandlers.server.ts
@@ -16,7 +16,10 @@ import { MetadataTooLargeError } from "~/utils/packets";
 import { QueueSizeLimitExceededError } from "~/v3/services/common.server";
 import { TriggerTaskService } from "~/v3/services/triggerTask.server";
 import { tracer } from "~/v3/tracer.server";
-import { createExceptionPropertiesFromError } from "./eventRepository/common.server";
+import {
+  convertDateToNanoseconds,
+  createExceptionPropertiesFromError,
+} from "./eventRepository/common.server";
 import {
   recordRunDebugLog,
   resolveEventRepositoryForStore,
@@ -429,7 +432,7 @@ export function registerRunEngineEventBusHandlers() {
       const eventRepository = resolveEventRepositoryForStore(run.taskEventStore);
 
       await eventRepository.recordEvent(retryMessage, {
-        startTime: BigInt(time.getTime() * 1000000),
+        startTime: convertDateToNanoseconds(time),
         taskSlug: run.taskIdentifier,
         environment,
         attributes: {


### PR DESCRIPTION
## Problem
OTLP nanosecond timestamp conversion uses `BigInt(ms * 1_000_000)` where the intermediate multiplication happens in Number space. For large millisecond timestamps (> 2^53 / 1e6), this loses precision before BigInt conversion.

## Change
Replace `BigInt(ms * 1_000_000)` with `BigInt(ms) * BigInt(1_000_000)` so the multiplication happens entirely in BigInt space, preventing precision loss.

Fixes #3292.

Made with [Cursor](https://cursor.com)