### PR TITLE
Fix(webapp): Notification style updates

### DIFF
--- a/apps/webapp/app/components/navigation/NotificationCard.tsx
+++ b/apps/webapp/app/components/navigation/NotificationCard.tsx
@@ -66,6 +66,9 @@ export function NotificationCard({
     setIsExpanded((v) => !v);
   };
 
+  const safeActionUrl = sanitizeUrl(actionUrl);
+  const safeImage = sanitizeUrl(image);
+
   return (
     <div className="group/card relative overflow-hidden rounded border border-charcoal-650 bg-charcoal-700/50 shadow-lg">
       {safeActionUrl && (
@@ -106,7 +109,7 @@ export function NotificationCard({
           </button>
         )}
 
-        {image && <img src={sanitizeImageUrl(image)} alt="" className="mt-1.5 rounded" />}
+        {safeImage && <img src={safeImage} alt="" className="mt-1.5 rounded" />}
       </div>
     </div>
   );
@@ -141,14 +144,14 @@ function getMarkdownComponents(onLinkClick?: () => void) {
   };
 }
 
-/** Sanitize image URL to prevent XSS via javascript: or data: URIs. */
-function sanitizeImageUrl(url: string): string {
+const SAFE_URL_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+
+/** Sanitize a URL to prevent XSS via javascript: or data: URIs. Returns "" if invalid. */
+function sanitizeUrl(url: string | undefined): string {
+  if (!url) return "";
   try {
     const parsed = new URL(url);
-    if (parsed.protocol === "https:" || parsed.protocol === "http:") {
-      return parsed.href;
-    }
-    return "";
+    return SAFE_URL_PROTOCOLS.has(parsed.protocol) ? parsed.href : "";
   } catch {
     return "";
   }

--- a/apps/webapp/app/components/navigation/NotificationCard.tsx
+++ b/apps/webapp/app/components/navigation/NotificationCard.tsx
@@ -3,23 +3,6 @@ import { useLayoutEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { cn } from "~/utils/cn";
 
-function sanitizeActionUrl(url?: string): string | undefined {
-  if (!url) return undefined;
-  const trimmed = url.trim();
-  if (!trimmed) return undefined;
-
-  try {
-    const parsed = new URL(trimmed, window.location.origin);
-    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
-      return parsed.toString();
-    }
-  } catch {
-    return undefined;
-  }
-
-  return undefined;
-}
-
 export function NotificationCard({
   title,
   description,
@@ -40,7 +23,6 @@ export function NotificationCard({
   const [isExpanded, setIsExpanded] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const descriptionRef = useRef<HTMLDivElement>(null);
-  const safeActionUrl = sanitizeActionUrl(actionUrl);
 
   useLayoutEffect(() => {
     const el = descriptionRef.current;

--- a/apps/webapp/app/components/navigation/NotificationCard.tsx
+++ b/apps/webapp/app/components/navigation/NotificationCard.tsx
@@ -87,7 +87,7 @@ export function NotificationCard({
         <button
           type="button"
           onClick={handleDismiss}
-          className="relative z-20 -mr-1 shrink-0 rounded p-0.5 text-text-dimmed opacity-0 transition group-hover/card:opacity-100 hover:bg-charcoal-700 hover:text-text-bright"
+          className="relative z-20 -mr-1 shrink-0 rounded p-0.5 text-text-dimmed opacity-0 transition group-hover/card:opacity-100 hover:bg-charcoal-700 hover:text-text-bright focus-visible:opacity-100"
         >
           <XMarkIcon className="size-3.5" />
         </button>

--- a/apps/webapp/app/components/navigation/NotificationCard.tsx
+++ b/apps/webapp/app/components/navigation/NotificationCard.tsx
@@ -69,6 +69,8 @@ export function NotificationCard({
         <button
           type="button"
           onClick={handleDismiss}
+          aria-label="Dismiss notification"
+          title="Dismiss notification"
           className="relative z-20 -mr-1 shrink-0 rounded p-0.5 text-text-dimmed opacity-0 transition group-hover/card:opacity-100 hover:bg-charcoal-700 hover:text-text-bright focus-visible:opacity-100"
         >
           <XMarkIcon className="size-3.5" />

--- a/apps/webapp/app/components/navigation/NotificationCard.tsx
+++ b/apps/webapp/app/components/navigation/NotificationCard.tsx
@@ -48,27 +48,25 @@ export function NotificationCard({
     setIsExpanded((v) => !v);
   };
 
-  const Wrapper = actionUrl ? "a" : "div";
-  const wrapperProps = actionUrl
-    ? {
-        href: actionUrl,
-        target: "_blank" as const,
-        rel: "noopener noreferrer" as const,
-        ...(onCardClick ? { onClick: onCardClick } : {}),
-      }
-    : {};
-
   return (
-    <Wrapper
-      {...wrapperProps}
-      className="group/card block overflow-hidden rounded border border-charcoal-650 bg-charcoal-700/50 no-underline shadow-lg"
-    >
+    <div className="group/card relative overflow-hidden rounded border border-charcoal-650 bg-charcoal-700/50 shadow-lg">
+      {actionUrl && (
+        <a
+          href={actionUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={title}
+          onClick={onCardClick}
+          className="absolute inset-0 z-10"
+        />
+      )}
+
       <div className="flex items-start gap-1 px-2.5 pt-2">
         <p className="flex-1 text-[13px] font-medium leading-normal text-text-bright">{title}</p>
         <button
           type="button"
           onClick={handleDismiss}
-          className="-mr-1 shrink-0 rounded p-0.5 text-text-dimmed opacity-0 transition group-hover/card:opacity-100 hover:bg-charcoal-700 hover:text-text-bright"
+          className="relative z-20 -mr-1 shrink-0 rounded p-0.5 text-text-dimmed opacity-0 transition group-hover/card:opacity-100 hover:bg-charcoal-700 hover:text-text-bright"
         >
           <XMarkIcon className="size-3.5" />
         </button>
@@ -84,7 +82,7 @@ export function NotificationCard({
           <button
             type="button"
             onClick={handleToggleExpand}
-            className="mt-0.5 text-xs text-indigo-400 hover:text-indigo-300"
+            className="relative z-20 mt-0.5 text-xs text-indigo-400 hover:text-indigo-300"
           >
             {isExpanded ? "Show less" : "Show more"}
           </button>
@@ -92,7 +90,7 @@ export function NotificationCard({
 
         {image && <img src={sanitizeImageUrl(image)} alt="" className="mt-1.5 rounded" />}
       </div>
-    </Wrapper>
+    </div>
   );
 }
 
@@ -106,7 +104,7 @@ function getMarkdownComponents(onLinkClick?: () => void) {
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        className="text-indigo-400 underline transition-colors hover:text-indigo-300"
+        className="relative z-20 text-indigo-400 underline transition-colors hover:text-indigo-300"
         onClick={(e) => {
           e.stopPropagation();
           onLinkClick?.();

--- a/apps/webapp/app/components/navigation/NotificationCard.tsx
+++ b/apps/webapp/app/components/navigation/NotificationCard.tsx
@@ -1,0 +1,139 @@
+import { XMarkIcon } from "@heroicons/react/20/solid";
+import { useLayoutEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import { cn } from "~/utils/cn";
+
+export function NotificationCard({
+  title,
+  description,
+  image,
+  actionUrl,
+  onDismiss,
+  onCardClick,
+  onLinkClick,
+}: {
+  title: string;
+  description: string;
+  image?: string;
+  actionUrl?: string;
+  onDismiss?: () => void;
+  onCardClick?: () => void;
+  onLinkClick?: () => void;
+}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const descriptionRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const el = descriptionRef.current;
+    if (!el) return;
+
+    const check = () => setIsOverflowing(el.scrollHeight - el.clientHeight > 1);
+    check();
+
+    const observer = new ResizeObserver(check);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [description]);
+
+  const handleDismiss = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onDismiss?.();
+  };
+
+  const handleToggleExpand = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsExpanded((v) => !v);
+  };
+
+  const Wrapper = actionUrl ? "a" : "div";
+  const wrapperProps = actionUrl
+    ? {
+        href: actionUrl,
+        target: "_blank" as const,
+        rel: "noopener noreferrer" as const,
+        ...(onCardClick ? { onClick: onCardClick } : {}),
+      }
+    : {};
+
+  return (
+    <Wrapper
+      {...wrapperProps}
+      className="group/card block overflow-hidden rounded border border-charcoal-650 bg-charcoal-700/50 no-underline shadow-lg"
+    >
+      <div className="flex items-start gap-1 px-2.5 pt-2">
+        <p className="flex-1 text-[13px] font-medium leading-normal text-text-bright">{title}</p>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          className="-mr-1 shrink-0 rounded p-0.5 text-text-dimmed opacity-0 transition group-hover/card:opacity-100 hover:bg-charcoal-700 hover:text-text-bright"
+        >
+          <XMarkIcon className="size-3.5" />
+        </button>
+      </div>
+
+      <div className="px-2.5 pb-2">
+        <div ref={descriptionRef} className={cn(!isExpanded && "line-clamp-3")}>
+          <ReactMarkdown components={getMarkdownComponents(onLinkClick)}>
+            {description}
+          </ReactMarkdown>
+        </div>
+        {(isOverflowing || isExpanded) && (
+          <button
+            type="button"
+            onClick={handleToggleExpand}
+            className="mt-0.5 text-xs text-indigo-400 hover:text-indigo-300"
+          >
+            {isExpanded ? "Show less" : "Show more"}
+          </button>
+        )}
+
+        {image && <img src={sanitizeImageUrl(image)} alt="" className="mt-1.5 rounded" />}
+      </div>
+    </Wrapper>
+  );
+}
+
+function getMarkdownComponents(onLinkClick?: () => void) {
+  return {
+    p: ({ children }: { children?: React.ReactNode }) => (
+      <p className="my-0.5 text-xs leading-normal text-text-dimmed">{children}</p>
+    ),
+    a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-indigo-400 underline transition-colors hover:text-indigo-300"
+        onClick={(e) => {
+          e.stopPropagation();
+          onLinkClick?.();
+        }}
+      >
+        {children}
+      </a>
+    ),
+    strong: ({ children }: { children?: React.ReactNode }) => (
+      <strong className="font-semibold text-text-bright">{children}</strong>
+    ),
+    em: ({ children }: { children?: React.ReactNode }) => <em>{children}</em>,
+    code: ({ children }: { children?: React.ReactNode }) => (
+      <code className="rounded bg-charcoal-700 px-1 py-0.5 text-[11px]">{children}</code>
+    ),
+  };
+}
+
+/** Sanitize image URL to prevent XSS via javascript: or data: URIs. */
+function sanitizeImageUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "https:" || parsed.protocol === "http:") {
+      return parsed.href;
+    }
+    return "";
+  } catch {
+    return "";
+  }
+}

--- a/apps/webapp/app/components/navigation/NotificationCard.tsx
+++ b/apps/webapp/app/components/navigation/NotificationCard.tsx
@@ -3,6 +3,23 @@ import { useLayoutEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { cn } from "~/utils/cn";
 
+function sanitizeActionUrl(url?: string): string | undefined {
+  if (!url) return undefined;
+  const trimmed = url.trim();
+  if (!trimmed) return undefined;
+
+  try {
+    const parsed = new URL(trimmed, window.location.origin);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.toString();
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
 export function NotificationCard({
   title,
   description,
@@ -23,6 +40,7 @@ export function NotificationCard({
   const [isExpanded, setIsExpanded] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const descriptionRef = useRef<HTMLDivElement>(null);
+  const safeActionUrl = sanitizeActionUrl(actionUrl);
 
   useLayoutEffect(() => {
     const el = descriptionRef.current;
@@ -50,9 +68,9 @@ export function NotificationCard({
 
   return (
     <div className="group/card relative overflow-hidden rounded border border-charcoal-650 bg-charcoal-700/50 shadow-lg">
-      {actionUrl && (
+      {safeActionUrl && (
         <a
-          href={actionUrl}
+          href={safeActionUrl}
           target="_blank"
           rel="noopener noreferrer"
           aria-label={title}

--- a/apps/webapp/app/components/navigation/NotificationPanel.tsx
+++ b/apps/webapp/app/components/navigation/NotificationPanel.tsx
@@ -1,13 +1,12 @@
-import { BellAlertIcon, ChevronRightIcon, XMarkIcon } from "@heroicons/react/20/solid";
+import { BellAlertIcon } from "@heroicons/react/20/solid";
 import { useFetcher } from "@remix-run/react";
-import { motion } from "framer-motion";
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import { Header3 } from "~/components/primitives/Headers";
+import { useCallback, useEffect, useRef, useState } from "react";
+import simplur from "simplur";
+import { Button } from "~/components/primitives/Buttons";
 import { Popover, PopoverContent, PopoverTrigger } from "~/components/primitives/Popover";
 import { SimpleTooltip } from "~/components/primitives/Tooltip";
 import { usePlatformNotifications } from "~/routes/resources.platform-notifications";
-import { cn } from "~/utils/cn";
+import { NotificationCard } from "./NotificationCard";
 
 type Notification = {
   id: string;
@@ -102,211 +101,57 @@ export function NotificationPanel({
     return null;
   }
 
+  const { title, description, image, actionUrl, dismissOnAction } = notification.payload.data;
   const card = (
     <NotificationCard
-      notification={notification}
-      onDismiss={handleDismiss}
+      title={title}
+      description={description}
+      image={image}
+      actionUrl={actionUrl}
+      onDismiss={() => handleDismiss(notification.id)}
+      onCardClick={() => {
+        fireClickBeacon(notification.id);
+        if (dismissOnAction) {
+          handleDismiss(notification.id);
+        }
+      }}
       onLinkClick={() => fireClickBeacon(notification.id)}
     />
   );
 
   return (
     <Popover>
-      <div className="p-1">
-        {/* Expanded sidebar: show card directly */}
-        <motion.div
-          initial={false}
-          animate={{
-            height: isCollapsed ? 0 : "auto",
-            opacity: isCollapsed ? 0 : 1,
-          }}
-          transition={{ duration: 0.15 }}
-          className="overflow-hidden"
-        >
-          {card}
-        </motion.div>
-
-        {/* Collapsed sidebar: show bell icon that opens popover */}
-        <motion.div
-          initial={false}
-          animate={{
-            height: isCollapsed ? "auto" : 0,
-            opacity: isCollapsed ? 1 : 0,
-          }}
-          transition={{ duration: 0.15 }}
-          className="overflow-hidden"
-        >
+      <div className={isCollapsed ? "p-1" : "p-2"}>
+        {isCollapsed ? (
           <SimpleTooltip
+            asChild
             button={
-              <PopoverTrigger className="flex !h-8 w-full items-center justify-center rounded border border-charcoal-650 bg-charcoal-750/50 transition-colors hover:border-charcoal-600 hover:bg-charcoal-700/50">
-                <div className="relative">
-                  <BellAlertIcon className="size-5 text-text-dimmed" />
-                  <span
-                    className="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-medium text-white"
-                    style={{ backgroundColor: "#6366f1" }}
-                  >
-                    {visibleNotifications.length}
-                  </span>
-                </div>
-              </PopoverTrigger>
+              <div className="relative">
+                <PopoverTrigger asChild>
+                  <Button variant="small-menu-item" className="h-8 w-[2.1875rem] justify-center">
+                    <BellAlertIcon className="size-5" />
+                  </Button>
+                </PopoverTrigger>
+                <span
+                  className="pointer-events-none absolute -top-[0.2rem] right-0 flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[0.625rem] font-medium text-text-bright"
+                  style={{ backgroundColor: "#6366f1" }}
+                >
+                  {visibleNotifications.length}
+                </span>
+              </div>
             }
-            content="Notifications"
+            content={simplur`${visibleNotifications.length} notification[|s]`}
             side="right"
             sideOffset={8}
             disableHoverableContent
-            asChild
           />
-        </motion.div>
+        ) : (
+          card
+        )}
       </div>
-      <PopoverContent side="right" sideOffset={8} align="start" className="w-56 !min-w-0 p-0">
+      <PopoverContent side="right" sideOffset={8} align="end" className="w-56 !min-w-0 p-0">
         {card}
       </PopoverContent>
     </Popover>
   );
-}
-
-function NotificationCard({
-  notification,
-  onDismiss,
-  onLinkClick,
-}: {
-  notification: Notification;
-  onDismiss: (id: string) => void;
-  onLinkClick: () => void;
-}) {
-  const { title, description, image, actionUrl, dismissOnAction } = notification.payload.data;
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [isOverflowing, setIsOverflowing] = useState(false);
-  const descriptionRef = useRef<HTMLDivElement>(null);
-
-  useLayoutEffect(() => {
-    const el = descriptionRef.current;
-    if (el) {
-      setIsOverflowing(el.scrollHeight > el.clientHeight);
-    }
-  }, [description]);
-
-  const handleDismiss = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    onDismiss(notification.id);
-  };
-
-  const handleToggleExpand = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsExpanded((v) => !v);
-  };
-
-  const handleCardClick = () => {
-    onLinkClick();
-    if (dismissOnAction) {
-      onDismiss(notification.id);
-    }
-  };
-
-  const Wrapper = actionUrl ? "a" : "div";
-  const wrapperProps = actionUrl
-    ? {
-        href: actionUrl,
-        target: "_blank" as const,
-        rel: "noopener noreferrer" as const,
-        onClick: handleCardClick,
-      }
-    : {};
-
-  return (
-    <Wrapper
-      {...wrapperProps}
-      className="group/card group relative block overflow-hidden rounded border transition-colors border-grid-bright bg-charcoal-750/50 no-underline"
-    >
-      {/* Header: title + dismiss */}
-      <div className="relative flex items-start gap-1 px-2 pt-1.5">
-        <Header3 className="flex-1 !text-xs">
-          {title}
-        </Header3>
-        <button
-          type="button"
-          onClick={handleDismiss}
-          className="shrink-0 rounded p-0.5 text-text-dimmed transition-colors hover:bg-charcoal-700 hover:text-text-bright"
-        >
-          <XMarkIcon className="size-3.5" />
-        </button>
-      </div>
-
-      {/* Body: description + chevron */}
-      <div className="relative px-2 pb-2">
-        <div className="flex gap-1">
-          <div className="min-w-0 flex-1">
-            <div
-              ref={descriptionRef}
-              className={cn(!isExpanded && "line-clamp-3")}
-            >
-              <ReactMarkdown components={getMarkdownComponents(onLinkClick)}>{description}</ReactMarkdown>
-            </div>
-            {(isOverflowing || isExpanded) && (
-              <button
-                type="button"
-                onClick={handleToggleExpand}
-                className="mt-0.5 text-xs text-indigo-400 hover:text-indigo-300"
-              >
-                {isExpanded ? "Show less" : "Show more"}
-              </button>
-            )}
-          </div>
-          {actionUrl && (
-            <div className="mt-1 flex shrink-0 items-center pb-1 text-text-dimmed group-hover/card:text-text-bright transition-colors">
-              <ChevronRightIcon className="size-4" />
-            </div>
-          )}
-        </div>
-
-        {image && (
-          <img src={sanitizeImageUrl(image)} alt="" className="mt-1.5 rounded" />
-        )}
-      </div>
-    </Wrapper>
-  );
-}
-
-/** Sanitize image URL to prevent XSS via javascript: or data: URIs. */
-function sanitizeImageUrl(url: string): string {
-  try {
-    const parsed = new URL(url);
-    if (parsed.protocol === "https:" || parsed.protocol === "http:") {
-      return parsed.href;
-    }
-    return "";
-  } catch {
-    return "";
-  }
-}
-
-function getMarkdownComponents(onLinkClick: () => void) {
-  return {
-    p: ({ children }: { children?: React.ReactNode }) => (
-      <p className="my-0.5 text-xs leading-relaxed text-text-dimmed">{children}</p>
-    ),
-    a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
-      <a
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-indigo-400 underline hover:text-indigo-300 transition-colors"
-        onClick={(e) => {
-          e.stopPropagation();
-          onLinkClick();
-        }}
-      >
-        {children}
-      </a>
-    ),
-    strong: ({ children }: { children?: React.ReactNode }) => (
-      <strong className="font-semibold text-text-bright">{children}</strong>
-    ),
-    em: ({ children }: { children?: React.ReactNode }) => <em>{children}</em>,
-    code: ({ children }: { children?: React.ReactNode }) => (
-      <code className="rounded bg-charcoal-700 px-1 py-0.5 text-[11px]">{children}</code>
-    ),
-  };
 }

--- a/apps/webapp/app/routes/admin.notifications.tsx
+++ b/apps/webapp/app/routes/admin.notifications.tsx
@@ -1,9 +1,8 @@
-import { ChevronRightIcon, TrashIcon, XMarkIcon } from "@heroicons/react/20/solid";
+import { TrashIcon } from "@heroicons/react/20/solid";
 import { useFetcher, useSearchParams } from "@remix-run/react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { redirect } from "@remix-run/server-runtime";
-import { useEffect, useRef, useState, useLayoutEffect } from "react";
-import ReactMarkdown from "react-markdown";
+import { useEffect, useState } from "react";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { z } from "zod";
 import {
@@ -20,13 +19,19 @@ import { Button } from "~/components/primitives/Buttons";
 import {
   Dialog,
   DialogContent,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "~/components/primitives/Dialog";
-import { Header3 } from "~/components/primitives/Headers";
+import { Checkbox, CheckboxWithLabel } from "~/components/primitives/Checkbox";
+import { Hint } from "~/components/primitives/Hint";
 import { Input } from "~/components/primitives/Input";
+import { Label } from "~/components/primitives/Label";
+import { NotificationCard } from "~/components/navigation/NotificationCard";
 import { PaginationControls } from "~/components/primitives/Pagination";
 import { Paragraph } from "~/components/primitives/Paragraph";
+import { Select, SelectItem } from "~/components/primitives/Select";
+import { TextArea } from "~/components/primitives/TextArea";
 import {
   Table,
   TableBlankRow,
@@ -48,7 +53,6 @@ import {
   updatePlatformNotification,
 } from "~/services/platformNotifications.server";
 import { createSearchParams } from "~/utils/searchParams";
-import { cn } from "~/utils/cn";
 
 const PAGE_SIZE = 20;
 
@@ -70,7 +74,11 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const { page: rawPage, hideInactive } = searchParams.params.getAll();
   const page = rawPage ?? 1;
 
-  const data = await getAdminNotificationsList({ page, pageSize: PAGE_SIZE, hideInactive: hideInactive ?? false });
+  const data = await getAdminNotificationsList({
+    page,
+    pageSize: PAGE_SIZE,
+    hideInactive: hideInactive ?? false,
+  });
 
   return typedjson({ ...data, userId });
 };
@@ -134,8 +142,7 @@ function parseNotificationFormData(formData: FormData) {
     : undefined;
 
   const discoveryFilePatterns = (formData.get("discoveryFilePatterns") as string) || "";
-  const discoveryContentPattern =
-    (formData.get("discoveryContentPattern") as string) || undefined;
+  const discoveryContentPattern = (formData.get("discoveryContentPattern") as string) || undefined;
   const discoveryMatchBehavior = (formData.get("discoveryMatchBehavior") as string) || "";
 
   const discovery =
@@ -191,7 +198,14 @@ function buildPayloadInput(fields: ReturnType<typeof parseNotificationFormData>)
 async function handleCreateAction(formData: FormData, userId: string, isPreview: boolean) {
   const fields = parseNotificationFormData(formData);
 
-  if (!fields.adminLabel || !fields.title || !fields.description || !fields.endsAt || !fields.surface || !fields.payloadType) {
+  if (
+    !fields.adminLabel ||
+    !fields.title ||
+    !fields.description ||
+    !fields.endsAt ||
+    !fields.surface ||
+    !fields.payloadType
+  ) {
     return typedjson({ error: "Missing required fields" }, { status: 400 });
   }
 
@@ -204,14 +218,18 @@ async function handleCreateAction(formData: FormData, userId: string, isPreview:
       ? { userId }
       : {
           ...(fields.scope === "USER" && fields.scopeUserId ? { userId: fields.scopeUserId } : {}),
-          ...(fields.scope === "ORGANIZATION" && fields.scopeOrganizationId ? { organizationId: fields.scopeOrganizationId } : {}),
-          ...(fields.scope === "PROJECT" && fields.scopeProjectId ? { projectId: fields.scopeProjectId } : {}),
+          ...(fields.scope === "ORGANIZATION" && fields.scopeOrganizationId
+            ? { organizationId: fields.scopeOrganizationId }
+            : {}),
+          ...(fields.scope === "PROJECT" && fields.scopeProjectId
+            ? { projectId: fields.scopeProjectId }
+            : {}),
         }),
     startsAt: isPreview
       ? new Date().toISOString()
       : fields.startsAt
-        ? new Date(fields.startsAt + "Z").toISOString()
-        : new Date().toISOString(),
+      ? new Date(fields.startsAt + "Z").toISOString()
+      : new Date().toISOString(),
     endsAt: isPreview
       ? new Date(Date.now() + 60 * 60 * 1000).toISOString()
       : new Date(fields.endsAt + "Z").toISOString(),
@@ -256,7 +274,10 @@ async function handleArchiveAction(formData: FormData) {
     return typedjson({ success: true });
   } catch (error) {
     logger.error("Failed to archive platform notification", { error, notificationId });
-    return typedjson({ error: "Failed to archive notification, please try again." }, { status: 500 });
+    return typedjson(
+      { error: "Failed to archive notification, please try again." },
+      { status: 500 }
+    );
   }
 }
 
@@ -271,7 +292,10 @@ async function handleDeleteAction(formData: FormData) {
     return typedjson({ success: true });
   } catch (error) {
     logger.error("Failed to delete platform notification", { error, notificationId });
-    return typedjson({ error: "Failed to delete notification, please try again." }, { status: 500 });
+    return typedjson(
+      { error: "Failed to delete notification, please try again." },
+      { status: 500 }
+    );
   }
 }
 
@@ -286,7 +310,10 @@ async function handlePublishNowAction(formData: FormData) {
     return typedjson({ success: true });
   } catch (error) {
     logger.error("Failed to publish platform notification", { error, notificationId });
-    return typedjson({ error: "Failed to publish notification, please try again." }, { status: 500 });
+    return typedjson(
+      { error: "Failed to publish notification, please try again." },
+      { status: 500 }
+    );
   }
 }
 
@@ -294,7 +321,16 @@ async function handleEditAction(formData: FormData) {
   const notificationId = formData.get("notificationId") as string;
   const fields = parseNotificationFormData(formData);
 
-  if (!notificationId || !fields.adminLabel || !fields.title || !fields.description || !fields.endsAt || !fields.surface || !fields.payloadType || !fields.startsAt) {
+  if (
+    !notificationId ||
+    !fields.adminLabel ||
+    !fields.title ||
+    !fields.description ||
+    !fields.endsAt ||
+    !fields.surface ||
+    !fields.payloadType ||
+    !fields.startsAt
+  ) {
     return typedjson({ error: "Missing required fields" }, { status: 400 });
   }
 
@@ -305,8 +341,12 @@ async function handleEditAction(formData: FormData) {
     surface: fields.surface as "CLI" | "WEBAPP",
     scope: fields.scope as "USER" | "PROJECT" | "ORGANIZATION" | "GLOBAL",
     ...(fields.scope === "USER" && fields.scopeUserId ? { userId: fields.scopeUserId } : {}),
-    ...(fields.scope === "ORGANIZATION" && fields.scopeOrganizationId ? { organizationId: fields.scopeOrganizationId } : {}),
-    ...(fields.scope === "PROJECT" && fields.scopeProjectId ? { projectId: fields.scopeProjectId } : {}),
+    ...(fields.scope === "ORGANIZATION" && fields.scopeOrganizationId
+      ? { organizationId: fields.scopeOrganizationId }
+      : {}),
+    ...(fields.scope === "PROJECT" && fields.scopeProjectId
+      ? { projectId: fields.scopeProjectId }
+      : {}),
     startsAt: new Date(fields.startsAt + "Z").toISOString(),
     endsAt: new Date(fields.endsAt + "Z").toISOString(),
     priority: fields.priority,
@@ -337,8 +377,12 @@ async function handleEditAction(formData: FormData) {
 export default function AdminNotificationsRoute() {
   const { notifications, total, page, pageCount } = useTypedLoaderData<typeof loader>();
   const [showCreate, setShowCreate] = useState(false);
-  const [detailNotification, setDetailNotification] = useState<(typeof notifications)[number] | null>(null);
-  const [editNotification, setEditNotification] = useState<(typeof notifications)[number] | null>(null);
+  const [detailNotification, setDetailNotification] = useState<
+    (typeof notifications)[number] | null
+  >(null);
+  const [editNotification, setEditNotification] = useState<(typeof notifications)[number] | null>(
+    null
+  );
 
   const [urlSearchParams, setUrlSearchParams] = useSearchParams();
   const hideInactive = urlSearchParams.get("hideInactive") === "true";
@@ -361,23 +405,21 @@ export default function AdminNotificationsRoute() {
       <div className="space-y-4">
         <div className="flex items-center justify-end">
           <Button variant="primary/small" onClick={() => setShowCreate(true)}>
-            Create Notification
+            Create notification
           </Button>
         </div>
 
         <Dialog
           open={showCreate}
-          onOpenChange={(open) => { if (!open) setShowCreate(false); }}
+          onOpenChange={(open) => {
+            if (!open) setShowCreate(false);
+          }}
         >
-          <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+          <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
             <DialogHeader>
-              <DialogTitle>Create Notification</DialogTitle>
+              <DialogTitle>Create notification</DialogTitle>
             </DialogHeader>
-            <NotificationForm
-              key="create"
-              mode="create"
-              onClose={() => setShowCreate(false)}
-            />
+            <NotificationForm key="create" mode="create" onClose={() => setShowCreate(false)} />
           </DialogContent>
         </Dialog>
 
@@ -386,12 +428,7 @@ export default function AdminNotificationsRoute() {
             {total} notifications (page {page} of {pageCount || 1})
           </Paragraph>
           <label className="flex items-center gap-2 text-xs text-text-dimmed">
-            <input
-              type="checkbox"
-              checked={hideInactive}
-              onChange={toggleHideInactive}
-              className="rounded border-grid-dimmed bg-charcoal-900"
-            />
+            <Checkbox checked={hideInactive} onChange={toggleHideInactive} />
             Hide inactive
           </label>
         </div>
@@ -427,7 +464,7 @@ export default function AdminNotificationsRoute() {
                       <button
                         type="button"
                         onClick={() => setDetailNotification(n)}
-                        className="text-sm font-medium text-text-bright hover:text-indigo-400 transition-colors text-left"
+                        className="text-left text-sm font-medium text-text-bright transition-colors hover:text-indigo-400"
                       >
                         {n.title}
                       </button>
@@ -448,33 +485,28 @@ export default function AdminNotificationsRoute() {
                       <span className="text-xs text-text-dimmed">{formatDate(n.endsAt)}</span>
                     </TableCell>
                     <TableCell>
-                      <span className="text-xs font-mono">{n.stats.seen}</span>
+                      <span className="font-mono text-xs">{n.stats.seen}</span>
                     </TableCell>
                     <TableCell>
-                      <span className="text-xs font-mono">{n.stats.clicked}</span>
+                      <span className="font-mono text-xs">{n.stats.clicked}</span>
                     </TableCell>
                     <TableCell>
-                      <span className="text-xs font-mono">{n.stats.dismissed}</span>
+                      <span className="font-mono text-xs">{n.stats.dismissed}</span>
                     </TableCell>
                     <TableCell>
                       <StatusBadge status={status} />
                     </TableCell>
                     <TableCell>
-                      <div className="flex items-center justify-end gap-1 opacity-0 group-hover/row:opacity-100 transition-opacity">
-                        {status === "pending" && (
-                          <PublishNowButton notificationId={n.id} />
-                        )}
-                        {(status === "pending" || status === "releasing" || status === "active") && (
-                          <Button
-                            variant="tertiary/small"
-                            onClick={() => setEditNotification(n)}
-                          >
+                      <div className="flex items-center justify-end gap-1 opacity-0 transition-opacity group-hover/row:opacity-100">
+                        {status === "pending" && <PublishNowButton notificationId={n.id} />}
+                        {(status === "pending" ||
+                          status === "releasing" ||
+                          status === "active") && (
+                          <Button variant="tertiary/small" onClick={() => setEditNotification(n)}>
                             Edit
                           </Button>
                         )}
-                        {status !== "archived" && (
-                          <ArchiveButton notificationId={n.id} />
-                        )}
+                        {status !== "archived" && <ArchiveButton notificationId={n.id} />}
                         <DeleteConfirmationButton notificationId={n.id} />
                       </div>
                     </TableCell>
@@ -494,7 +526,7 @@ export default function AdminNotificationsRoute() {
           if (!open) setDetailNotification(null);
         }}
       >
-        <DialogContent className="max-w-lg">
+        <DialogContent className="max-w-2xl">
           {detailNotification && (
             <>
               <DialogHeader>
@@ -512,11 +544,11 @@ export default function AdminNotificationsRoute() {
           if (!open) setEditNotification(null);
         }}
       >
-        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
           {editNotification && (
             <>
               <DialogHeader>
-                <DialogTitle>Edit Notification</DialogTitle>
+                <DialogTitle>Edit notification</DialogTitle>
               </DialogHeader>
               <NotificationForm
                 key={editNotification.id}
@@ -552,7 +584,7 @@ function PublishNowButton({ notificationId }: { notificationId: string }) {
   return (
     <Alert open={open} onOpenChange={setOpen}>
       <AlertTrigger asChild>
-        <Button variant="secondary/small">Publish Now</Button>
+        <Button variant="secondary/small">Publish now</Button>
       </AlertTrigger>
       <AlertContent>
         <AlertHeader>
@@ -593,8 +625,8 @@ function DeleteConfirmationButton({ notificationId }: { notificationId: string }
         <AlertHeader>
           <AlertTitle>Delete notification</AlertTitle>
           <AlertDescription>
-            This will permanently delete this notification and all its interaction data. This
-            action cannot be undone.
+            This will permanently delete this notification and all its interaction data. This action
+            cannot be undone.
           </AlertDescription>
         </AlertHeader>
         <AlertFooter>
@@ -651,13 +683,18 @@ function NotificationForm({
   onClose: () => void;
 }) {
   const fetcher = useFetcher<{ success?: boolean; error?: string; previewId?: string }>();
-  const [surface, setSurface] = useState<"CLI" | "WEBAPP">((n?.surface as "CLI" | "WEBAPP") ?? "WEBAPP");
+  const [surface, setSurface] = useState<"CLI" | "WEBAPP">(
+    (n?.surface as "CLI" | "WEBAPP") ?? "WEBAPP"
+  );
   const [payloadType, setPayloadType] = useState<string>(n?.payloadType ?? "card");
   const [scope, setScope] = useState<string>(n?.scope ?? "GLOBAL");
   const [title, setTitle] = useState(n?.payloadTitle ?? "");
   const [description, setDescription] = useState(n?.payloadDescription ?? "");
   const [actionUrl, setActionUrl] = useState(n?.payloadActionUrl ?? "");
   const [image, setImage] = useState(n?.payloadImage ?? "");
+  const [discoveryMatchBehavior, setDiscoveryMatchBehavior] = useState<string>(
+    n?.payloadDiscovery?.matchBehavior ?? ""
+  );
 
   const typeOptions = surface === "WEBAPP" ? WEBAPP_TYPES : CLI_TYPES;
 
@@ -686,50 +723,67 @@ function NotificationForm({
         </>
       )}
 
+      <input type="hidden" name="surface" value={surface} />
+      <input type="hidden" name="payloadType" value={payloadType} />
+      <input type="hidden" name="scope" value={scope} />
+
+      <div>
+        <Label variant="small">
+          Admin name <span className="text-red-400">*</span>
+        </Label>
+        <Input
+          name="adminLabel"
+          variant="medium"
+          fullWidth
+          defaultValue={n?.title ?? ""}
+          placeholder="Internal name for this notification"
+          className="mt-1"
+        />
+      </div>
+
       <div className="flex gap-3">
-        <div className="flex-1">
-          <label className="text-xs font-medium text-text-dimmed">Admin Label</label>
-          <Input
-            name="adminLabel"
-            variant="medium"
-            fullWidth
-            defaultValue={n?.title ?? ""}
-            placeholder="Internal name for this notification"
-            className="mt-1"
-          />
-        </div>
-
         <div className="w-28">
-          <label className="text-xs font-medium text-text-dimmed">Surface</label>
-          <select
-            name="surface"
+          <Label variant="small">Show in</Label>
+          <Select<"CLI" | "WEBAPP", "CLI" | "WEBAPP">
             value={surface}
-            onChange={(e) => handleSurfaceChange(e.target.value as "CLI" | "WEBAPP")}
-            className="mt-1 block w-full rounded-sm border border-grid-dimmed bg-charcoal-900 px-2 py-1.5 text-sm text-text-bright"
+            setValue={(v) => handleSurfaceChange(v as "CLI" | "WEBAPP")}
+            variant="tertiary/medium"
+            items={["WEBAPP", "CLI"]}
+            text={(v) => v}
+            className="mt-1 w-full"
           >
-            <option value="WEBAPP">WEBAPP</option>
-            <option value="CLI">CLI</option>
-          </select>
+            {(items) =>
+              items.map((item) => (
+                <SelectItem key={item} value={item}>
+                  {item}
+                </SelectItem>
+              ))
+            }
+          </Select>
         </div>
 
         <div className="w-28">
-          <label className="text-xs font-medium text-text-dimmed">Type</label>
-          <select
-            name="payloadType"
+          <Label variant="small">Display as</Label>
+          <Select<string, string>
             value={payloadType}
-            onChange={(e) => setPayloadType(e.target.value)}
-            className="mt-1 block w-full rounded-sm border border-grid-dimmed bg-charcoal-900 px-2 py-1.5 text-sm text-text-bright"
+            setValue={setPayloadType}
+            variant="tertiary/medium"
+            items={[...typeOptions]}
+            text={(v) => v}
+            className="mt-1 w-full"
           >
-            {typeOptions.map((t) => (
-              <option key={t} value={t}>
-                {t}
-              </option>
-            ))}
-          </select>
+            {(items) =>
+              items.map((item) => (
+                <SelectItem key={item} value={item}>
+                  {item}
+                </SelectItem>
+              ))
+            }
+          </Select>
         </div>
 
-        <div className="w-16">
-          <label className="text-xs font-medium text-text-dimmed">Priority</label>
+        <div className="w-20">
+          <Label variant="small">Priority</Label>
           <Input
             name="priority"
             variant="medium"
@@ -739,53 +793,75 @@ function NotificationForm({
             className="mt-1"
           />
         </div>
-      </div>
 
-      <div className="flex gap-3">
-        <div className="w-36">
-          <label className="text-xs font-medium text-text-dimmed">Scope</label>
-          <select
-            name="scope"
+        <div className="flex-1">
+          <Label variant="small">Scope</Label>
+          <Select<string, string>
             value={scope}
-            onChange={(e) => setScope(e.target.value)}
-            className="mt-1 block w-full rounded-sm border border-grid-dimmed bg-charcoal-900 px-2 py-1.5 text-sm text-text-bright"
+            setValue={setScope}
+            variant="tertiary/medium"
+            items={["GLOBAL", "USER", "ORGANIZATION", "PROJECT"]}
+            text={(v) => v}
+            className="mt-1 w-full"
           >
-            <option value="GLOBAL">GLOBAL</option>
-            <option value="USER">USER</option>
-            <option value="ORGANIZATION">ORGANIZATION</option>
-            <option value="PROJECT">PROJECT</option>
-          </select>
+            {(items) =>
+              items.map((item) => (
+                <SelectItem key={item} value={item}>
+                  {item}
+                </SelectItem>
+              ))
+            }
+          </Select>
         </div>
-
-        {scope === "USER" && (
-          <div className="flex-1">
-            <label className="text-xs font-medium text-text-dimmed">User ID</label>
-            <Input name="scopeUserId" variant="medium" fullWidth defaultValue={n?.userId ?? ""} placeholder="User ID" className="mt-1" />
-          </div>
-        )}
-
-        {scope === "ORGANIZATION" && (
-          <div className="flex-1">
-            <label className="text-xs font-medium text-text-dimmed">Organization ID</label>
-            <Input name="scopeOrganizationId" variant="medium" fullWidth defaultValue={n?.organizationId ?? ""} placeholder="Organization ID" className="mt-1" />
-          </div>
-        )}
-
-        {scope === "PROJECT" && (
-          <div className="flex-1">
-            <label className="text-xs font-medium text-text-dimmed">Project ID</label>
-            <Input name="scopeProjectId" variant="medium" fullWidth defaultValue={n?.projectId ?? ""} placeholder="Project ID" className="mt-1" />
-          </div>
-        )}
       </div>
+
+      {scope === "USER" && (
+        <div>
+          <Label variant="small">User ID</Label>
+          <Input
+            name="scopeUserId"
+            variant="medium"
+            fullWidth
+            defaultValue={n?.userId ?? ""}
+            placeholder="User ID"
+            className="mt-1"
+          />
+        </div>
+      )}
+
+      {scope === "ORGANIZATION" && (
+        <div>
+          <Label variant="small">Organization ID</Label>
+          <Input
+            name="scopeOrganizationId"
+            variant="medium"
+            fullWidth
+            defaultValue={n?.organizationId ?? ""}
+            placeholder="Organization ID"
+            className="mt-1"
+          />
+        </div>
+      )}
+
+      {scope === "PROJECT" && (
+        <div>
+          <Label variant="small">Project ID</Label>
+          <Input
+            name="scopeProjectId"
+            variant="medium"
+            fullWidth
+            defaultValue={n?.projectId ?? ""}
+            placeholder="Project ID"
+            className="mt-1"
+          />
+        </div>
+      )}
 
       {/* CLI live preview */}
       {surface === "CLI" && (title || description) && (
         <div>
-          <p className="text-[10px] font-medium text-text-dimmed/60 uppercase tracking-wider mb-1">
-            CLI Preview
-          </p>
-          <div className="rounded border border-grid-dimmed bg-charcoal-900 p-3 font-mono text-xs leading-relaxed">
+          <Label variant="small">CLI preview</Label>
+          <div className="mt-1 rounded border border-grid-dimmed bg-charcoal-900 p-3 font-mono text-xs leading-relaxed">
             {title && (
               <p className="font-bold text-text-bright">
                 <CliColorMarkup text={title} fallbackClass="text-text-bright" />
@@ -796,109 +872,112 @@ function NotificationForm({
                 <CliColorMarkup text={description} fallbackClass="text-text-dimmed" />
               </p>
             )}
-            {actionUrl && (
-              <p className="text-text-dimmed underline">{actionUrl}</p>
-            )}
+            {actionUrl && <p className="text-text-dimmed underline">{actionUrl}</p>}
           </div>
         </div>
       )}
 
-      <div>
-        <label className="text-xs font-medium text-text-dimmed">Title</label>
-        <Input
-          name="title"
-          variant="medium"
-          fullWidth
-          placeholder="Notification title"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          className="mt-1"
-        />
-      </div>
+      <hr className="-mx-4 border-grid-bright" />
 
-      <div>
-        <label className="text-xs font-medium text-text-dimmed">
-          Description{surface === "WEBAPP" ? " (markdown)" : ""}
-        </label>
-        {surface === "WEBAPP" ? (
-          <div className="mt-1 flex gap-3">
-            <textarea
+      {surface === "WEBAPP" ? (
+        <div className="flex gap-3">
+          <div className="min-w-0 flex-1 space-y-3">
+            <div>
+              <Label variant="small">
+                Title <span className="text-red-400">*</span>
+              </Label>
+              <TextArea
+                name="title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                rows={2}
+                placeholder="Notification title"
+                className="mt-1"
+              />
+            </div>
+            <div>
+              <Label variant="small">
+                Description (markdown) <span className="text-red-400">*</span>
+              </Label>
+              <TextArea
+                name="description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={6}
+                placeholder="Supports **bold**, *italic*, `code`, [links](url)..."
+                className="mt-1 font-mono"
+              />
+            </div>
+          </div>
+          <div className="w-56 shrink-0">
+            <Label variant="small">Preview</Label>
+            <div className="mt-1">
+              <NotificationCard
+                title={title || "Notification title"}
+                description={description || "Description preview will appear here..."}
+                actionUrl={actionUrl || undefined}
+                image={image || undefined}
+              />
+            </div>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div>
+            <Label variant="small">
+              Title <span className="text-red-400">*</span>
+            </Label>
+            <TextArea
+              name="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              rows={2}
+              placeholder="Notification title"
+              className="mt-1 font-mono"
+            />
+          </div>
+          <div>
+            <Label variant="small">
+              Description <span className="text-red-400">*</span>
+            </Label>
+            <TextArea
               name="description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={6}
-              placeholder="Supports **bold**, *italic*, `code`, [links](url)..."
-              className="block min-w-0 flex-1 rounded-sm border border-grid-dimmed bg-charcoal-900 px-2 py-1.5 text-sm text-text-bright placeholder:text-text-dimmed/50 font-mono resize-y"
+              placeholder="Plain text description..."
+              className="mt-1 font-mono"
             />
-            <div className="shrink-0">
-              <div className="text-[10px] font-medium text-text-dimmed/60 uppercase tracking-wider mb-1">
-                Preview
-              </div>
-              <div className="w-56">
-                <NotificationPreviewCard
-                  title={title || "Notification title"}
-                  description={description || "Description preview will appear here..."}
-                  actionUrl={actionUrl || undefined}
-                  image={image || undefined}
-                />
-              </div>
-            </div>
           </div>
-        ) : (
-          <textarea
-            name="description"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            rows={6}
-            placeholder="Plain text description..."
-            className="mt-1 block w-full rounded-sm border border-grid-dimmed bg-charcoal-900 px-2 py-1.5 text-sm text-text-bright placeholder:text-text-dimmed/50 font-mono resize-y"
+        </>
+      )}
+
+      <div>
+        <Label variant="small">Action URL</Label>
+        <Input
+          name="actionUrl"
+          variant="medium"
+          fullWidth
+          placeholder="https://..."
+          value={actionUrl}
+          onChange={(e) => setActionUrl(e.target.value)}
+          className="mt-1"
+        />
+        {surface === "WEBAPP" && (
+          <CheckboxWithLabel
+            name="dismissOnAction"
+            value="true"
+            defaultChecked={n?.payloadDismissOnAction ?? false}
+            variant="simple/small"
+            label="Dismiss on action click"
+            className="mt-2"
           />
         )}
       </div>
 
-      {surface === "WEBAPP" ? (
-        <div className="flex items-end gap-3">
-          <div className="flex-1">
-            <label className="text-xs font-medium text-text-dimmed">Action URL (optional)</label>
-            <Input
-              name="actionUrl"
-              variant="medium"
-              fullWidth
-              placeholder="https://..."
-              value={actionUrl}
-              onChange={(e) => setActionUrl(e.target.value)}
-              className="mt-1"
-            />
-          </div>
-          <label className="flex items-center gap-2 pb-1.5 text-xs text-text-dimmed whitespace-nowrap">
-            <input
-              type="checkbox"
-              name="dismissOnAction"
-              value="true"
-              defaultChecked={n?.payloadDismissOnAction ?? false}
-              className="rounded border-grid-dimmed bg-charcoal-900"
-            />
-            Dismiss on action click
-          </label>
-        </div>
-      ) : (
-        <div>
-          <label className="text-xs font-medium text-text-dimmed">Action URL (optional)</label>
-          <Input
-            name="actionUrl"
-            variant="medium"
-            fullWidth
-            placeholder="https://..."
-            value={actionUrl}
-            onChange={(e) => setActionUrl(e.target.value)}
-            className="mt-1"
-          />
-        </div>
-      )}
-
       {surface === "WEBAPP" && (
         <div>
-          <label className="text-xs font-medium text-text-dimmed">Image URL (optional)</label>
+          <Label variant="small">Image URL</Label>
           <Input
             name="image"
             variant="medium"
@@ -913,21 +992,25 @@ function NotificationForm({
 
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <label className="text-xs font-medium text-text-dimmed">Starts At (UTC)</label>
+          <Label variant="small">Starts at (UTC)</Label>
           <input
             name="startsAt"
             type="datetime-local"
-            defaultValue={n?.startsAt ? toDatetimeLocalUTC(new Date(n.startsAt)) : defaultStartsAt()}
-            className="mt-1 block w-full rounded-sm border border-grid-dimmed bg-charcoal-900 px-2 py-1.5 text-sm text-text-bright"
+            defaultValue={
+              n?.startsAt ? toDatetimeLocalUTC(new Date(n.startsAt)) : defaultStartsAt()
+            }
+            className="mt-1 block h-8 w-full rounded border border-charcoal-800 bg-charcoal-750 px-2 text-sm text-text-bright transition hover:border-charcoal-600 hover:bg-charcoal-650"
           />
         </div>
         <div>
-          <label className="text-xs font-medium text-text-dimmed">Ends At (UTC)</label>
+          <Label variant="small">
+            Ends at (UTC) <span className="text-red-400">*</span>
+          </Label>
           <input
             name="endsAt"
             type="datetime-local"
             defaultValue={n?.endsAt ? toDatetimeLocalUTC(new Date(n.endsAt)) : defaultEndsAt()}
-            className="mt-1 block w-full rounded-sm border border-grid-dimmed bg-charcoal-900 px-2 py-1.5 text-sm text-text-bright"
+            className="mt-1 block h-8 w-full rounded border border-charcoal-800 bg-charcoal-750 px-2 text-sm text-text-bright transition hover:border-charcoal-600 hover:bg-charcoal-650"
             required
           />
         </div>
@@ -935,9 +1018,11 @@ function NotificationForm({
 
       {surface === "CLI" && (
         <>
+          <input type="hidden" name="discoveryMatchBehavior" value={discoveryMatchBehavior} />
+
           <div className="grid grid-cols-3 gap-3 rounded border border-grid-dimmed bg-charcoal-900 p-3">
             <div>
-              <label className="text-xs font-medium text-text-dimmed">Max Show Count</label>
+              <Label variant="small">Max show count</Label>
               <Input
                 name="cliMaxShowCount"
                 variant="medium"
@@ -949,21 +1034,21 @@ function NotificationForm({
               />
             </div>
             <div>
-              <label className="text-xs font-medium text-text-dimmed">
-                Max Days After First Seen
-              </label>
+              <Label variant="small">Max days after first seen</Label>
               <Input
                 name="cliMaxDaysAfterFirstSeen"
                 variant="medium"
                 fullWidth
                 type="number"
-                defaultValue={n?.cliMaxDaysAfterFirstSeen != null ? String(n.cliMaxDaysAfterFirstSeen) : ""}
+                defaultValue={
+                  n?.cliMaxDaysAfterFirstSeen != null ? String(n.cliMaxDaysAfterFirstSeen) : ""
+                }
                 placeholder="e.g. 7"
                 className="mt-1"
               />
             </div>
             <div>
-              <label className="text-xs font-medium text-text-dimmed">Show Every (Nth)</label>
+              <Label variant="small">Show every (nth)</Label>
               <Input
                 name="cliShowEvery"
                 variant="medium"
@@ -976,13 +1061,13 @@ function NotificationForm({
             </div>
           </div>
 
-          <div className="rounded border border-grid-dimmed bg-charcoal-900 p-3 space-y-3">
-            <div className="text-xs font-medium text-text-dimmed">
+          <div className="space-y-3 rounded border border-grid-dimmed bg-charcoal-900 p-3">
+            <Paragraph variant="small" className="text-text-dimmed">
               Discovery (optional) — only show notification if file pattern matches
-            </div>
+            </Paragraph>
             <div className="grid grid-cols-3 gap-3">
               <div>
-                <label className="text-xs font-medium text-text-dimmed">File Patterns</label>
+                <Label variant="small">File patterns</Label>
                 <Input
                   name="discoveryFilePatterns"
                   variant="medium"
@@ -991,10 +1076,10 @@ function NotificationForm({
                   placeholder="trigger.config.ts, trigger.config.js"
                   className="mt-1"
                 />
-                <span className="text-[10px] text-text-dimmed/60">Comma-separated</span>
+                <Hint>Comma-separated</Hint>
               </div>
               <div>
-                <label className="text-xs font-medium text-text-dimmed">Content Pattern</label>
+                <Label variant="small">Content pattern</Label>
                 <Input
                   name="discoveryContentPattern"
                   variant="medium"
@@ -1003,75 +1088,80 @@ function NotificationForm({
                   placeholder="e.g. syncVercelEnvVars"
                   className="mt-1"
                 />
-                <span className="text-[10px] text-text-dimmed/60">Regex (optional)</span>
+                <Hint>Regex (optional)</Hint>
               </div>
               <div>
-                <label className="text-xs font-medium text-text-dimmed">Match Behavior</label>
-                <select
-                  name="discoveryMatchBehavior"
-                  defaultValue={n?.payloadDiscovery?.matchBehavior ?? ""}
-                  className="mt-1 block w-full rounded-sm border border-grid-dimmed bg-charcoal-900 px-2 py-1.5 text-sm text-text-bright"
+                <Label variant="small">Match behavior</Label>
+                <Select<string, string>
+                  value={discoveryMatchBehavior}
+                  setValue={setDiscoveryMatchBehavior}
+                  variant="tertiary/medium"
+                  items={["", "show-if-found", "show-if-not-found"]}
+                  placeholder="— none —"
+                  text={(v) => v || "— none —"}
+                  className="mt-1 w-full"
                 >
-                  <option value="">— none —</option>
-                  <option value="show-if-found">show-if-found</option>
-                  <option value="show-if-not-found">show-if-not-found</option>
-                </select>
+                  {(items) =>
+                    items.map((item) => (
+                      <SelectItem key={item || "none"} value={item}>
+                        {item || "— none —"}
+                      </SelectItem>
+                    ))
+                  }
+                </Select>
               </div>
             </div>
           </div>
         </>
       )}
 
-      <div className="flex items-center gap-2">
-        {isEdit ? (
-          <Button
-            type="submit"
-            variant="primary/small"
-            disabled={fetcher.state !== "idle"}
-          >
-            {fetcher.state !== "idle" ? "Saving..." : "Save Changes"}
+      <DialogFooter className="items-center">
+        <div className="flex items-center gap-3">
+          <Button type="button" variant="tertiary/medium" onClick={onClose}>
+            Cancel
           </Button>
-        ) : (
-          <>
-            <Button
-              type="submit"
-              name="_action"
-              value="create"
-              variant="primary/small"
-              disabled={fetcher.state !== "idle"}
-            >
-              {fetcher.state !== "idle" ? "Creating..." : "Create"}
+          {fetcher.data?.error && (
+            <span className="text-xs text-red-400">{fetcher.data.error}</span>
+          )}
+          {!isEdit && fetcher.data?.success && !fetcher.data.previewId && (
+            <span className="text-xs text-green-400">Created successfully</span>
+          )}
+          {!isEdit && fetcher.data?.previewId && (
+            <span className="text-xs text-green-400">
+              Preview sent (ID: {fetcher.data.previewId})
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          {isEdit ? (
+            <Button type="submit" variant="primary/medium" disabled={fetcher.state !== "idle"}>
+              {fetcher.state !== "idle" ? "Saving..." : "Save changes"}
             </Button>
-            <Button
-              type="submit"
-              name="_action"
-              value="create-preview"
-              variant="tertiary/small"
-              disabled={fetcher.state !== "idle"}
-            >
-              Send Preview to Me
-            </Button>
-          </>
-        )}
-        <Button
-          type="button"
-          variant="tertiary/small"
-          onClick={onClose}
-        >
-          Cancel
-        </Button>
-        {fetcher.data?.error && (
-          <span className="text-xs text-red-400">{fetcher.data.error}</span>
-        )}
-        {!isEdit && fetcher.data?.success && !fetcher.data.previewId && (
-          <span className="text-xs text-green-400">Created successfully</span>
-        )}
-        {!isEdit && fetcher.data?.previewId && (
-          <span className="text-xs text-green-400">
-            Preview sent (ID: {fetcher.data.previewId})
-          </span>
-        )}
-      </div>
+          ) : (
+            <>
+              <Button
+                type="submit"
+                name="_action"
+                value="create-preview"
+                variant="tertiary/medium"
+                disabled={fetcher.state !== "idle"}
+              >
+                Send preview to me
+              </Button>
+              <Button
+                type="submit"
+                name="_action"
+                value="create"
+                variant="primary/medium"
+                disabled={fetcher.state !== "idle"}
+              >
+                {fetcher.state !== "idle" ? "Creating..." : "Create"}
+              </Button>
+            </>
+          )}
+        </div>
+      </DialogFooter>
     </fetcher.Form>
   );
 }
@@ -1107,7 +1197,7 @@ function NotificationDetailContent({
         <div>
           <p className="mb-1 text-xs font-medium text-text-dimmed">Preview</p>
           {n.surface === "WEBAPP" ? (
-            <NotificationPreviewCard
+            <NotificationCard
               title={n.payloadTitle}
               description={n.payloadDescription}
               actionUrl={n.payloadActionUrl ?? undefined}
@@ -1144,22 +1234,26 @@ function NotificationDetailContent({
       </div>
 
       {/* CLI settings */}
-      {n.surface === "CLI" && (n.cliMaxShowCount || n.cliMaxDaysAfterFirstSeen || n.cliShowEvery) && (
-        <div>
-          <p className="mb-1 text-xs font-medium text-text-dimmed">CLI Settings</p>
-          <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
-            {n.cliMaxShowCount != null && (
-              <DetailRow label="Max show count" value={String(n.cliMaxShowCount)} />
-            )}
-            {n.cliMaxDaysAfterFirstSeen != null && (
-              <DetailRow label="Max days after first seen" value={String(n.cliMaxDaysAfterFirstSeen)} />
-            )}
-            {n.cliShowEvery != null && (
-              <DetailRow label="Show every N-th" value={String(n.cliShowEvery)} />
-            )}
+      {n.surface === "CLI" &&
+        (n.cliMaxShowCount || n.cliMaxDaysAfterFirstSeen || n.cliShowEvery) && (
+          <div>
+            <p className="mb-1 text-xs font-medium text-text-dimmed">CLI Settings</p>
+            <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+              {n.cliMaxShowCount != null && (
+                <DetailRow label="Max show count" value={String(n.cliMaxShowCount)} />
+              )}
+              {n.cliMaxDaysAfterFirstSeen != null && (
+                <DetailRow
+                  label="Max days after first seen"
+                  value={String(n.cliMaxDaysAfterFirstSeen)}
+                />
+              )}
+              {n.cliShowEvery != null && (
+                <DetailRow label="Show every N-th" value={String(n.cliShowEvery)} />
+              )}
+            </div>
           </div>
-        </div>
-      )}
+        )}
 
       {/* Stats */}
       <div>
@@ -1178,7 +1272,7 @@ function DetailRow({ label, value }: { label: string; value: string }) {
   return (
     <>
       <span className="text-text-dimmed">{label}</span>
-      <span className="text-text-bright break-all">{value}</span>
+      <span className="break-all text-text-bright">{value}</span>
     </>
   );
 }
@@ -1186,114 +1280,11 @@ function DetailRow({ label, value }: { label: string; value: string }) {
 function StatCard({ label, value }: { label: string; value: number }) {
   return (
     <div className="rounded border border-grid-dimmed bg-charcoal-900 p-2 text-center">
-      <p className="text-lg font-mono font-medium text-text-bright">{value}</p>
+      <p className="font-mono text-lg font-medium text-text-bright">{value}</p>
       <p className="text-xs text-text-dimmed">{label}</p>
     </div>
   );
 }
-
-// Mirrors NotificationCard from NotificationPanel.tsx — static preview, no interactions
-function NotificationPreviewCard({
-  title,
-  description,
-  actionUrl,
-  image,
-}: {
-  title: string;
-  description: string;
-  actionUrl?: string;
-  image?: string;
-}) {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [isOverflowing, setIsOverflowing] = useState(false);
-  const descriptionRef = useRef<HTMLDivElement>(null);
-
-  useLayoutEffect(() => {
-    const el = descriptionRef.current;
-    if (el) {
-      setIsOverflowing(el.scrollHeight > el.clientHeight);
-    }
-  }, [description]);
-
-  const Wrapper = actionUrl ? "a" : "div";
-  const wrapperProps = actionUrl
-    ? { href: actionUrl, target: "_blank" as const, rel: "noopener noreferrer" as const }
-    : {};
-
-  return (
-    <Wrapper
-      {...wrapperProps}
-      className="group/card group relative block overflow-hidden rounded border transition-colors border-grid-bright bg-charcoal-750/50 no-underline"
-    >
-      <div className="relative flex items-start gap-1 px-2 pt-1.5">
-        <Header3 className="flex-1 !text-xs">{title}</Header3>
-        <button
-          type="button"
-          className="shrink-0 rounded p-0.5 text-text-dimmed transition-colors hover:bg-charcoal-700 hover:text-text-bright"
-          tabIndex={-1}
-        >
-          <XMarkIcon className="size-3.5" />
-        </button>
-      </div>
-
-      <div className="relative px-2 pb-2">
-        <div className="flex gap-1">
-          <div className="min-w-0 flex-1">
-            <div ref={descriptionRef} className={cn(!isExpanded && "line-clamp-3")}>
-              <ReactMarkdown components={markdownComponents}>{description}</ReactMarkdown>
-            </div>
-            {(isOverflowing || isExpanded) && (
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  setIsExpanded((v) => !v);
-                }}
-                className="mt-0.5 text-xs text-indigo-400 hover:text-indigo-300"
-              >
-                {isExpanded ? "Show less" : "Show more"}
-              </button>
-            )}
-          </div>
-          {actionUrl && (
-            <div className="mt-1 flex shrink-0 items-center pb-1 text-text-dimmed group-hover/card:text-text-bright transition-colors">
-              <ChevronRightIcon className="size-4" />
-            </div>
-          )}
-        </div>
-
-        {image && (
-          <img src={sanitizeImageUrl(image)} alt="" className="mt-1.5 rounded px-2 pb-2" />
-        )}
-      </div>
-    </Wrapper>
-  );
-}
-
-const markdownComponents = {
-  p: ({ children }: { children?: React.ReactNode }) => (
-    <p className="my-0.5 text-xs leading-relaxed text-text-dimmed">{children}</p>
-  ),
-  a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
-    <a
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="text-indigo-400 underline hover:text-indigo-300 transition-colors"
-      onClick={(e) => e.stopPropagation()}
-    >
-      {children}
-    </a>
-  ),
-  strong: ({ children }: { children?: React.ReactNode }) => (
-    <strong className="font-semibold text-text-bright">{children}</strong>
-  ),
-  em: ({ children }: { children?: React.ReactNode }) => <em>{children}</em>,
-  code: ({ children }: { children?: React.ReactNode }) => (
-    <code className="rounded bg-charcoal-700 px-1 py-0.5 text-[11px]">{children}</code>
-  ),
-};
 
 const CLI_COLOR_MAP: Record<string, string> = {
   red: "text-red-500",
@@ -1340,7 +1331,11 @@ function CliColorMarkup({ text, fallbackClass }: { text: string; fallbackClass?:
       if (endIdx !== -1) {
         // Push text before the tag
         if (braceIdx > pos) {
-          parts.push(<span key={key++} className={fallbackClass}>{text.slice(pos, braceIdx)}</span>);
+          parts.push(
+            <span key={key++} className={fallbackClass}>
+              {text.slice(pos, braceIdx)}
+            </span>
+          );
         }
         // Push styled content
         parts.push(
@@ -1398,7 +1393,9 @@ function formatDate(date: string | Date): string {
 
 function toDatetimeLocalUTC(date: Date): string {
   const pad = (n: number) => String(n).padStart(2, "0");
-  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}T${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}`;
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}T${pad(
+    date.getUTCHours()
+  )}:${pad(date.getUTCMinutes())}`;
 }
 
 function defaultStartsAt(): string {
@@ -1407,19 +1404,6 @@ function defaultStartsAt(): string {
 
 function defaultEndsAt(): string {
   return toDatetimeLocalUTC(new Date(Date.now() + 30 * 24 * 60 * 60 * 1000));
-}
-
-/** Sanitize image URL to prevent XSS via javascript: or data: URIs. */
-function sanitizeImageUrl(url: string): string {
-  try {
-    const parsed = new URL(url);
-    if (parsed.protocol === "https:" || parsed.protocol === "http:") {
-      return parsed.href;
-    }
-    return "";
-  } catch {
-    return "";
-  }
 }
 
 type NotificationStatus = "active" | "pending" | "releasing" | "expired" | "archived";
@@ -1452,7 +1436,9 @@ function StatusBadge({ status }: { status: NotificationStatus }) {
   };
 
   return (
-    <span className={`inline-flex rounded-sm px-1.5 py-0.5 text-[11px] font-medium ${styles[status]}`}>
+    <span
+      className={`inline-flex rounded-sm px-1.5 py-0.5 text-[11px] font-medium ${styles[status]}`}
+    >
       {status}
     </span>
   );

--- a/apps/webapp/app/routes/admin.notifications.tsx
+++ b/apps/webapp/app/routes/admin.notifications.tsx
@@ -992,7 +992,9 @@ function NotificationForm({
 
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <Label variant="small">Starts at (UTC)</Label>
+          <Label variant="small">
+            Starts at (UTC) {isEdit && <span className="text-red-400">*</span>}
+          </Label>
           <input
             name="startsAt"
             type="datetime-local"
@@ -1000,6 +1002,7 @@ function NotificationForm({
               n?.startsAt ? toDatetimeLocalUTC(new Date(n.startsAt)) : defaultStartsAt()
             }
             className="mt-1 block h-8 w-full rounded border border-charcoal-800 bg-charcoal-750 px-2 text-sm text-text-bright transition hover:border-charcoal-600 hover:bg-charcoal-650"
+            required={isEdit}
           />
         </div>
         <div>

--- a/apps/webapp/app/routes/admin.notifications.tsx
+++ b/apps/webapp/app/routes/admin.notifications.tsx
@@ -59,6 +59,10 @@ const PAGE_SIZE = 20;
 const WEBAPP_TYPES = ["card", "changelog"] as const;
 const CLI_TYPES = ["info", "warn", "error", "success"] as const;
 
+/** Sentinel for the discovery "match behavior" select meaning "none / not configured". */
+const DISCOVERY_MATCH_NONE = "";
+const DISCOVERY_MATCH_LABEL = "— none —";
+
 const SearchParams = z.object({
   page: z.coerce.number().optional(),
   hideInactive: z.coerce.boolean().optional(),
@@ -143,10 +147,11 @@ function parseNotificationFormData(formData: FormData) {
 
   const discoveryFilePatterns = (formData.get("discoveryFilePatterns") as string) || "";
   const discoveryContentPattern = (formData.get("discoveryContentPattern") as string) || undefined;
-  const discoveryMatchBehavior = (formData.get("discoveryMatchBehavior") as string) || "";
+  const discoveryMatchBehavior =
+    (formData.get("discoveryMatchBehavior") as string) || DISCOVERY_MATCH_NONE;
 
   const discovery =
-    discoveryFilePatterns && discoveryMatchBehavior
+    discoveryFilePatterns && discoveryMatchBehavior !== DISCOVERY_MATCH_NONE
       ? {
           filePatterns: discoveryFilePatterns
             .split(",")
@@ -693,7 +698,7 @@ function NotificationForm({
   const [actionUrl, setActionUrl] = useState(n?.payloadActionUrl ?? "");
   const [image, setImage] = useState(n?.payloadImage ?? "");
   const [discoveryMatchBehavior, setDiscoveryMatchBehavior] = useState<string>(
-    n?.payloadDiscovery?.matchBehavior ?? ""
+    n?.payloadDiscovery?.matchBehavior ?? DISCOVERY_MATCH_NONE
   );
 
   const typeOptions = surface === "WEBAPP" ? WEBAPP_TYPES : CLI_TYPES;
@@ -1099,15 +1104,18 @@ function NotificationForm({
                   value={discoveryMatchBehavior}
                   setValue={setDiscoveryMatchBehavior}
                   variant="tertiary/medium"
-                  items={["", "show-if-found", "show-if-not-found"]}
-                  placeholder="— none —"
-                  text={(v) => v || "— none —"}
+                  items={[DISCOVERY_MATCH_NONE, "show-if-found", "show-if-not-found"]}
+                  placeholder={DISCOVERY_MATCH_LABEL}
+                  text={(v) => (v === DISCOVERY_MATCH_NONE ? DISCOVERY_MATCH_LABEL : v)}
                   className="mt-1 w-full"
                 >
                   {(items) =>
                     items.map((item) => (
-                      <SelectItem key={item || "none"} value={item}>
-                        {item || "— none —"}
+                      <SelectItem
+                        key={item === DISCOVERY_MATCH_NONE ? "none" : item}
+                        value={item}
+                      >
+                        {item === DISCOVERY_MATCH_NONE ? DISCOVERY_MATCH_LABEL : item}
                       </SelectItem>
                     ))
                   }


### PR DESCRIPTION
### Style updates to the notifications
- Tightened up the typography
- Brighter background to make it stand out a bit more
- A bit more padding to make it more readable
- Show the close button on hover instead
- Turned the notification into a separate component as it's shared on the admin page modal
- Minor tweaks to the behavior of toggling the notification beween open/closed side menu states

### Before
<img width="224" height="313" alt="before" src="https://github.com/user-attachments/assets/c9a9377c-4a3b-4477-921a-3c86385d3f0b" />

### After (with image)
<img width="239" height="284" alt="CleanShot 2026-05-11 at 17 22 01" src="https://github.com/user-attachments/assets/311b4dbc-4853-4e6c-9f83-8173b38bd466" />

### After (no image)
<img width="239" height="189" alt="after" src="https://github.com/user-attachments/assets/884e062b-3608-4cb3-a462-d50597257753" />
