### PR TITLE
fix(webapp): cap AI SDK OTel attribute size so ClickHouse JSON parse doesn't drop spans

### DIFF
--- a/.server-changes/otel-ai-sdk-attribute-truncation.md
+++ b/.server-changes/otel-ai-sdk-attribute-truncation.md
@@ -1,0 +1,21 @@
+---
+area: webapp
+type: fix
+---
+
+Tighten OTel span attribute truncation for Vercel AI SDK content keys
+(`ai.prompt*`, `ai.response.text/object/toolCalls/reasoning*`,
+`gen_ai.prompt`, `gen_ai.completion`, `gen_ai.request.messages`,
+`gen_ai.response.text`) to a 1KB per-attribute cap, plus a 32KB per-span
+backstop that drops these content keys in priority order if the assembled
+attributes JSON still exceeds it. Cost/token metadata (`ai.usage.*`,
+`ai.model.*`, `gen_ai.usage.*`, `gen_ai.response.model`, etc.) keeps the
+default 8KB cap so LLM enrichment continues to work.
+
+Extends the same truncation to span events' attributes. AI SDK telemetry
+emits one span event per conversation turn (`gen_ai.system.message`,
+`gen_ai.user.message`, etc.) carrying message content as event attributes,
+which previously flowed into ClickHouse uncapped because
+`spanEventsToEventEvents` did not run them through `truncateAttributes`.
+That field was the actual source of the oversized rows breaking the
+ClickHouse JSON parser and dropping whole batches.

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -498,6 +498,17 @@ const EnvironmentSchema = z
     TRIGGER_OTEL_ATTRIBUTE_PER_LINK_COUNT_LIMIT: z.string().default("10"),
     TRIGGER_OTEL_ATTRIBUTE_PER_EVENT_COUNT_LIMIT: z.string().default("10"),
 
+    // Server-side OTel ingestion limits applied in otlpExporter.server.ts.
+    // Default per-attribute cap (8KB) is enough for nearly all keys, but
+    // Vercel AI SDK content keys (ai.prompt*, ai.response.text/object/etc.,
+    // gen_ai.prompt, gen_ai.completion) carry tens of KB and have a tighter
+    // dedicated cap. The total cap is a backstop applied to the assembled
+    // attributes JSON; if exceeded, AI content keys are dropped in priority
+    // order. Both prevent oversized JSON from breaking ClickHouse inserts.
+    SERVER_OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT: z.coerce.number().int().default(8192),
+    SERVER_OTEL_AI_CONTENT_ATTRIBUTE_VALUE_LENGTH_LIMIT: z.coerce.number().int().default(1024),
+    SERVER_OTEL_SPAN_TOTAL_ATTRIBUTES_LENGTH_LIMIT: z.coerce.number().int().default(32768),
+
     CHECKPOINT_THRESHOLD_IN_MS: z.coerce.number().int().default(30000),
 
     // Internal OTEL environment variables

--- a/apps/webapp/app/v3/dynamicFlushScheduler.server.ts
+++ b/apps/webapp/app/v3/dynamicFlushScheduler.server.ts
@@ -196,11 +196,11 @@ export class DynamicFlushScheduler<T> {
     // Schedule all batches for concurrent processing
     const flushPromises = batchesToFlush.map((batch) =>
       this.limiter(async () => {
-        const itemCount = batch.length;
-
         const self = this;
 
         async function tryFlush(flushId: string, batchToFlush: T[], attempt: number = 1) {
+          const itemCount = batchToFlush.length;
+
           try {
             const startTime = Date.now();
             await self.callback(flushId, batchToFlush);

--- a/apps/webapp/app/v3/otlpAttributeLimits.ts
+++ b/apps/webapp/app/v3/otlpAttributeLimits.ts
@@ -1,0 +1,207 @@
+/**
+ * Pure helpers for OTel attribute truncation and per-span size capping.
+ * Lives in a separate module from `otlpExporter.server.ts` so tests can
+ * import the helpers without dragging in the env-parsing side effect of
+ * the server module's transitive dependencies.
+ */
+
+export type AttributeValue = string | number | boolean | undefined;
+export type AttributeMap = Record<string, AttributeValue>;
+
+/**
+ * Per-key cap overrides for `truncateAttributes`. A key matches an override
+ * when `key === prefix` or `key.startsWith(prefix + ".")` — i.e. the prefix
+ * covers the attribute itself and any dotted children. First matching entry
+ * wins; later entries are ignored.
+ */
+export type AttributeKeyOverride = { prefix: string; limit: number };
+
+export type SpanAttributeLimits = {
+  /** Per-attribute cap applied to every string-valued attribute. */
+  defaultValueLengthLimit: number;
+  /**
+   * Per-attribute cap applied only to known Vercel AI SDK content keys.
+   * These attributes (`ai.prompt*`, `ai.response.text/object/toolCalls/reasoning*`,
+   * `gen_ai.prompt`, `gen_ai.completion`, `gen_ai.request.messages`,
+   * `gen_ai.response.text`) routinely carry tens of KB of user prompt or
+   * model response, which is enough to push the assembled per-row JSON past
+   * ClickHouse's parse tolerance even after the default 8KB cap.
+   */
+  aiContentValueLengthLimit: number;
+  /**
+   * Backstop: if the serialized size of all truncated attributes still
+   * exceeds this many bytes, the AI content keys are dropped in priority
+   * order until the assembled JSON is under budget. Cost/token metadata is
+   * preserved.
+   */
+  totalAttributesLengthLimit: number;
+};
+
+/**
+ * Vercel AI SDK content keys to cap aggressively. Keep cost/token metadata
+ * out of this list — `ai.usage.*`, `ai.model.*`, `ai.operationId`,
+ * `ai.settings.*`, `ai.telemetry.*`, `gen_ai.usage.*`,
+ * `gen_ai.response.model`, `gen_ai.request.model`, `gen_ai.system`, and
+ * `gen_ai.operation.name` are needed by `enrichCreatableEvents` for cost
+ * and LLM enrichment.
+ */
+export const AI_CONTENT_KEY_OVERRIDES = (limit: number): AttributeKeyOverride[] => [
+  // `ai.prompt` covers `ai.prompt`, `ai.prompt.messages`, `ai.prompt.format`,
+  // `ai.prompt.tools`, `ai.prompt.toolChoice`, `ai.prompt.system`.
+  { prefix: "ai.prompt", limit },
+  { prefix: "ai.response.text", limit },
+  { prefix: "ai.response.object", limit },
+  { prefix: "ai.response.toolCalls", limit },
+  { prefix: "ai.response.reasoning", limit },
+  { prefix: "ai.response.reasoningDetails", limit },
+  { prefix: "gen_ai.prompt", limit },
+  { prefix: "gen_ai.completion", limit },
+  { prefix: "gen_ai.request.messages", limit },
+  { prefix: "gen_ai.response.text", limit },
+];
+
+/**
+ * Priority list of keys to drop when the assembled attributes JSON exceeds
+ * the total-size budget. Higher up = dropped first. Each entry is a prefix
+ * (same semantics as `AttributeKeyOverride`).
+ */
+export const AI_CONTENT_DROP_PRIORITY: string[] = [
+  "ai.prompt.messages",
+  "ai.prompt",
+  "ai.response.object",
+  "ai.response.text",
+  "ai.response.toolCalls",
+  "ai.response.reasoning",
+  "ai.response.reasoningDetails",
+  "gen_ai.prompt",
+  "gen_ai.completion",
+  "gen_ai.request.messages",
+  "gen_ai.response.text",
+];
+
+function matchKeyOverride(
+  key: string,
+  overrides: AttributeKeyOverride[] | undefined
+): AttributeKeyOverride | undefined {
+  if (!overrides) return undefined;
+  for (const override of overrides) {
+    if (key === override.prefix || key.startsWith(override.prefix + ".")) {
+      return override;
+    }
+  }
+  return undefined;
+}
+
+export function truncateAttributes(
+  attributes: AttributeMap | undefined,
+  maximumLength: number = 1024,
+  keyOverrides?: AttributeKeyOverride[]
+): AttributeMap | undefined {
+  if (!attributes) return undefined;
+
+  const truncatedAttributes: AttributeMap = {};
+
+  for (const [key, value] of Object.entries(attributes)) {
+    if (!key) continue;
+
+    if (typeof value === "string") {
+      const override = matchKeyOverride(key, keyOverrides);
+      const limit = override ? override.limit : maximumLength;
+      truncatedAttributes[key] = truncateAndDetectUnpairedSurrogate(value, limit);
+    } else {
+      truncatedAttributes[key] = value;
+    }
+  }
+
+  return truncatedAttributes;
+}
+
+/**
+ * Backstop applied after per-attribute truncation. If `JSON.stringify(attrs)`
+ * is still over `maxBytes`, walk `AI_CONTENT_DROP_PRIORITY` and remove any
+ * attributes that match (by `key === prefix` or `key.startsWith(prefix + ".")`)
+ * until the assembled size is under budget or the list is exhausted.
+ *
+ * Returns the original `attributes` reference unchanged when already under
+ * budget; otherwise returns a new object with the offending keys removed.
+ *
+ * If the size is still over budget after exhausting the drop list, calls
+ * `onResidualOverflow` (if provided) with the remaining size so the caller
+ * can log it. Downstream protection lives in
+ * `DynamicFlushScheduler.tryFlush`'s batch-split branch.
+ */
+export function capAssembledAttributesSize(
+  attributes: AttributeMap | undefined,
+  maxBytes: number,
+  onResidualOverflow?: (info: { remainingBytes: number; maxBytes: number }) => void
+): AttributeMap {
+  if (!attributes) return {};
+  if (maxBytes <= 0) return attributes;
+
+  let serialized = JSON.stringify(attributes);
+  if (serialized.length <= maxBytes) return attributes;
+
+  const result: AttributeMap = { ...attributes };
+
+  for (const prefix of AI_CONTENT_DROP_PRIORITY) {
+    for (const key of Object.keys(result)) {
+      if (key === prefix || key.startsWith(prefix + ".")) {
+        delete result[key];
+      }
+    }
+    serialized = JSON.stringify(result);
+    if (serialized.length <= maxBytes) return result;
+  }
+
+  onResidualOverflow?.({ remainingBytes: serialized.length, maxBytes });
+  return result;
+}
+
+function truncateAndDetectUnpairedSurrogate(str: string, maximumLength: number): string {
+  const truncatedString = smartTruncateString(str, maximumLength);
+
+  if (hasUnpairedSurrogateAtEnd(truncatedString)) {
+    return smartTruncateString(truncatedString, [...truncatedString].length - 1);
+  }
+
+  return truncatedString;
+}
+
+const ASCII_ONLY_REGEX = /^[\p{ASCII}]*$/u;
+
+function smartTruncateString(str: string, maximumLength: number): string {
+  if (!str) return "";
+  if (str.length <= maximumLength) return str;
+
+  const checkLength = Math.min(str.length, maximumLength * 2 + 2);
+
+  if (ASCII_ONLY_REGEX.test(str.slice(0, checkLength))) {
+    return str.slice(0, maximumLength);
+  }
+
+  return [...str.slice(0, checkLength)].slice(0, maximumLength).join("");
+}
+
+function hasUnpairedSurrogateAtEnd(str: string): boolean {
+  if (str.length === 0) return false;
+
+  const lastCode = str.charCodeAt(str.length - 1);
+
+  // Check if last character is an unpaired high surrogate
+  if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+    return true; // High surrogate at end = unpaired
+  }
+
+  // Check if last character is an unpaired low surrogate
+  if (lastCode >= 0xdc00 && lastCode <= 0xdfff) {
+    // Low surrogate is only valid if preceded by high surrogate
+    if (str.length === 1) return true; // Single low surrogate
+
+    const secondLastCode = str.charCodeAt(str.length - 2);
+    if (secondLastCode < 0xd800 || secondLastCode > 0xdbff) {
+      return true; // Low surrogate not preceded by high surrogate
+    }
+  }
+
+  return false;
+}

--- a/apps/webapp/app/v3/otlpExporter.server.ts
+++ b/apps/webapp/app/v3/otlpExporter.server.ts
@@ -41,6 +41,12 @@ import { waitForLlmPricingReady } from "./llmPricingRegistry.server";
 import { env } from "~/env.server";
 import { detectBadJsonStrings } from "~/utils/detectBadJsonStrings";
 import { singleton } from "~/utils/singleton";
+import {
+  AI_CONTENT_KEY_OVERRIDES,
+  capAssembledAttributesSize,
+  truncateAttributes,
+  type SpanAttributeLimits,
+} from "./otlpAttributeLimits";
 
 class OTLPExporter {
   private _tracer: Tracer;
@@ -51,7 +57,7 @@ class OTLPExporter {
     private readonly _clickhouseEventRepositoryV2: ClickhouseEventRepository,
     private readonly _metricsFlushScheduler: DynamicFlushScheduler<MetricsV1Input>,
     private readonly _verbose: boolean,
-    private readonly _spanAttributeValueLengthLimit: number
+    private readonly _attributeLimits: SpanAttributeLimits
   ) {
     this._tracer = trace.getTracer("otlp-exporter");
   }
@@ -62,7 +68,7 @@ class OTLPExporter {
 
       const eventsWithStores = this.#filterResourceSpans(request.resourceSpans).flatMap(
         (resourceSpan) => {
-          return convertSpansToCreateableEvents(resourceSpan, this._spanAttributeValueLengthLimit);
+          return convertSpansToCreateableEvents(resourceSpan, this._attributeLimits);
         }
       );
 
@@ -82,7 +88,7 @@ class OTLPExporter {
         (resourceMetrics) => {
           return convertMetricsToClickhouseRows(
             resourceMetrics,
-            this._spanAttributeValueLengthLimit
+            this._attributeLimits.defaultValueLengthLimit
           );
         }
       );
@@ -103,7 +109,7 @@ class OTLPExporter {
 
       const eventsWithStores = this.#filterResourceLogs(request.resourceLogs).flatMap(
         (resourceLog) => {
-          return convertLogsToCreateableEvents(resourceLog, this._spanAttributeValueLengthLimit);
+          return convertLogsToCreateableEvents(resourceLog, this._attributeLimits);
         }
       );
 
@@ -250,12 +256,13 @@ class OTLPExporter {
 
 function convertLogsToCreateableEvents(
   resourceLog: ResourceLogs,
-  spanAttributeValueLengthLimit: number
+  attributeLimits: SpanAttributeLimits
 ): { events: Array<CreateEventInput>; taskEventStore: string } {
   const resourceAttributes = resourceLog.resource?.attributes ?? [];
 
   const resourceProperties = extractEventProperties(resourceAttributes);
 
+  // Resource attributes don't carry AI SDK content; no per-key overrides needed.
   const userDefinedResourceAttributes = truncateAttributes(
     convertKeyValueItemsToMap(resourceAttributes ?? [], [], undefined, [
       SemanticInternalAttributes.USAGE,
@@ -271,7 +278,7 @@ function convertLogsToCreateableEvents(
       "cli",
       "cloud",
     ]),
-    spanAttributeValueLengthLimit
+    attributeLimits.defaultValueLengthLimit
   );
 
   const taskEventStore =
@@ -292,7 +299,7 @@ function convertLogsToCreateableEvents(
           SemanticInternalAttributes.METADATA
         );
 
-        const properties =
+        const properties = capAssembledAttributesSize(
           truncateAttributes(
             convertKeyValueItemsToMap(log.attributes ?? [], [], undefined, [
               SemanticInternalAttributes.USAGE,
@@ -302,8 +309,11 @@ function convertLogsToCreateableEvents(
               SemanticInternalAttributes.METRIC_EVENTS,
               SemanticInternalAttributes.TRIGGER,
             ]),
-            spanAttributeValueLengthLimit
-          ) ?? {};
+            attributeLimits.defaultValueLengthLimit,
+            AI_CONTENT_KEY_OVERRIDES(attributeLimits.aiContentValueLengthLimit)
+          ) ?? {},
+          attributeLimits.totalAttributesLengthLimit
+        );
 
         return {
           traceId: binaryToHex(log.traceId),
@@ -351,12 +361,13 @@ function convertLogsToCreateableEvents(
 
 function convertSpansToCreateableEvents(
   resourceSpan: ResourceSpans,
-  spanAttributeValueLengthLimit: number
+  attributeLimits: SpanAttributeLimits
 ): { events: Array<CreateEventInput>; taskEventStore: string } {
   const resourceAttributes = resourceSpan.resource?.attributes ?? [];
 
   const resourceProperties = extractEventProperties(resourceAttributes);
 
+  // Resource attributes don't carry AI SDK content; no per-key overrides needed.
   const userDefinedResourceAttributes = truncateAttributes(
     convertKeyValueItemsToMap(resourceAttributes ?? [], [], undefined, [
       SemanticInternalAttributes.USAGE,
@@ -372,7 +383,7 @@ function convertSpansToCreateableEvents(
       "cli",
       "cloud",
     ]),
-    spanAttributeValueLengthLimit
+    attributeLimits.defaultValueLengthLimit
   );
 
   const taskEventStore =
@@ -395,7 +406,7 @@ function convertSpansToCreateableEvents(
 
         const runTags = extractArrayAttribute(span.attributes ?? [], SemanticInternalAttributes.RUN_TAGS);
 
-        const properties =
+        const properties = capAssembledAttributesSize(
           truncateAttributes(
             convertKeyValueItemsToMap(span.attributes ?? [], [], undefined, [
               SemanticInternalAttributes.USAGE,
@@ -405,8 +416,11 @@ function convertSpansToCreateableEvents(
               SemanticInternalAttributes.METRIC_EVENTS,
               SemanticInternalAttributes.TRIGGER,
             ]),
-            spanAttributeValueLengthLimit
-          ) ?? {};
+            attributeLimits.defaultValueLengthLimit,
+            AI_CONTENT_KEY_OVERRIDES(attributeLimits.aiContentValueLengthLimit)
+          ) ?? {},
+          attributeLimits.totalAttributesLengthLimit
+        );
 
         return {
           traceId: binaryToHex(span.traceId),
@@ -425,7 +439,7 @@ function convertSpansToCreateableEvents(
           level: "TRACE" as const,
           status: spanStatusToEventStatus(span.status),
           startTime: span.startTimeUnixNano,
-          events: spanEventsToEventEvents(span.events ?? []),
+          events: spanEventsToEventEvents(span.events ?? [], attributeLimits),
           duration: span.endTimeUnixNano - span.startTimeUnixNano,
           properties,
           resourceProperties: userDefinedResourceAttributes,
@@ -469,7 +483,7 @@ function floorToTenSecondBucket(timeUnixNano: bigint | number): string {
 
 function convertMetricsToClickhouseRows(
   resourceMetrics: ResourceMetrics,
-  spanAttributeValueLengthLimit: number
+  _spanAttributeValueLengthLimit: number
 ): MetricsV1Input[] {
   const resourceAttributes = resourceMetrics.resource?.attributes ?? [];
   const resourceProperties = extractEventProperties(resourceAttributes);
@@ -776,12 +790,29 @@ function detectPrimitiveValue(
   return attributes;
 }
 
-function spanEventsToEventEvents(events: Span_Event[]): CreateEventInput["events"] {
+function spanEventsToEventEvents(
+  events: Span_Event[],
+  attributeLimits: SpanAttributeLimits
+): CreateEventInput["events"] {
   return events.map((event) => {
+    // AI SDK telemetry emits one span event per conversation turn
+    // (`gen_ai.system.message`, `gen_ai.user.message`, etc.) with the message
+    // content carried as event attributes. Without the same truncation we
+    // apply to the main span attributes, those events push the row past
+    // ClickHouse's JSON parse tolerance and fail the whole insert.
+    const properties = capAssembledAttributesSize(
+      truncateAttributes(
+        convertKeyValueItemsToMap(event.attributes ?? []),
+        attributeLimits.defaultValueLengthLimit,
+        AI_CONTENT_KEY_OVERRIDES(attributeLimits.aiContentValueLengthLimit)
+      ) ?? {},
+      attributeLimits.totalAttributesLengthLimit
+    );
+
     return {
       name: event.name,
       time: convertUnixNanoToDate(event.timeUnixNano),
-      properties: convertKeyValueItemsToMap(event.attributes ?? []),
+      properties,
     };
   });
 }
@@ -1100,76 +1131,6 @@ function binaryToHex(buffer: Buffer | string | undefined): string | undefined {
   return Buffer.from(Array.from(buffer)).toString("hex");
 }
 
-function truncateAttributes(
-  attributes: Record<string, string | number | boolean | undefined> | undefined,
-  maximumLength: number = 1024
-): Record<string, string | number | boolean | undefined> | undefined {
-  if (!attributes) return undefined;
-
-  const truncatedAttributes: Record<string, string | number | boolean | undefined> = {};
-
-  for (const [key, value] of Object.entries(attributes)) {
-    if (!key) continue;
-
-    if (typeof value === "string") {
-      truncatedAttributes[key] = truncateAndDetectUnpairedSurrogate(value, maximumLength);
-    } else {
-      truncatedAttributes[key] = value;
-    }
-  }
-
-  return truncatedAttributes;
-}
-
-function truncateAndDetectUnpairedSurrogate(str: string, maximumLength: number): string {
-  const truncatedString = smartTruncateString(str, maximumLength);
-
-  if (hasUnpairedSurrogateAtEnd(truncatedString)) {
-    return smartTruncateString(truncatedString, [...truncatedString].length - 1);
-  }
-
-  return truncatedString;
-}
-
-const ASCII_ONLY_REGEX = /^[\p{ASCII}]*$/u;
-
-function smartTruncateString(str: string, maximumLength: number): string {
-  if (!str) return "";
-  if (str.length <= maximumLength) return str;
-
-  const checkLength = Math.min(str.length, maximumLength * 2 + 2);
-
-  if (ASCII_ONLY_REGEX.test(str.slice(0, checkLength))) {
-    return str.slice(0, maximumLength);
-  }
-
-  return [...str.slice(0, checkLength)].slice(0, maximumLength).join("");
-}
-
-function hasUnpairedSurrogateAtEnd(str: string): boolean {
-  if (str.length === 0) return false;
-
-  const lastCode = str.charCodeAt(str.length - 1);
-
-  // Check if last character is an unpaired high surrogate
-  if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
-    return true; // High surrogate at end = unpaired
-  }
-
-  // Check if last character is an unpaired low surrogate
-  if (lastCode >= 0xdc00 && lastCode <= 0xdfff) {
-    // Low surrogate is only valid if preceded by high surrogate
-    if (str.length === 1) return true; // Single low surrogate
-
-    const secondLastCode = str.charCodeAt(str.length - 2);
-    if (secondLastCode < 0xd800 || secondLastCode > 0xdbff) {
-      return true; // Low surrogate not preceded by high surrogate
-    }
-  }
-
-  return false;
-}
-
 export const otlpExporter = singleton("otlpExporter", initializeOTLPExporter);
 
 function initializeOTLPExporter() {
@@ -1184,14 +1145,18 @@ function initializeOTLPExporter() {
     loadSheddingEnabled: false,
   });
 
+  const attributeLimits: SpanAttributeLimits = {
+    defaultValueLengthLimit: env.SERVER_OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT,
+    aiContentValueLengthLimit: env.SERVER_OTEL_AI_CONTENT_ATTRIBUTE_VALUE_LENGTH_LIMIT,
+    totalAttributesLengthLimit: env.SERVER_OTEL_SPAN_TOTAL_ATTRIBUTES_LENGTH_LIMIT,
+  };
+
   return new OTLPExporter(
     eventRepository,
     clickhouseEventRepository,
     clickhouseEventRepositoryV2,
     metricsFlushScheduler,
     process.env.OTLP_EXPORTER_VERBOSE === "1",
-    process.env.SERVER_OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
-      ? parseInt(process.env.SERVER_OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT, 10)
-      : 8192
+    attributeLimits
   );
 }

--- a/apps/webapp/test/otlpAttributeLimits.test.ts
+++ b/apps/webapp/test/otlpAttributeLimits.test.ts
@@ -1,0 +1,194 @@
+import {
+  AI_CONTENT_DROP_PRIORITY,
+  AI_CONTENT_KEY_OVERRIDES,
+  capAssembledAttributesSize,
+  truncateAttributes,
+} from "~/v3/otlpAttributeLimits";
+
+describe("truncateAttributes", () => {
+  it("truncates string values to the default cap", () => {
+    const out = truncateAttributes({ "user.message": "x".repeat(10_000) }, 100);
+    expect(typeof out?.["user.message"]).toBe("string");
+    expect((out?.["user.message"] as string).length).toBeLessThanOrEqual(100);
+  });
+
+  it("leaves non-string values untouched", () => {
+    const out = truncateAttributes(
+      {
+        "user.count": 42,
+        "user.flag": true,
+        "user.missing": undefined,
+      },
+      100
+    );
+    expect(out?.["user.count"]).toBe(42);
+    expect(out?.["user.flag"]).toBe(true);
+    expect(out?.["user.missing"]).toBeUndefined();
+  });
+
+  it("applies a per-key override to matching prefix and dotted children", () => {
+    const overrides = [{ prefix: "ai.prompt", limit: 32 }];
+    const out = truncateAttributes(
+      {
+        "ai.prompt": "p".repeat(1000),
+        "ai.prompt.messages": "m".repeat(1000),
+        "ai.prompt.tools": "t".repeat(1000),
+        "ai.model.id": "claude-sonnet-4-20250514",
+      },
+      4096,
+      overrides
+    );
+    expect((out?.["ai.prompt"] as string).length).toBeLessThanOrEqual(32);
+    expect((out?.["ai.prompt.messages"] as string).length).toBeLessThanOrEqual(32);
+    expect((out?.["ai.prompt.tools"] as string).length).toBeLessThanOrEqual(32);
+    // Non-matching key keeps the default cap (well below it).
+    expect(out?.["ai.model.id"]).toBe("claude-sonnet-4-20250514");
+  });
+
+  it("first-matching override wins", () => {
+    const overrides = [
+      { prefix: "ai.prompt", limit: 8 },
+      { prefix: "ai.prompt.messages", limit: 1024 }, // shadowed
+    ];
+    const out = truncateAttributes(
+      { "ai.prompt.messages": "x".repeat(500) },
+      4096,
+      overrides
+    );
+    expect((out?.["ai.prompt.messages"] as string).length).toBeLessThanOrEqual(8);
+  });
+
+  it("does not match a key that only shares a prefix substring (no dot boundary)", () => {
+    const overrides = [{ prefix: "ai.prompt", limit: 8 }];
+    const out = truncateAttributes(
+      // "ai.prompts" should NOT match "ai.prompt"; the override requires
+      // exact match or a dot boundary.
+      { "ai.prompts": "x".repeat(500) },
+      4096,
+      overrides
+    );
+    expect((out?.["ai.prompts"] as string).length).toBe(500);
+  });
+
+  it("returns undefined when input is undefined", () => {
+    expect(truncateAttributes(undefined, 100)).toBeUndefined();
+  });
+});
+
+describe("AI_CONTENT_KEY_OVERRIDES", () => {
+  it("targets prompt content keys but not cost / model metadata", () => {
+    const overrides = AI_CONTENT_KEY_OVERRIDES(1024);
+    const prefixes = overrides.map((o) => o.prefix);
+
+    // Content keys we want capped.
+    expect(prefixes).toContain("ai.prompt");
+    expect(prefixes).toContain("ai.response.text");
+    expect(prefixes).toContain("ai.response.object");
+    expect(prefixes).toContain("ai.response.toolCalls");
+    expect(prefixes).toContain("gen_ai.prompt");
+    expect(prefixes).toContain("gen_ai.completion");
+    expect(prefixes).toContain("gen_ai.request.messages");
+
+    // Cost/model metadata MUST NOT be in the override list — those keys
+    // feed enrichCreatableEvents and the dashboard's LLM pills.
+    expect(prefixes).not.toContain("ai.usage");
+    expect(prefixes).not.toContain("ai.model");
+    expect(prefixes).not.toContain("ai.operationId");
+    expect(prefixes).not.toContain("ai.settings");
+    expect(prefixes).not.toContain("ai.telemetry");
+    expect(prefixes).not.toContain("gen_ai.usage");
+    expect(prefixes).not.toContain("gen_ai.response.model");
+    expect(prefixes).not.toContain("gen_ai.request.model");
+    expect(prefixes).not.toContain("gen_ai.system");
+    expect(prefixes).not.toContain("gen_ai.operation.name");
+
+    // Every override carries the limit we passed in.
+    for (const o of overrides) {
+      expect(o.limit).toBe(1024);
+    }
+  });
+});
+
+describe("capAssembledAttributesSize", () => {
+  it("is a no-op when input is already under budget", () => {
+    const input = {
+      "ai.prompt.messages": "small",
+      "ai.usage.input_tokens": 10,
+    };
+    const out = capAssembledAttributesSize(input, 4096);
+    expect(out).toEqual(input);
+  });
+
+  it("returns an empty object when input is undefined", () => {
+    expect(capAssembledAttributesSize(undefined, 4096)).toEqual({});
+  });
+
+  it("drops AI content keys in priority order until under budget", () => {
+    // Build a payload where the AI content alone overflows 2KB but cost
+    // metadata fits comfortably. After dropping `ai.prompt.messages` the
+    // remaining payload is well under budget, so subsequent priority
+    // entries should NOT be dropped.
+    const input = {
+      "ai.prompt.messages": "x".repeat(4000),
+      "ai.response.text": "y",
+      "ai.response.object": "z",
+      "ai.usage.input_tokens": 100,
+      "ai.usage.output_tokens": 50,
+      "gen_ai.response.model": "claude-sonnet-4-20250514",
+      "ai.model.id": "claude-sonnet-4-20250514",
+    } as Record<string, string | number | boolean | undefined>;
+
+    const out = capAssembledAttributesSize(input, 2048);
+
+    expect(out["ai.prompt.messages"]).toBeUndefined();
+    // Cost / model metadata is preserved.
+    expect(out["ai.usage.input_tokens"]).toBe(100);
+    expect(out["ai.usage.output_tokens"]).toBe(50);
+    expect(out["gen_ai.response.model"]).toBe("claude-sonnet-4-20250514");
+    expect(out["ai.model.id"]).toBe("claude-sonnet-4-20250514");
+    // Lower-priority content keys that weren't needed to fit the budget
+    // are preserved.
+    expect(out["ai.response.text"]).toBe("y");
+    expect(out["ai.response.object"]).toBe("z");
+    expect(JSON.stringify(out).length).toBeLessThanOrEqual(2048);
+  });
+
+  it("drops keys with dotted children matching a priority prefix", () => {
+    const input = {
+      "ai.prompt": "p".repeat(1000),
+      "ai.prompt.messages": "m".repeat(1000),
+      "ai.prompt.tools": "t".repeat(1000),
+      "ai.usage.input_tokens": 5,
+    } as Record<string, string | number | boolean | undefined>;
+
+    // Cap below the ai.prompt.* payload total so the whole prompt namespace
+    // gets dropped.
+    const out = capAssembledAttributesSize(input, 256);
+
+    expect(out["ai.prompt"]).toBeUndefined();
+    expect(out["ai.prompt.messages"]).toBeUndefined();
+    expect(out["ai.prompt.tools"]).toBeUndefined();
+    expect(out["ai.usage.input_tokens"]).toBe(5);
+  });
+
+  it("AI_CONTENT_DROP_PRIORITY puts highest-volume content first", () => {
+    // ai.prompt.messages is the heaviest in practice (full conversation
+    // history). It should be the first thing to go.
+    expect(AI_CONTENT_DROP_PRIORITY[0]).toBe("ai.prompt.messages");
+  });
+
+  it("preserves non-AI attributes regardless of priority list", () => {
+    const input = {
+      "user.event": "y".repeat(5000),
+      "ai.prompt.messages": "x".repeat(5000),
+    } as Record<string, string | number | boolean | undefined>;
+
+    const out = capAssembledAttributesSize(input, 1024);
+
+    expect(out["ai.prompt.messages"]).toBeUndefined();
+    // User-defined non-AI attribute stays even though it's the only thing
+    // pushing the budget. The drop list only covers AI content prefixes —
+    // we don't silently shrink customer data.
+    expect(typeof out["user.event"]).toBe("string");
+  });
+});


### PR DESCRIPTION
Tighten OTel span attribute truncation for Vercel AI SDK content keys
(`ai.prompt*`, `ai.response.text/object/toolCalls/reasoning*`,
`gen_ai.prompt`, `gen_ai.completion`, `gen_ai.request.messages`,
`gen_ai.response.text`) to a 1KB per-attribute cap, plus a 32KB per-span
backstop that drops these content keys in priority order if the
assembled attributes JSON still exceeds it. Cost/token metadata
(`ai.usage.*`, `ai.model.*`, `gen_ai.usage.*`, `gen_ai.response.model`,
etc.) keeps the default 8KB cap so LLM enrichment continues to work.

Extends the same truncation to span events' attributes. AI SDK
telemetry emits one span event per conversation turn
(`gen_ai.system.message`, `gen_ai.user.message`, etc.) carrying message
content as event attributes, which previously flowed into ClickHouse
uncapped because `spanEventsToEventEvents` did not run them through
`truncateAttributes`. That field was the actual source of the oversized
rows breaking the ClickHouse JSON parser and dropping whole batches.