### PR TITLE
fix: prevent IEEE 754 precision loss in OTLP nanosecond timestamps

### DIFF
--- a/.server-changes/fix-otlp-nanosecond-precision.md
+++ b/.server-changes/fix-otlp-nanosecond-precision.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Fix IEEE 754 precision loss in OTLP nanosecond timestamps by converting epoch ms to BigInt before multiplication

--- a/apps/webapp/app/v3/eventRepository/common.server.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.ts
@@ -21,7 +21,7 @@ export function extractContextFromCarrier(carrier: Record<string, unknown>) {
 }
 
 export function getNowInNanoseconds(): bigint {
-  return BigInt(new Date().getTime() * 1_000_000);
+  return BigInt(new Date().getTime()) * BigInt(1_000_000);
 }
 
 export function getDateFromNanoseconds(nanoseconds: bigint): Date {
@@ -35,7 +35,7 @@ export function calculateDurationFromStart(
 ) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  const duration = Number(BigInt($endtime.getTime() * 1_000_000) - startTime);
+  const duration = Number(BigInt($endtime.getTime()) * BigInt(1_000_000) - startTime);
 
   if (minimumDuration && duration < minimumDuration) {
     return minimumDuration;

--- a/apps/webapp/app/v3/eventRepository/index.server.ts
+++ b/apps/webapp/app/v3/eventRepository/index.server.ts
@@ -215,7 +215,7 @@ async function recordRunEvent(
         runId: foundRun.friendlyId,
         ...attributes,
       },
-      startTime: BigInt((startTime?.getTime() ?? Date.now()) * 1_000_000),
+      startTime: BigInt(startTime?.getTime() ?? Date.now()) * BigInt(1_000_000),
       ...optionsRest,
     });
 

--- a/apps/webapp/app/v3/runEngineHandlers.server.ts
+++ b/apps/webapp/app/v3/runEngineHandlers.server.ts
@@ -429,7 +429,7 @@ export function registerRunEngineEventBusHandlers() {
       const eventRepository = resolveEventRepositoryForStore(run.taskEventStore);
 
       await eventRepository.recordEvent(retryMessage, {
-        startTime: BigInt(time.getTime() * 1000000),
+        startTime: BigInt(time.getTime()) * BigInt(1_000_000),
         taskSlug: run.taskIdentifier,
         environment,
         attributes: {


### PR DESCRIPTION
Closes #3292

## What
Convert epoch milliseconds to `BigInt` before multiplying by `1_000_000` in four OTLP-event timestamp computations, so the multiplication happens in BigInt-land instead of as a JS Number.

## Why
`epoch_ms * 1_000_000` (≈1.7e18) exceeds `Number.MAX_SAFE_INTEGER` (~9e15), causing ~256ns rounding errors in roughly 0.2% of cases. This already-correct pattern (`BigInt(ms) * BigInt(1_000_000)`) exists in `convertDateToNanoseconds()` in the same file — the four other call sites just hadn't adopted it. See issue #3292 for the full breakdown.

Affected lines:
- `apps/webapp/app/v3/eventRepository/common.server.ts:24` — `getNowInNanoseconds()`
- `apps/webapp/app/v3/eventRepository/common.server.ts:38` — `calculateDurationFromStart()`
- `apps/webapp/app/v3/eventRepository/index.server.ts:218` — `recordRunDebugLog()` startTime
- `apps/webapp/app/v3/runEngineHandlers.server.ts:432` — retry event recording

## Notes
- Opened as draft — please review before marking ready.
- `.server-changes/` entry added per `apps/webapp/CLAUDE.md` conventions (server-only change, no public package touched).
- Verification: not run locally — change is mechanical and 4 lines across 3 files. CI typecheck should cover it.