### PR TITLE
ci: GHCR commit-SHA tag, OCI labels, and build provenance

### DIFF
--- a/.github/workflows/publish-webapp.yml
+++ b/.github/workflows/publish-webapp.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
   packages: write
   id-token: write
+  attestations: write
 
 on:
   workflow_call:
@@ -58,6 +59,12 @@ jobs:
             image_tags=$image_tags,$ref_without_tag:v4-beta
           fi
 
+          # when pushing the mutable main tag, also push an immutable-by-convention
+          # full-commit-sha tag so a commit can be resolved to a specific digest
+          if [[ "${STEPS_GET_TAG_OUTPUTS_TAG}" == "main" ]]; then
+            image_tags=$image_tags,$ref_without_tag:${GITHUB_SHA}
+          fi
+
           echo "image_tags=${image_tags}" >> "$GITHUB_OUTPUT"
         env:
           STEPS_GET_TAG_OUTPUTS_TAG: ${{ steps.get_tag.outputs.tag }}
@@ -74,6 +81,7 @@ jobs:
             echo "BUILD_GIT_SHA=${GITHUB_SHA}"
             echo "BUILD_GIT_REF_NAME=${GITHUB_REF_NAME}"
             echo "BUILD_TIMESTAMP_SECONDS=$(date +%s)"
+            echo "BUILD_TIMESTAMP_RFC3339=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           } >> "$GITHUB_OUTPUT"
         env:
           STEPS_GET_TAG_OUTPUTS_TAG: ${{ steps.get_tag.outputs.tag }}
@@ -87,6 +95,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🐳 Build image and push to GitHub Container Registry
+        id: build_push
         uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
         with:
           file: ./docker/Dockerfile
@@ -98,8 +107,16 @@ jobs:
             BUILD_GIT_SHA=${{ steps.set_build_info.outputs.BUILD_GIT_SHA }}
             BUILD_GIT_REF_NAME=${{ steps.set_build_info.outputs.BUILD_GIT_REF_NAME }}
             BUILD_TIMESTAMP_SECONDS=${{ steps.set_build_info.outputs.BUILD_TIMESTAMP_SECONDS }}
+            BUILD_TIMESTAMP_RFC3339=${{ steps.set_build_info.outputs.BUILD_TIMESTAMP_RFC3339 }}
             SENTRY_RELEASE=${{ steps.set_build_info.outputs.BUILD_GIT_SHA }}
             SENTRY_ORG=triggerdev
             SENTRY_PROJECT=trigger-cloud
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: 🪪 Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/triggerdotdev/trigger.dev
+          subject-digest: ${{ steps.build_push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/publish-webapp.yml
+++ b/.github/workflows/publish-webapp.yml
@@ -115,6 +115,10 @@ jobs:
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: 🪪 Attest build provenance
+        # Image is already pushed by this point — don't fail releases (and the
+        # downstream publish-helm job) on a Sigstore/GHCR-referrer hiccup. Real
+        # config errors still surface as a step warning in the workflow run.
+        continue-on-error: true
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ghcr.io/triggerdotdev/trigger.dev

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,6 +68,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     uses: ./.github/workflows/publish-webapp.yml
     secrets:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     uses: ./.github/workflows/publish.yml
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -98,10 +98,16 @@ ARG BUILD_APP_VERSION
 ARG BUILD_GIT_SHA
 ARG BUILD_GIT_REF_NAME
 ARG BUILD_TIMESTAMP_SECONDS
+ARG BUILD_TIMESTAMP_RFC3339
 ENV BUILD_APP_VERSION=${BUILD_APP_VERSION} \
     BUILD_GIT_SHA=${BUILD_GIT_SHA} \
     BUILD_GIT_REF_NAME=${BUILD_GIT_REF_NAME} \
     BUILD_TIMESTAMP_SECONDS=${BUILD_TIMESTAMP_SECONDS}
+
+LABEL org.opencontainers.image.source="https://github.com/triggerdotdev/trigger.dev" \
+      org.opencontainers.image.revision="${BUILD_GIT_SHA}" \
+      org.opencontainers.image.version="${BUILD_APP_VERSION}" \
+      org.opencontainers.image.created="${BUILD_TIMESTAMP_RFC3339}"
 
 EXPOSE 3000
 


### PR DESCRIPTION
- Tags webapp images by full commit SHA on `main` pushes (`ghcr.io/triggerdotdev/trigger.dev:<sha>`) so any commit can be resolved to a digest easily.
- Adds OCI labels (`source`, `revision`, `version`, `created`) so `docker inspect`, vulnerability scanners, and
registry browsers see source/commit/version directly.
- Signs each pushed digest with SLSA build provenance via `actions/attest-build-provenance@v4.1.0` (pinned by SHA), enabling `gh attestation verify oci://...` against the source commit and workflow.