### PR TITLE
ci: skip typecheck for workflow-only PRs

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -33,7 +33,9 @@ jobs:
               - '!docs/**'
               - '!.changeset/**'
               - '!hosting/**'
-              - '!.github/workflows/helm-prerelease.yml'
+              - '!.github/**'
+              - '.github/workflows/pr_checks.yml'
+              - '.github/workflows/typecheck.yml'
             webapp:
               - 'apps/webapp/**'
               - 'packages/**'


### PR DESCRIPTION
The `code` paths filter currently matches `**` minus a tiny exclusion list, so a PR that only touches `.github/workflows/*.yml` still flips `code == true` and runs typecheck (~2 min on the runner).

Exclude `.github/**` from `code`, then re-include just `pr_checks.yml` and `typecheck.yml` so a change to either of those still triggers the full code check matrix.

Effect:
- workflow-only PRs (this one, future dependabot/codeql/etc.) skip typecheck; `all-checks` treats the skipped job as non-failure so the required status passes.
- modifying `pr_checks.yml` or `typecheck.yml` themselves still triggers typecheck.
- the existing per-suite filters (`webapp`, `packages`, `internal`, `cli`, `sdk`) already re-include the specific workflows that gate them, so they're unaffected.