### PR TITLE
fix: prevent IEEE 754 precision loss in BigInt nanosecond conversions

### DIFF
--- a/apps/webapp/app/v3/eventRepository/common.server.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.ts
@@ -21,7 +21,7 @@ export function extractContextFromCarrier(carrier: Record<string, unknown>) {
 }
 
 export function getNowInNanoseconds(): bigint {
-  return BigInt(new Date().getTime() * 1_000_000);
+  return BigInt(new Date().getTime()) * BigInt(1_000_000);
 }
 
 export function getDateFromNanoseconds(nanoseconds: bigint): Date {
@@ -35,7 +35,7 @@ export function calculateDurationFromStart(
 ) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  const duration = Number(BigInt($endtime.getTime() * 1_000_000) - startTime);
+  const duration = Number(BigInt($endtime.getTime()) * BigInt(1_000_000) - startTime);
 
   if (minimumDuration && duration < minimumDuration) {
     return minimumDuration;

--- a/apps/webapp/app/v3/eventRepository/index.server.ts
+++ b/apps/webapp/app/v3/eventRepository/index.server.ts
@@ -215,7 +215,7 @@ async function recordRunEvent(
         runId: foundRun.friendlyId,
         ...attributes,
       },
-      startTime: BigInt((startTime?.getTime() ?? Date.now()) * 1_000_000),
+      startTime: BigInt(startTime?.getTime() ?? Date.now()) * BigInt(1_000_000),
       ...optionsRest,
     });
 

--- a/apps/webapp/app/v3/runEngineHandlers.server.ts
+++ b/apps/webapp/app/v3/runEngineHandlers.server.ts
@@ -429,7 +429,7 @@ export function registerRunEngineEventBusHandlers() {
       const eventRepository = resolveEventRepositoryForStore(run.taskEventStore);
 
       await eventRepository.recordEvent(retryMessage, {
-        startTime: BigInt(time.getTime() * 1000000),
+        startTime: BigInt(time.getTime()) * BigInt(1_000_000),
         taskSlug: run.taskIdentifier,
         environment,
         attributes: {


### PR DESCRIPTION
## Problem

Several places multiply epoch milliseconds by `1_000_000` **before** converting to `BigInt`, causing IEEE 754 float precision loss (~±256 ns errors):

```ts
// Bug: multiplication happens in float-land; result ~1.7e18 > Number.MAX_SAFE_INTEGER
BigInt(new Date().getTime() * 1_000_000)
```

The product (~1.7×10¹⁸) exceeds `Number.MAX_SAFE_INTEGER` (~9×10¹⁵), so the float loses the last few bits before BigInt sees it.

## Fix

Convert to `BigInt` first, then multiply — matching the already-correct pattern in `convertDateToNanoseconds()` in the same file:

```ts
// Correct: BigInt arithmetic, no precision loss
BigInt(new Date().getTime()) * BigInt(1_000_000)
```

## Affected locations (4 sites across 3 files)

| File | Function |
|------|----------|
| `apps/webapp/app/v3/eventRepository/common.server.ts` | `getNowInNanoseconds()` |
| `apps/webapp/app/v3/eventRepository/common.server.ts` | `calculateDurationFromStart()` |
| `apps/webapp/app/v3/eventRepository/index.server.ts` | `recordRunEvent()` |
| `apps/webapp/app/v3/runEngineHandlers.server.ts` | retry event recording |

Fixes #3292