### PR TITLE
ci: skip typecheck for refs and non-code file PRs

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -34,6 +34,9 @@ jobs:
               - '!.changeset/**'
               - '!hosting/**'
               - '!.github/**'
+              - '!references/**'
+              - '!**/*.md'
+              - '!**/.env.example'
               - '.github/workflows/pr_checks.yml'
               - '.github/workflows/typecheck.yml'
             webapp:


### PR DESCRIPTION
Follow-up to #3615. The `code` filter currently fires typecheck for any change outside `docs/`, `.changeset/`, `hosting/`, or `.github/` - so a docs-only PR like #3623 (touching `references/ai-chat/.env.example` + `README.md`) triggered the typecheck job. None of the `references/*` packages declare a `typecheck` script either, so even when a real code change lands there, `turbo run typecheck` skips them. Running the job is pure cost.

Tightens the filter to also exclude:

- `references/**` - playground projects, none of them contribute to `turbo run typecheck` today
- `**/*.md` - markdown anywhere
- `**/.env.example` - example env files anywhere

Two known gaps left open:

- references/ have no real CI typecheck coverage. Separate question - either add `typecheck` scripts to each (or top-level `tsc -p`), or accept playground status.
- `changes` job still runs (it's a path-filter step) but the dependent jobs all skip on irrelevant PRs.