### PR TITLE
fix(core): use Promise.allSettled in TracingSDK flush/shutdown

### DIFF
--- a/.changeset/fix-tracing-sdk-flush.md
+++ b/.changeset/fix-tracing-sdk-flush.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Fixed TracingSDK.flush() and shutdown() to use Promise.allSettled instead of Promise.all, preventing one provider's rejection from abandoning the other providers' in-flight exports. This fixes an issue where user-emitted trace data (logger.info calls, child spans) could be silently dropped on shutdown when any provider fails to flush.

--- a/packages/core/src/v3/otel/tracingSDK.ts
+++ b/packages/core/src/v3/otel/tracingSDK.ts
@@ -369,19 +369,31 @@ export class TracingSDK {
   }
 
   public async flush() {
-    await Promise.all([
+    const results = await Promise.allSettled([
       this._traceProvider.forceFlush(),
       this._logProvider.forceFlush(),
       this._meterProvider.forceFlush(),
     ]);
+    const providerNames = ["trace", "log", "meter"] as const;
+    results.forEach((result, index) => {
+      if (result.status === "rejected") {
+        console.error(`Failed to flush ${providerNames[index]} provider:`, result.reason);
+      }
+    });
   }
 
   public async shutdown() {
-    await Promise.all([
+    const results = await Promise.allSettled([
       this._traceProvider.shutdown(),
       this._logProvider.shutdown(),
       this._meterProvider.shutdown(),
     ]);
+    const providerNames = ["trace", "log", "meter"] as const;
+    results.forEach((result, index) => {
+      if (result.status === "rejected") {
+        console.error(`Failed to shutdown ${providerNames[index]} provider:`, result.reason);
+      }
+    });
   }
 }
 

--- a/packages/core/src/v3/otel/tracingSDK.ts
+++ b/packages/core/src/v3/otel/tracingSDK.ts
@@ -376,14 +376,15 @@ export class TracingSDK {
     ]);
     const providerNames = ["trace", "log", "meter"] as const;
     const errors: Error[] = [];
+    const failedNames: string[] = [];
     results.forEach((result, index) => {
       if (result.status === "rejected") {
-        console.error(`Failed to flush ${providerNames[index]} provider:`, result.reason);
+        failedNames.push(providerNames[index]);
         errors.push(result.reason instanceof Error ? result.reason : new Error(String(result.reason)));
       }
     });
     if (errors.length > 0) {
-      throw new AggregateError(errors, "One or more providers failed to flush");
+      throw new AggregateError(errors, `One or more providers failed to flush: ${failedNames.join(", ")}`);
     }
   }
 
@@ -395,14 +396,15 @@ export class TracingSDK {
     ]);
     const providerNames = ["trace", "log", "meter"] as const;
     const errors: Error[] = [];
+    const failedNames: string[] = [];
     results.forEach((result, index) => {
       if (result.status === "rejected") {
-        console.error(`Failed to shutdown ${providerNames[index]} provider:`, result.reason);
+        failedNames.push(providerNames[index]);
         errors.push(result.reason instanceof Error ? result.reason : new Error(String(result.reason)));
       }
     });
     if (errors.length > 0) {
-      throw new AggregateError(errors, "One or more providers failed to shutdown");
+      throw new AggregateError(errors, `One or more providers failed to shutdown: ${failedNames.join(", ")}`);
     }
   }
 }

--- a/packages/core/src/v3/otel/tracingSDK.ts
+++ b/packages/core/src/v3/otel/tracingSDK.ts
@@ -375,11 +375,16 @@ export class TracingSDK {
       this._meterProvider.forceFlush(),
     ]);
     const providerNames = ["trace", "log", "meter"] as const;
+    const errors: Error[] = [];
     results.forEach((result, index) => {
       if (result.status === "rejected") {
         console.error(`Failed to flush ${providerNames[index]} provider:`, result.reason);
+        errors.push(result.reason instanceof Error ? result.reason : new Error(String(result.reason)));
       }
     });
+    if (errors.length > 0) {
+      throw new AggregateError(errors, "One or more providers failed to flush");
+    }
   }
 
   public async shutdown() {
@@ -389,11 +394,16 @@ export class TracingSDK {
       this._meterProvider.shutdown(),
     ]);
     const providerNames = ["trace", "log", "meter"] as const;
+    const errors: Error[] = [];
     results.forEach((result, index) => {
       if (result.status === "rejected") {
         console.error(`Failed to shutdown ${providerNames[index]} provider:`, result.reason);
+        errors.push(result.reason instanceof Error ? result.reason : new Error(String(result.reason)));
       }
     });
+    if (errors.length > 0) {
+      throw new AggregateError(errors, "One or more providers failed to shutdown");
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Switch `TracingSDK.flush()` and `shutdown()` from `Promise.all` to `Promise.allSettled`
- Prevents one provider's rejection from abandoning other providers' in-flight exports
- Adds per-provider error logging for better debugging

Fixes #3556

## Test plan

- [ ] Deploy to self-hosted environment with `processKeepAliveEnabled: false`
- [ ] Run task with `logger.info()` calls and verify they appear in trace
- [ ] Verify no "Failed to flush tracingSDK" errors in runner logs
