### PR TITLE
fix(webapp): stop leaking exception messages on 5xx API responses

### DIFF
--- a/.server-changes/sanitize-api-500-errors.md
+++ b/.server-changes/sanitize-api-500-errors.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Stop leaking raw exception messages on 500 responses across webapp API routes; return a generic error string and log the full error server-side instead.

--- a/apps/webapp/app/routes/admin.api.v1.platform-notifications.ts
+++ b/apps/webapp/app/routes/admin.api.v1.platform-notifications.ts
@@ -1,5 +1,6 @@
 import { type ActionFunctionArgs, json } from "@remix-run/server-runtime";
 import { err, ok, type Result } from "neverthrow";
+import { logger } from "~/services/logger.server";
 import { authenticateAdminRequest } from "~/services/personalAccessToken.server";
 import {
   createPlatformNotification,
@@ -42,7 +43,8 @@ export async function action({ request }: ActionFunctionArgs) {
       return json({ error: "Validation failed", details: error.issues }, { status: 400 });
     }
 
-    return json({ error: error.message }, { status: 500 });
+    logger.error("Failed to create platform notification", { error });
+    return json({ error: "Something went wrong" }, { status: 500 });
   }
 
   return json(result.value, { status: 201 });

--- a/apps/webapp/app/routes/admin.api.v1.platform-notifications.ts
+++ b/apps/webapp/app/routes/admin.api.v1.platform-notifications.ts
@@ -44,7 +44,7 @@ export async function action({ request }: ActionFunctionArgs) {
     }
 
     logger.error("Failed to create platform notification", { error });
-    return json({ error: "Something went wrong" }, { status: 500 });
+    return json({ error: "Something went wrong, please try again." }, { status: 500 });
   }
 
   return json(result.value, { status: 201 });

--- a/apps/webapp/app/routes/admin.notifications.tsx
+++ b/apps/webapp/app/routes/admin.notifications.tsx
@@ -37,6 +37,7 @@ import {
   TableRow,
 } from "~/components/primitives/Table";
 import { prisma } from "~/db.server";
+import { logger } from "~/services/logger.server";
 import { requireUserId } from "~/services/session.server";
 import {
   archivePlatformNotification,
@@ -234,7 +235,8 @@ async function handleCreateAction(formData: FormData, userId: string, isPreview:
         { status: 400 }
       );
     }
-    return typedjson({ error: err.message }, { status: 500 });
+    logger.error("Failed to create platform notification", { error: err });
+    return typedjson({ error: "Something went wrong" }, { status: 500 });
   }
 
   if (isPreview) {
@@ -310,7 +312,8 @@ async function handleEditAction(formData: FormData) {
         { status: 400 }
       );
     }
-    return typedjson({ error: err.message }, { status: 500 });
+    logger.error("Failed to update platform notification", { error: err });
+    return typedjson({ error: "Something went wrong" }, { status: 500 });
   }
 
   return typedjson({ success: true, id: result.value.id });

--- a/apps/webapp/app/routes/admin.notifications.tsx
+++ b/apps/webapp/app/routes/admin.notifications.tsx
@@ -236,7 +236,7 @@ async function handleCreateAction(formData: FormData, userId: string, isPreview:
       );
     }
     logger.error("Failed to create platform notification", { error: err });
-    return typedjson({ error: "Something went wrong" }, { status: 500 });
+    return typedjson({ error: "Something went wrong, please try again." }, { status: 500 });
   }
 
   if (isPreview) {
@@ -256,7 +256,7 @@ async function handleArchiveAction(formData: FormData) {
     return typedjson({ success: true });
   } catch (error) {
     logger.error("Failed to archive platform notification", { error, notificationId });
-    return typedjson({ error: "Failed to archive notification" }, { status: 500 });
+    return typedjson({ error: "Failed to archive notification, please try again." }, { status: 500 });
   }
 }
 
@@ -271,7 +271,7 @@ async function handleDeleteAction(formData: FormData) {
     return typedjson({ success: true });
   } catch (error) {
     logger.error("Failed to delete platform notification", { error, notificationId });
-    return typedjson({ error: "Failed to delete notification" }, { status: 500 });
+    return typedjson({ error: "Failed to delete notification, please try again." }, { status: 500 });
   }
 }
 
@@ -286,7 +286,7 @@ async function handlePublishNowAction(formData: FormData) {
     return typedjson({ success: true });
   } catch (error) {
     logger.error("Failed to publish platform notification", { error, notificationId });
-    return typedjson({ error: "Failed to publish notification" }, { status: 500 });
+    return typedjson({ error: "Failed to publish notification, please try again." }, { status: 500 });
   }
 }
 
@@ -328,7 +328,7 @@ async function handleEditAction(formData: FormData) {
       );
     }
     logger.error("Failed to update platform notification", { error: err });
-    return typedjson({ error: "Something went wrong" }, { status: 500 });
+    return typedjson({ error: "Something went wrong, please try again." }, { status: 500 });
   }
 
   return typedjson({ success: true, id: result.value.id });

--- a/apps/webapp/app/routes/admin.notifications.tsx
+++ b/apps/webapp/app/routes/admin.notifications.tsx
@@ -251,8 +251,13 @@ async function handleArchiveAction(formData: FormData) {
     return typedjson({ error: "Missing notificationId" }, { status: 400 });
   }
 
-  await archivePlatformNotification(notificationId);
-  return typedjson({ success: true });
+  try {
+    await archivePlatformNotification(notificationId);
+    return typedjson({ success: true });
+  } catch (error) {
+    logger.error("Failed to archive platform notification", { error });
+    return typedjson({ error: "Failed to archive notification" }, { status: 500 });
+  }
 }
 
 async function handleDeleteAction(formData: FormData) {
@@ -261,8 +266,13 @@ async function handleDeleteAction(formData: FormData) {
     return typedjson({ error: "Missing notificationId" }, { status: 400 });
   }
 
-  await deletePlatformNotification(notificationId);
-  return typedjson({ success: true });
+  try {
+    await deletePlatformNotification(notificationId);
+    return typedjson({ success: true });
+  } catch (error) {
+    logger.error("Failed to delete platform notification", { error });
+    return typedjson({ error: "Failed to delete notification" }, { status: 500 });
+  }
 }
 
 async function handlePublishNowAction(formData: FormData) {
@@ -271,8 +281,13 @@ async function handlePublishNowAction(formData: FormData) {
     return typedjson({ error: "Missing notificationId" }, { status: 400 });
   }
 
-  await publishNowPlatformNotification(notificationId);
-  return typedjson({ success: true });
+  try {
+    await publishNowPlatformNotification(notificationId);
+    return typedjson({ success: true });
+  } catch (error) {
+    logger.error("Failed to publish platform notification", { error });
+    return typedjson({ error: "Failed to publish notification" }, { status: 500 });
+  }
 }
 
 async function handleEditAction(formData: FormData) {

--- a/apps/webapp/app/routes/admin.notifications.tsx
+++ b/apps/webapp/app/routes/admin.notifications.tsx
@@ -255,7 +255,7 @@ async function handleArchiveAction(formData: FormData) {
     await archivePlatformNotification(notificationId);
     return typedjson({ success: true });
   } catch (error) {
-    logger.error("Failed to archive platform notification", { error });
+    logger.error("Failed to archive platform notification", { error, notificationId });
     return typedjson({ error: "Failed to archive notification" }, { status: 500 });
   }
 }
@@ -270,7 +270,7 @@ async function handleDeleteAction(formData: FormData) {
     await deletePlatformNotification(notificationId);
     return typedjson({ success: true });
   } catch (error) {
-    logger.error("Failed to delete platform notification", { error });
+    logger.error("Failed to delete platform notification", { error, notificationId });
     return typedjson({ error: "Failed to delete notification" }, { status: 500 });
   }
 }
@@ -285,7 +285,7 @@ async function handlePublishNowAction(formData: FormData) {
     await publishNowPlatformNotification(notificationId);
     return typedjson({ success: true });
   } catch (error) {
-    logger.error("Failed to publish platform notification", { error });
+    logger.error("Failed to publish platform notification", { error, notificationId });
     return typedjson({ error: "Failed to publish notification" }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v1.batches.$batchParam.results.ts
+++ b/apps/webapp/app/routes/api.v1.batches.$batchParam.results.ts
@@ -38,6 +38,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     return json(result);
   } catch (error) {
     logger.error("Failed to load batch results", { error });
-    return json({ error: "Something went wrong" }, { status: 500 });
+    return json({ error: "Something went wrong, please try again." }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v1.batches.$batchParam.results.ts
+++ b/apps/webapp/app/routes/api.v1.batches.$batchParam.results.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { ApiBatchResultsPresenter } from "~/presenters/v3/ApiBatchResultsPresenter.server";
 import { ApiRunResultPresenter } from "~/presenters/v3/ApiRunResultPresenter.server";
 import { authenticateApiRequest } from "~/services/apiAuth.server";
+import { logger } from "~/services/logger.server";
 
 const ParamsSchema = z.object({
   /* This is the batch friendly ID */
@@ -36,10 +37,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
     return json(result);
   } catch (error) {
-    if (error instanceof Error) {
-      return json({ error: error.message }, { status: 500 });
-    } else {
-      return json({ error: JSON.stringify(error) }, { status: 500 });
-    }
+    logger.error("Failed to load batch results", { error });
+    return json({ error: "Something went wrong" }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v1.deployments.$deploymentId.finalize.ts
+++ b/apps/webapp/app/routes/api.v1.deployments.$deploymentId.finalize.ts
@@ -54,12 +54,9 @@ export async function action({ request, params }: ActionFunctionArgs) {
   } catch (error) {
     if (error instanceof ServiceValidationError) {
       return json({ error: error.message }, { status: 400 });
-    } else if (error instanceof Error) {
-      logger.error("Error finalizing deployment", { error: error.message });
-      return json({ error: `Internal server error: ${error.message}` }, { status: 500 });
-    } else {
-      logger.error("Error finalizing deployment", { error: String(error) });
-      return json({ error: "Internal server error" }, { status: 500 });
     }
+
+    logger.error("Error finalizing deployment", { error });
+    return json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v1.deployments.ts
+++ b/apps/webapp/app/routes/api.v1.deployments.ts
@@ -55,13 +55,10 @@ export async function action({ request, params }: ActionFunctionArgs) {
   } catch (error) {
     if (error instanceof ServiceValidationError) {
       return json({ error: error.message }, { status: 400 });
-    } else if (error instanceof Error) {
-      logger.error("Error initializing deployment", { error: error.message });
-      return json({ error: `Internal server error: ${error.message}` }, { status: 500 });
-    } else {
-      logger.error("Error initializing deployment", { error: String(error) });
-      return json({ error: "Internal server error" }, { status: 500 });
     }
+
+    logger.error("Error initializing deployment", { error });
+    return json({ error: "Internal server error" }, { status: 500 });
   }
 }
 

--- a/apps/webapp/app/routes/api.v1.projects.$projectRef.alertChannels.ts
+++ b/apps/webapp/app/routes/api.v1.projects.$projectRef.alertChannels.ts
@@ -90,6 +90,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
     }
 
     logger.error("Failed to create alert channel", { error });
-    return json({ error: "Something went wrong" }, { status: 500 });
+    return json({ error: "Something went wrong, please try again." }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v1.projects.$projectRef.alertChannels.ts
+++ b/apps/webapp/app/routes/api.v1.projects.$projectRef.alertChannels.ts
@@ -5,6 +5,7 @@ import {
   ApiAlertChannelPresenter,
   ApiCreateAlertChannel,
 } from "~/presenters/v3/ApiAlertChannelPresenter.server";
+import { logger } from "~/services/logger.server";
 import { authenticateApiRequestWithPersonalAccessToken } from "~/services/personalAccessToken.server";
 import { CreateAlertChannelService } from "~/v3/services/alerts/createAlertChannel.server";
 import { ServiceValidationError } from "~/v3/services/baseService.server";
@@ -88,9 +89,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
       return json({ error: error.message }, { status: 422 });
     }
 
-    return json(
-      { error: error instanceof Error ? error.message : "Internal Server Error" },
-      { status: 500 }
-    );
+    logger.error("Failed to create alert channel", { error });
+    return json({ error: "Something went wrong" }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v1.queues.ts
+++ b/apps/webapp/app/routes/api.v1.queues.ts
@@ -37,7 +37,7 @@ export const loader = createLoaderApiRoute(
       }
 
       logger.error("Failed to list queues", { error });
-      return json({ error: "Something went wrong" }, { status: 500 });
+      return json({ error: "Something went wrong, please try again." }, { status: 500 });
     }
   }
 );

--- a/apps/webapp/app/routes/api.v1.queues.ts
+++ b/apps/webapp/app/routes/api.v1.queues.ts
@@ -2,6 +2,7 @@ import { json } from "@remix-run/server-runtime";
 import { type QueueItem } from "@trigger.dev/core/v3";
 import { z } from "zod";
 import { QueueListPresenter } from "~/presenters/v3/QueueListPresenter.server";
+import { logger } from "~/services/logger.server";
 import { createLoaderApiRoute } from "~/services/routeBuilders/apiBuilder.server";
 import { ServiceValidationError } from "~/v3/services/baseService.server";
 
@@ -35,10 +36,8 @@ export const loader = createLoaderApiRoute(
         return json({ error: error.message }, { status: 422 });
       }
 
-      return json(
-        { error: error instanceof Error ? error.message : "Internal Server Error" },
-        { status: 500 }
-      );
+      logger.error("Failed to list queues", { error });
+      return json({ error: "Something went wrong" }, { status: 500 });
     }
   }
 );

--- a/apps/webapp/app/routes/api.v1.runs.$runFriendlyId.input-streams.wait.ts
+++ b/apps/webapp/app/routes/api.v1.runs.$runFriendlyId.input-streams.wait.ts
@@ -11,6 +11,7 @@ import {
   deleteInputStreamWaitpoint,
   setInputStreamWaitpoint,
 } from "~/services/inputStreamWaitpointCache.server";
+import { logger } from "~/services/logger.server";
 import { getRealtimeStreamInstance } from "~/services/realtime/v1StreamsGlobal.server";
 import { createActionApiRoute } from "~/services/routeBuilders/apiBuilder.server";
 import { parseDelay } from "~/utils/delays";
@@ -138,10 +139,9 @@ const { action, loader } = createActionApiRoute(
     } catch (error) {
       if (error instanceof ServiceValidationError) {
         return json({ error: error.message }, { status: 422 });
-      } else if (error instanceof Error) {
-        return json({ error: error.message }, { status: 500 });
       }
 
+      logger.error("Failed to create input-stream waitpoint", { error });
       return json({ error: "Something went wrong" }, { status: 500 });
     }
   }

--- a/apps/webapp/app/routes/api.v1.runs.$runId.tags.ts
+++ b/apps/webapp/app/routes/api.v1.runs.$runId.tags.ts
@@ -87,6 +87,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return json({ message: `Successfully set ${newTags.length} new tags.` }, { status: 200 });
   } catch (error) {
     logger.error("Failed to add run tags", { error });
-    return json({ error: "Something went wrong" }, { status: 500 });
+    return json({ error: "Something went wrong, please try again." }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v1.runs.$runId.tags.ts
+++ b/apps/webapp/app/routes/api.v1.runs.$runId.tags.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { prisma } from "~/db.server";
 import { MAX_TAGS_PER_RUN } from "~/models/taskRunTag.server";
 import { authenticateApiRequest } from "~/services/apiAuth.server";
+import { logger } from "~/services/logger.server";
 
 const ParamsSchema = z.object({
   runId: z.string(),
@@ -85,9 +86,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
     return json({ message: `Successfully set ${newTags.length} new tags.` }, { status: 200 });
   } catch (error) {
-    return json(
-      { error: error instanceof Error ? error.message : "Internal Server Error" },
-      { status: 500 }
-    );
+    logger.error("Failed to add run tags", { error });
+    return json({ error: "Something went wrong" }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v1.runs.$runParam.attempts.ts
+++ b/apps/webapp/app/routes/api.v1.runs.$runParam.attempts.ts
@@ -2,6 +2,7 @@ import type { ActionFunctionArgs } from "@remix-run/server-runtime";
 import { json } from "@remix-run/server-runtime";
 import { z } from "zod";
 import { authenticateApiRequest } from "~/services/apiAuth.server";
+import { logger } from "~/services/logger.server";
 import { ServiceValidationError } from "~/v3/services/baseService.server";
 import { CreateTaskRunAttemptService } from "~/v3/services/createTaskRunAttempt.server";
 
@@ -40,9 +41,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
       return json({ error: error.message }, { status: error.status ?? 422 });
     }
 
-    return json(
-      { error: error instanceof Error ? error.message : "Internal Server Error" },
-      { status: 500 }
-    );
+    logger.error("Failed to create run attempt", { error });
+    return json({ error: "Something went wrong" }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v1.runs.$runParam.attempts.ts
+++ b/apps/webapp/app/routes/api.v1.runs.$runParam.attempts.ts
@@ -42,6 +42,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
     }
 
     logger.error("Failed to create run attempt", { error });
-    return json({ error: "Something went wrong" }, { status: 500 });
+    return json({ error: "Something went wrong, please try again." }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v1.runs.$runParam.reschedule.ts
+++ b/apps/webapp/app/routes/api.v1.runs.$runParam.reschedule.ts
@@ -88,6 +88,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
     }
 
     logger.error("Failed to reschedule run", { error });
-    return json({ error: "Something went wrong" }, { status: 500 });
+    return json({ error: "Something went wrong, please try again." }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v1.runs.$runParam.reschedule.ts
+++ b/apps/webapp/app/routes/api.v1.runs.$runParam.reschedule.ts
@@ -6,6 +6,7 @@ import { getApiVersion } from "~/api/versions";
 import { prisma } from "~/db.server";
 import { ApiRetrieveRunPresenter } from "~/presenters/v3/ApiRetrieveRunPresenter.server";
 import { authenticateApiRequest } from "~/services/apiAuth.server";
+import { logger } from "~/services/logger.server";
 import { ServiceValidationError } from "~/v3/services/baseService.server";
 import { RescheduleTaskRunService } from "~/v3/services/rescheduleTaskRun.server";
 
@@ -84,10 +85,9 @@ export async function action({ request, params }: ActionFunctionArgs) {
   } catch (error) {
     if (error instanceof ServiceValidationError) {
       return json({ error: error.message }, { status: 400 });
-    } else if (error instanceof Error) {
-      return json({ error: error.message }, { status: 500 });
-    } else {
-      return json({ error: "An unknown error occurred" }, { status: 500 });
     }
+
+    logger.error("Failed to reschedule run", { error });
+    return json({ error: "Something went wrong" }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v1.runs.$runParam.result.ts
+++ b/apps/webapp/app/routes/api.v1.runs.$runParam.result.ts
@@ -37,6 +37,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     return json(result);
   } catch (error) {
     logger.error("Failed to load run result", { error });
-    return json({ error: "Something went wrong" }, { status: 500 });
+    return json({ error: "Something went wrong, please try again." }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v1.runs.$runParam.result.ts
+++ b/apps/webapp/app/routes/api.v1.runs.$runParam.result.ts
@@ -3,6 +3,7 @@ import { json } from "@remix-run/server-runtime";
 import { z } from "zod";
 import { ApiRunResultPresenter } from "~/presenters/v3/ApiRunResultPresenter.server";
 import { authenticateApiRequest } from "~/services/apiAuth.server";
+import { logger } from "~/services/logger.server";
 
 const ParamsSchema = z.object({
   /* This is the run friendly ID */
@@ -35,10 +36,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
     return json(result);
   } catch (error) {
-    if (error instanceof Error) {
-      return json({ error: error.message }, { status: 500 });
-    } else {
-      return json({ error: JSON.stringify(error) }, { status: 500 });
-    }
+    logger.error("Failed to load run result", { error });
+    return json({ error: "Something went wrong" }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v1.schedules.$scheduleId.activate.ts
+++ b/apps/webapp/app/routes/api.v1.schedules.$scheduleId.activate.ts
@@ -70,6 +70,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return json(presenter.toJSONResponse(result), { status: 200 });
   } catch (error) {
     logger.error("Failed to activate schedule", { error });
-    return json({ error: "Something went wrong" }, { status: 500 });
+    return json({ error: "Something went wrong, please try again." }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v1.schedules.$scheduleId.activate.ts
+++ b/apps/webapp/app/routes/api.v1.schedules.$scheduleId.activate.ts
@@ -5,6 +5,7 @@ import { prisma } from "~/db.server";
 import { scheduleUniqWhereClause, scheduleWhereClause } from "~/models/schedules.server";
 import { ViewSchedulePresenter } from "~/presenters/v3/ViewSchedulePresenter.server";
 import { authenticateApiRequest } from "~/services/apiAuth.server";
+import { logger } from "~/services/logger.server";
 
 const ParamsSchema = z.object({
   scheduleId: z.string(),
@@ -68,9 +69,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
     return json(presenter.toJSONResponse(result), { status: 200 });
   } catch (error) {
-    return json(
-      { error: error instanceof Error ? error.message : "Internal Server Error" },
-      { status: 500 }
-    );
+    logger.error("Failed to activate schedule", { error });
+    return json({ error: "Something went wrong" }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v1.schedules.$scheduleId.deactivate.ts
+++ b/apps/webapp/app/routes/api.v1.schedules.$scheduleId.deactivate.ts
@@ -70,6 +70,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return json(presenter.toJSONResponse(result), { status: 200 });
   } catch (error) {
     logger.error("Failed to deactivate schedule", { error });
-    return json({ error: "Something went wrong" }, { status: 500 });
+    return json({ error: "Something went wrong, please try again." }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v1.schedules.$scheduleId.deactivate.ts
+++ b/apps/webapp/app/routes/api.v1.schedules.$scheduleId.deactivate.ts
@@ -5,6 +5,7 @@ import { prisma } from "~/db.server";
 import { scheduleUniqWhereClause, scheduleWhereClause } from "~/models/schedules.server";
 import { ViewSchedulePresenter } from "~/presenters/v3/ViewSchedulePresenter.server";
 import { authenticateApiRequest } from "~/services/apiAuth.server";
+import { logger } from "~/services/logger.server";
 
 const ParamsSchema = z.object({
   scheduleId: z.string(),
@@ -68,9 +69,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
     return json(presenter.toJSONResponse(result), { status: 200 });
   } catch (error) {
-    return json(
-      { error: error instanceof Error ? error.message : "Internal Server Error" },
-      { status: 500 }
-    );
+    logger.error("Failed to deactivate schedule", { error });
+    return json({ error: "Something went wrong" }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v1.schedules.$scheduleId.ts
+++ b/apps/webapp/app/routes/api.v1.schedules.$scheduleId.ts
@@ -59,7 +59,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           );
         } else {
           logger.error("Failed to delete schedule", { error });
-          return json({ error: "Something went wrong" }, { status: 500 });
+          return json({ error: "Something went wrong, please try again." }, { status: 500 });
         }
       }
     }
@@ -110,7 +110,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
         }
 
         logger.error("Failed to upsert schedule", { error });
-        return json({ error: "Something went wrong" }, { status: 500 });
+        return json({ error: "Something went wrong, please try again." }, { status: 500 });
       }
     }
   }

--- a/apps/webapp/app/routes/api.v1.schedules.$scheduleId.ts
+++ b/apps/webapp/app/routes/api.v1.schedules.$scheduleId.ts
@@ -6,6 +6,7 @@ import { Prisma, prisma } from "~/db.server";
 import { scheduleUniqWhereClause } from "~/models/schedules.server";
 import { ViewSchedulePresenter } from "~/presenters/v3/ViewSchedulePresenter.server";
 import { authenticateApiRequest } from "~/services/apiAuth.server";
+import { logger } from "~/services/logger.server";
 import { UpsertSchedule } from "~/v3/schedules";
 import { ServiceValidationError } from "~/v3/services/baseService.server";
 import { UpsertTaskScheduleService } from "~/v3/services/upsertTaskSchedule.server";
@@ -57,10 +58,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
             { status: error.code === "P2025" ? 404 : 422 }
           );
         } else {
-          return json(
-            { error: error instanceof Error ? error.message : "Internal Server Error" },
-            { status: 500 }
-          );
+          logger.error("Failed to delete schedule", { error });
+          return json({ error: "Something went wrong" }, { status: 500 });
         }
       }
     }
@@ -110,10 +109,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
           return json({ error: error.message }, { status: 422 });
         }
 
-        return json(
-          { error: error instanceof Error ? error.message : "Internal Server Error" },
-          { status: 500 }
-        );
+        logger.error("Failed to upsert schedule", { error });
+        return json({ error: "Something went wrong" }, { status: 500 });
       }
     }
   }

--- a/apps/webapp/app/routes/api.v1.schedules.ts
+++ b/apps/webapp/app/routes/api.v1.schedules.ts
@@ -73,7 +73,7 @@ export async function action({ request }: ActionFunctionArgs) {
     }
 
     logger.error("Failed to create schedule", { error });
-    return json({ error: "Something went wrong" }, { status: 500 });
+    return json({ error: "Something went wrong, please try again." }, { status: 500 });
   }
 }
 

--- a/apps/webapp/app/routes/api.v1.schedules.ts
+++ b/apps/webapp/app/routes/api.v1.schedules.ts
@@ -4,6 +4,7 @@ import { CreateScheduleOptions, ScheduleObject } from "@trigger.dev/core/v3";
 import { z } from "zod";
 import { ScheduleListPresenter } from "~/presenters/v3/ScheduleListPresenter.server";
 import { authenticateApiRequest } from "~/services/apiAuth.server";
+import { logger } from "~/services/logger.server";
 import { UpsertSchedule } from "~/v3/schedules";
 import { ServiceValidationError } from "~/v3/services/baseService.server";
 import { UpsertTaskScheduleService } from "~/v3/services/upsertTaskSchedule.server";
@@ -71,10 +72,8 @@ export async function action({ request }: ActionFunctionArgs) {
       return json({ error: error.message }, { status: 422 });
     }
 
-    return json(
-      { error: error instanceof Error ? error.message : "Internal Server Error" },
-      { status: 500 }
-    );
+    logger.error("Failed to create schedule", { error });
+    return json({ error: "Something went wrong" }, { status: 500 });
   }
 }
 

--- a/apps/webapp/app/routes/api.v1.tasks.$taskId.trigger.ts
+++ b/apps/webapp/app/routes/api.v1.tasks.$taskId.trigger.ts
@@ -153,10 +153,9 @@ const { action, loader } = createActionApiRoute(
         return json({ error: error.message }, { status: error.status ?? 422 });
       } else if (error instanceof OutOfEntitlementError) {
         return json({ error: error.message }, { status: 422 });
-      } else if (error instanceof Error) {
-        return json({ error: error.message }, { status: 500 });
       }
 
+      logger.error("Trigger task failed", { error });
       return json({ error: "Something went wrong" }, { status: 500 });
     }
   }

--- a/apps/webapp/app/routes/api.v1.waitpoints.tokens.ts
+++ b/apps/webapp/app/routes/api.v1.waitpoints.tokens.ts
@@ -10,6 +10,7 @@ import {
   ApiWaitpointListSearchParams,
 } from "~/presenters/v3/ApiWaitpointListPresenter.server";
 import { type AuthenticatedEnvironment } from "~/services/apiAuth.server";
+import { logger } from "~/services/logger.server";
 import { generateHttpCallbackUrl } from "~/services/httpCallback.server";
 import {
   createActionApiRoute,
@@ -92,10 +93,9 @@ const { action } = createActionApiRoute(
     } catch (error) {
       if (error instanceof ServiceValidationError) {
         return json({ error: error.message }, { status: 422 });
-      } else if (error instanceof Error) {
-        return json({ error: error.message }, { status: 500 });
       }
 
+      logger.error("Failed to create waitpoint token", { error });
       return json({ error: "Something went wrong" }, { status: 500 });
     }
   }

--- a/apps/webapp/app/routes/api.v2.deployments.$deploymentId.finalize.ts
+++ b/apps/webapp/app/routes/api.v2.deployments.$deploymentId.finalize.ts
@@ -54,12 +54,9 @@ export async function action({ request, params }: ActionFunctionArgs) {
   } catch (error) {
     if (error instanceof ServiceValidationError) {
       return json({ error: error.message }, { status: 400 });
-    } else if (error instanceof Error) {
-      logger.error("Error finalizing deployment", { error: error.message });
-      return json({ error: `Internal server error: ${error.message}` }, { status: 500 });
-    } else {
-      logger.error("Error finalizing deployment", { error: String(error) });
-      return json({ error: "Internal server error" }, { status: 500 });
     }
+
+    logger.error("Error finalizing deployment", { error });
+    return json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v3.batches.$batchId.items.ts
+++ b/apps/webapp/app/routes/api.v3.batches.$batchId.items.ts
@@ -112,10 +112,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
       },
     });
 
-    if (error instanceof Error) {
-      return json({ error: error.message }, { status: 500 });
-    }
-
     return json({ error: "Something went wrong" }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/api.v3.deployments.$deploymentId.finalize.ts
+++ b/apps/webapp/app/routes/api.v3.deployments.$deploymentId.finalize.ts
@@ -75,11 +75,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
         if (error instanceof ServiceValidationError) {
           errorMessage = { error: error.message };
-        } else if (error instanceof Error) {
-          logger.error("Error finalizing deployment", { error: error.message });
-          errorMessage = { error: `Internal server error: ${error.message}` };
         } else {
-          logger.error("Error finalizing deployment", { error: String(error) });
+          logger.error("Error finalizing deployment", { error });
           errorMessage = { error: "Internal server error" };
         }
 
@@ -93,12 +90,9 @@ export async function action({ request, params }: ActionFunctionArgs) {
   } catch (error) {
     if (error instanceof ServiceValidationError) {
       return json({ error: error.message }, { status: 400 });
-    } else if (error instanceof Error) {
-      logger.error("Error finalizing deployment", { error: error.message });
-      return json({ error: `Internal server error: ${error.message}` }, { status: 500 });
-    } else {
-      logger.error("Error finalizing deployment", { error: String(error) });
-      return json({ error: "Internal server error" }, { status: 500 });
     }
+
+    logger.error("Error finalizing deployment", { error });
+    return json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/apps/webapp/app/routes/realtime.v1.sessions.$session.$io.append.ts
+++ b/apps/webapp/app/routes/realtime.v1.sessions.$session.$io.append.ts
@@ -140,7 +140,7 @@ const { action, loader } = createActionApiRoute(
         io: params.io,
         error: appendError,
       });
-      return json({ ok: false, error: "Something went wrong" }, { status: 500 });
+      return json({ ok: false, error: "Something went wrong, please try again." }, { status: 500 });
     }
 
     // Fire any run-scoped waitpoints registered against this channel. Best

--- a/apps/webapp/app/routes/realtime.v1.sessions.$session.$io.append.ts
+++ b/apps/webapp/app/routes/realtime.v1.sessions.$session.$io.append.ts
@@ -135,7 +135,12 @@ const { action, loader } = createActionApiRoute(
           { status: appendError.status ?? 422 }
         );
       }
-      return json({ ok: false, error: appendError.message }, { status: 500 });
+      logger.error("Failed to append to session stream", {
+        sessionId: session.id,
+        io: params.io,
+        error: appendError,
+      });
+      return json({ ok: false, error: "Something went wrong" }, { status: 500 });
     }
 
     // Fire any run-scoped waitpoints registered against this channel. Best


### PR DESCRIPTION
When a webapp API route's catch-all 500 branch handles a non-typed exception, it returns the raw `error.message` to the caller. If the exception originates from an internal subsystem (the ORM client, an infra dependency, etc.) the server-side error string is surfaced verbatim in the response body — exposing implementation details the API surface shouldn't carry.

The leak shows up in three shapes across the routes:

- `return json({ error: error.message }, { status: 500 })`
- `return json({ error: error instanceof Error ? error.message : "Internal Server Error" }, { status: 500 })`
- ``return json({ error: `Internal server error: ${error.message}` }, { status: 500 })``

(plus a couple of analogous neverthrow-Result variants on admin routes.)

## Fix

Across 19 webapp routes, replace each leaking branch with a generic body (`"Something went wrong"` / `"Internal Server Error"` to match the file's existing fallback) and add `logger.error(...)` so full visibility is preserved server-side. Catch blocks that branch on typed user-input errors (`ServiceValidationError`, `EngineServiceValidationError`, `OutOfEntitlementError`, `PrismaClientKnownRequestError`) are left intact — those messages are constructed deliberately and intended to be customer-facing.

## Test plan

- [x] `pnpm run typecheck --filter webapp`
- [x] Per-route manual probe: inject a synthetic `Error` at the top of the catch'd `try` block (or fake the wrapped call's rejection / Result error), curl the route with the dev API key, confirm the response body changed from the synthetic message verbatim → generic body. 21/21 leak sites verified end-to-end.
- [x] 4xx-typed-error paths spot-checked: throwing `ServiceValidationError` from inside the catch'd try still surfaces its message at 422 as intended.
