### PR TITLE
fix(run-engine): sweeper LREMs the worker queue list when acking marked runs

### DIFF
--- a/.server-changes/run-queue-sweeper-stale-entry.md
+++ b/.server-changes/run-queue-sweeper-stale-entry.md
@@ -1,0 +1,9 @@
+---
+area: webapp
+type: fix
+---
+
+Concurrency sweeper now removes the message from the worker queue list
+when acking marked runs, eliminating stale `messageKey` tombstones that
+produced "Failed to dequeue message from worker queue" errors when
+consumed by a later BLPOP.

--- a/internal-packages/run-engine/src/run-queue/index.ts
+++ b/internal-packages/run-engine/src/run-queue/index.ts
@@ -2847,7 +2847,7 @@ export class RunQueue {
 
     await this.acknowledgeMessage(run.orgId, run.messageId, {
       skipDequeueProcessing: true,
-      removeFromWorkerQueue: false,
+      removeFromWorkerQueue: true,
     });
   }
 

--- a/internal-packages/run-engine/src/run-queue/tests/concurrencySweeper.test.ts
+++ b/internal-packages/run-engine/src/run-queue/tests/concurrencySweeper.test.ts
@@ -177,19 +177,17 @@ describe("RunQueue Concurrency Sweeper", () => {
   );
 
   // When the sweeper acks a run whose messageKey value is still sitting on the worker
-  // queue list (e.g. fast-path enqueued, never BLPOP'd), it deletes the message body but
-  // leaves a stale tombstone on the list. The next BLPOP returns that tombstone, GET
-  // returns nil, and the dequeue path logs "Failed to dequeue message from worker queue".
+  // queue list (e.g. fast-path enqueued, never BLPOP'd), it must remove the entry from
+  // the list as well as deleting the message body. Otherwise the list keeps a stale
+  // tombstone — the next BLPOP returns the messageKey, GET returns nil, and the dequeue
+  // path logs "Failed to dequeue message from worker queue".
   redisTest(
-    "should not produce 'Failed to dequeue message from worker queue' after sweeper acks a fast-path-enqueued run",
+    "should clear the worker queue list when sweeper acks a fast-path-enqueued run",
     async ({ redisContainer }) => {
       let enableConcurrencySweeper = false;
-      const logger = new Logger("RunQueue", "debug");
-      const errorSpy = vi.spyOn(logger, "error");
 
       const queue = new RunQueue({
         ...testOptions,
-        logger,
         logLevel: "debug",
         queueSelectionStrategy: new FairQueueSelectionStrategy({
           redis: {
@@ -242,31 +240,26 @@ describe("RunQueue Concurrency Sweeper", () => {
         expect(await queue.readMessage(messageDev.orgId, messageDev.runId)).toBeDefined();
 
         // Sweeper now considers the run completed (test callback returns it), so
-        // processMarkedRun acks with removeFromWorkerQueue: false.
+        // processMarkedRun acks with removeFromWorkerQueue: true.
         enableConcurrencySweeper = true;
         await setTimeout(5_000);
 
-        // Sweeper has run: operational concurrency released, message body deleted.
+        // Sweeper has run: operational concurrency released, message body deleted, AND
+        // the messageKey value has been LREM'd from the worker queue list. Without the
+        // LREM, the list would still contain the messageKey, and the next BLPOP would
+        // pop the tombstone and emit "Failed to dequeue message from worker queue".
         expect(await queue.operationalCurrentConcurrencyOfEnvironment(authenticatedEnvDev)).toBe(0);
         expect(await queue.readMessage(messageDev.orgId, messageDev.runId)).toBeUndefined();
+        expect(await queue.peekAllOnWorkerQueue(authenticatedEnvDev.id)).toEqual([]);
 
-        // Trigger a blocking dequeue with a short timeout — production uses blockingPop:true,
-        // which is the only path that emits this error log.
+        // A subsequent blocking dequeue finds nothing — no real message and no tombstone.
         const dequeued = await queue.dequeueMessageFromWorkerQueue(
           "test_consumer",
           authenticatedEnvDev.id,
           { blockingPop: true, blockingPopTimeoutSeconds: 2 }
         );
         expect(dequeued).toBeUndefined();
-
-        // BUG: the dequeue path logs the exact Sentry-visible error. Match the message and
-        // the structured fields one-to-one with what TRIGGER-CLOUD-VC reports.
-        const failedDequeueErrors = errorSpy.mock.calls.filter(
-          ([msg]) => msg === "Failed to dequeue message from worker queue"
-        );
-        expect(failedDequeueErrors).toHaveLength(0);
       } finally {
-        errorSpy.mockRestore();
         await queue.quit();
       }
     }

--- a/internal-packages/run-engine/src/run-queue/tests/concurrencySweeper.test.ts
+++ b/internal-packages/run-engine/src/run-queue/tests/concurrencySweeper.test.ts
@@ -175,4 +175,100 @@ describe("RunQueue Concurrency Sweeper", () => {
       }
     }
   );
+
+  // When the sweeper acks a run whose messageKey value is still sitting on the worker
+  // queue list (e.g. fast-path enqueued, never BLPOP'd), it deletes the message body but
+  // leaves a stale tombstone on the list. The next BLPOP returns that tombstone, GET
+  // returns nil, and the dequeue path logs "Failed to dequeue message from worker queue".
+  redisTest(
+    "should not produce 'Failed to dequeue message from worker queue' after sweeper acks a fast-path-enqueued run",
+    async ({ redisContainer }) => {
+      let enableConcurrencySweeper = false;
+      const logger = new Logger("RunQueue", "debug");
+      const errorSpy = vi.spyOn(logger, "error");
+
+      const queue = new RunQueue({
+        ...testOptions,
+        logger,
+        logLevel: "debug",
+        queueSelectionStrategy: new FairQueueSelectionStrategy({
+          redis: {
+            keyPrefix: "runqueue:test:",
+            host: redisContainer.getHost(),
+            port: redisContainer.getPort(),
+          },
+          keys: testOptions.keys,
+        }),
+        workerOptions: {
+          pollIntervalMs: 100,
+          immediatePollIntervalMs: 100,
+        },
+        redis: {
+          keyPrefix: "runqueue:test:",
+          host: redisContainer.getHost(),
+          port: redisContainer.getPort(),
+        },
+        concurrencySweeper: {
+          scanSchedule: "* * * * * *",
+          scanJitterInMs: 5,
+          processMarkedSchedule: "* * * * * *",
+          processMarkedJitterInMs: 5,
+          callback: async (runIds) => {
+            if (!enableConcurrencySweeper) {
+              return [];
+            }
+            return [{ id: messageDev.runId, orgId: "o1234" }];
+          },
+        },
+      });
+
+      try {
+        await queue.updateEnvConcurrencyLimits(authenticatedEnvDev);
+
+        // Fast-path enqueue: SET messageKey, RPUSH messageKeyValue onto worker queue list,
+        // SADD runId into currentConcurrency. The message is on the list waiting to be popped.
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: messageDev,
+          workerQueue: authenticatedEnvDev.id,
+          enableFastPath: true,
+        });
+
+        // Pre-conditions: list has the entry, run is "in-flight" per operational concurrency,
+        // body exists. Fast-path bumps the operational currentConcurrency (SADD) but not
+        // currentDequeued — the displayed concurrency is bumped only when a worker BLPOPs.
+        expect(await queue.peekAllOnWorkerQueue(authenticatedEnvDev.id)).toHaveLength(1);
+        expect(await queue.operationalCurrentConcurrencyOfEnvironment(authenticatedEnvDev)).toBe(1);
+        expect(await queue.readMessage(messageDev.orgId, messageDev.runId)).toBeDefined();
+
+        // Sweeper now considers the run completed (test callback returns it), so
+        // processMarkedRun acks with removeFromWorkerQueue: false.
+        enableConcurrencySweeper = true;
+        await setTimeout(5_000);
+
+        // Sweeper has run: operational concurrency released, message body deleted.
+        expect(await queue.operationalCurrentConcurrencyOfEnvironment(authenticatedEnvDev)).toBe(0);
+        expect(await queue.readMessage(messageDev.orgId, messageDev.runId)).toBeUndefined();
+
+        // Trigger a blocking dequeue with a short timeout — production uses blockingPop:true,
+        // which is the only path that emits this error log.
+        const dequeued = await queue.dequeueMessageFromWorkerQueue(
+          "test_consumer",
+          authenticatedEnvDev.id,
+          { blockingPop: true, blockingPopTimeoutSeconds: 2 }
+        );
+        expect(dequeued).toBeUndefined();
+
+        // BUG: the dequeue path logs the exact Sentry-visible error. Match the message and
+        // the structured fields one-to-one with what TRIGGER-CLOUD-VC reports.
+        const failedDequeueErrors = errorSpy.mock.calls.filter(
+          ([msg]) => msg === "Failed to dequeue message from worker queue"
+        );
+        expect(failedDequeueErrors).toHaveLength(0);
+      } finally {
+        errorSpy.mockRestore();
+        await queue.quit();
+      }
+    }
+  );
 });


### PR DESCRIPTION
The concurrency sweeper's `processMarkedRun` calls `acknowledgeMessage` with `removeFromWorkerQueue: false`. The Lua script always `DEL`s the message body but only `LREM`s the worker queue list when the flag is set. Result: any run that was pushed onto the worker queue list (fast-path enqueue or `processQueueForWorkerQueue` promotion) but not yet `BLPOP`'d when the sweeper finds it leaves a stale `messageKey` value sitting on the list. The next worker `BLPOP` returns the tombstone, `GET messageKey` returns nil, and the dequeue path logs `Failed to dequeue message from worker queue`.

The original assumption was that sweeper-acked runs had already been BLPOP'd off the list (entry already gone, nothing to LREM). That holds when the worker BLPOPs and then dies, but not when fast-path enqueue or `processQueueForWorkerQueue` adds the entry to the list and the run then ages past the sweeper's 10-minute completed-at threshold without ever being popped.

Switch to `removeFromWorkerQueue: true`. Cost is one extra `LREM` per swept run, O(N) over the worker queue list length. Sweeper acks are bounded by the cron schedule (every 5 minutes, max 100 marked runs per fire), so the added Redis work is negligible relative to baseline ack workload.

## Test

`internal-packages/run-engine/src/run-queue/tests/concurrencySweeper.test.ts` adds a regression test that fast-path enqueues a message, runs the sweeper, then dequeues. Pre-fix the dequeue path logs the "Failed to dequeue message from worker queue" error; post-fix the worker queue list is left clean and the dequeue returns undefined silently.