### PR TITLE
feat(webapp): admin editor for org concurrency quota

### DIFF
--- a/.server-changes/admin-concurrency-quota.md
+++ b/.server-changes/admin-concurrency-quota.md
@@ -1,0 +1,10 @@
+---
+area: webapp
+type: feature
+---
+
+Admin Back office: editor for an org's concurrency quota cap (the per-org
+override on how much extra concurrency the org can purchase). Sits as a new
+section on the existing per-org back-office page alongside API/Batch rate
+limits and Maximum projects. Calls cloud's billing service to update
+billing.Limits.extraConcurrencyQuota.

--- a/apps/webapp/app/components/admin/backOffice/ConcurrencyQuotaSection.server.ts
+++ b/apps/webapp/app/components/admin/backOffice/ConcurrencyQuotaSection.server.ts
@@ -3,38 +3,11 @@ import { logger } from "~/services/logger.server";
 import { setExtraConcurrencyQuota } from "~/services/platform.v3.server";
 import { CONCURRENCY_QUOTA_INTENT } from "./ConcurrencyQuotaSection";
 
-const RawSchema = z.object({
+const SetConcurrencyQuotaSchema = z.object({
   intent: z.literal(CONCURRENCY_QUOTA_INTENT),
-  // Checkbox arrives as "on" / "true" when checked, absent when not.
-  usePlanDefault: z.string().optional(),
-  // Empty string when "Use plan default" is checked (the input is disabled).
-  extraConcurrencyQuota: z.string().optional(),
-});
-
-const SetConcurrencyQuotaSchema = RawSchema.transform((raw, ctx) => {
-  const usePlanDefault = !!raw.usePlanDefault;
-  if (usePlanDefault) {
-    return { extraConcurrencyQuota: null as number | null };
-  }
-  const trimmed = (raw.extraConcurrencyQuota ?? "").trim();
-  if (trimmed.length === 0) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Enter a non-negative integer or check 'Use plan default'.",
-      path: ["extraConcurrencyQuota"],
-    });
-    return z.NEVER;
-  }
-  const parsed = Number(trimmed);
-  if (!Number.isInteger(parsed) || parsed < 0) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Quota must be a non-negative integer.",
-      path: ["extraConcurrencyQuota"],
-    });
-    return z.NEVER;
-  }
-  return { extraConcurrencyQuota: parsed as number | null };
+  // Capped at PostgreSQL INTEGER max for safety; cloud will reject anything
+  // unreasonably high on its own (likely with quota_too_high).
+  extraConcurrencyQuota: z.coerce.number().int().min(0).max(2_147_483_647),
 });
 
 export type ConcurrencyQuotaActionResult =
@@ -102,7 +75,7 @@ function mapCodeToMessage(
 ): string {
   switch (code) {
     case "invalid_body":
-      return "Quota must be a non-negative integer (or check 'Use plan default').";
+      return "Quota must be a non-negative integer.";
     case "quota_too_high":
       // Cloud's `error` string embeds the actual ceiling, prefer it verbatim.
       return fallback || "Cap is too high.";

--- a/apps/webapp/app/components/admin/backOffice/ConcurrencyQuotaSection.server.ts
+++ b/apps/webapp/app/components/admin/backOffice/ConcurrencyQuotaSection.server.ts
@@ -1,0 +1,116 @@
+import { z } from "zod";
+import { logger } from "~/services/logger.server";
+import { setExtraConcurrencyQuota } from "~/services/platform.v3.server";
+import { CONCURRENCY_QUOTA_INTENT } from "./ConcurrencyQuotaSection";
+
+const RawSchema = z.object({
+  intent: z.literal(CONCURRENCY_QUOTA_INTENT),
+  // Checkbox arrives as "on" / "true" when checked, absent when not.
+  usePlanDefault: z.string().optional(),
+  // Empty string when "Use plan default" is checked (the input is disabled).
+  extraConcurrencyQuota: z.string().optional(),
+});
+
+const SetConcurrencyQuotaSchema = RawSchema.transform((raw, ctx) => {
+  const usePlanDefault = !!raw.usePlanDefault;
+  if (usePlanDefault) {
+    return { extraConcurrencyQuota: null as number | null };
+  }
+  const trimmed = (raw.extraConcurrencyQuota ?? "").trim();
+  if (trimmed.length === 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Enter a non-negative integer or check 'Use plan default'.",
+      path: ["extraConcurrencyQuota"],
+    });
+    return z.NEVER;
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Quota must be a non-negative integer.",
+      path: ["extraConcurrencyQuota"],
+    });
+    return z.NEVER;
+  }
+  return { extraConcurrencyQuota: parsed as number | null };
+});
+
+export type ConcurrencyQuotaActionResult =
+  | { ok: true }
+  | {
+      ok: false;
+      errors: Record<string, string[] | undefined>;
+      formError?: string;
+    };
+
+export async function handleConcurrencyQuotaAction(
+  formData: FormData,
+  orgId: string,
+  adminUserId: string
+): Promise<ConcurrencyQuotaActionResult> {
+  const submission = SetConcurrencyQuotaSchema.safeParse(
+    Object.fromEntries(formData)
+  );
+  if (!submission.success) {
+    return { ok: false, errors: submission.error.flatten().fieldErrors };
+  }
+
+  const result = await setExtraConcurrencyQuota(orgId, {
+    extraConcurrencyQuota: submission.data.extraConcurrencyQuota,
+  });
+
+  if (!result) {
+    return {
+      ok: false,
+      errors: {},
+      formError:
+        "Billing client unavailable — check BILLING_API_URL/BILLING_API_KEY config.",
+    };
+  }
+
+  if (!result.success) {
+    // The platform client's generic error path strips `code` to `error` only
+    // until the BillingClient.fetch passthrough fix lands; cast keeps the
+    // route forward-compatible so precise UI copy renders automatically once
+    // it does.
+    const err = result as {
+      success: false;
+      error: string;
+      code?: string;
+    };
+    return {
+      ok: false,
+      errors: {},
+      formError: mapCodeToMessage(err.code, err.error),
+    };
+  }
+
+  logger.info("admin.backOffice.concurrencyQuota", {
+    adminUserId,
+    orgId,
+    next: submission.data.extraConcurrencyQuota,
+  });
+
+  return { ok: true };
+}
+
+function mapCodeToMessage(
+  code: string | undefined,
+  fallback: string
+): string {
+  switch (code) {
+    case "invalid_body":
+      return "Quota must be a non-negative integer (or check 'Use plan default').";
+    case "quota_too_high":
+      // Cloud's `error` string embeds the actual ceiling, prefer it verbatim.
+      return fallback || "Cap is too high.";
+    case "org_not_found":
+      return "Organization not found.";
+    case "limits_not_found":
+      return "This org has no billing limits row yet.";
+    default:
+      return fallback || "Failed to update concurrency quota.";
+  }
+}

--- a/apps/webapp/app/components/admin/backOffice/ConcurrencyQuotaSection.tsx
+++ b/apps/webapp/app/components/admin/backOffice/ConcurrencyQuotaSection.tsx
@@ -1,7 +1,6 @@
 import { Form } from "@remix-run/react";
 import { useEffect, useState } from "react";
 import { Button } from "~/components/primitives/Buttons";
-import { Checkbox } from "~/components/primitives/Checkbox";
 import { FormError } from "~/components/primitives/FormError";
 import { Header2 } from "~/components/primitives/Headers";
 import { Input } from "~/components/primitives/Input";
@@ -36,7 +35,6 @@ export function ConcurrencyQuotaSection({
     errors && field in errors ? errors[field]?.[0] : undefined;
 
   const [isEditing, setIsEditing] = useState(hasFieldErrors || !!formError);
-  const [usePlanDefault, setUsePlanDefault] = useState(false);
   const [value, setValue] = useState(String(currentQuota));
 
   useEffect(() => {
@@ -49,9 +47,23 @@ export function ConcurrencyQuotaSection({
 
   const cancelEdit = () => {
     setValue(String(currentQuota));
-    setUsePlanDefault(false);
     setIsEditing(false);
   };
+
+  const trimmedValue = value.trim();
+  const parsed = Number(trimmedValue);
+  const isValidPreview =
+    trimmedValue.length > 0 &&
+    Number.isInteger(parsed) &&
+    parsed >= 0;
+  const delta = isValidPreview ? parsed - currentQuota : 0;
+  const deltaLabel =
+    delta > 0
+      ? `+${delta.toLocaleString()}`
+      : delta < 0
+        ? delta.toLocaleString()
+        : "no change";
+  const headroomAfter = isValidPreview ? parsed - purchased : 0;
 
   return (
     <section className="flex flex-col gap-3 rounded-md border border-charcoal-700 bg-charcoal-800 p-4">
@@ -111,32 +123,41 @@ export function ConcurrencyQuotaSection({
               name="extraConcurrencyQuota"
               type="number"
               min={0}
-              value={usePlanDefault ? "" : value}
+              value={value}
               onChange={(e) => setValue(e.target.value)}
-              disabled={usePlanDefault}
-              required={!usePlanDefault}
+              required
             />
             <FormError>{fieldError("extraConcurrencyQuota")}</FormError>
           </div>
 
-          <div className="flex items-center gap-2">
-            <Checkbox
-              id="usePlanDefault"
-              name="usePlanDefault"
-              value="true"
-              checked={usePlanDefault}
-              onChange={(e) => setUsePlanDefault(e.target.checked)}
-            />
-            <Label htmlFor="usePlanDefault">
-              Use plan default (clears any per-org override)
-            </Label>
-          </div>
+          {isValidPreview && (
+            <div className="rounded-md border border-charcoal-700 bg-charcoal-900 px-3 py-2">
+              <Paragraph variant="small">
+                Cap: {currentQuota.toLocaleString()} →{" "}
+                {parsed.toLocaleString()} ({deltaLabel})
+              </Paragraph>
+              <Paragraph variant="small" className="text-text-dimmed">
+                Already purchased: {purchased.toLocaleString()}
+              </Paragraph>
+              {headroomAfter >= 0 ? (
+                <Paragraph variant="small" className="text-text-dimmed">
+                  After save: {headroomAfter.toLocaleString()} more buyable.
+                </Paragraph>
+              ) : (
+                <Paragraph variant="small" className="text-amber-500">
+                  Below already-purchased — org would be{" "}
+                  {(-headroomAfter).toLocaleString()} over the new cap. They'd
+                  keep what they have but couldn't buy more until you raise it.
+                </Paragraph>
+              )}
+            </div>
+          )}
 
           <div className="flex items-center gap-2">
             <Button
               type="submit"
               variant="primary/medium"
-              disabled={isSubmitting || (!usePlanDefault && !value.trim())}
+              disabled={isSubmitting || !value.trim()}
             >
               Save
             </Button>

--- a/apps/webapp/app/components/admin/backOffice/ConcurrencyQuotaSection.tsx
+++ b/apps/webapp/app/components/admin/backOffice/ConcurrencyQuotaSection.tsx
@@ -1,0 +1,156 @@
+import { Form } from "@remix-run/react";
+import { useEffect, useState } from "react";
+import { Button } from "~/components/primitives/Buttons";
+import { Checkbox } from "~/components/primitives/Checkbox";
+import { FormError } from "~/components/primitives/FormError";
+import { Header2 } from "~/components/primitives/Headers";
+import { Input } from "~/components/primitives/Input";
+import { Label } from "~/components/primitives/Label";
+import { Paragraph } from "~/components/primitives/Paragraph";
+import * as Property from "~/components/primitives/PropertyTable";
+
+export const CONCURRENCY_QUOTA_INTENT = "set-concurrency-quota";
+export const CONCURRENCY_QUOTA_SAVED_VALUE = "concurrency-quota";
+
+type FieldErrors = Record<string, string[] | undefined> | null;
+
+type Props = {
+  currentQuota: number;
+  purchased: number;
+  errors: FieldErrors;
+  formError: string | null;
+  savedJustNow: boolean;
+  isSubmitting: boolean;
+};
+
+export function ConcurrencyQuotaSection({
+  currentQuota,
+  purchased,
+  errors,
+  formError,
+  savedJustNow,
+  isSubmitting,
+}: Props) {
+  const hasFieldErrors = !!errors && Object.keys(errors).length > 0;
+  const fieldError = (field: string) =>
+    errors && field in errors ? errors[field]?.[0] : undefined;
+
+  const [isEditing, setIsEditing] = useState(hasFieldErrors || !!formError);
+  const [usePlanDefault, setUsePlanDefault] = useState(false);
+  const [value, setValue] = useState(String(currentQuota));
+
+  useEffect(() => {
+    if (hasFieldErrors || formError) setIsEditing(true);
+  }, [hasFieldErrors, formError]);
+
+  useEffect(() => {
+    if (savedJustNow && !hasFieldErrors && !formError) setIsEditing(false);
+  }, [savedJustNow, hasFieldErrors, formError]);
+
+  const cancelEdit = () => {
+    setValue(String(currentQuota));
+    setUsePlanDefault(false);
+    setIsEditing(false);
+  };
+
+  return (
+    <section className="flex flex-col gap-3 rounded-md border border-charcoal-700 bg-charcoal-800 p-4">
+      <div className="flex items-center justify-between">
+        <Header2>Concurrency quota</Header2>
+        {!isEditing && (
+          <Button
+            variant="tertiary/small"
+            onClick={() => setIsEditing(true)}
+            disabled={isSubmitting}
+          >
+            Edit
+          </Button>
+        )}
+      </div>
+
+      <Paragraph variant="small">
+        Cap on how much extra concurrency this org can purchase. Increases
+        unlock self-serve purchase up to the new cap; the org still has to
+        complete the purchase from the billing flow.
+      </Paragraph>
+
+      {savedJustNow && (
+        <div className="rounded-md border border-green-600/40 bg-green-600/10 px-3 py-2">
+          <Paragraph variant="small" className="text-green-500">
+            Saved.
+          </Paragraph>
+        </div>
+      )}
+
+      {formError && (
+        <div className="rounded-md border border-red-600/40 bg-red-600/10 px-3 py-2">
+          <Paragraph variant="small" className="text-red-500">
+            {formError}
+          </Paragraph>
+        </div>
+      )}
+
+      {!isEditing ? (
+        <Property.Table>
+          <Property.Item>
+            <Property.Label>Max extra concurrency this org can purchase on top of their plan</Property.Label>
+            <Property.Value>{currentQuota.toLocaleString()}</Property.Value>
+          </Property.Item>
+          <Property.Item>
+            <Property.Label>Already purchased</Property.Label>
+            <Property.Value>{purchased.toLocaleString()}</Property.Value>
+          </Property.Item>
+        </Property.Table>
+      ) : (
+        <Form method="post" className="flex flex-col gap-3 pt-2">
+          <input type="hidden" name="intent" value={CONCURRENCY_QUOTA_INTENT} />
+
+          <div className="flex flex-col gap-1">
+            <Label>Max extra concurrency this org can purchase on top of their plan</Label>
+            <Input
+              name="extraConcurrencyQuota"
+              type="number"
+              min={0}
+              value={usePlanDefault ? "" : value}
+              onChange={(e) => setValue(e.target.value)}
+              disabled={usePlanDefault}
+              required={!usePlanDefault}
+            />
+            <FormError>{fieldError("extraConcurrencyQuota")}</FormError>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="usePlanDefault"
+              name="usePlanDefault"
+              value="true"
+              checked={usePlanDefault}
+              onChange={(e) => setUsePlanDefault(e.target.checked)}
+            />
+            <Label htmlFor="usePlanDefault">
+              Use plan default (clears any per-org override)
+            </Label>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button
+              type="submit"
+              variant="primary/medium"
+              disabled={isSubmitting || (!usePlanDefault && !value.trim())}
+            >
+              Save
+            </Button>
+            <Button
+              type="button"
+              variant="tertiary/medium"
+              onClick={cancelEdit}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+          </div>
+        </Form>
+      )}
+    </section>
+  );
+}

--- a/apps/webapp/app/routes/admin.back-office.orgs.$orgId.tsx
+++ b/apps/webapp/app/routes/admin.back-office.orgs.$orgId.tsx
@@ -26,6 +26,12 @@ import {
   resolveEffectiveBatchRateLimit,
 } from "~/components/admin/backOffice/BatchRateLimitSection.server";
 import {
+  CONCURRENCY_QUOTA_INTENT,
+  CONCURRENCY_QUOTA_SAVED_VALUE,
+  ConcurrencyQuotaSection,
+} from "~/components/admin/backOffice/ConcurrencyQuotaSection";
+import { handleConcurrencyQuotaAction } from "~/components/admin/backOffice/ConcurrencyQuotaSection.server";
+import {
   MAX_PROJECTS_INTENT,
   MAX_PROJECTS_SAVED_VALUE,
   MaxProjectsSection,
@@ -36,6 +42,7 @@ import { CopyableText } from "~/components/primitives/CopyableText";
 import { Header1 } from "~/components/primitives/Headers";
 import { Paragraph } from "~/components/primitives/Paragraph";
 import { prisma } from "~/db.server";
+import { getCurrentPlan } from "~/services/platform.v3.server";
 import { requireUser } from "~/services/session.server";
 
 const SAVED_QUERY_KEY = "saved";
@@ -73,7 +80,14 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     org.batchRateLimitConfig
   );
 
-  return typedjson({ org, apiEffective, batchEffective });
+  const currentPlan = await getCurrentPlan(org.id);
+  const concurrencyAddOn = currentPlan?.v3Subscription?.addOns?.concurrentRuns;
+  const concurrencyQuota = {
+    currentQuota: concurrencyAddOn?.quota ?? 0,
+    purchased: concurrencyAddOn?.purchased ?? 0,
+  };
+
+  return typedjson({ org, apiEffective, batchEffective, concurrencyQuota });
 }
 
 export async function action({ request, params }: ActionFunctionArgs) {
@@ -129,6 +143,23 @@ export async function action({ request, params }: ActionFunctionArgs) {
     );
   }
 
+  if (intent === CONCURRENCY_QUOTA_INTENT) {
+    const result = await handleConcurrencyQuotaAction(formData, orgId, user.id);
+    if (!result.ok) {
+      return typedjson(
+        {
+          section: CONCURRENCY_QUOTA_SAVED_VALUE,
+          errors: result.errors,
+          formError: result.formError ?? null,
+        },
+        { status: 400 }
+      );
+    }
+    return redirect(
+      `/admin/back-office/orgs/${orgId}?${SAVED_QUERY_KEY}=${CONCURRENCY_QUOTA_SAVED_VALUE}`
+    );
+  }
+
   return typedjson(
     { section: null, errors: { intent: ["Unknown intent."] } },
     { status: 400 }
@@ -136,7 +167,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 }
 
 export default function BackOfficeOrgPage() {
-  const { org, apiEffective, batchEffective } =
+  const { org, apiEffective, batchEffective, concurrencyQuota } =
     useTypedLoaderData<typeof loader>();
   const actionData = useTypedActionData<typeof action>();
   const navigation = useNavigation();
@@ -147,12 +178,19 @@ export default function BackOfficeOrgPage() {
     navigation.state !== "idle" && submittingIntent === BATCH_RATE_LIMIT_INTENT;
   const isSubmittingMaxProjects =
     navigation.state !== "idle" && submittingIntent === MAX_PROJECTS_INTENT;
+  const isSubmittingConcurrencyQuota =
+    navigation.state !== "idle" &&
+    submittingIntent === CONCURRENCY_QUOTA_INTENT;
 
   const errorSection =
     actionData && "section" in actionData ? actionData.section : null;
   const errors =
     actionData && "errors" in actionData
       ? (actionData.errors as Record<string, string[] | undefined>)
+      : null;
+  const formError =
+    actionData && "formError" in actionData
+      ? ((actionData as { formError?: string | null }).formError ?? null)
       : null;
 
   const [searchParams, setSearchParams] = useSearchParams();
@@ -179,7 +217,7 @@ export default function BackOfficeOrgPage() {
   }, [savedSection, setSearchParams]);
 
   return (
-    <div className="flex flex-col gap-6 py-4">
+    <div className="flex shrink-0 flex-col gap-6 pb-12 pt-4">
       <div className="flex items-center justify-between">
         <div className="flex flex-col gap-1">
           <Header1>{org.title}</Header1>
@@ -211,6 +249,17 @@ export default function BackOfficeOrgPage() {
         errors={errorSection === MAX_PROJECTS_SAVED_VALUE ? errors : null}
         savedJustNow={savedSection === MAX_PROJECTS_SAVED_VALUE}
         isSubmitting={isSubmittingMaxProjects}
+      />
+
+      <ConcurrencyQuotaSection
+        currentQuota={concurrencyQuota.currentQuota}
+        purchased={concurrencyQuota.purchased}
+        errors={errorSection === CONCURRENCY_QUOTA_SAVED_VALUE ? errors : null}
+        formError={
+          errorSection === CONCURRENCY_QUOTA_SAVED_VALUE ? formError : null
+        }
+        savedJustNow={savedSection === CONCURRENCY_QUOTA_SAVED_VALUE}
+        isSubmitting={isSubmittingConcurrencyQuota}
       />
     </div>
   );

--- a/apps/webapp/app/routes/admin.tsx
+++ b/apps/webapp/app/routes/admin.tsx
@@ -16,7 +16,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export default function Page() {
   return (
-    <div className="h-full w-full">
+    <div className="flex h-full w-full flex-col">
       <div className="flex items-center justify-between p-4">
         <Tabs
           tabs={[

--- a/apps/webapp/app/services/platform.v3.server.ts
+++ b/apps/webapp/app/services/platform.v3.server.ts
@@ -436,6 +436,48 @@ export async function setConcurrencyAddOn(organizationId: string, amount: number
   }
 }
 
+// Admin-only: raise (or revert) the per-org cap on extra purchasable
+// concurrency. Hits cloud's POST /api/admin/orgs/:orgId/concurrency-quota,
+// which writes billing.Limits.extraConcurrencyQuota. The local cast layers
+// the new method on top of BillingClient until @trigger.dev/platform is
+// bumped to the version that exports it natively.
+type SetExtraConcurrencyQuotaResult =
+  | {
+      success: true;
+      orgId: string;
+      extraConcurrencyQuota: number | null;
+    }
+  | {
+      success: false;
+      error: string;
+      code?: string;
+    };
+
+export async function setExtraConcurrencyQuota(
+  organizationId: string,
+  body: { extraConcurrencyQuota: number | null }
+) {
+  if (!client) return undefined;
+
+  try {
+    const result = await (
+      client as unknown as {
+        setExtraConcurrencyQuota: (
+          orgId: string,
+          body: { extraConcurrencyQuota: number | null }
+        ) => Promise<SetExtraConcurrencyQuotaResult>;
+      }
+    ).setExtraConcurrencyQuota(organizationId, body);
+    if (!result.success) {
+      recordPlatformFailure("setExtraConcurrencyQuota", "no_success");
+    }
+    return result;
+  } catch (e) {
+    recordPlatformFailure("setExtraConcurrencyQuota", "caught");
+    return undefined;
+  }
+}
+
 export async function setSeatsAddOn(organizationId: string, amount: number) {
   if (!client) return undefined;
 


### PR DESCRIPTION

Adds a **Concurrency quota** section to the per-org Back office page (`/admin/back-office/orgs/:orgId`). Gives admins a UI to adjust the per-org cap on extra purchasable concurrency that previously had to be set out-of-band. Follows the same `*Section.tsx + *Section.server.ts` pattern as the existing API rate limit / Batch rate limit / Maximum projects sections.

Edit mode shows a live preview while typing: the cap delta, already-purchased amount, and resulting headroom after save. If the new cap would drop below already-purchased, an amber warning makes the state explicit.

## How it works

1. Admin opens an org's Back office page.
2. Clicks **Edit** on Concurrency quota, types a new value, hits **Save**.
3. Webapp calls `BillingClient.setExtraConcurrencyQuota` on the platform client.
4. The billing service updates the org's quota and the page refreshes.

## Branch base

Stacked on top of [`feat/admin-back-office-org-limits`](https://github.com/triggerdotdev/trigger.dev/pull/3475) — this PR targets that branch (not `main`) so the diff stays focused on the concurrency-quota work. It builds on the latest admin Back office UI: the `*Section.tsx + *Section.server.ts` pattern and the per-org page intent-dispatch wiring introduced there.

## Dependencies

Depends on a release of `@trigger.dev/platform` that exports `BillingClient.setExtraConcurrencyQuota`. 

## Notes

- Small layout fix to `admin.tsx` — added `flex flex-col` on the outer wrapper so content isn't clipped at the bottom of the viewport when sections overflow.
- The wrapper for `setExtraConcurrencyQuota` in `platform.v3.server.ts` casts to a local response type until the platform package exports the method natively. Drops to a clean import in the follow-up version-bump commit.

## Test plan

- [ ] Open an org's Back office page, scroll to Concurrency quota.
- [ ] View mode shows current cap + already-purchased.
- [ ] Edit → type a value → live preview shows correct delta + headroom.
- [ ] Save with a valid value → "Saved." banner; reload reflects the new cap.
- [ ] Save with an invalid value (negative, non-integer, empty) → field error.
- [ ] Type a value below already-purchased → amber warning renders.
- [ ] Per-`code` error banners render once the platform package's error-passthrough fix is released.
