### PR TITLE
feat(webapp): preserve admin tabs search query between Users and Organizations

### DIFF
--- a/.server-changes/admin-tabs-preserve-search.md
+++ b/.server-changes/admin-tabs-preserve-search.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+Preserve search string when switching between the Users and Organizations tabs in the admin dashboard.

--- a/apps/webapp/app/routes/admin.tsx
+++ b/apps/webapp/app/routes/admin.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "@remix-run/react";
+import { Outlet, useSearchParams } from "@remix-run/react";
 import { typedjson } from "remix-typedjson";
 import { LinkButton } from "~/components/primitives/Buttons";
 import { Tabs } from "~/components/primitives/Tabs";
@@ -10,6 +10,10 @@ export const loader = dashboardLoader(
 );
 
 export default function Page() {
+  const [searchParams] = useSearchParams();
+  const search = searchParams.get("search");
+  const searchSuffix = search ? `?search=${encodeURIComponent(search)}` : "";
+
   return (
     <div className="h-full w-full">
       <div className="flex items-center justify-between p-4">
@@ -17,11 +21,11 @@ export default function Page() {
           tabs={[
             {
               label: "Users",
-              to: "/admin",
+              to: `/admin${searchSuffix}`,
             },
             {
               label: "Organizations",
-              to: "/admin/orgs",
+              to: `/admin/orgs${searchSuffix}`,
             },
             {
               label: "Concurrency",


### PR DESCRIPTION
Switching between the Users and Organizations tabs in the admin dashboard now keeps the current `?search=` value, so you can flip between the two without re-typing your filter. Other admin tabs don't take `search` and so don't carry it.