### PR TITLE
fix(webapp,run-engine): honor per-queue length cap on concurrency-key queues

### DIFF
--- a/.server-changes/fix-ck-queue-length-cap-and-dashboard.md
+++ b/.server-changes/fix-ck-queue-length-cap-and-dashboard.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Per-queue length limits and the dashboard's "Queued | Running" columns now reflect the true total across all concurrency-key variants. Previously both read 0 for any queue that used concurrency keys, allowing the per-queue cap to be bypassed.

--- a/internal-packages/run-engine/src/run-queue/index.ts
+++ b/internal-packages/run-engine/src/run-queue/index.ts
@@ -2577,7 +2577,8 @@ export class RunQueue {
         messageQueue,
         JSON.stringify(message),
         String(messageScore),
-        ckWildcardName
+        ckWildcardName,
+        this.options.redis.keyPrefix ?? ""
       );
     } else {
       await this.redis.nackMessage(
@@ -3461,7 +3462,9 @@ end
 -- Slow path: normal enqueue
 redis.call('SET', messageKey, messageData)
 
--- Lazy-init lengthCounter from existing ckIndex variants (once per base queue, ever).
+-- Lazy-init lengthCounter from existing ckIndex variants (once per base queue per 24h).
+-- The 24h TTL means the counter periodically re-anchors to truth, bounding any drift
+-- that accumulated during rolling-deploy overlap windows.
 -- Run BEFORE the ZADD so we capture pre-state; the subsequent INCR accounts for the new message.
 -- The counter tracks ONLY CK-variant messages — the read path adds ZCARD(base) separately,
 -- so the base zset is intentionally excluded here.
@@ -3471,12 +3474,16 @@ if redis.call('EXISTS', lengthCounterKey) == 0 then
   for _, v in ipairs(variants) do
     total = total + tonumber(redis.call('ZCARD', keyPrefix .. v) or '0')
   end
-  redis.call('SET', lengthCounterKey, total)
+  redis.call('SET', lengthCounterKey, total, 'EX', 86400)
 end
 
-redis.call('ZADD', queueKey, messageScore, messageId)
+-- INCR is gated on ZADD returning 1 (new entry). A duplicate enqueue (same messageId
+-- already in the variant zset) returns 0 and must not bump the counter.
+local added = redis.call('ZADD', queueKey, messageScore, messageId)
 redis.call('ZADD', envQueueKey, messageScore, messageId)
-redis.call('INCR', lengthCounterKey)
+if added == 1 then
+  redis.call('INCR', lengthCounterKey)
+end
 
 -- Rebalance CK index
 local earliest = redis.call('ZRANGE', queueKey, 0, 0, 'WITHSCORES')
@@ -3571,23 +3578,24 @@ end
 -- Slow path: normal enqueue
 redis.call('SET', messageKey, messageData)
 
--- Lazy-init lengthCounter from existing ckIndex variants (once per base queue, ever).
--- Run BEFORE the ZADD so we capture pre-state; the subsequent INCR accounts for the new message.
--- The counter tracks ONLY CK-variant messages — the read path adds ZCARD(base) separately,
--- so the base zset is intentionally excluded here.
+-- Lazy-init lengthCounter from existing ckIndex variants (once per base queue per 24h).
+-- See enqueueMessageCkTracked for the TTL rationale.
 if redis.call('EXISTS', lengthCounterKey) == 0 then
   local total = 0
   local variants = redis.call('ZRANGE', ckIndexKey, 0, -1)
   for _, v in ipairs(variants) do
     total = total + tonumber(redis.call('ZCARD', keyPrefix .. v) or '0')
   end
-  redis.call('SET', lengthCounterKey, total)
+  redis.call('SET', lengthCounterKey, total, 'EX', 86400)
 end
 
-redis.call('ZADD', queueKey, messageScore, messageId)
+-- INCR is gated on ZADD returning 1 (new entry).
+local added = redis.call('ZADD', queueKey, messageScore, messageId)
 redis.call('ZADD', envQueueKey, messageScore, messageId)
 redis.call('ZADD', ttlQueueKey, ttlScore, ttlMember)
-redis.call('INCR', lengthCounterKey)
+if added == 1 then
+  redis.call('INCR', lengthCounterKey)
+end
 
 -- Rebalance CK index
 local earliest = redis.call('ZRANGE', queueKey, 0, 0, 'WITHSCORES')
@@ -3692,7 +3700,7 @@ for i, member in ipairs(expiredMembers) do
       redis.call('SREM', envDequeuedKey, runId)
 
       -- Rebalance CK index if this is a CK queue
-      local ckMatch = string.match(rawQueueKey, "^(.+):ck:.+$")
+      local ckMatch = string.match(rawQueueKey, "(.-):ck:")
       if ckMatch then
         local ckIndexKey = keyPrefix .. ckMatch .. ":ckIndex"
         local earliest = redis.call('ZRANGE', queueKey, 0, 0, 'WITHSCORES')
@@ -3797,7 +3805,7 @@ for i, member in ipairs(expiredMembers) do
       redis.call('SREM', envDequeuedKey, runId)
 
       -- Rebalance CK index AND update counters if this is a CK queue
-      local ckMatch = string.match(rawQueueKey, "^(.+):ck:.+$")
+      local ckMatch = string.match(rawQueueKey, "(.-):ck:")
       if ckMatch then
         local lengthCounterKey = keyPrefix .. ckMatch .. ":lengthCounter"
         local runningCounterKey = keyPrefix .. ckMatch .. ":runningCounter"
@@ -4325,11 +4333,17 @@ local queue = messageData.queue
 local queueCurrentDequeuedKey = keyPrefix .. queue .. ':currentDequeued'
 local envCurrentDequeuedKey = keyPrefix .. string.match(queue, "(.+):queue:") .. ':currentDequeued'
 
--- If CK, bump the runningCounter for the base queue (lazy init from ckIndex).
+-- SADD first so we know if this dequeue is new (return 1) or a duplicate (return 0).
+-- INCR runningCounter is gated on the new-membership result so re-dequeues don't inflate.
+local addedDeq = redis.call('SADD', queueCurrentDequeuedKey, messageData.runId)
+redis.call('SADD', envCurrentDequeuedKey, messageData.runId)
+
+-- If CK + new addition, bump the runningCounter for the base queue (lazy init from ckIndex).
 -- The counter tracks ONLY CK-variant currentDequeued — the read path adds the base
--- SCARD separately, so we exclude the base currentDequeued here.
+-- SCARD separately, so we exclude the base currentDequeued here. 24h TTL on init
+-- bounds any drift from rolling-deploy v1/v2 overlap.
 local baseQueue = string.match(queue, "(.-):ck:")
-if baseQueue then
+if baseQueue and addedDeq == 1 then
   local runningCounterKey = keyPrefix .. baseQueue .. ':runningCounter'
   if redis.call('EXISTS', runningCounterKey) == 0 then
     local ckIndexKey = keyPrefix .. baseQueue .. ':ckIndex'
@@ -4338,13 +4352,13 @@ if baseQueue then
     for _, v in ipairs(variants) do
       total = total + tonumber(redis.call('SCARD', keyPrefix .. v .. ':currentDequeued') or '0')
     end
-    redis.call('SET', runningCounterKey, total)
+    -- Subtract 1 because we already SADD'd our own runId above, which the per-variant
+    -- SCARDs now reflect. Without this, the lazy-init seed double-counts the new member
+    -- relative to what the subsequent INCR will add.
+    redis.call('SET', runningCounterKey, math.max(0, total - 1), 'EX', 86400)
   end
   redis.call('INCR', runningCounterKey)
 end
-
-redis.call('SADD', queueCurrentDequeuedKey, messageData.runId)
-redis.call('SADD', envCurrentDequeuedKey, messageData.runId)
 
 return message
       `,
@@ -4749,6 +4763,8 @@ local messageQueueName = ARGV[2]
 local messageData = ARGV[3]
 local messageScore = tonumber(ARGV[4])
 local ckWildcardName = ARGV[5]
+-- keyPrefix for prepending to variant names stored as values in ckIndex (lazy-init only)
+local keyPrefix = ARGV[6]
 
 local function decrFloored(key)
   if tonumber(redis.call('GET', key) or '0') > 0 then
@@ -4764,6 +4780,19 @@ local removedFromDequeued = redis.call('SREM', queueCurrentDequeuedKey, messageI
 redis.call('SREM', envCurrentDequeuedKey, messageId)
 if removedFromDequeued == 1 then
   decrFloored(runningCounterKey)
+end
+
+-- Lazy-init lengthCounter if missing (e.g. expired via 24h TTL). nack re-queues a
+-- message, which means lengthCounter must be present before we INCR. Without this,
+-- a nack after counter expiry would create the counter at 1 and stay drifted until
+-- next reset.
+if redis.call('EXISTS', lengthCounterKey) == 0 then
+  local total = 0
+  local variants = redis.call('ZRANGE', ckIndexKey, 0, -1)
+  for _, v in ipairs(variants) do
+    total = total + tonumber(redis.call('ZCARD', keyPrefix .. v) or '0')
+  end
+  redis.call('SET', lengthCounterKey, total, 'EX', 86400)
 end
 
 -- ZADD back to the variant zset. INCR lengthCounter only if it's a new entry.
@@ -5511,6 +5540,7 @@ declare module "@internal/redis" {
       messageData: string,
       messageScore: string,
       ckWildcardName: string,
+      keyPrefix: string,
       callback?: Callback<void>
     ): Result<void, Context>;
 

--- a/internal-packages/run-engine/src/run-queue/index.ts
+++ b/internal-packages/run-engine/src/run-queue/index.ts
@@ -4673,6 +4673,7 @@ redis.call('SREM', envCurrentDequeuedKey, messageId)
     this.redis.defineCommand("acknowledgeMessageCkTracked", {
       numberOfKeys: 12,
       lua: `
+-- Keys:
 local masterQueueKey = KEYS[1]
 local messageKey = KEYS[2]
 local messageQueueKey = KEYS[3]
@@ -4686,6 +4687,7 @@ local ckIndexKey = KEYS[10]
 local lengthCounterKey = KEYS[11]
 local runningCounterKey = KEYS[12]
 
+-- Args:
 local messageId = ARGV[1]
 local messageQueueName = ARGV[2]
 local messageKeyValue = ARGV[3]
@@ -4698,9 +4700,12 @@ local function decrFloored(key)
   end
 end
 
+-- Remove the message from the message key
 redis.call('DEL', messageKey)
 
--- ZREM from the variant zset (defensive). If it actually removed something, decr lengthCounter.
+-- Remove the message from the CK-specific queue. The ZREM is defensive — by
+-- ack time the message is normally in currentConcurrency, not the zset — but
+-- if it does remove something, the counter was tracking that entry so decr.
 local removedFromZset = redis.call('ZREM', messageQueueKey, messageId)
 redis.call('ZREM', envQueueKey, messageId)
 if removedFromZset == 1 then
@@ -4726,6 +4731,8 @@ end
 -- Remove old-format entry from master queue (transition cleanup)
 redis.call('ZREM', masterQueueKey, messageQueueName)
 
+-- Update the concurrency keys. DECR runningCounter only when SREM
+-- currentDequeued actually removed an entry (the message was in flight).
 redis.call('SREM', queueCurrentConcurrencyKey, messageId)
 redis.call('SREM', envCurrentConcurrencyKey, messageId)
 local removedFromDequeued = redis.call('SREM', queueCurrentDequeuedKey, messageId)
@@ -4734,6 +4741,7 @@ if removedFromDequeued == 1 then
   decrFloored(runningCounterKey)
 end
 
+-- Remove the message from the worker queue
 if removeFromWorkerQueue == '1' then
   redis.call('LREM', workerQueueKey, 0, messageKeyValue)
 end
@@ -4746,6 +4754,7 @@ end
     this.redis.defineCommand("nackMessageCkTracked", {
       numberOfKeys: 11,
       lua: `
+-- Keys:
 local masterQueueKey = KEYS[1]
 local messageKey = KEYS[2]
 local messageQueueKey = KEYS[3]
@@ -4758,6 +4767,7 @@ local ckIndexKey = KEYS[9]
 local lengthCounterKey = KEYS[10]
 local runningCounterKey = KEYS[11]
 
+-- Args:
 local messageId = ARGV[1]
 local messageQueueName = ARGV[2]
 local messageData = ARGV[3]
@@ -4772,8 +4782,10 @@ local function decrFloored(key)
   end
 end
 
+-- Update the message data
 redis.call('SET', messageKey, messageData)
 
+-- Update the concurrency keys
 redis.call('SREM', queueCurrentConcurrencyKey, messageId)
 redis.call('SREM', envCurrentConcurrencyKey, messageId)
 local removedFromDequeued = redis.call('SREM', queueCurrentDequeuedKey, messageId)
@@ -4795,18 +4807,21 @@ if redis.call('EXISTS', lengthCounterKey) == 0 then
   redis.call('SET', lengthCounterKey, total, 'EX', 86400)
 end
 
--- ZADD back to the variant zset. INCR lengthCounter only if it's a new entry.
+-- Enqueue the message back into the CK-specific queue. INCR lengthCounter only if
+-- it's a new entry (ZADD returns 1).
 local added = redis.call('ZADD', messageQueueKey, messageScore, messageId)
 redis.call('ZADD', envQueueKey, messageScore, messageId)
 if added == 1 then
   redis.call('INCR', lengthCounterKey)
 end
 
+-- Rebalance CK index
 local earliest = redis.call('ZRANGE', messageQueueKey, 0, 0, 'WITHSCORES')
 if #earliest > 0 then
   redis.call('ZADD', ckIndexKey, earliest[2], messageQueueName)
 end
 
+-- Rebalance master queue with ck:* member
 local earliestIdx = redis.call('ZRANGE', ckIndexKey, 0, 0, 'WITHSCORES')
 if #earliestIdx == 0 then
   redis.call('ZREM', masterQueueKey, ckWildcardName)
@@ -4814,6 +4829,7 @@ else
   redis.call('ZADD', masterQueueKey, earliestIdx[2], ckWildcardName)
 end
 
+-- Remove old-format entry from master queue (transition cleanup)
 redis.call('ZREM', masterQueueKey, messageQueueName)
 `,
     });
@@ -4823,6 +4839,7 @@ redis.call('ZREM', masterQueueKey, messageQueueName)
     this.redis.defineCommand("moveToDeadLetterQueueCkTracked", {
       numberOfKeys: 12,
       lua: `
+-- Keys:
 local masterQueueKey = KEYS[1]
 local messageKey = KEYS[2]
 local messageQueue = KEYS[3]
@@ -4836,6 +4853,7 @@ local ckIndexKey = KEYS[10]
 local lengthCounterKey = KEYS[11]
 local runningCounterKey = KEYS[12]
 
+-- Args:
 local messageId = ARGV[1]
 local messageQueueName = ARGV[2]
 local ckWildcardName = ARGV[3]
@@ -4846,12 +4864,16 @@ local function decrFloored(key)
   end
 end
 
+-- Remove the message from the CK-specific queue. ZREM may be a no-op if the
+-- message was already moved to currentConcurrency; only decr when it actually
+-- removes something.
 local removedFromZset = redis.call('ZREM', messageQueue, messageId)
 redis.call('ZREM', envQueueKey, messageId)
 if removedFromZset == 1 then
   decrFloored(lengthCounterKey)
 end
 
+-- Rebalance CK index
 local earliest = redis.call('ZRANGE', messageQueue, 0, 0, 'WITHSCORES')
 if #earliest == 0 then
   redis.call('ZREM', ckIndexKey, messageQueueName)
@@ -4859,6 +4881,7 @@ else
   redis.call('ZADD', ckIndexKey, earliest[2], messageQueueName)
 end
 
+-- Rebalance master queue with ck:* member
 local earliestIdx = redis.call('ZRANGE', ckIndexKey, 0, 0, 'WITHSCORES')
 if #earliestIdx == 0 then
   redis.call('ZREM', masterQueueKey, ckWildcardName)
@@ -4866,10 +4889,14 @@ else
   redis.call('ZADD', masterQueueKey, earliestIdx[2], ckWildcardName)
 end
 
+-- Remove old-format entry from master queue (transition cleanup)
 redis.call('ZREM', masterQueueKey, messageQueueName)
 
+-- Add the message to the dead letter queue
 redis.call('ZADD', deadLetterQueueKey, tonumber(redis.call('TIME')[1]), messageId)
 
+-- Update the concurrency keys. DECR runningCounter only when SREM
+-- currentDequeued actually removed an entry.
 redis.call('SREM', queueCurrentConcurrencyKey, messageId)
 redis.call('SREM', envCurrentConcurrencyKey, messageId)
 local removedFromDequeued = redis.call('SREM', queueCurrentDequeuedKey, messageId)

--- a/internal-packages/run-engine/src/run-queue/index.ts
+++ b/internal-packages/run-engine/src/run-queue/index.ts
@@ -397,7 +397,31 @@ export class RunQueue {
     queue: string,
     concurrencyKey?: string
   ) {
-    return this.redis.zcard(this.keys.queueKey(env, queue, concurrencyKey));
+    // Per-variant length when caller specifies a concurrency key
+    if (concurrencyKey) {
+      return this.redis.zcard(this.keys.queueKey(env, queue, concurrencyKey));
+    }
+
+    // Aggregate base-queue length = ZCARD(base) + GET(lengthCounter).
+    // The counter is non-existent for queues that have never had a CK enqueue —
+    // in that case it returns null which we treat as 0 and the base ZCARD is
+    // the whole truth.
+    const baseKey = this.keys.queueKey(env, queue);
+    const lengthCounterKey = this.keys.queueLengthCounterKey(env, queue);
+
+    const pipeline = this.redis.pipeline();
+    pipeline.zcard(baseKey);
+    pipeline.get(lengthCounterKey);
+    const results = await pipeline.exec();
+
+    if (!results) {
+      return 0;
+    }
+    const [baseErr, baseVal] = results[0];
+    const [ctrErr, ctrVal] = results[1];
+    const baseCount = baseErr || baseVal == null ? 0 : (baseVal as number);
+    const ctrCount = ctrErr || ctrVal == null ? 0 : Number(ctrVal);
+    return baseCount + ctrCount;
   }
 
   public async lengthOfQueueAvailableMessages(
@@ -481,33 +505,34 @@ export class RunQueue {
     env: MinimalAuthenticatedEnvironment,
     queues: string[]
   ): Promise<Record<string, number>> {
+    // For each queue, SCARD(base:currentDequeued) + GET(runningCounter). Missing
+    // counter is treated as 0 so non-CK queues just see the base SCARD.
     const pipeline = this.redis.pipeline();
-
-    // Queue up all SCARD commands in the pipeline
     queues.forEach((queue) => {
       pipeline.scard(this.keys.queueCurrentDequeuedKey(env, queue));
+      pipeline.get(this.keys.queueRunningCounterKey(env, queue));
     });
 
-    // Execute pipeline and get results
     const results = await pipeline.exec();
 
-    // If results is null, return all queues with 0 concurrency
-    if (!results) {
-      return queues.reduce(
+    const empty = (): Record<string, number> =>
+      queues.reduce(
         (acc, queue) => {
           acc[queue] = 0;
           return acc;
         },
         {} as Record<string, number>
       );
-    }
 
-    // Map results back to queue names, handling potential errors
+    if (!results) return empty();
+
     return queues.reduce(
       (acc, queue, index) => {
-        const [err, value] = results[index];
-        // If there was an error or value is null/undefined, use 0
-        acc[queue] = err || value == null ? 0 : (value as number);
+        const [baseErr, baseVal] = results[index * 2];
+        const [ctrErr, ctrVal] = results[index * 2 + 1];
+        const baseCount = baseErr || baseVal == null ? 0 : (baseVal as number);
+        const ctrCount = ctrErr || ctrVal == null ? 0 : Number(ctrVal);
+        acc[queue] = baseCount + ctrCount;
         return acc;
       },
       {} as Record<string, number>
@@ -518,29 +543,34 @@ export class RunQueue {
     env: MinimalAuthenticatedEnvironment,
     queues: string[]
   ): Promise<Record<string, number>> {
+    // For each queue, ZCARD(base) + GET(lengthCounter). Missing counter is
+    // treated as 0 so non-CK queues just see the base ZCARD.
     const pipeline = this.redis.pipeline();
-
-    // Queue up all ZCARD commands in the pipeline
     queues.forEach((queue) => {
       pipeline.zcard(this.keys.queueKey(env, queue));
+      pipeline.get(this.keys.queueLengthCounterKey(env, queue));
     });
 
     const results = await pipeline.exec();
 
-    if (!results) {
-      return queues.reduce(
+    const empty = (): Record<string, number> =>
+      queues.reduce(
         (acc, queue) => {
           acc[queue] = 0;
           return acc;
         },
         {} as Record<string, number>
       );
-    }
+
+    if (!results) return empty();
 
     return queues.reduce(
       (acc, queue, index) => {
-        const [err, value] = results![index];
-        acc[queue] = err || value == null ? 0 : (value as number);
+        const [baseErr, baseVal] = results[index * 2];
+        const [ctrErr, ctrVal] = results[index * 2 + 1];
+        const baseCount = baseErr || baseVal == null ? 0 : (baseVal as number);
+        const ctrCount = ctrErr || ctrVal == null ? 0 : Number(ctrVal);
+        acc[queue] = baseCount + ctrCount;
         return acc;
       },
       {} as Record<string, number>
@@ -945,6 +975,20 @@ export class RunQueue {
           [SemanticAttributes.RUN_ID]: messageId,
           [SemanticAttributes.CONCURRENCY_KEY]: message.concurrencyKey,
         });
+
+        // CK queues route through the Tracked variant so the base-queue
+        // runningCounter stays in sync. Non-CK queues keep the original
+        // release path — no counter to maintain.
+        if (message.concurrencyKey) {
+          return this.redis.releaseConcurrencyTracked(
+            this.keys.queueCurrentConcurrencyKeyFromQueue(message.queue),
+            this.keys.envCurrentConcurrencyKeyFromQueue(message.queue),
+            this.keys.queueCurrentDequeuedKeyFromQueue(message.queue),
+            this.keys.envCurrentDequeuedKeyFromQueue(message.queue),
+            this.keys.queueRunningCounterKeyFromQueue(message.queue),
+            messageId
+          );
+        }
 
         return this.redis.releaseConcurrency(
           this.keys.queueCurrentConcurrencyKeyFromQueue(message.queue),
@@ -1379,7 +1423,7 @@ export class RunQueue {
     const visibilityTimeoutMs = (ttlSystem.visibilityTimeoutMs ?? 30_000).toString();
 
     // Atomically get and remove expired runs from TTL set, ack them from normal queues, and enqueue to TTL worker
-    const results = await this.redis.expireTtlRuns(
+    const results = await this.redis.expireTtlRunsTracked(
       ttlQueueKey,
       keyPrefix,
       now.toString(),
@@ -1831,9 +1875,12 @@ export class RunQueue {
     if (message.concurrencyKey) {
       const ckIndexKey = this.keys.ckIndexKeyFromQueue(message.queue);
       const ckWildcardName = this.keys.toCkWildcard(message.queue);
+      const lengthCounterKey = this.keys.queueLengthCounterKeyFromQueue(message.queue);
+      const baseQueueKey = this.keys.baseQueueKeyFromQueue(message.queue);
+      const ckKeyPrefix = this.options.redis.keyPrefix ?? "";
 
       if (ttlInfo) {
-        result = await this.redis.enqueueMessageWithTtlCk(
+        result = await this.redis.enqueueMessageWithTtlCkTracked(
           // keys
           masterQueueKey,
           queueKey,
@@ -1849,6 +1896,8 @@ export class RunQueue {
           queueConcurrencyLimitKey,
           envConcurrencyLimitKey,
           envConcurrencyLimitBurstFactorKey,
+          lengthCounterKey,
+          baseQueueKey,
           // args
           queueName,
           messageId,
@@ -1861,10 +1910,11 @@ export class RunQueue {
           defaultEnvConcurrencyLimit,
           defaultEnvConcurrencyBurstFactor,
           currentTime,
-          enableFastPathArg
+          enableFastPathArg,
+          ckKeyPrefix
         );
       } else {
-        result = await this.redis.enqueueMessageCk(
+        result = await this.redis.enqueueMessageCkTracked(
           // keys
           masterQueueKey,
           queueKey,
@@ -1879,6 +1929,8 @@ export class RunQueue {
           queueConcurrencyLimitKey,
           envConcurrencyLimitKey,
           envConcurrencyLimitBurstFactorKey,
+          lengthCounterKey,
+          baseQueueKey,
           // args
           queueName,
           messageId,
@@ -1889,7 +1941,8 @@ export class RunQueue {
           defaultEnvConcurrencyLimit,
           defaultEnvConcurrencyBurstFactor,
           currentTime,
-          enableFastPathArg
+          enableFastPathArg,
+          ckKeyPrefix
         );
       }
     } else if (ttlInfo) {
@@ -2129,7 +2182,9 @@ export class RunQueue {
         maxCount,
       });
 
-      const result = await this.redis.dequeueMessagesFromCkQueue(
+      const lengthCounterKey = this.keys.queueLengthCounterKeyFromQueue(ckWildcardQueue);
+
+      const result = await this.redis.dequeueMessagesFromCkQueueTracked(
         //keys
         ckIndexKey,
         queueConcurrencyLimitKey,
@@ -2140,6 +2195,7 @@ export class RunQueue {
         envQueueKey,
         masterQueueKey,
         ttlQueueKey,
+        lengthCounterKey,
         //args
         ckWildcardQueue,
         String(Date.now()),
@@ -2374,8 +2430,10 @@ export class RunQueue {
     if (message.concurrencyKey) {
       const ckIndexKey = this.keys.ckIndexKeyFromQueue(message.queue);
       const ckWildcardName = this.keys.toCkWildcard(message.queue);
+      const lengthCounterKey = this.keys.queueLengthCounterKeyFromQueue(message.queue);
+      const runningCounterKey = this.keys.queueRunningCounterKeyFromQueue(message.queue);
 
-      return this.redis.acknowledgeMessageCk(
+      return this.redis.acknowledgeMessageCkTracked(
         masterQueueKey,
         messageKey,
         messageQueue,
@@ -2386,6 +2444,8 @@ export class RunQueue {
         envQueueKey,
         workerQueueKey,
         ckIndexKey,
+        lengthCounterKey,
+        runningCounterKey,
         messageId,
         messageQueue,
         messageKeyValue,
@@ -2441,6 +2501,17 @@ export class RunQueue {
       service: this.name,
     });
 
+    if (queue.includes(":ck:")) {
+      return this.redis.clearMessageFromConcurrencySetsTracked(
+        queueCurrentConcurrencyKey,
+        envCurrentConcurrencyKey,
+        queueCurrentDequeuedKey,
+        envCurrentDequeuedKey,
+        this.keys.queueRunningCounterKeyFromQueue(queue),
+        messageId
+      );
+    }
+
     return this.redis.clearMessageFromConcurrencySets(
       queueCurrentConcurrencyKey,
       envCurrentConcurrencyKey,
@@ -2485,8 +2556,10 @@ export class RunQueue {
     if (message.concurrencyKey) {
       const ckIndexKey = this.keys.ckIndexKeyFromQueue(message.queue);
       const ckWildcardName = this.keys.toCkWildcard(message.queue);
+      const lengthCounterKey = this.keys.queueLengthCounterKeyFromQueue(message.queue);
+      const runningCounterKey = this.keys.queueRunningCounterKeyFromQueue(message.queue);
 
-      await this.redis.nackMessageCk(
+      await this.redis.nackMessageCkTracked(
         //keys
         masterQueueKey,
         messageKey,
@@ -2497,6 +2570,8 @@ export class RunQueue {
         envCurrentDequeuedKey,
         envQueueKey,
         ckIndexKey,
+        lengthCounterKey,
+        runningCounterKey,
         //args
         messageId,
         messageQueue,
@@ -2542,8 +2617,10 @@ export class RunQueue {
     if (message.concurrencyKey) {
       const ckIndexKey = this.keys.ckIndexKeyFromQueue(message.queue);
       const ckWildcardName = this.keys.toCkWildcard(message.queue);
+      const lengthCounterKey = this.keys.queueLengthCounterKeyFromQueue(message.queue);
+      const runningCounterKey = this.keys.queueRunningCounterKeyFromQueue(message.queue);
 
-      await this.redis.moveToDeadLetterQueueCk(
+      await this.redis.moveToDeadLetterQueueCkTracked(
         masterQueueKey,
         messageKey,
         messageQueue,
@@ -2554,6 +2631,8 @@ export class RunQueue {
         envQueueKey,
         deadLetterQueueKey,
         ckIndexKey,
+        lengthCounterKey,
+        runningCounterKey,
         messageId,
         messageQueue,
         ckWildcardName
@@ -2857,7 +2936,7 @@ export class RunQueue {
         messageKey,
       });
 
-      const rawMessage = await this.redis.dequeueMessageFromKey(
+      const rawMessage = await this.redis.dequeueMessageFromKeyTracked(
         messageKey,
         this.options.redis.keyPrefix ?? ""
       );
@@ -3306,6 +3385,235 @@ return 0
       `,
     });
 
+    // Tracked variants of the CK enqueue scripts. Identical to the originals except
+    // they maintain a per-base-queue `lengthCounter` so the trigger-time queue-length
+    // cap and the dashboard's "Queued" column can see the true aggregate across all
+    // CK variants. The counter is lazy-initialized inside the script the first time
+    // a CK enqueue touches a base queue by summing ZCARDs across the existing
+    // ckIndex variants + the base queue zset. The runningCounter is touched in the
+    // *Tracked variants of dequeueMessageFromKey and the ack/nack/dlq/release/clear
+    // scripts.
+    this.redis.defineCommand("enqueueMessageCkTracked", {
+      numberOfKeys: 15,
+      lua: `
+local masterQueueKey = KEYS[1]
+local queueKey = KEYS[2]
+local messageKey = KEYS[3]
+local queueCurrentConcurrencyKey = KEYS[4]
+local envCurrentConcurrencyKey = KEYS[5]
+local queueCurrentDequeuedKey = KEYS[6]
+local envCurrentDequeuedKey = KEYS[7]
+local envQueueKey = KEYS[8]
+local ckIndexKey = KEYS[9]
+-- Fast-path keys (KEYS 10-13)
+local workerQueueKey = KEYS[10]
+local queueConcurrencyLimitKey = KEYS[11]
+local envConcurrencyLimitKey = KEYS[12]
+local envConcurrencyLimitBurstFactorKey = KEYS[13]
+-- Counter keys (KEYS 14-15)
+local lengthCounterKey = KEYS[14]
+local baseQueueKey = KEYS[15]
+
+local queueName = ARGV[1]
+local messageId = ARGV[2]
+local messageData = ARGV[3]
+local messageScore = ARGV[4]
+local ckWildcardName = ARGV[5]
+-- Fast-path args (ARGV 6-10)
+local messageKeyValue = ARGV[6]
+local defaultEnvConcurrencyLimit = ARGV[7]
+local defaultEnvConcurrencyBurstFactor = ARGV[8]
+local currentTime = ARGV[9]
+local enableFastPath = ARGV[10]
+-- keyPrefix for prepending to variant names stored as values in ckIndex
+local keyPrefix = ARGV[11]
+
+-- Fast path: check if we can skip the queue and go directly to worker queue
+if enableFastPath == '1' then
+  local available = redis.call('ZRANGEBYSCORE', queueKey, '-inf', currentTime, 'LIMIT', 0, 1)
+  if #available == 0 then
+    local envCurrent = tonumber(redis.call('SCARD', envCurrentConcurrencyKey) or '0')
+    local envLimit = tonumber(redis.call('GET', envConcurrencyLimitKey) or defaultEnvConcurrencyLimit)
+    local envBurstFactor = tonumber(redis.call('GET', envConcurrencyLimitBurstFactorKey) or defaultEnvConcurrencyBurstFactor)
+    local envLimitWithBurst = math.floor(envLimit * envBurstFactor)
+
+    if envCurrent < envLimitWithBurst then
+      local queueCurrent = tonumber(redis.call('SCARD', queueCurrentConcurrencyKey) or '0')
+      local queueLimit = math.min(
+        tonumber(redis.call('GET', queueConcurrencyLimitKey) or '1000000'),
+        envLimit
+      )
+
+      if queueCurrent < queueLimit then
+        redis.call('SET', messageKey, messageData)
+        redis.call('SADD', queueCurrentConcurrencyKey, messageId)
+        redis.call('SADD', envCurrentConcurrencyKey, messageId)
+        redis.call('RPUSH', workerQueueKey, messageKeyValue)
+        -- Fast-path skips the CK variant zset entirely; lengthCounter is unchanged.
+        -- runningCounter is bumped later by dequeueMessageFromKeyTracked when the
+        -- worker pulls the message from the worker queue.
+        return 1
+      end
+    end
+  end
+end
+
+-- Slow path: normal enqueue
+redis.call('SET', messageKey, messageData)
+
+-- Lazy-init lengthCounter from existing ckIndex variants (once per base queue, ever).
+-- Run BEFORE the ZADD so we capture pre-state; the subsequent INCR accounts for the new message.
+-- The counter tracks ONLY CK-variant messages — the read path adds ZCARD(base) separately,
+-- so the base zset is intentionally excluded here.
+if redis.call('EXISTS', lengthCounterKey) == 0 then
+  local total = 0
+  local variants = redis.call('ZRANGE', ckIndexKey, 0, -1)
+  for _, v in ipairs(variants) do
+    total = total + tonumber(redis.call('ZCARD', keyPrefix .. v) or '0')
+  end
+  redis.call('SET', lengthCounterKey, total)
+end
+
+redis.call('ZADD', queueKey, messageScore, messageId)
+redis.call('ZADD', envQueueKey, messageScore, messageId)
+redis.call('INCR', lengthCounterKey)
+
+-- Rebalance CK index
+local earliest = redis.call('ZRANGE', queueKey, 0, 0, 'WITHSCORES')
+if #earliest > 0 then
+  redis.call('ZADD', ckIndexKey, earliest[2], queueName)
+end
+
+-- Rebalance master queue with ck:* member
+local earliestIdx = redis.call('ZRANGE', ckIndexKey, 0, 0, 'WITHSCORES')
+if #earliestIdx > 0 then
+  redis.call('ZADD', masterQueueKey, earliestIdx[2], ckWildcardName)
+end
+
+-- Remove old-format entry from master queue (transition cleanup)
+redis.call('ZREM', masterQueueKey, queueName)
+
+-- Update the concurrency keys
+redis.call('SREM', queueCurrentConcurrencyKey, messageId)
+redis.call('SREM', envCurrentConcurrencyKey, messageId)
+redis.call('SREM', queueCurrentDequeuedKey, messageId)
+redis.call('SREM', envCurrentDequeuedKey, messageId)
+
+return 0
+      `,
+    });
+
+    this.redis.defineCommand("enqueueMessageWithTtlCkTracked", {
+      numberOfKeys: 16,
+      lua: `
+local masterQueueKey = KEYS[1]
+local queueKey = KEYS[2]
+local messageKey = KEYS[3]
+local queueCurrentConcurrencyKey = KEYS[4]
+local envCurrentConcurrencyKey = KEYS[5]
+local queueCurrentDequeuedKey = KEYS[6]
+local envCurrentDequeuedKey = KEYS[7]
+local envQueueKey = KEYS[8]
+local ttlQueueKey = KEYS[9]
+local ckIndexKey = KEYS[10]
+-- Fast-path keys (KEYS 11-14)
+local workerQueueKey = KEYS[11]
+local queueConcurrencyLimitKey = KEYS[12]
+local envConcurrencyLimitKey = KEYS[13]
+local envConcurrencyLimitBurstFactorKey = KEYS[14]
+-- Counter keys (KEYS 15-16)
+local lengthCounterKey = KEYS[15]
+local baseQueueKey = KEYS[16]
+
+local queueName = ARGV[1]
+local messageId = ARGV[2]
+local messageData = ARGV[3]
+local messageScore = ARGV[4]
+local ttlMember = ARGV[5]
+local ttlScore = ARGV[6]
+local ckWildcardName = ARGV[7]
+-- Fast-path args (ARGV 8-12)
+local messageKeyValue = ARGV[8]
+local defaultEnvConcurrencyLimit = ARGV[9]
+local defaultEnvConcurrencyBurstFactor = ARGV[10]
+local currentTime = ARGV[11]
+local enableFastPath = ARGV[12]
+-- keyPrefix for prepending to variant names stored as values in ckIndex
+local keyPrefix = ARGV[13]
+
+-- Fast path: check if we can skip the queue and go directly to worker queue
+if enableFastPath == '1' then
+  local available = redis.call('ZRANGEBYSCORE', queueKey, '-inf', currentTime, 'LIMIT', 0, 1)
+  if #available == 0 then
+    local envCurrent = tonumber(redis.call('SCARD', envCurrentConcurrencyKey) or '0')
+    local envLimit = tonumber(redis.call('GET', envConcurrencyLimitKey) or defaultEnvConcurrencyLimit)
+    local envBurstFactor = tonumber(redis.call('GET', envConcurrencyLimitBurstFactorKey) or defaultEnvConcurrencyBurstFactor)
+    local envLimitWithBurst = math.floor(envLimit * envBurstFactor)
+
+    if envCurrent < envLimitWithBurst then
+      local queueCurrent = tonumber(redis.call('SCARD', queueCurrentConcurrencyKey) or '0')
+      local queueLimit = math.min(
+        tonumber(redis.call('GET', queueConcurrencyLimitKey) or '1000000'),
+        envLimit
+      )
+
+      if queueCurrent < queueLimit then
+        redis.call('SET', messageKey, messageData)
+        redis.call('SADD', queueCurrentConcurrencyKey, messageId)
+        redis.call('SADD', envCurrentConcurrencyKey, messageId)
+        redis.call('RPUSH', workerQueueKey, messageKeyValue)
+        return 1
+      end
+    end
+  end
+end
+
+-- Slow path: normal enqueue
+redis.call('SET', messageKey, messageData)
+
+-- Lazy-init lengthCounter from existing ckIndex variants (once per base queue, ever).
+-- Run BEFORE the ZADD so we capture pre-state; the subsequent INCR accounts for the new message.
+-- The counter tracks ONLY CK-variant messages — the read path adds ZCARD(base) separately,
+-- so the base zset is intentionally excluded here.
+if redis.call('EXISTS', lengthCounterKey) == 0 then
+  local total = 0
+  local variants = redis.call('ZRANGE', ckIndexKey, 0, -1)
+  for _, v in ipairs(variants) do
+    total = total + tonumber(redis.call('ZCARD', keyPrefix .. v) or '0')
+  end
+  redis.call('SET', lengthCounterKey, total)
+end
+
+redis.call('ZADD', queueKey, messageScore, messageId)
+redis.call('ZADD', envQueueKey, messageScore, messageId)
+redis.call('ZADD', ttlQueueKey, ttlScore, ttlMember)
+redis.call('INCR', lengthCounterKey)
+
+-- Rebalance CK index
+local earliest = redis.call('ZRANGE', queueKey, 0, 0, 'WITHSCORES')
+if #earliest > 0 then
+  redis.call('ZADD', ckIndexKey, earliest[2], queueName)
+end
+
+-- Rebalance master queue with ck:* member
+local earliestIdx = redis.call('ZRANGE', ckIndexKey, 0, 0, 'WITHSCORES')
+if #earliestIdx > 0 then
+  redis.call('ZADD', masterQueueKey, earliestIdx[2], ckWildcardName)
+end
+
+-- Remove old-format entry from master queue (transition cleanup)
+redis.call('ZREM', masterQueueKey, queueName)
+
+-- Update the concurrency keys
+redis.call('SREM', queueCurrentConcurrencyKey, messageId)
+redis.call('SREM', envCurrentConcurrencyKey, messageId)
+redis.call('SREM', queueCurrentDequeuedKey, messageId)
+redis.call('SREM', envCurrentDequeuedKey, messageId)
+
+return 0
+      `,
+    });
+
     // Expire TTL runs - atomically removes from TTL set, acknowledges from normal queue, and enqueues to TTL worker
     this.redis.defineCommand("expireTtlRuns", {
       numberOfKeys: 1,
@@ -3406,6 +3714,118 @@ for i, member in ipairs(expiredMembers) do
       redis.call('HSET', workerItemsKey, runId, serializedItem)
 
       -- Add to results
+      table.insert(results, member)
+    end
+  end
+end
+
+return results
+      `,
+    });
+
+    // Tracked variant: same as expireTtlRuns, with floored DECRs of the
+    // per-base-queue lengthCounter (for every successful ZREM from a CK variant)
+    // and runningCounter (when SREM from currentDequeued actually removed something).
+    this.redis.defineCommand("expireTtlRunsTracked", {
+      numberOfKeys: 1,
+      lua: `
+local ttlQueueKey = KEYS[1]
+local keyPrefix = ARGV[1]
+local currentTime = tonumber(ARGV[2])
+local batchSize = tonumber(ARGV[3])
+local shardCount = tonumber(ARGV[4])
+local workerQueueKey = ARGV[5]
+local workerItemsKey = ARGV[6]
+local visibilityTimeoutMs = tonumber(ARGV[7])
+
+local function decrFloored(key)
+  if tonumber(redis.call('GET', key) or '0') > 0 then
+    redis.call('DECR', key)
+  end
+end
+
+local expiredMembers = redis.call('ZRANGEBYSCORE', ttlQueueKey, '-inf', currentTime, 'LIMIT', 0, batchSize)
+
+if #expiredMembers == 0 then
+  return {}
+end
+
+local time = redis.call('TIME')
+local nowMs = tonumber(time[1]) * 1000 + math.floor(tonumber(time[2]) / 1000)
+
+local results = {}
+
+for i, member in ipairs(expiredMembers) do
+  local pipePos1 = string.find(member, "|", 1, true)
+  if pipePos1 then
+    local pipePos2 = string.find(member, "|", pipePos1 + 1, true)
+    if pipePos2 then
+      local rawQueueKey = string.sub(member, 1, pipePos1 - 1)
+      local runId = string.sub(member, pipePos1 + 1, pipePos2 - 1)
+      local orgId = string.sub(member, pipePos2 + 1)
+
+      local queueKey = keyPrefix .. rawQueueKey
+
+      redis.call('ZREM', ttlQueueKey, member)
+
+      local orgKeyStart = string.find(rawQueueKey, "{org:", 1, true)
+      local orgKeyEnd = string.find(rawQueueKey, "}", orgKeyStart, true)
+      local orgFromQueue = string.sub(rawQueueKey, orgKeyStart + 5, orgKeyEnd - 1)
+
+      local messageKey = keyPrefix .. "{org:" .. orgFromQueue .. "}:message:" .. runId
+
+      redis.call('DEL', messageKey)
+
+      -- ZREM from queue; if successful AND this is a CK variant, DECR lengthCounter.
+      local removedFromZset = redis.call('ZREM', queueKey, runId)
+
+      local envMatch = string.match(rawQueueKey, ":env:([^:]+)")
+      if envMatch then
+        local envQueueKey = keyPrefix .. "{org:" .. orgFromQueue .. "}:env:" .. envMatch
+        redis.call('ZREM', envQueueKey, runId)
+      end
+
+      local concurrencyKey = queueKey .. ":currentConcurrency"
+      local dequeuedKey = queueKey .. ":currentDequeued"
+      redis.call('SREM', concurrencyKey, runId)
+      local removedFromDequeued = redis.call('SREM', dequeuedKey, runId)
+
+      local projMatch = string.match(rawQueueKey, ":proj:([^:]+):env:")
+      local envConcurrencyKey = keyPrefix .. "{org:" .. orgFromQueue .. "}:proj:" .. (projMatch or "") .. ":env:" .. (envMatch or "") .. ":currentConcurrency"
+      local envDequeuedKey = keyPrefix .. "{org:" .. orgFromQueue .. "}:proj:" .. (projMatch or "") .. ":env:" .. (envMatch or "") .. ":currentDequeued"
+      redis.call('SREM', envConcurrencyKey, runId)
+      redis.call('SREM', envDequeuedKey, runId)
+
+      -- Rebalance CK index AND update counters if this is a CK queue
+      local ckMatch = string.match(rawQueueKey, "^(.+):ck:.+$")
+      if ckMatch then
+        local lengthCounterKey = keyPrefix .. ckMatch .. ":lengthCounter"
+        local runningCounterKey = keyPrefix .. ckMatch .. ":runningCounter"
+        if removedFromZset == 1 then
+          decrFloored(lengthCounterKey)
+        end
+        if removedFromDequeued == 1 then
+          decrFloored(runningCounterKey)
+        end
+
+        local ckIndexKey = keyPrefix .. ckMatch .. ":ckIndex"
+        local earliest = redis.call('ZRANGE', queueKey, 0, 0, 'WITHSCORES')
+        if #earliest == 0 then
+          redis.call('ZREM', ckIndexKey, rawQueueKey)
+        else
+          redis.call('ZADD', ckIndexKey, earliest[2], rawQueueKey)
+        end
+      end
+
+      local serializedItem = cjson.encode({
+        job = "expireTtlRun",
+        item = { runId = runId, orgId = orgId, queueKey = rawQueueKey },
+        visibilityTimeoutMs = visibilityTimeoutMs,
+        attempt = 0
+      })
+      redis.call('ZADD', workerQueueKey, nowMs, runId)
+      redis.call('HSET', workerItemsKey, runId, serializedItem)
+
       table.insert(results, member)
     end
   end
@@ -3684,6 +4104,151 @@ return results
       `,
     });
 
+    // Tracked variant: same as dequeueMessagesFromCkQueue plus DECR of the
+    // per-base-queue lengthCounter for every message removed from a CK variant
+    // (normal dequeue, TTL-expired, or stale-orphan path — all of which were
+    // counted at enqueue time).
+    this.redis.defineCommand("dequeueMessagesFromCkQueueTracked", {
+      numberOfKeys: 10,
+      lua: `
+local ckIndexKey = KEYS[1]
+local queueConcurrencyLimitKey = KEYS[2]
+local envConcurrencyLimitKey = KEYS[3]
+local envConcurrencyLimitBurstFactorKey = KEYS[4]
+local envCurrentConcurrencyKey = KEYS[5]
+local messageKeyPrefix = KEYS[6]
+local envQueueKey = KEYS[7]
+local masterQueueKey = KEYS[8]
+local ttlQueueKey = KEYS[9]
+local lengthCounterKey = KEYS[10]
+
+local ckWildcardName = ARGV[1]
+local currentTime = tonumber(ARGV[2])
+local defaultEnvConcurrencyLimit = ARGV[3]
+local defaultEnvConcurrencyBurstFactor = ARGV[4]
+local keyPrefix = ARGV[5]
+local maxCount = tonumber(ARGV[6] or '1')
+
+local function decrLengthCounter()
+  if tonumber(redis.call('GET', lengthCounterKey) or '0') > 0 then
+    redis.call('DECR', lengthCounterKey)
+  end
+end
+
+-- Check env concurrency
+local envCurrentConcurrency = tonumber(redis.call('SCARD', envCurrentConcurrencyKey) or '0')
+local envConcurrencyLimit = tonumber(redis.call('GET', envConcurrencyLimitKey) or defaultEnvConcurrencyLimit)
+local envConcurrencyLimitBurstFactor = tonumber(redis.call('GET', envConcurrencyLimitBurstFactorKey) or defaultEnvConcurrencyBurstFactor)
+local envConcurrencyLimitWithBurstFactor = math.floor(envConcurrencyLimit * envConcurrencyLimitBurstFactor)
+
+if envCurrentConcurrency >= envConcurrencyLimitWithBurstFactor then
+  return nil
+end
+
+local queueConcurrencyLimit = math.min(tonumber(redis.call('GET', queueConcurrencyLimitKey) or '1000000'), envConcurrencyLimit)
+
+local envAvailableCapacity = envConcurrencyLimitWithBurstFactor - envCurrentConcurrency
+local actualMaxCount = math.min(maxCount, envAvailableCapacity)
+
+if actualMaxCount <= 0 then
+  return nil
+end
+
+local ckQueues = redis.call('ZRANGEBYSCORE', ckIndexKey, '-inf', tostring(currentTime), 'LIMIT', 0, actualMaxCount * 3)
+
+if #ckQueues == 0 then
+  local anyIdx = redis.call('ZRANGE', ckIndexKey, 0, 0, 'WITHSCORES')
+  if #anyIdx == 0 then
+    redis.call('ZREM', masterQueueKey, ckWildcardName)
+  else
+    redis.call('ZADD', masterQueueKey, anyIdx[2], ckWildcardName)
+  end
+  return nil
+end
+
+local results = {}
+local dequeuedCount = 0
+
+for _, ckQueueName in ipairs(ckQueues) do
+  if dequeuedCount >= actualMaxCount then
+    break
+  end
+
+  local fullQueueKey = keyPrefix .. ckQueueName
+
+  local ckConcurrencyKey = fullQueueKey .. ':currentConcurrency'
+  local ckCurrentConcurrency = tonumber(redis.call('SCARD', ckConcurrencyKey) or '0')
+
+  if ckCurrentConcurrency < queueConcurrencyLimit then
+    local messages = redis.call('ZRANGEBYSCORE', fullQueueKey, '-inf', tostring(currentTime), 'WITHSCORES', 'LIMIT', 0, 1)
+
+    if #messages >= 2 then
+      local messageId = messages[1]
+      local messageScore = messages[2]
+
+      local messageKey = messageKeyPrefix .. messageId
+      local messagePayload = redis.call('GET', messageKey)
+
+      if messagePayload then
+        local messageData = cjson.decode(messagePayload)
+        local ttlExpiresAt = messageData and messageData.ttlExpiresAt
+
+        if ttlExpiresAt and ttlExpiresAt <= currentTime then
+          redis.call('ZREM', fullQueueKey, messageId)
+          redis.call('ZREM', envQueueKey, messageId)
+          decrLengthCounter()
+        else
+          redis.call('ZREM', fullQueueKey, messageId)
+          redis.call('ZREM', envQueueKey, messageId)
+          decrLengthCounter()
+          redis.call('SADD', ckConcurrencyKey, messageId)
+          redis.call('SADD', envCurrentConcurrencyKey, messageId)
+
+          if ttlQueueKey and ttlQueueKey ~= '' and ttlExpiresAt then
+            local ttlMember = ckQueueName .. '|' .. messageId .. '|' .. (messageData.orgId or '')
+            redis.call('ZREM', ttlQueueKey, ttlMember)
+          end
+
+          table.insert(results, messageId)
+          table.insert(results, messageScore)
+          table.insert(results, messagePayload)
+
+          dequeuedCount = dequeuedCount + 1
+        end
+      else
+        redis.call('ZREM', fullQueueKey, messageId)
+        redis.call('ZREM', envQueueKey, messageId)
+        decrLengthCounter()
+      end
+
+      local earliest = redis.call('ZRANGE', fullQueueKey, 0, 0, 'WITHSCORES')
+      if #earliest == 0 then
+        redis.call('ZREM', ckIndexKey, ckQueueName)
+      else
+        redis.call('ZADD', ckIndexKey, earliest[2], ckQueueName)
+      end
+    else
+      local any = redis.call('ZRANGE', fullQueueKey, 0, 0, 'WITHSCORES')
+      if #any == 0 then
+        redis.call('ZREM', ckIndexKey, ckQueueName)
+      else
+        redis.call('ZADD', ckIndexKey, any[2], ckQueueName)
+      end
+    end
+  end
+end
+
+local earliestIdx = redis.call('ZRANGE', ckIndexKey, 0, 0, 'WITHSCORES')
+if #earliestIdx == 0 then
+  redis.call('ZREM', masterQueueKey, ckWildcardName)
+else
+  redis.call('ZADD', masterQueueKey, earliestIdx[2], ckWildcardName)
+end
+
+return results
+      `,
+    });
+
     this.redis.defineCommand("dequeueMessageFromWorkerQueueNonBlocking", {
       numberOfKeys: 1,
       lua: `
@@ -3732,6 +4297,55 @@ redis.call('SADD', queueCurrentDequeuedKey, messageData.runId)
 redis.call('SADD', envCurrentDequeuedKey, messageData.runId)
 
 -- Return the message data
+return message
+      `,
+    });
+
+    // Tracked variant: same as dequeueMessageFromKey, plus runningCounter INCR
+    // when the message lives on a CK variant queue. The runningCounter is
+    // lazy-initialized from the existing ckIndex variants' currentDequeued sets.
+    // Note: ckIndex only tracks variants that currently have queued messages,
+    // so the init misses any variant that's "running-only" (all messages
+    // dequeued, none queued). Those are reabsorbed naturally as messages ack
+    // (floored DECR) and new dequeues land.
+    this.redis.defineCommand("dequeueMessageFromKeyTracked", {
+      numberOfKeys: 1,
+      lua: `
+local messageKey = KEYS[1]
+local keyPrefix = ARGV[1]
+
+local message = redis.call('GET', messageKey)
+if not message then
+  return nil
+end
+
+local messageData = cjson.decode(message)
+local queue = messageData.queue
+
+local queueCurrentDequeuedKey = keyPrefix .. queue .. ':currentDequeued'
+local envCurrentDequeuedKey = keyPrefix .. string.match(queue, "(.+):queue:") .. ':currentDequeued'
+
+-- If CK, bump the runningCounter for the base queue (lazy init from ckIndex).
+-- The counter tracks ONLY CK-variant currentDequeued — the read path adds the base
+-- SCARD separately, so we exclude the base currentDequeued here.
+local baseQueue = string.match(queue, "(.-):ck:")
+if baseQueue then
+  local runningCounterKey = keyPrefix .. baseQueue .. ':runningCounter'
+  if redis.call('EXISTS', runningCounterKey) == 0 then
+    local ckIndexKey = keyPrefix .. baseQueue .. ':ckIndex'
+    local total = 0
+    local variants = redis.call('ZRANGE', ckIndexKey, 0, -1)
+    for _, v in ipairs(variants) do
+      total = total + tonumber(redis.call('SCARD', keyPrefix .. v .. ':currentDequeued') or '0')
+    end
+    redis.call('SET', runningCounterKey, total)
+  end
+  redis.call('INCR', runningCounterKey)
+end
+
+redis.call('SADD', queueCurrentDequeuedKey, messageData.runId)
+redis.call('SADD', envCurrentDequeuedKey, messageData.runId)
+
 return message
       `,
     });
@@ -4038,6 +4652,205 @@ redis.call('SREM', envCurrentDequeuedKey, messageId)
 `,
     });
 
+    // Tracked variant: same as acknowledgeMessageCk, plus floored DECRs of the
+    // per-base-queue lengthCounter (defensive — only fires when the ZREM actually
+    // removed something) and runningCounter (when SREM currentDequeued actually
+    // removed something).
+    this.redis.defineCommand("acknowledgeMessageCkTracked", {
+      numberOfKeys: 12,
+      lua: `
+local masterQueueKey = KEYS[1]
+local messageKey = KEYS[2]
+local messageQueueKey = KEYS[3]
+local queueCurrentConcurrencyKey = KEYS[4]
+local envCurrentConcurrencyKey = KEYS[5]
+local queueCurrentDequeuedKey = KEYS[6]
+local envCurrentDequeuedKey = KEYS[7]
+local envQueueKey = KEYS[8]
+local workerQueueKey = KEYS[9]
+local ckIndexKey = KEYS[10]
+local lengthCounterKey = KEYS[11]
+local runningCounterKey = KEYS[12]
+
+local messageId = ARGV[1]
+local messageQueueName = ARGV[2]
+local messageKeyValue = ARGV[3]
+local removeFromWorkerQueue = ARGV[4]
+local ckWildcardName = ARGV[5]
+
+local function decrFloored(key)
+  if tonumber(redis.call('GET', key) or '0') > 0 then
+    redis.call('DECR', key)
+  end
+end
+
+redis.call('DEL', messageKey)
+
+-- ZREM from the variant zset (defensive). If it actually removed something, decr lengthCounter.
+local removedFromZset = redis.call('ZREM', messageQueueKey, messageId)
+redis.call('ZREM', envQueueKey, messageId)
+if removedFromZset == 1 then
+  decrFloored(lengthCounterKey)
+end
+
+-- Rebalance CK index
+local earliestInCkQueue = redis.call('ZRANGE', messageQueueKey, 0, 0, 'WITHSCORES')
+if #earliestInCkQueue == 0 then
+  redis.call('ZREM', ckIndexKey, messageQueueName)
+else
+  redis.call('ZADD', ckIndexKey, earliestInCkQueue[2], messageQueueName)
+end
+
+-- Rebalance master queue with ck:* member
+local earliestInCkIndex = redis.call('ZRANGE', ckIndexKey, 0, 0, 'WITHSCORES')
+if #earliestInCkIndex == 0 then
+  redis.call('ZREM', masterQueueKey, ckWildcardName)
+else
+  redis.call('ZADD', masterQueueKey, earliestInCkIndex[2], ckWildcardName)
+end
+
+-- Remove old-format entry from master queue (transition cleanup)
+redis.call('ZREM', masterQueueKey, messageQueueName)
+
+redis.call('SREM', queueCurrentConcurrencyKey, messageId)
+redis.call('SREM', envCurrentConcurrencyKey, messageId)
+local removedFromDequeued = redis.call('SREM', queueCurrentDequeuedKey, messageId)
+redis.call('SREM', envCurrentDequeuedKey, messageId)
+if removedFromDequeued == 1 then
+  decrFloored(runningCounterKey)
+end
+
+if removeFromWorkerQueue == '1' then
+  redis.call('LREM', workerQueueKey, 0, messageKeyValue)
+end
+`,
+    });
+
+    // Tracked variant: same as nackMessageCk. SREM currentDequeued may DECR
+    // runningCounter (floored); ZADD back to the variant zset INCRs
+    // lengthCounter only when ZADD reported a new entry.
+    this.redis.defineCommand("nackMessageCkTracked", {
+      numberOfKeys: 11,
+      lua: `
+local masterQueueKey = KEYS[1]
+local messageKey = KEYS[2]
+local messageQueueKey = KEYS[3]
+local queueCurrentConcurrencyKey = KEYS[4]
+local envCurrentConcurrencyKey = KEYS[5]
+local queueCurrentDequeuedKey = KEYS[6]
+local envCurrentDequeuedKey = KEYS[7]
+local envQueueKey = KEYS[8]
+local ckIndexKey = KEYS[9]
+local lengthCounterKey = KEYS[10]
+local runningCounterKey = KEYS[11]
+
+local messageId = ARGV[1]
+local messageQueueName = ARGV[2]
+local messageData = ARGV[3]
+local messageScore = tonumber(ARGV[4])
+local ckWildcardName = ARGV[5]
+
+local function decrFloored(key)
+  if tonumber(redis.call('GET', key) or '0') > 0 then
+    redis.call('DECR', key)
+  end
+end
+
+redis.call('SET', messageKey, messageData)
+
+redis.call('SREM', queueCurrentConcurrencyKey, messageId)
+redis.call('SREM', envCurrentConcurrencyKey, messageId)
+local removedFromDequeued = redis.call('SREM', queueCurrentDequeuedKey, messageId)
+redis.call('SREM', envCurrentDequeuedKey, messageId)
+if removedFromDequeued == 1 then
+  decrFloored(runningCounterKey)
+end
+
+-- ZADD back to the variant zset. INCR lengthCounter only if it's a new entry.
+local added = redis.call('ZADD', messageQueueKey, messageScore, messageId)
+redis.call('ZADD', envQueueKey, messageScore, messageId)
+if added == 1 then
+  redis.call('INCR', lengthCounterKey)
+end
+
+local earliest = redis.call('ZRANGE', messageQueueKey, 0, 0, 'WITHSCORES')
+if #earliest > 0 then
+  redis.call('ZADD', ckIndexKey, earliest[2], messageQueueName)
+end
+
+local earliestIdx = redis.call('ZRANGE', ckIndexKey, 0, 0, 'WITHSCORES')
+if #earliestIdx == 0 then
+  redis.call('ZREM', masterQueueKey, ckWildcardName)
+else
+  redis.call('ZADD', masterQueueKey, earliestIdx[2], ckWildcardName)
+end
+
+redis.call('ZREM', masterQueueKey, messageQueueName)
+`,
+    });
+
+    // Tracked variant: same as moveToDeadLetterQueueCk. ZREM may DECR
+    // lengthCounter (defensive); SREM currentDequeued may DECR runningCounter.
+    this.redis.defineCommand("moveToDeadLetterQueueCkTracked", {
+      numberOfKeys: 12,
+      lua: `
+local masterQueueKey = KEYS[1]
+local messageKey = KEYS[2]
+local messageQueue = KEYS[3]
+local queueCurrentConcurrencyKey = KEYS[4]
+local envCurrentConcurrencyKey = KEYS[5]
+local queueCurrentDequeuedKey = KEYS[6]
+local envCurrentDequeuedKey = KEYS[7]
+local envQueueKey = KEYS[8]
+local deadLetterQueueKey = KEYS[9]
+local ckIndexKey = KEYS[10]
+local lengthCounterKey = KEYS[11]
+local runningCounterKey = KEYS[12]
+
+local messageId = ARGV[1]
+local messageQueueName = ARGV[2]
+local ckWildcardName = ARGV[3]
+
+local function decrFloored(key)
+  if tonumber(redis.call('GET', key) or '0') > 0 then
+    redis.call('DECR', key)
+  end
+end
+
+local removedFromZset = redis.call('ZREM', messageQueue, messageId)
+redis.call('ZREM', envQueueKey, messageId)
+if removedFromZset == 1 then
+  decrFloored(lengthCounterKey)
+end
+
+local earliest = redis.call('ZRANGE', messageQueue, 0, 0, 'WITHSCORES')
+if #earliest == 0 then
+  redis.call('ZREM', ckIndexKey, messageQueueName)
+else
+  redis.call('ZADD', ckIndexKey, earliest[2], messageQueueName)
+end
+
+local earliestIdx = redis.call('ZRANGE', ckIndexKey, 0, 0, 'WITHSCORES')
+if #earliestIdx == 0 then
+  redis.call('ZREM', masterQueueKey, ckWildcardName)
+else
+  redis.call('ZADD', masterQueueKey, earliestIdx[2], ckWildcardName)
+end
+
+redis.call('ZREM', masterQueueKey, messageQueueName)
+
+redis.call('ZADD', deadLetterQueueKey, tonumber(redis.call('TIME')[1]), messageId)
+
+redis.call('SREM', queueCurrentConcurrencyKey, messageId)
+redis.call('SREM', envCurrentConcurrencyKey, messageId)
+local removedFromDequeued = redis.call('SREM', queueCurrentDequeuedKey, messageId)
+redis.call('SREM', envCurrentDequeuedKey, messageId)
+if removedFromDequeued == 1 then
+  decrFloored(runningCounterKey)
+end
+`,
+    });
+
     this.redis.defineCommand("releaseConcurrency", {
       numberOfKeys: 4,
       lua: `
@@ -4055,6 +4868,34 @@ redis.call('SREM', queueCurrentConcurrencyKey, messageId)
 redis.call('SREM', envCurrentConcurrencyKey, messageId)
 redis.call('SREM', queueCurrentDequeuedKey, messageId)
 redis.call('SREM', envCurrentDequeuedKey, messageId)
+`,
+    });
+
+    // Tracked variant: same as releaseConcurrency, with a floored DECR of the
+    // base-queue runningCounter when SREM currentDequeued actually removed
+    // something. Caller should only invoke this variant for CK queues — non-CK
+    // queues should keep calling releaseConcurrency.
+    this.redis.defineCommand("releaseConcurrencyTracked", {
+      numberOfKeys: 5,
+      lua: `
+local queueCurrentConcurrencyKey = KEYS[1]
+local envCurrentConcurrencyKey = KEYS[2]
+local queueCurrentDequeuedKey = KEYS[3]
+local envCurrentDequeuedKey = KEYS[4]
+local runningCounterKey = KEYS[5]
+
+local messageId = ARGV[1]
+
+redis.call('SREM', queueCurrentConcurrencyKey, messageId)
+redis.call('SREM', envCurrentConcurrencyKey, messageId)
+local removedFromDequeued = redis.call('SREM', queueCurrentDequeuedKey, messageId)
+redis.call('SREM', envCurrentDequeuedKey, messageId)
+
+if removedFromDequeued == 1 then
+  if tonumber(redis.call('GET', runningCounterKey) or '0') > 0 then
+    redis.call('DECR', runningCounterKey)
+  end
+end
 `,
     });
 
@@ -4154,6 +4995,32 @@ redis.call('SREM', queueCurrentConcurrencyKey, messageId)
 redis.call('SREM', envCurrentConcurrencyKey, messageId)
 redis.call('SREM', queueCurrentDequeuedKey, messageId)
 redis.call('SREM', envCurrentDequeuedKey, messageId)
+`,
+    });
+
+    // Tracked variant of clearMessageFromConcurrencySets — see releaseConcurrencyTracked
+    // for the contract. Only invoke for CK queues.
+    this.redis.defineCommand("clearMessageFromConcurrencySetsTracked", {
+      numberOfKeys: 5,
+      lua: `
+local queueCurrentConcurrencyKey = KEYS[1]
+local envCurrentConcurrencyKey = KEYS[2]
+local queueCurrentDequeuedKey = KEYS[3]
+local envCurrentDequeuedKey = KEYS[4]
+local runningCounterKey = KEYS[5]
+
+local messageId = ARGV[1]
+
+redis.call('SREM', queueCurrentConcurrencyKey, messageId)
+redis.call('SREM', envCurrentConcurrencyKey, messageId)
+local removedFromDequeued = redis.call('SREM', queueCurrentDequeuedKey, messageId)
+redis.call('SREM', envCurrentDequeuedKey, messageId)
+
+if removedFromDequeued == 1 then
+  if tonumber(redis.call('GET', runningCounterKey) or '0') > 0 then
+    redis.call('DECR', runningCounterKey)
+  end
+end
 `,
     });
   }
@@ -4512,6 +5379,189 @@ declare module "@internal/redis" {
       messageId: string,
       messageQueueName: string,
       ckWildcardName: string,
+      callback?: Callback<void>
+    ): Result<void, Context>;
+
+    // Tracked variants: maintain per-base-queue lengthCounter / runningCounter
+    // for CK queues. See defineCommand bodies for details.
+    enqueueMessageCkTracked(
+      masterQueueKey: string,
+      queue: string,
+      messageKey: string,
+      queueCurrentConcurrencyKey: string,
+      envCurrentConcurrencyKey: string,
+      queueCurrentDequeuedKey: string,
+      envCurrentDequeuedKey: string,
+      envQueueKey: string,
+      ckIndexKey: string,
+      workerQueueKey: string,
+      queueConcurrencyLimitKey: string,
+      envConcurrencyLimitKey: string,
+      envConcurrencyLimitBurstFactorKey: string,
+      lengthCounterKey: string,
+      baseQueueKey: string,
+      queueName: string,
+      messageId: string,
+      messageData: string,
+      messageScore: string,
+      ckWildcardName: string,
+      messageKeyValue: string,
+      defaultEnvConcurrencyLimit: string,
+      defaultEnvConcurrencyBurstFactor: string,
+      currentTime: string,
+      enableFastPath: string,
+      keyPrefix: string,
+      callback?: Callback<number>
+    ): Result<number, Context>;
+
+    enqueueMessageWithTtlCkTracked(
+      masterQueueKey: string,
+      queue: string,
+      messageKey: string,
+      queueCurrentConcurrencyKey: string,
+      envCurrentConcurrencyKey: string,
+      queueCurrentDequeuedKey: string,
+      envCurrentDequeuedKey: string,
+      envQueueKey: string,
+      ttlQueueKey: string,
+      ckIndexKey: string,
+      workerQueueKey: string,
+      queueConcurrencyLimitKey: string,
+      envConcurrencyLimitKey: string,
+      envConcurrencyLimitBurstFactorKey: string,
+      lengthCounterKey: string,
+      baseQueueKey: string,
+      queueName: string,
+      messageId: string,
+      messageData: string,
+      messageScore: string,
+      ttlMember: string,
+      ttlScore: string,
+      ckWildcardName: string,
+      messageKeyValue: string,
+      defaultEnvConcurrencyLimit: string,
+      defaultEnvConcurrencyBurstFactor: string,
+      currentTime: string,
+      enableFastPath: string,
+      keyPrefix: string,
+      callback?: Callback<number>
+    ): Result<number, Context>;
+
+    dequeueMessagesFromCkQueueTracked(
+      ckIndexKey: string,
+      queueConcurrencyLimitKey: string,
+      envConcurrencyLimitKey: string,
+      envConcurrencyLimitBurstFactorKey: string,
+      envCurrentConcurrencyKey: string,
+      messageKeyPrefix: string,
+      envQueueKey: string,
+      masterQueueKey: string,
+      ttlQueueKey: string,
+      lengthCounterKey: string,
+      ckWildcardName: string,
+      currentTime: string,
+      defaultEnvConcurrencyLimit: string,
+      defaultEnvConcurrencyBurstFactor: string,
+      keyPrefix: string,
+      maxCount: string,
+      callback?: Callback<string[]>
+    ): Result<string[], Context>;
+
+    dequeueMessageFromKeyTracked(
+      messageKey: string,
+      keyPrefix: string,
+      callback?: Callback<string | null>
+    ): Result<string | null, Context>;
+
+    acknowledgeMessageCkTracked(
+      masterQueueKey: string,
+      messageKey: string,
+      messageQueue: string,
+      queueCurrentConcurrencyKey: string,
+      envCurrentConcurrencyKey: string,
+      queueCurrentDequeuedKey: string,
+      envCurrentDequeuedKey: string,
+      envQueueKey: string,
+      workerQueueKey: string,
+      ckIndexKey: string,
+      lengthCounterKey: string,
+      runningCounterKey: string,
+      messageId: string,
+      messageQueueName: string,
+      messageKeyValue: string,
+      removeFromWorkerQueue: string,
+      ckWildcardName: string,
+      callback?: Callback<void>
+    ): Result<void, Context>;
+
+    nackMessageCkTracked(
+      masterQueueKey: string,
+      messageKey: string,
+      messageQueue: string,
+      queueCurrentConcurrencyKey: string,
+      envCurrentConcurrencyKey: string,
+      queueCurrentDequeuedKey: string,
+      envCurrentDequeuedKey: string,
+      envQueueKey: string,
+      ckIndexKey: string,
+      lengthCounterKey: string,
+      runningCounterKey: string,
+      messageId: string,
+      messageQueueName: string,
+      messageData: string,
+      messageScore: string,
+      ckWildcardName: string,
+      callback?: Callback<void>
+    ): Result<void, Context>;
+
+    moveToDeadLetterQueueCkTracked(
+      masterQueueKey: string,
+      messageKey: string,
+      messageQueue: string,
+      queueCurrentConcurrencyKey: string,
+      envCurrentConcurrencyKey: string,
+      queueCurrentDequeuedKey: string,
+      envCurrentDequeuedKey: string,
+      envQueueKey: string,
+      deadLetterQueueKey: string,
+      ckIndexKey: string,
+      lengthCounterKey: string,
+      runningCounterKey: string,
+      messageId: string,
+      messageQueueName: string,
+      ckWildcardName: string,
+      callback?: Callback<void>
+    ): Result<void, Context>;
+
+    expireTtlRunsTracked(
+      ttlQueueKey: string,
+      keyPrefix: string,
+      currentTime: string,
+      batchSize: string,
+      shardCount: string,
+      workerQueueKey: string,
+      workerItemsKey: string,
+      visibilityTimeoutMs: string,
+      callback?: Callback<string[]>
+    ): Result<string[], Context>;
+
+    releaseConcurrencyTracked(
+      queueCurrentConcurrencyKey: string,
+      envCurrentConcurrencyKey: string,
+      queueCurrentDequeuedKey: string,
+      envCurrentDequeuedKey: string,
+      runningCounterKey: string,
+      messageId: string,
+      callback?: Callback<void>
+    ): Result<void, Context>;
+
+    clearMessageFromConcurrencySetsTracked(
+      queueCurrentConcurrencyKey: string,
+      envCurrentConcurrencyKey: string,
+      queueCurrentDequeuedKey: string,
+      envCurrentDequeuedKey: string,
+      runningCounterKey: string,
+      messageId: string,
       callback?: Callback<void>
     ): Result<void, Context>;
   }

--- a/internal-packages/run-engine/src/run-queue/index.ts
+++ b/internal-packages/run-engine/src/run-queue/index.ts
@@ -4825,7 +4825,10 @@ end
 -- Update the message data
 redis.call('SET', messageKey, messageData)
 
--- Update the concurrency keys
+-- Update the concurrency keys. nack only DECRs runningCounter, never INCRs it,
+-- so we skip the eager lazy-init here (unlike releaseConcurrencyTracked, which
+-- mirrors the same DECR pattern with init). A post-TTL nack's floored DECR
+-- no-ops; the next dequeueMessageFromKeyTracked reseeds from current state.
 redis.call('SREM', queueCurrentConcurrencyKey, messageId)
 redis.call('SREM', envCurrentConcurrencyKey, messageId)
 local removedFromDequeued = redis.call('SREM', queueCurrentDequeuedKey, messageId)

--- a/internal-packages/run-engine/src/run-queue/index.ts
+++ b/internal-packages/run-engine/src/run-queue/index.ts
@@ -986,7 +986,9 @@ export class RunQueue {
             this.keys.queueCurrentDequeuedKeyFromQueue(message.queue),
             this.keys.envCurrentDequeuedKeyFromQueue(message.queue),
             this.keys.queueRunningCounterKeyFromQueue(message.queue),
-            messageId
+            this.keys.ckIndexKeyFromQueue(message.queue),
+            messageId,
+            this.options.redis.keyPrefix ?? ""
           );
         }
 
@@ -2508,7 +2510,9 @@ export class RunQueue {
         queueCurrentDequeuedKey,
         envCurrentDequeuedKey,
         this.keys.queueRunningCounterKeyFromQueue(queue),
-        messageId
+        this.keys.ckIndexKeyFromQueue(queue),
+        messageId,
+        this.options.redis.keyPrefix ?? ""
       );
     }
 
@@ -4335,6 +4339,9 @@ local envCurrentDequeuedKey = keyPrefix .. string.match(queue, "(.+):queue:") ..
 
 -- SADD first so we know if this dequeue is new (return 1) or a duplicate (return 0).
 -- INCR runningCounter is gated on the new-membership result so re-dequeues don't inflate.
+-- The alternative (lazy-init before SADD) was rejected because we need the SADD return
+-- value to gate the INCR, and the lazy-init seed under SADD-first already reflects the
+-- new membership. We compensate with the total-1 in the seed math below.
 local addedDeq = redis.call('SADD', queueCurrentDequeuedKey, messageData.runId)
 redis.call('SADD', envCurrentDequeuedKey, messageData.runId)
 
@@ -4932,15 +4939,33 @@ redis.call('SREM', envCurrentDequeuedKey, messageId)
     // something. Caller should only invoke this variant for CK queues — non-CK
     // queues should keep calling releaseConcurrency.
     this.redis.defineCommand("releaseConcurrencyTracked", {
-      numberOfKeys: 5,
+      numberOfKeys: 6,
       lua: `
+-- Keys:
 local queueCurrentConcurrencyKey = KEYS[1]
 local envCurrentConcurrencyKey = KEYS[2]
 local queueCurrentDequeuedKey = KEYS[3]
 local envCurrentDequeuedKey = KEYS[4]
 local runningCounterKey = KEYS[5]
+local ckIndexKey = KEYS[6]
 
+-- Args:
 local messageId = ARGV[1]
+local keyPrefix = ARGV[2]
+
+-- Lazy-init runningCounter if missing (e.g. expired via 24h TTL). Runs BEFORE
+-- the SREM so the seed captures pre-release state; the subsequent DECR accounts
+-- for the message we're about to release. Without this, a release landing after
+-- counter expiry would silently no-op the DECR and the next dequeue would seed
+-- to post-release truth — bounded drift but inconsistent with nack/enqueue.
+if redis.call('EXISTS', runningCounterKey) == 0 then
+  local total = 0
+  local variants = redis.call('ZRANGE', ckIndexKey, 0, -1)
+  for _, v in ipairs(variants) do
+    total = total + tonumber(redis.call('SCARD', keyPrefix .. v .. ':currentDequeued') or '0')
+  end
+  redis.call('SET', runningCounterKey, total, 'EX', 86400)
+end
 
 redis.call('SREM', queueCurrentConcurrencyKey, messageId)
 redis.call('SREM', envCurrentConcurrencyKey, messageId)
@@ -5057,15 +5082,29 @@ redis.call('SREM', envCurrentDequeuedKey, messageId)
     // Tracked variant of clearMessageFromConcurrencySets — see releaseConcurrencyTracked
     // for the contract. Only invoke for CK queues.
     this.redis.defineCommand("clearMessageFromConcurrencySetsTracked", {
-      numberOfKeys: 5,
+      numberOfKeys: 6,
       lua: `
+-- Keys:
 local queueCurrentConcurrencyKey = KEYS[1]
 local envCurrentConcurrencyKey = KEYS[2]
 local queueCurrentDequeuedKey = KEYS[3]
 local envCurrentDequeuedKey = KEYS[4]
 local runningCounterKey = KEYS[5]
+local ckIndexKey = KEYS[6]
 
+-- Args:
 local messageId = ARGV[1]
+local keyPrefix = ARGV[2]
+
+-- Lazy-init runningCounter if missing — see releaseConcurrencyTracked for rationale.
+if redis.call('EXISTS', runningCounterKey) == 0 then
+  local total = 0
+  local variants = redis.call('ZRANGE', ckIndexKey, 0, -1)
+  for _, v in ipairs(variants) do
+    total = total + tonumber(redis.call('SCARD', keyPrefix .. v .. ':currentDequeued') or '0')
+  end
+  redis.call('SET', runningCounterKey, total, 'EX', 86400)
+end
 
 redis.call('SREM', queueCurrentConcurrencyKey, messageId)
 redis.call('SREM', envCurrentConcurrencyKey, messageId)
@@ -5608,7 +5647,9 @@ declare module "@internal/redis" {
       queueCurrentDequeuedKey: string,
       envCurrentDequeuedKey: string,
       runningCounterKey: string,
+      ckIndexKey: string,
       messageId: string,
+      keyPrefix: string,
       callback?: Callback<void>
     ): Result<void, Context>;
 
@@ -5618,7 +5659,9 @@ declare module "@internal/redis" {
       queueCurrentDequeuedKey: string,
       envCurrentDequeuedKey: string,
       runningCounterKey: string,
+      ckIndexKey: string,
       messageId: string,
+      keyPrefix: string,
       callback?: Callback<void>
     ): Result<void, Context>;
   }

--- a/internal-packages/run-engine/src/run-queue/index.ts
+++ b/internal-packages/run-engine/src/run-queue/index.ts
@@ -76,6 +76,14 @@ export type RunQueueOptions = {
   masterQueueCooloffCountThreshold?: number;
   masterQueueConsumerDequeueCount?: number;
   processWorkerQueueDebounceMs?: number;
+  /**
+   * TTL (seconds) applied to the per-base-queue lengthCounter/runningCounter on
+   * lazy-init. Bounds the maximum window for any drift accumulated during a
+   * rolling-deploy v1/v2 overlap. INCR/DECR do NOT extend the TTL, so the
+   * counter expires this long after init regardless of activity, and the next
+   * CK operation re-anchors from ckIndex. Default: 86400 (24h).
+   */
+  counterTtlSeconds?: number;
   workerOptions?: {
     pollIntervalMs?: number;
     immediatePollIntervalMs?: number;
@@ -186,6 +194,7 @@ export class RunQueue {
   public keys: RunQueueKeyProducer;
   private queueSelectionStrategy: RunQueueSelectionStrategy;
   private shardCount: number;
+  private counterTtlSeconds: number;
   private abortController: AbortController;
   private worker: Worker<typeof workerCatalog>;
   private workerQueueResolver: WorkerQueueResolver;
@@ -195,6 +204,7 @@ export class RunQueue {
 
   constructor(public readonly options: RunQueueOptions) {
     this.shardCount = options.shardCount ?? 2;
+    this.counterTtlSeconds = options.counterTtlSeconds ?? 86400;
     this.retryOptions = options.retryOptions ?? defaultRetrySettings;
     this.redis = createRedisClient(options.redis, {
       onError: (error) => {
@@ -988,7 +998,8 @@ export class RunQueue {
             this.keys.queueRunningCounterKeyFromQueue(message.queue),
             this.keys.ckIndexKeyFromQueue(message.queue),
             messageId,
-            this.options.redis.keyPrefix ?? ""
+            this.options.redis.keyPrefix ?? "",
+            String(this.counterTtlSeconds)
           );
         }
 
@@ -1913,7 +1924,8 @@ export class RunQueue {
           defaultEnvConcurrencyBurstFactor,
           currentTime,
           enableFastPathArg,
-          ckKeyPrefix
+          ckKeyPrefix,
+          String(this.counterTtlSeconds)
         );
       } else {
         result = await this.redis.enqueueMessageCkTracked(
@@ -1944,7 +1956,8 @@ export class RunQueue {
           defaultEnvConcurrencyBurstFactor,
           currentTime,
           enableFastPathArg,
-          ckKeyPrefix
+          ckKeyPrefix,
+          String(this.counterTtlSeconds)
         );
       }
     } else if (ttlInfo) {
@@ -2512,7 +2525,8 @@ export class RunQueue {
         this.keys.queueRunningCounterKeyFromQueue(queue),
         this.keys.ckIndexKeyFromQueue(queue),
         messageId,
-        this.options.redis.keyPrefix ?? ""
+        this.options.redis.keyPrefix ?? "",
+        String(this.counterTtlSeconds)
       );
     }
 
@@ -2582,7 +2596,8 @@ export class RunQueue {
         JSON.stringify(message),
         String(messageScore),
         ckWildcardName,
-        this.options.redis.keyPrefix ?? ""
+        this.options.redis.keyPrefix ?? "",
+        String(this.counterTtlSeconds)
       );
     } else {
       await this.redis.nackMessage(
@@ -2943,7 +2958,8 @@ export class RunQueue {
 
       const rawMessage = await this.redis.dequeueMessageFromKeyTracked(
         messageKey,
-        this.options.redis.keyPrefix ?? ""
+        this.options.redis.keyPrefix ?? "",
+        String(this.counterTtlSeconds)
       );
 
       if (!rawMessage) {
@@ -3432,6 +3448,8 @@ local currentTime = ARGV[9]
 local enableFastPath = ARGV[10]
 -- keyPrefix for prepending to variant names stored as values in ckIndex
 local keyPrefix = ARGV[11]
+-- TTL (seconds) applied to counter lazy-init SETs
+local counterTtl = ARGV[12]
 
 -- Fast path: check if we can skip the queue and go directly to worker queue
 if enableFastPath == '1' then
@@ -3478,7 +3496,7 @@ if redis.call('EXISTS', lengthCounterKey) == 0 then
   for _, v in ipairs(variants) do
     total = total + tonumber(redis.call('ZCARD', keyPrefix .. v) or '0')
   end
-  redis.call('SET', lengthCounterKey, total, 'EX', 86400)
+  redis.call('SET', lengthCounterKey, total, 'EX', counterTtl)
 end
 
 -- INCR is gated on ZADD returning 1 (new entry). A duplicate enqueue (same messageId
@@ -3551,6 +3569,8 @@ local currentTime = ARGV[11]
 local enableFastPath = ARGV[12]
 -- keyPrefix for prepending to variant names stored as values in ckIndex
 local keyPrefix = ARGV[13]
+-- TTL (seconds) applied to counter lazy-init SETs
+local counterTtl = ARGV[14]
 
 -- Fast path: check if we can skip the queue and go directly to worker queue
 if enableFastPath == '1' then
@@ -3590,7 +3610,7 @@ if redis.call('EXISTS', lengthCounterKey) == 0 then
   for _, v in ipairs(variants) do
     total = total + tonumber(redis.call('ZCARD', keyPrefix .. v) or '0')
   end
-  redis.call('SET', lengthCounterKey, total, 'EX', 86400)
+  redis.call('SET', lengthCounterKey, total, 'EX', counterTtl)
 end
 
 -- INCR is gated on ZADD returning 1 (new entry).
@@ -4325,6 +4345,8 @@ return message
       lua: `
 local messageKey = KEYS[1]
 local keyPrefix = ARGV[1]
+-- TTL (seconds) applied to counter lazy-init SETs
+local counterTtl = ARGV[2]
 
 local message = redis.call('GET', messageKey)
 if not message then
@@ -4355,14 +4377,23 @@ if baseQueue and addedDeq == 1 then
   if redis.call('EXISTS', runningCounterKey) == 0 then
     local ckIndexKey = keyPrefix .. baseQueue .. ':ckIndex'
     local total = 0
+    local ownVariantSeen = false
     local variants = redis.call('ZRANGE', ckIndexKey, 0, -1)
     for _, v in ipairs(variants) do
+      if v == queue then
+        ownVariantSeen = true
+      end
       total = total + tonumber(redis.call('SCARD', keyPrefix .. v .. ':currentDequeued') or '0')
     end
-    -- Subtract 1 because we already SADD'd our own runId above, which the per-variant
-    -- SCARDs now reflect. Without this, the lazy-init seed double-counts the new member
-    -- relative to what the subsequent INCR will add.
-    redis.call('SET', runningCounterKey, math.max(0, total - 1), 'EX', 86400)
+    -- Fast-path messages skip the variant zset and ckIndex entirely (see
+    -- enqueueMessageCkTracked fast path). If our variant isn't in ckIndex, the loop
+    -- missed its SCARD; add it manually. Either way, the SCARD we sum already
+    -- reflects our just-SADD'd member, so subtract 1 before SETting (the INCR
+    -- below will add it back).
+    if not ownVariantSeen then
+      total = total + tonumber(redis.call('SCARD', queueCurrentDequeuedKey) or '0')
+    end
+    redis.call('SET', runningCounterKey, math.max(0, total - 1), 'EX', counterTtl)
   end
   redis.call('INCR', runningCounterKey)
 end
@@ -4782,6 +4813,8 @@ local messageScore = tonumber(ARGV[4])
 local ckWildcardName = ARGV[5]
 -- keyPrefix for prepending to variant names stored as values in ckIndex (lazy-init only)
 local keyPrefix = ARGV[6]
+-- TTL (seconds) applied to counter lazy-init SETs
+local counterTtl = ARGV[7]
 
 local function decrFloored(key)
   if tonumber(redis.call('GET', key) or '0') > 0 then
@@ -4811,7 +4844,7 @@ if redis.call('EXISTS', lengthCounterKey) == 0 then
   for _, v in ipairs(variants) do
     total = total + tonumber(redis.call('ZCARD', keyPrefix .. v) or '0')
   end
-  redis.call('SET', lengthCounterKey, total, 'EX', 86400)
+  redis.call('SET', lengthCounterKey, total, 'EX', counterTtl)
 end
 
 -- Enqueue the message back into the CK-specific queue. INCR lengthCounter only if
@@ -4952,6 +4985,8 @@ local ckIndexKey = KEYS[6]
 -- Args:
 local messageId = ARGV[1]
 local keyPrefix = ARGV[2]
+-- TTL (seconds) applied to counter lazy-init SETs
+local counterTtl = ARGV[3]
 
 -- Lazy-init runningCounter if missing (e.g. expired via 24h TTL). Runs BEFORE
 -- the SREM so the seed captures pre-release state; the subsequent DECR accounts
@@ -4964,7 +4999,7 @@ if redis.call('EXISTS', runningCounterKey) == 0 then
   for _, v in ipairs(variants) do
     total = total + tonumber(redis.call('SCARD', keyPrefix .. v .. ':currentDequeued') or '0')
   end
-  redis.call('SET', runningCounterKey, total, 'EX', 86400)
+  redis.call('SET', runningCounterKey, total, 'EX', counterTtl)
 end
 
 redis.call('SREM', queueCurrentConcurrencyKey, messageId)
@@ -5095,6 +5130,8 @@ local ckIndexKey = KEYS[6]
 -- Args:
 local messageId = ARGV[1]
 local keyPrefix = ARGV[2]
+-- TTL (seconds) applied to counter lazy-init SETs
+local counterTtl = ARGV[3]
 
 -- Lazy-init runningCounter if missing — see releaseConcurrencyTracked for rationale.
 if redis.call('EXISTS', runningCounterKey) == 0 then
@@ -5103,7 +5140,7 @@ if redis.call('EXISTS', runningCounterKey) == 0 then
   for _, v in ipairs(variants) do
     total = total + tonumber(redis.call('SCARD', keyPrefix .. v .. ':currentDequeued') or '0')
   end
-  redis.call('SET', runningCounterKey, total, 'EX', 86400)
+  redis.call('SET', runningCounterKey, total, 'EX', counterTtl)
 end
 
 redis.call('SREM', queueCurrentConcurrencyKey, messageId)
@@ -5506,6 +5543,7 @@ declare module "@internal/redis" {
       currentTime: string,
       enableFastPath: string,
       keyPrefix: string,
+      counterTtl: string,
       callback?: Callback<number>
     ): Result<number, Context>;
 
@@ -5539,6 +5577,7 @@ declare module "@internal/redis" {
       currentTime: string,
       enableFastPath: string,
       keyPrefix: string,
+      counterTtl: string,
       callback?: Callback<number>
     ): Result<number, Context>;
 
@@ -5565,6 +5604,7 @@ declare module "@internal/redis" {
     dequeueMessageFromKeyTracked(
       messageKey: string,
       keyPrefix: string,
+      counterTtl: string,
       callback?: Callback<string | null>
     ): Result<string | null, Context>;
 
@@ -5607,6 +5647,7 @@ declare module "@internal/redis" {
       messageScore: string,
       ckWildcardName: string,
       keyPrefix: string,
+      counterTtl: string,
       callback?: Callback<void>
     ): Result<void, Context>;
 
@@ -5650,6 +5691,7 @@ declare module "@internal/redis" {
       ckIndexKey: string,
       messageId: string,
       keyPrefix: string,
+      counterTtl: string,
       callback?: Callback<void>
     ): Result<void, Context>;
 
@@ -5662,6 +5704,7 @@ declare module "@internal/redis" {
       ckIndexKey: string,
       messageId: string,
       keyPrefix: string,
+      counterTtl: string,
       callback?: Callback<void>
     ): Result<void, Context>;
   }

--- a/internal-packages/run-engine/src/run-queue/keyProducer.ts
+++ b/internal-packages/run-engine/src/run-queue/keyProducer.ts
@@ -18,6 +18,8 @@ const constants = {
   MASTER_QUEUE_PART: "masterQueue",
   WORKER_QUEUE_PART: "workerQueue",
   CK_INDEX_PART: "ckIndex",
+  LENGTH_COUNTER_PART: "lengthCounter",
+  RUNNING_COUNTER_PART: "runningCounter",
 } as const;
 
 export class RunQueueFullKeyProducer implements RunQueueKeyProducer {
@@ -313,6 +315,22 @@ export class RunQueueFullKeyProducer implements RunQueueKeyProducer {
 
   baseQueueKeyFromQueue(queue: string): string {
     return queue.replace(/:ck:.+$/, "");
+  }
+
+  queueLengthCounterKey(env: RunQueueKeyProducerEnvironment, queue: string): string {
+    return `${this.queueKey(env, queue)}:${constants.LENGTH_COUNTER_PART}`;
+  }
+
+  queueLengthCounterKeyFromQueue(queue: string): string {
+    return `${this.baseQueueKeyFromQueue(queue)}:${constants.LENGTH_COUNTER_PART}`;
+  }
+
+  queueRunningCounterKey(env: RunQueueKeyProducerEnvironment, queue: string): string {
+    return `${this.queueKey(env, queue)}:${constants.RUNNING_COUNTER_PART}`;
+  }
+
+  queueRunningCounterKeyFromQueue(queue: string): string {
+    return `${this.baseQueueKeyFromQueue(queue)}:${constants.RUNNING_COUNTER_PART}`;
   }
 
   isCkWildcard(queue: string): boolean {

--- a/internal-packages/run-engine/src/run-queue/tests/ckCounters.test.ts
+++ b/internal-packages/run-engine/src/run-queue/tests/ckCounters.test.ts
@@ -2,7 +2,6 @@ import { redisTest } from "@internal/testcontainers";
 import { trace } from "@internal/tracing";
 import { Logger } from "@trigger.dev/core/logger";
 import { describe } from "vitest";
-import { setTimeout } from "node:timers/promises";
 import { FairQueueSelectionStrategy } from "../fairQueueSelectionStrategy.js";
 import { RunQueue } from "../index.js";
 import { RunQueueFullKeyProducer } from "../keyProducer.js";
@@ -322,6 +321,107 @@ describe("CK base-queue counters", () => {
         );
 
         expect(Number(await queue.redis.get(runningCounterKey))).toBe(0);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
+    "lengthCounter has 24h TTL after lazy-init",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer);
+      try {
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: makeMessage({ runId: "r1", concurrencyKey: "ck-a" }),
+          workerQueue: authenticatedEnvDev.id,
+          skipDequeueProcessing: true,
+        });
+
+        const counterKey = testOptions.keys.queueLengthCounterKey(
+          authenticatedEnvDev,
+          "task/my-task"
+        );
+        const ttl = await queue.redis.ttl(counterKey);
+        // Expect roughly 86400; allow slack for test scheduling.
+        expect(ttl).toBeGreaterThan(86000);
+        expect(ttl).toBeLessThanOrEqual(86400);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
+    "duplicate CK enqueue (same runId) does not inflate lengthCounter",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer);
+      try {
+        const msg = makeMessage({ runId: "r1", concurrencyKey: "ck-a" });
+
+        // First enqueue: counter goes 0 -> 1
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: msg,
+          workerQueue: authenticatedEnvDev.id,
+          skipDequeueProcessing: true,
+        });
+
+        // Same runId again: ZADD returns 0 (already in zset), counter must stay at 1
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: msg,
+          workerQueue: authenticatedEnvDev.id,
+          skipDequeueProcessing: true,
+        });
+
+        expect(await queue.lengthOfQueue(authenticatedEnvDev, msg.queue)).toBe(1);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
+    "nack lazy-inits lengthCounter when it expired",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer);
+      try {
+        const msg = makeMessage({ runId: "r1", concurrencyKey: "ck-a" });
+        // Seed three messages on the CK variant so the lazy-init has a non-trivial floor.
+        for (let i = 0; i < 3; i++) {
+          await queue.enqueueMessage({
+            env: authenticatedEnvDev,
+            message: makeMessage({ runId: `seed-${i}`, concurrencyKey: "ck-a" }),
+            workerQueue: authenticatedEnvDev.id,
+            skipDequeueProcessing: true,
+          });
+        }
+
+        // Simulate counter expiry (the 24h TTL kicked in).
+        const counterKey = testOptions.keys.queueLengthCounterKey(
+          authenticatedEnvDev,
+          "task/my-task"
+        );
+        await queue.redis.del(counterKey);
+        expect(await queue.redis.exists(counterKey)).toBe(0);
+
+        // Dequeue one to currentConcurrency so we have something to nack back.
+        const shard = testOptions.keys.masterQueueShardForEnvironment(msg.environmentId, 2);
+        await queue.testDequeueFromMasterQueue(shard, msg.environmentId, 1);
+
+        // Nack a CK message. nackMessageCkTracked should lazy-init the counter
+        // (find 2 already in zset + 1 we're re-queuing) rather than starting from 1.
+        await queue.nackMessage({
+          orgId: msg.orgId,
+          messageId: "seed-0",
+          skipDequeueProcessing: true,
+        });
+
+        // 3 originals, 1 was dequeued (still re-queued by nack), counter should now reflect all 3.
+        const observed = await queue.lengthOfQueue(authenticatedEnvDev, msg.queue);
+        expect(observed).toBe(3);
       } finally {
         await queue.quit();
       }

--- a/internal-packages/run-engine/src/run-queue/tests/ckCounters.test.ts
+++ b/internal-packages/run-engine/src/run-queue/tests/ckCounters.test.ts
@@ -1,7 +1,7 @@
 import { redisTest } from "@internal/testcontainers";
 import { trace } from "@internal/tracing";
 import { Logger } from "@trigger.dev/core/logger";
-import { describe } from "node:test";
+import { describe } from "vitest";
 import { setTimeout } from "node:timers/promises";
 import { FairQueueSelectionStrategy } from "../fairQueueSelectionStrategy.js";
 import { RunQueue } from "../index.js";

--- a/internal-packages/run-engine/src/run-queue/tests/ckCounters.test.ts
+++ b/internal-packages/run-engine/src/run-queue/tests/ckCounters.test.ts
@@ -1,0 +1,330 @@
+import { redisTest } from "@internal/testcontainers";
+import { trace } from "@internal/tracing";
+import { Logger } from "@trigger.dev/core/logger";
+import { describe } from "node:test";
+import { setTimeout } from "node:timers/promises";
+import { FairQueueSelectionStrategy } from "../fairQueueSelectionStrategy.js";
+import { RunQueue } from "../index.js";
+import { RunQueueFullKeyProducer } from "../keyProducer.js";
+import { InputPayload } from "../types.js";
+import { Decimal } from "@trigger.dev/database";
+
+const testOptions = {
+  name: "rq",
+  tracer: trace.getTracer("rq"),
+  workers: 1,
+  defaultEnvConcurrency: 25,
+  logger: new Logger("RunQueue", "warn"),
+  retryOptions: {
+    maxAttempts: 5,
+    factor: 1.1,
+    minTimeoutInMs: 100,
+    maxTimeoutInMs: 1_000,
+    randomize: true,
+  },
+  keys: new RunQueueFullKeyProducer(),
+};
+
+const authenticatedEnvDev = {
+  id: "e1234",
+  type: "DEVELOPMENT" as const,
+  maximumConcurrencyLimit: 10,
+  concurrencyLimitBurstFactor: new Decimal(2.0),
+  project: { id: "p1234" },
+  organization: { id: "o1234" },
+};
+
+function createQueue(redisContainer: any) {
+  return new RunQueue({
+    ...testOptions,
+    queueSelectionStrategy: new FairQueueSelectionStrategy({
+      redis: {
+        keyPrefix: "runqueue:test:",
+        host: redisContainer.getHost(),
+        port: redisContainer.getPort(),
+      },
+      keys: testOptions.keys,
+    }),
+    redis: {
+      keyPrefix: "runqueue:test:",
+      host: redisContainer.getHost(),
+      port: redisContainer.getPort(),
+    },
+  });
+}
+
+function makeMessage(overrides: Partial<InputPayload> = {}): InputPayload {
+  return {
+    runId: "r1",
+    taskIdentifier: "task/my-task",
+    orgId: "o1234",
+    projectId: "p1234",
+    environmentId: "e1234",
+    environmentType: "DEVELOPMENT",
+    queue: "task/my-task",
+    timestamp: Date.now(),
+    attempt: 0,
+    ...overrides,
+  };
+}
+
+vi.setConfig({ testTimeout: 60_000 });
+
+describe("CK base-queue counters", () => {
+  redisTest(
+    "lengthOfQueue returns aggregate across CK variants",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer);
+      try {
+        const now = Date.now();
+        const messages = [
+          makeMessage({ runId: "r1", concurrencyKey: "ck-a", timestamp: now }),
+          makeMessage({ runId: "r2", concurrencyKey: "ck-a", timestamp: now + 1 }),
+          makeMessage({ runId: "r3", concurrencyKey: "ck-b", timestamp: now + 2 }),
+          makeMessage({ runId: "r4", concurrencyKey: "ck-c", timestamp: now + 3 }),
+        ];
+
+        for (const msg of messages) {
+          await queue.enqueueMessage({
+            env: authenticatedEnvDev,
+            message: msg,
+            workerQueue: authenticatedEnvDev.id,
+            skipDequeueProcessing: true,
+          });
+        }
+
+        // Aggregate (no CK arg) should sum all variants
+        expect(await queue.lengthOfQueue(authenticatedEnvDev, messages[0].queue)).toBe(4);
+
+        // Per-variant still works
+        expect(
+          await queue.lengthOfQueue(authenticatedEnvDev, messages[0].queue, "ck-a")
+        ).toBe(2);
+        expect(
+          await queue.lengthOfQueue(authenticatedEnvDev, messages[0].queue, "ck-b")
+        ).toBe(1);
+
+        // Plural lengthOfQueues should also see the aggregate
+        const lengths = await queue.lengthOfQueues(authenticatedEnvDev, [messages[0].queue]);
+        expect(lengths[messages[0].queue]).toBe(4);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
+    "lazy init from pre-existing CK backlog",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer);
+      try {
+        const now = Date.now();
+        const baseMsg = makeMessage({ runId: "seed", concurrencyKey: "ck-a", timestamp: now });
+
+        // Pre-populate two variants via direct ZADD to simulate pre-deploy backlog
+        // (no counter touched). ioredis auto-prefixes keys with `runqueue:test:`,
+        // so we pass un-prefixed keys.
+        const variantA = testOptions.keys.queueKey(authenticatedEnvDev, baseMsg.queue, "ck-a");
+        const variantB = testOptions.keys.queueKey(authenticatedEnvDev, baseMsg.queue, "ck-b");
+        const ckIndexKey = testOptions.keys.ckIndexKeyFromQueue(variantA);
+        for (let i = 0; i < 10; i++) {
+          await queue.redis.zadd(variantA, now + i, `old-a-${i}`);
+        }
+        for (let i = 0; i < 5; i++) {
+          await queue.redis.zadd(variantB, now + i, `old-b-${i}`);
+        }
+        await queue.redis.zadd(ckIndexKey, now, variantA);
+        await queue.redis.zadd(ckIndexKey, now, variantB);
+
+        // Counter should not yet exist
+        const counterKey = testOptions.keys.queueLengthCounterKeyFromQueue(variantA);
+        expect(await queue.redis.exists(counterKey)).toBe(0);
+
+        // First CK enqueue: lazy init should compute 15 (pre-state), then INCR to 16
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: makeMessage({ runId: "new-a", concurrencyKey: "ck-a", timestamp: now + 100 }),
+          workerQueue: authenticatedEnvDev.id,
+          skipDequeueProcessing: true,
+        });
+
+        const counterVal = await queue.redis.get(counterKey);
+        expect(Number(counterVal)).toBe(16);
+
+        // lengthOfQueue should also reflect 16
+        expect(await queue.lengthOfQueue(authenticatedEnvDev, baseMsg.queue)).toBe(16);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
+    "non-CK queue regression: counter never created",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer);
+      try {
+        for (let i = 0; i < 5; i++) {
+          await queue.enqueueMessage({
+            env: authenticatedEnvDev,
+            message: makeMessage({ runId: `r${i}`, timestamp: Date.now() + i }),
+            workerQueue: authenticatedEnvDev.id,
+            skipDequeueProcessing: true,
+          });
+        }
+
+        // Counter key should not exist for a pure non-CK queue
+        const counterKey = testOptions.keys.queueLengthCounterKey(authenticatedEnvDev, "task/my-task");
+        expect(await queue.redis.exists(counterKey)).toBe(0);
+
+        // But lengthOfQueue still returns 5 via base ZCARD
+        expect(await queue.lengthOfQueue(authenticatedEnvDev, "task/my-task")).toBe(5);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
+    "mixed CK + non-CK on same base queue",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer);
+      try {
+        // 3 non-CK + 2 CK on same base queue name
+        for (let i = 0; i < 3; i++) {
+          await queue.enqueueMessage({
+            env: authenticatedEnvDev,
+            message: makeMessage({ runId: `nonck-${i}`, timestamp: Date.now() + i }),
+            workerQueue: authenticatedEnvDev.id,
+            skipDequeueProcessing: true,
+          });
+        }
+        for (let i = 0; i < 2; i++) {
+          await queue.enqueueMessage({
+            env: authenticatedEnvDev,
+            message: makeMessage({
+              runId: `ck-${i}`,
+              concurrencyKey: "ck-a",
+              timestamp: Date.now() + 100 + i,
+            }),
+            workerQueue: authenticatedEnvDev.id,
+            skipDequeueProcessing: true,
+          });
+        }
+
+        expect(await queue.lengthOfQueue(authenticatedEnvDev, "task/my-task")).toBe(5);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
+    "length counter decrements on dequeue",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer);
+      try {
+        const now = Date.now() - 1000;
+        const msgs = [
+          makeMessage({ runId: "r1", concurrencyKey: "ck-a", timestamp: now }),
+          makeMessage({ runId: "r2", concurrencyKey: "ck-b", timestamp: now + 1 }),
+        ];
+        for (const msg of msgs) {
+          await queue.enqueueMessage({
+            env: authenticatedEnvDev,
+            message: msg,
+            workerQueue: authenticatedEnvDev.id,
+            skipDequeueProcessing: true,
+          });
+        }
+        expect(await queue.lengthOfQueue(authenticatedEnvDev, msgs[0].queue)).toBe(2);
+
+        const shard = testOptions.keys.masterQueueShardForEnvironment(msgs[0].environmentId, 2);
+        await queue.testDequeueFromMasterQueue(shard, msgs[0].environmentId, 10);
+
+        // Both dequeued → counter should be 0
+        expect(await queue.lengthOfQueue(authenticatedEnvDev, msgs[0].queue)).toBe(0);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
+    "running counter bumps when dequeueMessageFromKey is called for a CK message",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer);
+      try {
+        // Seed a message at its expected key and invoke the Tracked variant directly.
+        // This mirrors what dequeueMessageFromWorkerQueue would do once a worker
+        // pulls a message off the worker queue.
+        const msg = makeMessage({ runId: "r1", concurrencyKey: "ck-a" });
+        const queueKey = testOptions.keys.queueKey(authenticatedEnvDev, msg.queue, "ck-a");
+        const messageKey = testOptions.keys.messageKey(msg.orgId, msg.runId);
+        const runningCounterKey =
+          testOptions.keys.queueRunningCounterKeyFromQueue(queueKey);
+
+        await queue.redis.set(
+          messageKey,
+          JSON.stringify({ ...msg, queue: queueKey, version: "2", workerQueue: "wq" })
+        );
+
+        for (let i = 0; i < 3; i++) {
+          await queue.redis.set(
+            testOptions.keys.messageKey(msg.orgId, `r${i}`),
+            JSON.stringify({
+              ...msg,
+              runId: `r${i}`,
+              queue: queueKey,
+              version: "2",
+              workerQueue: "wq",
+            })
+          );
+          await queue.redis.dequeueMessageFromKeyTracked(
+            testOptions.keys.messageKey(msg.orgId, `r${i}`),
+            "runqueue:test:"
+          );
+        }
+
+        expect(Number(await queue.redis.get(runningCounterKey))).toBe(3);
+
+        const running = await queue.currentConcurrencyOfQueues(authenticatedEnvDev, [
+          msg.queue,
+        ]);
+        expect(running[msg.queue]).toBe(3);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
+    "floor-at-zero protects against spurious decrements",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer);
+      try {
+        const variantA = testOptions.keys.queueKey(
+          authenticatedEnvDev,
+          "task/my-task",
+          "ck-a"
+        );
+        const runningCounterKey = testOptions.keys.queueRunningCounterKeyFromQueue(variantA);
+        await queue.redis.set(runningCounterKey, "0");
+
+        // Call the Tracked release directly with un-prefixed keys (ioredis prepends the prefix)
+        await queue.redis.releaseConcurrencyTracked(
+          testOptions.keys.queueCurrentConcurrencyKeyFromQueue(variantA),
+          testOptions.keys.envCurrentConcurrencyKey(authenticatedEnvDev),
+          testOptions.keys.queueCurrentDequeuedKeyFromQueue(variantA),
+          testOptions.keys.envCurrentDequeuedKey(authenticatedEnvDev),
+          runningCounterKey,
+          "phantom-message"
+        );
+
+        expect(Number(await queue.redis.get(runningCounterKey))).toBe(0);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+});

--- a/internal-packages/run-engine/src/run-queue/tests/ckCounters.test.ts
+++ b/internal-packages/run-engine/src/run-queue/tests/ckCounters.test.ts
@@ -8,6 +8,10 @@ import { RunQueueFullKeyProducer } from "../keyProducer.js";
 import { InputPayload } from "../types.js";
 import { Decimal } from "@trigger.dev/database";
 
+// String form of the default counterTtlSeconds (86400). Tracked Lua scripts
+// take TTL as an ARG; tests that invoke the scripts directly pass this.
+const DEFAULT_COUNTER_TTL = "86400";
+
 const testOptions = {
   name: "rq",
   tracer: trace.getTracer("rq"),
@@ -282,7 +286,7 @@ describe("CK base-queue counters", () => {
           await queue.redis.dequeueMessageFromKeyTracked(
             testOptions.keys.messageKey(msg.orgId, `r${i}`),
             "runqueue:test:",
-            "86400"
+            DEFAULT_COUNTER_TTL
           );
         }
 
@@ -321,7 +325,7 @@ describe("CK base-queue counters", () => {
           testOptions.keys.ckIndexKeyFromQueue(variantA),
           "phantom-message",
           "runqueue:test:",
-          "86400"
+          DEFAULT_COUNTER_TTL
         );
 
         expect(Number(await queue.redis.get(runningCounterKey))).toBe(0);
@@ -443,11 +447,11 @@ describe("CK base-queue counters", () => {
         );
 
         // First call: SADD returns 1, runningCounter goes 0 -> 1.
-        await queue.redis.dequeueMessageFromKeyTracked(messageKey, "runqueue:test:", "86400");
+        await queue.redis.dequeueMessageFromKeyTracked(messageKey, "runqueue:test:", DEFAULT_COUNTER_TTL);
         expect(Number(await queue.redis.get(runningCounterKey))).toBe(1);
 
         // Second call on the same messageKey: SADD returns 0, runningCounter must stay at 1.
-        await queue.redis.dequeueMessageFromKeyTracked(messageKey, "runqueue:test:", "86400");
+        await queue.redis.dequeueMessageFromKeyTracked(messageKey, "runqueue:test:", DEFAULT_COUNTER_TTL);
         expect(Number(await queue.redis.get(runningCounterKey))).toBe(1);
       } finally {
         await queue.quit();
@@ -545,7 +549,7 @@ describe("CK base-queue counters", () => {
           messageKey,
           JSON.stringify({ ...msg, queue: fastVariant, version: "2", workerQueue: "wq" })
         );
-        await queue.redis.dequeueMessageFromKeyTracked(messageKey, "runqueue:test:", "86400");
+        await queue.redis.dequeueMessageFromKeyTracked(messageKey, "runqueue:test:", DEFAULT_COUNTER_TTL);
 
         // True running across all variants: 3 (fast prior) + 1 (fast new) + 1 (other) = 5.
         // Without the ownVariantSeen fix, the seed would miss the fast variant entirely
@@ -627,7 +631,9 @@ describe("CK base-queue counters", () => {
           "task/my-task"
         );
         const ttl = await queue.redis.ttl(counterKey);
-        expect(ttl).toBeGreaterThanOrEqual(55);
+        // Generous lower bound — CI workers can occasionally stall multiple
+        // seconds between the lazy-init SET and the TTL read.
+        expect(ttl).toBeGreaterThanOrEqual(50);
         expect(ttl).toBeLessThanOrEqual(60);
       } finally {
         await queue.quit();

--- a/internal-packages/run-engine/src/run-queue/tests/ckCounters.test.ts
+++ b/internal-packages/run-engine/src/run-queue/tests/ckCounters.test.ts
@@ -281,7 +281,8 @@ describe("CK base-queue counters", () => {
           );
           await queue.redis.dequeueMessageFromKeyTracked(
             testOptions.keys.messageKey(msg.orgId, `r${i}`),
-            "runqueue:test:"
+            "runqueue:test:",
+            "86400"
           );
         }
 
@@ -319,7 +320,8 @@ describe("CK base-queue counters", () => {
           runningCounterKey,
           testOptions.keys.ckIndexKeyFromQueue(variantA),
           "phantom-message",
-          "runqueue:test:"
+          "runqueue:test:",
+          "86400"
         );
 
         expect(Number(await queue.redis.get(runningCounterKey))).toBe(0);
@@ -441,11 +443,11 @@ describe("CK base-queue counters", () => {
         );
 
         // First call: SADD returns 1, runningCounter goes 0 -> 1.
-        await queue.redis.dequeueMessageFromKeyTracked(messageKey, "runqueue:test:");
+        await queue.redis.dequeueMessageFromKeyTracked(messageKey, "runqueue:test:", "86400");
         expect(Number(await queue.redis.get(runningCounterKey))).toBe(1);
 
         // Second call on the same messageKey: SADD returns 0, runningCounter must stay at 1.
-        await queue.redis.dequeueMessageFromKeyTracked(messageKey, "runqueue:test:");
+        await queue.redis.dequeueMessageFromKeyTracked(messageKey, "runqueue:test:", "86400");
         expect(Number(await queue.redis.get(runningCounterKey))).toBe(1);
       } finally {
         await queue.quit();
@@ -492,6 +494,141 @@ describe("CK base-queue counters", () => {
         // 3 originals, 1 was dequeued (still re-queued by nack), counter should now reflect all 3.
         const observed = await queue.lengthOfQueue(authenticatedEnvDev, msg.queue);
         expect(observed).toBe(3);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
+    "fast-path-variant dequeue seeds runningCounter without missing its own SCARD",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer);
+      try {
+        // Simulate: a CK variant has 3 running messages from prior fast-path enqueues
+        // (so the variant zset is empty and ckIndex does NOT include this variant).
+        // Another variant of the same base queue IS in ckIndex with 1 running message.
+        // Counter is missing (post-TTL-expiry). A new dequeue lands on the fast-path
+        // variant. The lazy-init must add the fast-path variant's SCARD even though
+        // it's not in ckIndex.
+        const msg = makeMessage({ runId: "fp-new", concurrencyKey: "ck-fastpath" });
+        const fastVariant = testOptions.keys.queueKey(
+          authenticatedEnvDev,
+          msg.queue,
+          "ck-fastpath"
+        );
+        const otherVariant = testOptions.keys.queueKey(
+          authenticatedEnvDev,
+          msg.queue,
+          "ck-other"
+        );
+        const ckIndexKey = testOptions.keys.ckIndexKeyFromQueue(fastVariant);
+        const runningCounterKey =
+          testOptions.keys.queueRunningCounterKeyFromQueue(fastVariant);
+
+        // Seed 3 prior fast-path runs into the fast variant's currentDequeued (no zset, no ckIndex).
+        for (let i = 0; i < 3; i++) {
+          await queue.redis.sadd(`${fastVariant}:currentDequeued`, `prior-${i}`);
+        }
+
+        // Seed the other variant: 1 zset entry (so it's in ckIndex) + 1 currentDequeued.
+        await queue.redis.zadd(otherVariant, Date.now(), "other-q-1");
+        await queue.redis.zadd(ckIndexKey, Date.now(), otherVariant);
+        await queue.redis.sadd(`${otherVariant}:currentDequeued`, "other-r-1");
+
+        // Counter is intentionally missing — simulates post-TTL state.
+        expect(await queue.redis.exists(runningCounterKey)).toBe(0);
+
+        // New fast-path dequeue lands on the fast variant.
+        const messageKey = testOptions.keys.messageKey(msg.orgId, msg.runId);
+        await queue.redis.set(
+          messageKey,
+          JSON.stringify({ ...msg, queue: fastVariant, version: "2", workerQueue: "wq" })
+        );
+        await queue.redis.dequeueMessageFromKeyTracked(messageKey, "runqueue:test:", "86400");
+
+        // True running across all variants: 3 (fast prior) + 1 (fast new) + 1 (other) = 5.
+        // Without the ownVariantSeen fix, the seed would miss the fast variant entirely
+        // and counter would end at 1 (other variant SCARD = 1, INCR for new dequeue) — off by 4.
+        const counterVal = Number(await queue.redis.get(runningCounterKey));
+        expect(counterVal).toBe(5);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
+    "release lazy-inits runningCounter when missing",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer);
+      try {
+        const msg = makeMessage({ runId: "r1", concurrencyKey: "ck-a" });
+        const variant = testOptions.keys.queueKey(authenticatedEnvDev, msg.queue, "ck-a");
+        const runningCounterKey = testOptions.keys.queueRunningCounterKeyFromQueue(variant);
+
+        // Enqueue so ckIndex picks up the variant.
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: msg,
+          workerQueue: authenticatedEnvDev.id,
+          skipDequeueProcessing: true,
+        });
+        // Seed two running messages directly into currentDequeued so release has something to remove.
+        await queue.redis.sadd(`${variant}:currentDequeued`, msg.runId);
+        await queue.redis.sadd(`${variant}:currentDequeued`, "r2");
+
+        // Counter is missing — simulates post-TTL state without waiting.
+        expect(await queue.redis.exists(runningCounterKey)).toBe(0);
+
+        // releaseAllConcurrency calls releaseConcurrencyTracked under the hood for CK queues.
+        await queue.releaseAllConcurrency(msg.orgId, msg.runId);
+
+        // Pre-release truth was 2 in flight; after release one remains. Counter should be 1.
+        const counterVal = Number(await queue.redis.get(runningCounterKey));
+        expect(counterVal).toBe(1);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
+    "counterTtlSeconds option is honored on lazy-init",
+    async ({ redisContainer }) => {
+      // Build a queue with a short TTL and verify the counter is SET with it.
+      const queue = new RunQueue({
+        ...testOptions,
+        counterTtlSeconds: 60,
+        queueSelectionStrategy: new FairQueueSelectionStrategy({
+          redis: {
+            keyPrefix: "runqueue:test:",
+            host: redisContainer.getHost(),
+            port: redisContainer.getPort(),
+          },
+          keys: testOptions.keys,
+        }),
+        redis: {
+          keyPrefix: "runqueue:test:",
+          host: redisContainer.getHost(),
+          port: redisContainer.getPort(),
+        },
+      });
+      try {
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: makeMessage({ runId: "r1", concurrencyKey: "ck-a" }),
+          workerQueue: authenticatedEnvDev.id,
+          skipDequeueProcessing: true,
+        });
+
+        const counterKey = testOptions.keys.queueLengthCounterKey(
+          authenticatedEnvDev,
+          "task/my-task"
+        );
+        const ttl = await queue.redis.ttl(counterKey);
+        expect(ttl).toBeGreaterThanOrEqual(55);
+        expect(ttl).toBeLessThanOrEqual(60);
       } finally {
         await queue.quit();
       }

--- a/internal-packages/run-engine/src/run-queue/tests/ckCounters.test.ts
+++ b/internal-packages/run-engine/src/run-queue/tests/ckCounters.test.ts
@@ -317,7 +317,9 @@ describe("CK base-queue counters", () => {
           testOptions.keys.queueCurrentDequeuedKeyFromQueue(variantA),
           testOptions.keys.envCurrentDequeuedKey(authenticatedEnvDev),
           runningCounterKey,
-          "phantom-message"
+          testOptions.keys.ckIndexKeyFromQueue(variantA),
+          "phantom-message",
+          "runqueue:test:"
         );
 
         expect(Number(await queue.redis.get(runningCounterKey))).toBe(0);
@@ -344,8 +346,8 @@ describe("CK base-queue counters", () => {
           "task/my-task"
         );
         const ttl = await queue.redis.ttl(counterKey);
-        // Expect roughly 86400; allow slack for test scheduling.
-        expect(ttl).toBeGreaterThan(86000);
+        // Expect roughly 86400; allow only a few seconds of slack for test scheduling.
+        expect(ttl).toBeGreaterThanOrEqual(86390);
         expect(ttl).toBeLessThanOrEqual(86400);
       } finally {
         await queue.quit();
@@ -377,6 +379,74 @@ describe("CK base-queue counters", () => {
         });
 
         expect(await queue.lengthOfQueue(authenticatedEnvDev, msg.queue)).toBe(1);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
+    "duplicate nack (runId already in variant zset) does not inflate lengthCounter",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer);
+      try {
+        const msg = makeMessage({ runId: "r1", concurrencyKey: "ck-a" });
+
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: msg,
+          workerQueue: authenticatedEnvDev.id,
+          skipDequeueProcessing: true,
+        });
+        expect(await queue.lengthOfQueue(authenticatedEnvDev, msg.queue)).toBe(1);
+
+        // Nack without dequeuing first — the message is still in the variant zset.
+        // ZADD returns 0 (already present), so lengthCounter must not bump.
+        await queue.nackMessage({
+          orgId: msg.orgId,
+          messageId: msg.runId,
+          skipDequeueProcessing: true,
+          incrementAttemptCount: false,
+        });
+        expect(await queue.lengthOfQueue(authenticatedEnvDev, msg.queue)).toBe(1);
+
+        // A second nack on the same runId must still be a no-op for the counter.
+        await queue.nackMessage({
+          orgId: msg.orgId,
+          messageId: msg.runId,
+          skipDequeueProcessing: true,
+          incrementAttemptCount: false,
+        });
+        expect(await queue.lengthOfQueue(authenticatedEnvDev, msg.queue)).toBe(1);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
+    "duplicate dequeueMessageFromKey (same runId) does not inflate runningCounter",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer);
+      try {
+        const msg = makeMessage({ runId: "r1", concurrencyKey: "ck-a" });
+        const queueKey = testOptions.keys.queueKey(authenticatedEnvDev, msg.queue, "ck-a");
+        const messageKey = testOptions.keys.messageKey(msg.orgId, msg.runId);
+        const runningCounterKey =
+          testOptions.keys.queueRunningCounterKeyFromQueue(queueKey);
+
+        await queue.redis.set(
+          messageKey,
+          JSON.stringify({ ...msg, queue: queueKey, version: "2", workerQueue: "wq" })
+        );
+
+        // First call: SADD returns 1, runningCounter goes 0 -> 1.
+        await queue.redis.dequeueMessageFromKeyTracked(messageKey, "runqueue:test:");
+        expect(Number(await queue.redis.get(runningCounterKey))).toBe(1);
+
+        // Second call on the same messageKey: SADD returns 0, runningCounter must stay at 1.
+        await queue.redis.dequeueMessageFromKeyTracked(messageKey, "runqueue:test:");
+        expect(Number(await queue.redis.get(runningCounterKey))).toBe(1);
       } finally {
         await queue.quit();
       }

--- a/internal-packages/run-engine/src/run-queue/types.ts
+++ b/internal-packages/run-engine/src/run-queue/types.ts
@@ -131,6 +131,12 @@ export interface RunQueueKeyProducer {
   baseQueueKeyFromQueue(queue: string): string;
   isCkWildcard(queue: string): boolean;
   toCkWildcard(queue: string): string;
+
+  // Per-base-queue counters for CK queues
+  queueLengthCounterKey(env: RunQueueKeyProducerEnvironment, queue: string): string;
+  queueLengthCounterKeyFromQueue(queue: string): string;
+  queueRunningCounterKey(env: RunQueueKeyProducerEnvironment, queue: string): string;
+  queueRunningCounterKeyFromQueue(queue: string): string;
 }
 
 export type EnvQueues = {

--- a/references/hello-world/src/trigger/ckCounters.ts
+++ b/references/hello-world/src/trigger/ckCounters.ts
@@ -1,0 +1,101 @@
+import { logger, queue, task } from "@trigger.dev/sdk";
+import { setTimeout } from "node:timers/promises";
+
+async function tryCatch<T>(
+  promise: Promise<T>
+): Promise<[Error, undefined] | [undefined, T]> {
+  try {
+    return [undefined, await promise];
+  } catch (err) {
+    return [err instanceof Error ? err : new Error(String(err)), undefined];
+  }
+}
+
+// Slow CK queue: concurrency=2 so only 2 run at a time, the rest pile up in the
+// per-CK-variant zsets. The Tracked Lua scripts should keep the per-base-queue
+// lengthCounter in sync; before the fix, the dashboard's "Queued" column and the
+// `validateQueueLimits` cap would read 0 from the empty base zset.
+const ckCountersQueue = queue({
+  name: "ck-counters-test-queue",
+  concurrencyLimit: 2,
+});
+
+// Slow worker — sleeps long enough to leave a backlog visible during inspection.
+export const ckCountersWorker = task({
+  id: "ck-counters-worker",
+  queue: ckCountersQueue,
+  retry: { maxAttempts: 1 },
+  run: async (payload: { id: string; waitMs: number }) => {
+    logger.info(`ck-counters-worker ${payload.id} started`);
+    await setTimeout(payload.waitMs);
+    logger.info(`ck-counters-worker ${payload.id} finished`);
+    return { id: payload.id };
+  },
+});
+
+// Drives a deterministic backlog:
+//   2 CKs (alpha, beta), 5 runs per CK, waitMs configurable.
+//   With concurrency=2, 2 of them run while ~8 sit in the CK-variant zsets.
+//   Inspect Redis during the wait to verify counters.
+export const ckCountersBacklog = task({
+  id: "ck-counters-backlog",
+  retry: { maxAttempts: 1 },
+  maxDuration: 600,
+  run: async (payload: {
+    ckCount?: number;
+    perCk?: number;
+    waitMs?: number;
+    inspectSeconds?: number;
+  }) => {
+    const ckCount = payload.ckCount ?? 2;
+    const perCk = payload.perCk ?? 5;
+    const waitMs = payload.waitMs ?? 30_000;
+    const inspectSeconds = payload.inspectSeconds ?? 0;
+
+    const total = ckCount * perCk;
+    logger.info("ck-counters-backlog triggering child runs", {
+      ckCount,
+      perCk,
+      waitMs,
+      total,
+    });
+
+    let triggered = 0;
+    let rejected = 0;
+    const rejectionMessages: string[] = [];
+
+    for (let c = 0; c < ckCount; c++) {
+      const ck = `ck-${String.fromCharCode(97 + c)}`;
+      for (let i = 0; i < perCk; i++) {
+        const [err, handle] = await tryCatch(
+          ckCountersWorker.trigger(
+            { id: `${ck}-${i}`, waitMs },
+            { concurrencyKey: ck }
+          )
+        );
+
+        if (err) {
+          rejected += 1;
+          rejectionMessages.push(`${ck}-${i}: ${err.message}`);
+          logger.warn(`Trigger rejected for ${ck}-${i}`, { error: err.message });
+        } else {
+          triggered += 1;
+          logger.info(`Triggered ${ck}-${i}`, { runId: handle?.id });
+        }
+      }
+    }
+
+    logger.info("ck-counters-backlog done triggering", {
+      triggered,
+      rejected,
+      rejectionMessages,
+    });
+
+    if (inspectSeconds > 0) {
+      logger.info(`Holding parent open for ${inspectSeconds}s for inspection…`);
+      await setTimeout(inspectSeconds * 1000);
+    }
+
+    return { triggered, rejected, rejectionMessages };
+  },
+});


### PR DESCRIPTION
## Summary

Queues that use concurrency keys can no longer bypass the per-queue length cap, and the "Queued | Running" columns in the dashboard now show the true total across all CK variants instead of 0.

The cap and the dashboard both relied on `ZCARD` of the base queue key, but CK-keyed runs live under `<base>:ck:<variant>` keys. Any queue that used concurrency keys read 0 — letting a single CK variant grow unbounded past the user's configured cap.

## Fix

Two per-base-queue counters are maintained inside the CK Lua scripts: `<base>:lengthCounter` and `<base>:runningCounter`. Non-CK enqueue/dequeue paths are untouched.

Counters are lazy-initialized the first time a CK enqueue (or nack) lands on a queue: the Lua script sums `ZCARD` across the variants tracked by `ckIndex`, sets the counter, then `INCR`s. Pre-existing CK backlog on already-populated queues is captured automatically — no batch migration required.

`INCR`/`DECR` is gated on `ZADD`/`SADD` returning 1 (a new entry vs an idempotent no-op), so duplicate enqueues or re-dequeues don't inflate the counter.

The counter is `SET` with a 24-hour TTL on init. `INCR`/`DECR` do not extend the TTL, so the counter expires daily and the next CK operation re-seeds it from `ckIndex`. This bounds any drift that accumulates during the rolling-deploy overlap window — where old (un-Tracked) and new (Tracked) webapp instances briefly coexist — to ≤24 hours, with no admin sweep or background reconciler needed.

Read paths pipeline `ZCARD`/`SCARD` on the base key + `GET` on the counter and sum. A missing counter is treated as 0, so pure non-CK queues see the same answer as before.

The counter-aware scripts ship alongside the originals with a `Tracked` suffix for rolling-deploy safety; a follow-up PR will drop the originals once this has rolled out.

## Test plan

- [ ] `pnpm run test --filter @internal/run-engine` — 116 tests pass, including a new `ckCounters.test.ts` covering lazy init from pre-existing backlog, churn, floor-at-zero, the non-CK regression case, mixed CK + non-CK on the same base queue, idempotent re-enqueue (ZADD-already-exists), 24h TTL on the counter, and nack re-seeding after counter expiry.
- [ ] Verified end-to-end against a live local environment:
  - Triggered 24 CK enqueues across 4 variants → `lengthCounter=16`, `runningCounter=8`, dashboard showed Queued=16 / Running=8 for the CK queue.
  - Set the env queue cap to 16, triggered 12 more enqueues → 8 succeeded, 4 rejected with `QueueSizeLimitExceededError`.
  - Deleted the counter on a queue with 31 messages already sitting in CK variants, triggered one more enqueue → counter materialized to 31 from the `ckIndex` sum, then INCR'd.