### PR TITLE
feat(sdk): replace `maxDuration` with `maxComputeSeconds` (user-facing rename) [TRI-9126]

### DIFF
--- a/.changeset/max-compute-seconds.md
+++ b/.changeset/max-compute-seconds.md
@@ -1,0 +1,7 @@
+---
+"@trigger.dev/core": patch
+"@trigger.dev/sdk": patch
+"trigger.dev": patch
+---
+
+Add `maxComputeSeconds` as the user-facing replacement for `maxDuration` on `defineConfig`, task definitions, and trigger options. The new name makes the unit (compute-time seconds) unambiguous at the call site. `maxDuration` is JSDoc-deprecated and still accepted; if both are set, `maxComputeSeconds` wins. The `init` templates have been updated to use the new name.

--- a/packages/cli-v3/src/config.ts
+++ b/packages/cli-v3/src/config.ts
@@ -341,11 +341,16 @@ function validateConfig(config: TriggerConfig, warn = true) {
     config.build.extensions.push(adaptResolveEnvVarsToSyncEnvVarsExtension(resolveEnvVarsFn));
   }
 
-  if (!config.maxDuration) {
+  // Resolve maxComputeSeconds → maxDuration so plain-object exports that bypass
+  // defineConfig() still work. This mirrors the resolution defineConfig() applies
+  // at the SDK boundary; downstream CLI/runtime code only reads `maxDuration`.
+  const resolvedMaxDuration = config.maxComputeSeconds ?? config.maxDuration;
+  if (!resolvedMaxDuration) {
     throw new Error(
-      `The "maxDuration" trigger.config option is now required, and must be at least 5 seconds.`
+      `The "maxComputeSeconds" trigger.config option is now required, and must be at least 5 seconds.`
     );
   }
+  config.maxDuration = resolvedMaxDuration;
 
   if (config.runtime && config.runtime === "bun") {
     warn &&

--- a/packages/cli-v3/templates/examples/schedule.mjs.template
+++ b/packages/cli-v3/templates/examples/schedule.mjs.template
@@ -4,8 +4,8 @@ export const firstScheduledTask = schedules.task({
   id: "first-scheduled-task",
   // Every hour
   cron: "0 * * * *",
-  // Set an optional maxDuration to prevent tasks from running indefinitely
-  maxDuration: 300, // Stop executing after 300 secs (5 mins) of compute
+  // Set an optional maxComputeSeconds to prevent tasks from running indefinitely
+  maxComputeSeconds: 300, // Stop executing after 300 secs (5 mins) of compute
   run: async (payload, { ctx }) => {
     // The payload contains the last run timestamp that you can use to check if this is the first run
     // And calculate the time since the last run

--- a/packages/cli-v3/templates/examples/schedule.ts.template
+++ b/packages/cli-v3/templates/examples/schedule.ts.template
@@ -4,8 +4,8 @@ export const firstScheduledTask = schedules.task({
   id: "first-scheduled-task",
   // Every hour
   cron: "0 * * * *",
-  // Set an optional maxDuration to prevent tasks from running indefinitely
-  maxDuration: 300, // Stop executing after 300 secs (5 mins) of compute
+  // Set an optional maxComputeSeconds to prevent tasks from running indefinitely
+  maxComputeSeconds: 300, // Stop executing after 300 secs (5 mins) of compute
   run: async (payload, { ctx }) => {
     // The payload contains the last run timestamp that you can use to check if this is the first run
     // And calculate the time since the last run

--- a/packages/cli-v3/templates/examples/simple.mjs.template
+++ b/packages/cli-v3/templates/examples/simple.mjs.template
@@ -2,8 +2,8 @@ import { logger, task, wait } from "@trigger.dev/sdk/v3";
 
 export const helloWorldTask = task({
   id: "hello-world",
-  // Set an optional maxDuration to prevent tasks from running indefinitely
-  maxDuration: 300, // Stop executing after 300 secs (5 mins) of compute
+  // Set an optional maxComputeSeconds to prevent tasks from running indefinitely
+  maxComputeSeconds: 300, // Stop executing after 300 secs (5 mins) of compute
   run: async (payload, { ctx }) => {
     logger.log("Hello, world!", { payload, ctx });
 

--- a/packages/cli-v3/templates/examples/simple.ts.template
+++ b/packages/cli-v3/templates/examples/simple.ts.template
@@ -2,8 +2,8 @@ import { logger, task, wait } from "@trigger.dev/sdk/v3";
 
 export const helloWorldTask = task({
   id: "hello-world",
-  // Set an optional maxDuration to prevent tasks from running indefinitely
-  maxDuration: 300, // Stop executing after 300 secs (5 mins) of compute
+  // Set an optional maxComputeSeconds to prevent tasks from running indefinitely
+  maxComputeSeconds: 300, // Stop executing after 300 secs (5 mins) of compute
   run: async (payload: any, { ctx }) => {
     logger.log("Hello, world!", { payload, ctx });
 

--- a/packages/cli-v3/templates/trigger.config.mjs.template
+++ b/packages/cli-v3/templates/trigger.config.mjs.template
@@ -4,10 +4,10 @@ export default defineConfig({
   project: "${projectRef}",
   runtime: "${runtime}",
   logLevel: "log",
-  // The max compute seconds a task is allowed to run. If the task run exceeds this duration, it will be stopped.
+  // The max compute seconds a task is allowed to run. If the run exceeds this, it will be stopped.
   // You can override this on an individual task.
   // See https://trigger.dev/docs/runs/max-duration
-  maxDuration: 3600,
+  maxComputeSeconds: 3600,
   retries: {
     enabledInDev: true,
     default: {

--- a/packages/cli-v3/templates/trigger.config.ts.template
+++ b/packages/cli-v3/templates/trigger.config.ts.template
@@ -4,10 +4,10 @@ export default defineConfig({
   project: "${projectRef}",
   runtime: "${runtime}",
   logLevel: "log",
-  // The max compute seconds a task is allowed to run. If the task run exceeds this duration, it will be stopped.
+  // The max compute seconds a task is allowed to run. If the run exceeds this, it will be stopped.
   // You can override this on an individual task.
   // See https://trigger.dev/docs/runs/max-duration
-  maxDuration: 3600,
+  maxComputeSeconds: 3600,
   retries: {
     enabledInDev: true,
     default: {

--- a/packages/core/src/v3/config.ts
+++ b/packages/core/src/v3/config.ts
@@ -166,15 +166,27 @@ export type TriggerConfig = {
   logLevel?: LogLevel;
 
   /**
+   * The maximum duration in compute-time **seconds** that a task run is allowed to run. If the task run exceeds this duration, it will be stopped.
+   *
+   * Minimum value is 5 seconds.
+   *
+   * Setting this value will affect all tasks in the project. You can override it on a per-task basis.
+   *
+   * @see https://trigger.dev/docs/tasks/overview#maxcomputeseconds-option
+   */
+  maxComputeSeconds?: number;
+
+  /**
    * The maximum duration in compute-time seconds that a task run is allowed to run. If the task run exceeds this duration, it will be stopped.
    *
    * Minimum value is 5 seconds
    *
    * Setting this value will effect all tasks in the project.
    *
+   * @deprecated Use `maxComputeSeconds` instead — same semantics, clearer unit. If both are set, `maxComputeSeconds` wins.
    * @see https://trigger.dev/docs/tasks/overview#maxduration-option
    */
-  maxDuration: number;
+  maxDuration?: number;
 
   /**
    * Set a default time-to-live (TTL) for all task runs in the project. If a run is not executed within this time, it will be removed from the queue and never execute.

--- a/packages/core/src/v3/errors.ts
+++ b/packages/core/src/v3/errors.ts
@@ -656,7 +656,9 @@ export class MaxDurationExceededError extends Error {
     public readonly maxDurationInSeconds: number,
     public readonly elapsedTimeInSeconds: number
   ) {
-    super(`Run exceeded maximum compute time (maxDuration) of ${maxDurationInSeconds} seconds`);
+    super(
+      `Run exceeded maximum compute time (maxComputeSeconds) of ${maxDurationInSeconds} seconds`
+    );
 
     this.name = "MaxDurationExceededError";
   }
@@ -754,6 +756,12 @@ const prettyInternalErrors: Partial<
     link: {
       name: "Read our troubleshooting guide",
       href: links.docs.troubleshooting.uncaughtException,
+    },
+  },
+  MAX_DURATION_EXCEEDED: {
+    link: {
+      name: "How to set maxComputeSeconds (maxDuration)",
+      href: links.docs.maxDuration,
     },
   },
 };

--- a/packages/core/src/v3/links.ts
+++ b/packages/core/src/v3/links.ts
@@ -26,6 +26,7 @@ export const links = {
       personalAccessToken:
         "https://trigger.dev/docs/github-actions#creating-a-personal-access-token",
     },
+    maxDuration: "https://trigger.dev/docs/runs/max-duration",
   },
   site: {
     home: "https://trigger.dev",

--- a/packages/core/src/v3/types/tasks.ts
+++ b/packages/core/src/v3/types/tasks.ts
@@ -272,9 +272,18 @@ type CommonTaskOptions<
     | MachinePresetName;
 
   /**
+   * The maximum duration in compute-time **seconds** that a task run is allowed to run. If the task run exceeds this duration, it will be stopped.
+   *
+   * Minimum value is 5 seconds.
+   */
+  maxComputeSeconds?: number;
+
+  /**
    * The maximum duration in compute-time seconds that a task run is allowed to run. If the task run exceeds this duration, it will be stopped.
    *
    * Minimum value is 5 seconds
+   *
+   * @deprecated Use `maxComputeSeconds` instead — same semantics, clearer unit. If both are set, `maxComputeSeconds` wins.
    */
   maxDuration?: number;
 
@@ -907,11 +916,22 @@ export type TriggerOptions = {
   metadata?: Record<string, SerializableJson>;
 
   /**
+   * The maximum duration in compute-time **seconds** that a task run is allowed to run. If the task run exceeds this duration, it will be stopped.
+   *
+   * This will override the task's `maxComputeSeconds` (or the legacy `maxDuration`).
+   *
+   * Minimum value is 5 seconds.
+   */
+  maxComputeSeconds?: number;
+
+  /**
    * The maximum duration in compute-time seconds that a task run is allowed to run. If the task run exceeds this duration, it will be stopped.
    *
    * This will override the task's maxDuration.
    *
    * Minimum value is 5 seconds
+   *
+   * @deprecated Use `maxComputeSeconds` instead — same semantics, clearer unit. If both are set, `maxComputeSeconds` wins.
    */
   maxDuration?: number;
 

--- a/packages/trigger-sdk/src/v3/config.test.ts
+++ b/packages/trigger-sdk/src/v3/config.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { defineConfig } from "./config.js";
+
+describe("defineConfig - maxComputeSeconds", () => {
+  it("uses maxComputeSeconds when only maxComputeSeconds is set", () => {
+    const cfg = defineConfig({ project: "p", maxComputeSeconds: 600 });
+    expect(cfg.maxDuration).toBe(600);
+  });
+
+  it("uses maxDuration when only maxDuration is set", () => {
+    const cfg = defineConfig({ project: "p", maxDuration: 600 });
+    expect(cfg.maxDuration).toBe(600);
+  });
+
+  it("prefers maxComputeSeconds when both are set", () => {
+    const cfg = defineConfig({ project: "p", maxComputeSeconds: 600, maxDuration: 9999 });
+    expect(cfg.maxDuration).toBe(600);
+  });
+
+  it("leaves maxDuration unset when neither is provided", () => {
+    const cfg = defineConfig({ project: "p" });
+    expect(cfg.maxDuration).toBeUndefined();
+  });
+
+  it("strips maxComputeSeconds from the returned config", () => {
+    const cfg = defineConfig({ project: "p", maxComputeSeconds: 600 });
+    expect((cfg as { maxComputeSeconds?: number }).maxComputeSeconds).toBeUndefined();
+  });
+});

--- a/packages/trigger-sdk/src/v3/config.ts
+++ b/packages/trigger-sdk/src/v3/config.ts
@@ -9,7 +9,15 @@ export type {
 } from "@trigger.dev/core/v3";
 
 export function defineConfig(config: TriggerConfig): TriggerConfig {
-  return config;
+  // `maxComputeSeconds` is the new name for `maxDuration`. If both are set, the new
+  // name wins. Internally the SDK and platform still read `maxDuration`, so we
+  // collapse the two fields here at the user-facing boundary.
+  const { maxComputeSeconds, maxDuration, ...rest } = config;
+  const resolved = maxComputeSeconds ?? maxDuration;
+  return {
+    ...rest,
+    ...(resolved !== undefined ? { maxDuration: resolved } : {}),
+  };
 }
 
 export type { TriggerConfig };

--- a/packages/trigger-sdk/src/v3/maxComputeSeconds.test.ts
+++ b/packages/trigger-sdk/src/v3/maxComputeSeconds.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { resolveMaxComputeSeconds } from "./maxComputeSeconds.js";
+
+describe("resolveMaxComputeSeconds", () => {
+  it("returns maxComputeSeconds when only maxComputeSeconds is set", () => {
+    expect(resolveMaxComputeSeconds({ maxComputeSeconds: 300 })).toBe(300);
+  });
+
+  it("returns maxDuration when only maxDuration is set", () => {
+    expect(resolveMaxComputeSeconds({ maxDuration: 300 })).toBe(300);
+  });
+
+  it("prefers maxComputeSeconds when both are set", () => {
+    expect(resolveMaxComputeSeconds({ maxComputeSeconds: 300, maxDuration: 999 })).toBe(300);
+  });
+
+  it("returns undefined when neither is set", () => {
+    expect(resolveMaxComputeSeconds({})).toBeUndefined();
+  });
+});

--- a/packages/trigger-sdk/src/v3/maxComputeSeconds.ts
+++ b/packages/trigger-sdk/src/v3/maxComputeSeconds.ts
@@ -1,0 +1,13 @@
+/**
+ * Collapse the user-facing `maxComputeSeconds` (new name) and `maxDuration` (deprecated)
+ * into a single value. If both are provided, `maxComputeSeconds` wins.
+ *
+ * Internal SDK/CLI/platform code only reads `maxDuration`, so all call sites that
+ * accept user input should funnel through this helper before forwarding the value.
+ */
+export function resolveMaxComputeSeconds(input: {
+  maxComputeSeconds?: number;
+  maxDuration?: number;
+}): number | undefined {
+  return input.maxComputeSeconds ?? input.maxDuration;
+}

--- a/packages/trigger-sdk/src/v3/shared.ts
+++ b/packages/trigger-sdk/src/v3/shared.ts
@@ -31,6 +31,7 @@ import {
   TaskRunExecutionResult,
   TaskRunPromise,
 } from "@trigger.dev/core/v3";
+import { resolveMaxComputeSeconds } from "./maxComputeSeconds.js";
 import { tracer } from "./tracer.js";
 
 import type {
@@ -258,7 +259,7 @@ export function createTask<
     machine: typeof params.machine === "string" ? { preset: params.machine } : params.machine,
     triggerSource: params.triggerSource,
     agentConfig: params.agentConfig,
-    maxDuration: params.maxDuration,
+    maxDuration: resolveMaxComputeSeconds(params),
     ttl: params.ttl,
     payloadSchema: params.jsonSchema,
     fns: {
@@ -412,7 +413,7 @@ export function createSchemaTask<
     machine: typeof params.machine === "string" ? { preset: params.machine } : params.machine,
     triggerSource: params.triggerSource,
     agentConfig: params.agentConfig,
-    maxDuration: params.maxDuration,
+    maxDuration: resolveMaxComputeSeconds(params),
     ttl: params.ttl,
     fns: {
       run: params.run,
@@ -733,7 +734,7 @@ export async function batchTriggerById<TTask extends AnyTask>(
             tags: item.options?.tags,
             maxAttempts: item.options?.maxAttempts,
             metadata: item.options?.metadata,
-            maxDuration: item.options?.maxDuration,
+            maxDuration: item.options ? resolveMaxComputeSeconds(item.options) : undefined,
             idempotencyKey:
               (await makeIdempotencyKey(item.options?.idempotencyKey)) ?? batchItemIdempotencyKey,
             idempotencyKeyTTL: item.options?.idempotencyKeyTTL ?? options?.idempotencyKeyTTL,
@@ -990,7 +991,7 @@ export async function batchTriggerByIdAndWait<TTask extends AnyTask>(
             tags: item.options?.tags,
             maxAttempts: item.options?.maxAttempts,
             metadata: item.options?.metadata,
-            maxDuration: item.options?.maxDuration,
+            maxDuration: item.options ? resolveMaxComputeSeconds(item.options) : undefined,
             idempotencyKey:
               (await makeIdempotencyKey(item.options?.idempotencyKey)) ?? batchItemIdempotencyKey,
             idempotencyKeyTTL: item.options?.idempotencyKeyTTL ?? options?.idempotencyKeyTTL,
@@ -1028,7 +1029,10 @@ export async function batchTriggerByIdAndWait<TTask extends AnyTask>(
           ctx,
         });
 
-        const runs = await handleBatchTaskRunExecutionResultV2(result.items, response.taskIdentifiers);
+        const runs = await handleBatchTaskRunExecutionResultV2(
+          result.items,
+          response.taskIdentifiers
+        );
 
         return {
           id: result.id,
@@ -1072,7 +1076,10 @@ export async function batchTriggerByIdAndWait<TTask extends AnyTask>(
           ctx,
         });
 
-        const runs = await handleBatchTaskRunExecutionResultV2(result.items, response.taskIdentifiers);
+        const runs = await handleBatchTaskRunExecutionResultV2(
+          result.items,
+          response.taskIdentifiers
+        );
 
         return {
           id: result.id,
@@ -1249,7 +1256,7 @@ export async function batchTriggerTasks<TTasks extends readonly AnyTask[]>(
             tags: item.options?.tags,
             maxAttempts: item.options?.maxAttempts,
             metadata: item.options?.metadata,
-            maxDuration: item.options?.maxDuration,
+            maxDuration: item.options ? resolveMaxComputeSeconds(item.options) : undefined,
             idempotencyKey:
               (await makeIdempotencyKey(item.options?.idempotencyKey)) ?? batchItemIdempotencyKey,
             idempotencyKeyTTL: item.options?.idempotencyKeyTTL ?? options?.idempotencyKeyTTL,
@@ -1511,7 +1518,7 @@ export async function batchTriggerAndWaitTasks<TTasks extends readonly AnyTask[]
             tags: item.options?.tags,
             maxAttempts: item.options?.maxAttempts,
             metadata: item.options?.metadata,
-            maxDuration: item.options?.maxDuration,
+            maxDuration: item.options ? resolveMaxComputeSeconds(item.options) : undefined,
             idempotencyKey:
               (await makeIdempotencyKey(item.options?.idempotencyKey)) ?? batchItemIdempotencyKey,
             idempotencyKeyTTL: item.options?.idempotencyKeyTTL ?? options?.idempotencyKeyTTL,
@@ -1549,7 +1556,10 @@ export async function batchTriggerAndWaitTasks<TTasks extends readonly AnyTask[]
           ctx,
         });
 
-        const runs = await handleBatchTaskRunExecutionResultV2(result.items, response.taskIdentifiers);
+        const runs = await handleBatchTaskRunExecutionResultV2(
+          result.items,
+          response.taskIdentifiers
+        );
 
         return {
           id: result.id,
@@ -1596,7 +1606,10 @@ export async function batchTriggerAndWaitTasks<TTasks extends readonly AnyTask[]
           ctx,
         });
 
-        const runs = await handleBatchTaskRunExecutionResultV2(result.items, response.taskIdentifiers);
+        const runs = await handleBatchTaskRunExecutionResultV2(
+          result.items,
+          response.taskIdentifiers
+        );
 
         return {
           id: result.id,
@@ -1913,7 +1926,7 @@ async function* transformBatchItemsStream<TTask extends AnyTask>(
         tags: item.options?.tags,
         maxAttempts: item.options?.maxAttempts,
         metadata: item.options?.metadata,
-        maxDuration: item.options?.maxDuration,
+        maxDuration: item.options ? resolveMaxComputeSeconds(item.options) : undefined,
         idempotencyKey:
           (await makeIdempotencyKey(item.options?.idempotencyKey)) ?? batchItemIdempotencyKey,
         idempotencyKeyTTL: item.options?.idempotencyKeyTTL ?? options?.idempotencyKeyTTL,
@@ -1966,7 +1979,7 @@ async function* transformBatchItemsStreamForWait<TTask extends AnyTask>(
         tags: item.options?.tags,
         maxAttempts: item.options?.maxAttempts,
         metadata: item.options?.metadata,
-        maxDuration: item.options?.maxDuration,
+        maxDuration: item.options ? resolveMaxComputeSeconds(item.options) : undefined,
         idempotencyKey:
           (await makeIdempotencyKey(item.options?.idempotencyKey)) ?? batchItemIdempotencyKey,
         idempotencyKeyTTL: item.options?.idempotencyKeyTTL ?? options?.idempotencyKeyTTL,
@@ -2016,7 +2029,7 @@ async function* transformBatchByTaskItemsStream<TTasks extends readonly AnyTask[
         tags: item.options?.tags,
         maxAttempts: item.options?.maxAttempts,
         metadata: item.options?.metadata,
-        maxDuration: item.options?.maxDuration,
+        maxDuration: item.options ? resolveMaxComputeSeconds(item.options) : undefined,
         idempotencyKey:
           (await makeIdempotencyKey(item.options?.idempotencyKey)) ?? batchItemIdempotencyKey,
         idempotencyKeyTTL: item.options?.idempotencyKeyTTL ?? options?.idempotencyKeyTTL,
@@ -2068,7 +2081,7 @@ async function* transformBatchByTaskItemsStreamForWait<TTasks extends readonly A
         tags: item.options?.tags,
         maxAttempts: item.options?.maxAttempts,
         metadata: item.options?.metadata,
-        maxDuration: item.options?.maxDuration,
+        maxDuration: item.options ? resolveMaxComputeSeconds(item.options) : undefined,
         idempotencyKey:
           (await makeIdempotencyKey(item.options?.idempotencyKey)) ?? batchItemIdempotencyKey,
         idempotencyKeyTTL: item.options?.idempotencyKeyTTL ?? options?.idempotencyKeyTTL,
@@ -2120,7 +2133,7 @@ async function* transformSingleTaskBatchItemsStream<TPayload>(
         tags: item.options?.tags,
         maxAttempts: item.options?.maxAttempts,
         metadata: item.options?.metadata,
-        maxDuration: item.options?.maxDuration,
+        maxDuration: item.options ? resolveMaxComputeSeconds(item.options) : undefined,
         idempotencyKey:
           (await makeIdempotencyKey(item.options?.idempotencyKey)) ?? batchItemIdempotencyKey,
         idempotencyKeyTTL: item.options?.idempotencyKeyTTL ?? options?.idempotencyKeyTTL,
@@ -2181,7 +2194,7 @@ async function* transformSingleTaskBatchItemsStreamForWait<TPayload>(
         tags: item.options?.tags,
         maxAttempts: item.options?.maxAttempts,
         metadata: item.options?.metadata,
-        maxDuration: item.options?.maxDuration,
+        maxDuration: item.options ? resolveMaxComputeSeconds(item.options) : undefined,
         idempotencyKey: finalIdempotencyKey?.toString(),
         idempotencyKeyTTL: item.options?.idempotencyKeyTTL ?? options?.idempotencyKeyTTL,
         idempotencyKeyOptions,
@@ -2231,7 +2244,7 @@ async function trigger_internal<TRunTypes extends AnyRunTypes>(
         tags: options?.tags,
         maxAttempts: options?.maxAttempts,
         metadata: options?.metadata,
-        maxDuration: options?.maxDuration,
+        maxDuration: options ? resolveMaxComputeSeconds(options) : undefined,
         parentRunId: taskContext.ctx?.run.id,
         machine: options?.machine,
         priority: options?.priority,
@@ -2315,7 +2328,7 @@ async function batchTrigger_internal<TRunTypes extends AnyRunTypes>(
             tags: item.options?.tags,
             maxAttempts: item.options?.maxAttempts,
             metadata: item.options?.metadata,
-            maxDuration: item.options?.maxDuration,
+            maxDuration: item.options ? resolveMaxComputeSeconds(item.options) : undefined,
             idempotencyKey: finalIdempotencyKey?.toString(),
             idempotencyKeyTTL: item.options?.idempotencyKeyTTL ?? options?.idempotencyKeyTTL,
             idempotencyKeyOptions,
@@ -2488,7 +2501,7 @@ async function triggerAndWait_internal<TIdentifier extends string, TPayload, TOu
             tags: options?.tags,
             maxAttempts: options?.maxAttempts,
             metadata: options?.metadata,
-            maxDuration: options?.maxDuration,
+            maxDuration: options ? resolveMaxComputeSeconds(options) : undefined,
             resumeParentOnCompletion: true,
             parentRunId: ctx.run.id,
             idempotencyKey: processedIdempotencyKey?.toString(),
@@ -2738,7 +2751,7 @@ async function batchTriggerAndWait_internal<TIdentifier extends string, TPayload
             tags: item.options?.tags,
             maxAttempts: item.options?.maxAttempts,
             metadata: item.options?.metadata,
-            maxDuration: item.options?.maxDuration,
+            maxDuration: item.options ? resolveMaxComputeSeconds(item.options) : undefined,
             idempotencyKey: finalIdempotencyKey?.toString(),
             idempotencyKeyTTL: item.options?.idempotencyKeyTTL ?? options?.idempotencyKeyTTL,
             idempotencyKeyOptions,

--- a/references/hello-world/src/trigger/example.ts
+++ b/references/hello-world/src/trigger/example.ts
@@ -139,7 +139,7 @@ export const maxDurationTask = task({
     maxTimeoutInMs: 2_000,
     factor: 1.4,
   },
-  maxDuration: 5,
+  maxComputeSeconds: 5,
   run: async (payload: { sleepFor: number }, { signal, ctx }) => {
     await setTimeout(payload.sleepFor * 1000, { signal });
   },
@@ -150,7 +150,7 @@ export const maxDurationParentTask = task({
   run: async (payload: { sleepFor?: number; maxDuration?: number }, { ctx, signal }) => {
     const result = await maxDurationTask.triggerAndWait(
       { sleepFor: payload.sleepFor ?? 10 },
-      { maxDuration: timeout.None }
+      { maxComputeSeconds: timeout.None }
     );
 
     return result;

--- a/references/hello-world/trigger.config.ts
+++ b/references/hello-world/trigger.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     maxExecutionsPerProcess: 20,
   },
   logLevel: "debug",
-  maxDuration: 3600,
+  maxComputeSeconds: 3600,
   ttl: "1h",
   retries: {
     enabledInDev: true,


### PR DESCRIPTION
## Summary

User-facing rename of `maxDuration` → `maxComputeSeconds` on `defineConfig`, task definitions, and trigger options. The legacy `maxDuration` field stays in place but is JSDoc-deprecated; if both are set, `maxComputeSeconds` wins. Internal SDK/CLI/run-engine code (~380 references to `maxDurationInSeconds`) is **not** touched — translation happens at the user-facing boundary only.

Linear: [TRI-9126](https://linear.app/triggerdotdev/issue/TRI-9126/replace-maxduration-with-maxcomputeseconds-user-facing-rename)

## Why

`maxDuration` is in seconds but users frequently pass milliseconds by mistake (e.g. `maxDuration: 300000` thinking "5 minutes"). The new name makes the unit unambiguous at the call site.

## What changed

- **`@trigger.dev/core`** — added `maxComputeSeconds?: number` and JSDoc-deprecated `maxDuration` on `TriggerConfig`, `CommonTaskOptions`, and `TriggerOptions`.
- **`@trigger.dev/sdk`** — `defineConfig` collapses `maxComputeSeconds ?? maxDuration` into the existing `maxDuration` slot. New `resolveMaxComputeSeconds` helper applied at all 16 user-input sites in `shared.ts` (task definitions, `trigger`, `triggerAndWait`, `batchTrigger`, `batchTriggerAndWait`).
- **`trigger.dev` CLI** — six init templates updated (`trigger.config.ts/.mjs`, `examples/simple.ts/.mjs`, `examples/schedule.ts/.mjs`).
- **`references/hello-world`** — `trigger.config.ts` and `example.ts` (`maxDurationTask` per-task value + `maxDurationParentTask` per-trigger override) updated for manual testing.
- **Tests** — 9 new precedence tests for `defineConfig` and the resolver helper.
- **Changeset** — patch on `@trigger.dev/core`, `@trigger.dev/sdk`, `trigger.dev`.

## Out of scope

- Internal `maxDurationInSeconds` field (DB, ClickHouse, run engine, MarQS, dashboard presenters) — unchanged.
- The `getMaxDuration()` precedence helper in `packages/core/src/v3/isomorphic/maxDuration.ts` — unchanged.
- Public docs at `docs/` — separate dedicated pass.
- `rules/` and `.claude/skills/trigger-dev-tasks/` — explicitly excluded by repo conventions.
- Runtime warning when `maxDuration` is used — out of scope; deprecation is JSDoc-only for now.

## Test plan

- [x] `pnpm run build --filter @trigger.dev/core` — clean
- [x] `pnpm run build --filter @trigger.dev/sdk` — clean
- [x] Core test suite — 442/442 pass
- [x] SDK test suite — 19/19 pass (incl. 9 new)
- [ ] Manual: `cd references/hello-world && pnpm exec trigger dev`, trigger `max-duration` task, confirm 5s timeout still kicks in
- [ ] Manual: trigger `max-duration-parent` and confirm `{ maxComputeSeconds: timeout.None }` overrides the task's per-task limit
- [ ] Manual: fresh `trigger init` in a temp dir, confirm generated `trigger.config.ts` and example task use `maxComputeSeconds`

🤖 Generated with [Claude Code](https://claude.com/claude-code)