### PR TITLE
fix(helm): bump clickhouse subchart 9.3.7 -> 9.4.4 (clickhouse 25.7.5)

### DIFF
--- a/hosting/k8s/helm/Chart.lock
+++ b/hosting/k8s/helm/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 21.2.6
 - name: clickhouse
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 9.3.7
+  version: 9.4.4
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 17.0.9
-digest: sha256:b6cef61abc0b8bcdf4e6d7d86bd8dd7999dd07543f5532f3d94797ffdf0ad30b
-generated: "2025-06-27T19:27:24.075488134+01:00"
+digest: sha256:e1b572ab8eca0cc376311398c27b1734d8a598095fccc81dd9c32b2c8b9c1149
+generated: "2026-05-05T10:31:58.493590751+01:00"

--- a/hosting/k8s/helm/Chart.yaml
+++ b/hosting/k8s/helm/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
     repository: "oci://registry-1.docker.io/bitnamicharts"
     condition: redis.deploy
   - name: clickhouse
-    version: "9.3.7"
+    version: "9.4.4"
     repository: "oci://registry-1.docker.io/bitnamicharts"
     condition: clickhouse.deploy
   - name: minio

--- a/hosting/k8s/helm/values.yaml
+++ b/hosting/k8s/helm/values.yaml
@@ -542,7 +542,7 @@ clickhouse:
   image:
     # Use bitnami legacy repo
     repository: bitnamilegacy/clickhouse
-    # image: docker.io/bitnamilegacy/clickhouse:25.6.1-debian-12-r0
+    # image: docker.io/bitnamilegacy/clickhouse:25.7.5-debian-12-r0
 
   # TLS/Secure connection configuration
   secure: false # Set to true to use HTTPS and secure connections


### PR DESCRIPTION
Fixes #3520. The bundled bitnami clickhouse subchart was pinned at `9.3.7` (clickhouse `25.6.1-debian-12-r0`), which hits a memory-tracker accounting bug under sustained ingest - the global counter overflows to ~7 EiB and every query gets rejected by OvercommitTracker until the pod is restarted. Self-hosters running 4.0.5 through 4.4.5 are exposed regardless of chart version since the subchart pin hadn't moved.

Bumping to `9.4.4` (clickhouse `25.7.5-debian-12-r0`) pulls in the 25.7.x memory-tracker fixes. This is also the latest publicly packaged release at `oci://registry-1.docker.io/bitnamicharts` - that registry has been frozen since 2025-08-28 (Bitnami catalog changes), but the chart source remains under Apache 2 on `bitnami/charts`. The image continues to resolve via `bitnamilegacy/clickhouse` per the existing `values.yaml` override, since `bitnami/clickhouse` itself moved to paid-only.

Verified locally: `helm dependency update` + `helm lint` + `helm template` + kubeconform across all 57 rendered manifests. Rendered statefulset image is `docker.io/bitnamilegacy/clickhouse:25.7.5-debian-12-r0`.