### PR TITLE
fix: normalize underscore max old space flags

### DIFF
--- a/.changeset/quiet-pots-relax.md
+++ b/.changeset/quiet-pots-relax.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Replace underscore-form Node.js max-old-space-size flags when normalizing NODE_OPTIONS.

--- a/packages/core/src/v3/machines/index.ts
+++ b/packages/core/src/v3/machines/index.ts
@@ -45,7 +45,7 @@ export function nodeOptionsWithMaxOldSpaceSize(
   let options = existingOptions ?? "";
 
   //remove existing max-old-space-size flag
-  options = options.replace(/--max-old-space-size=\d+/g, "").trim();
+  options = options.replace(/--max[-_]old[-_]space[-_]size=\d+/g, "").trim();
 
   //get max-old-space-size flag
   const flag = maxOldSpaceSizeFlag(machine, overhead);

--- a/packages/core/src/v3/machines/max-old-space.test.ts
+++ b/packages/core/src/v3/machines/max-old-space.test.ts
@@ -36,6 +36,14 @@ describe("nodeOptionsWithMaxOldSpaceSize", () => {
     expect(result).toBe(`--inspect ${expectedFlag}`);
   });
 
+  it("replaces existing max_old_space_size flag", () => {
+    const result = nodeOptionsWithMaxOldSpaceSize(
+      "--max_old_space_size=4096 --inspect",
+      testMachine
+    );
+    expect(result).toBe(`--inspect ${expectedFlag}`);
+  });
+
   it("handles multiple existing max-old-space-size flags", () => {
     const result = nodeOptionsWithMaxOldSpaceSize(
       "--max-old-space-size=4096 --inspect --max-old-space-size=8192",


### PR DESCRIPTION
## Summary

Tiny papercut fix: `nodeOptionsWithMaxOldSpaceSize()` now strips the Node-accepted `--max_old_space_size=...` form before adding its own heap flag.

Without this, valid `NODE_OPTIONS` can end up with two heap-size flags. Kinda sneaky, easy to miss.

Related: #1897

## Repro

```sh
node --max_old_space_size=64 -e "console.log('ok')"
```

Node 20 accepts that flag. The old helper only removed `--max-old-space-size=...`, so this input:

```txt
--max_old_space_size=4096 --inspect
```

turned into:

```txt
--max_old_space_size=4096 --inspect --max-old-space-size=819
```

This is triggerable in practice: no cloud quota or hard ceiling blocks it, it is just a valid Node/V8 flag in `NODE_OPTIONS`. The repo also uses this underscore form in the deploy image code, so yep, it is not just theory.

## Tests

```sh
pnpm --dir packages/core test src/v3/machines/max-old-space.test.ts --run
pnpm --dir packages/core typecheck
```