### PR TITLE
fix(core): drop unique-symbol brand on LocalsKey to fix dual-package builds

### DIFF
--- a/.changeset/locals-key-dual-package-fix.md
+++ b/.changeset/locals-key-dual-package-fix.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Fix `LocalsKey<T>` type incompatibility across dual-package builds. The phantom value-type brand no longer uses a module-level `unique symbol`, so a single TypeScript compilation that resolves the type from both the ESM and CJS outputs (which can happen under certain pnpm hoisting layouts) no longer sees two structurally-incompatible variants of the same type.

--- a/packages/core/src/v3/locals/manager.ts
+++ b/packages/core/src/v3/locals/manager.ts
@@ -5,7 +5,7 @@ export class NoopLocalsManager implements LocalsManager {
     return {
       __type: Symbol(),
       id,
-    } as unknown as LocalsKey<T>;
+    };
   }
 
   getLocal<T>(key: LocalsKey<T>): T | undefined {
@@ -23,7 +23,7 @@ export class StandardLocalsManager implements LocalsManager {
     return {
       __type: key,
       id,
-    } as unknown as LocalsKey<T>;
+    };
   }
 
   getLocal<T>(key: LocalsKey<T>): T | undefined {

--- a/packages/core/src/v3/locals/types.ts
+++ b/packages/core/src/v3/locals/types.ts
@@ -1,10 +1,22 @@
-declare const __local: unique symbol;
-type BrandLocal<T> = { [__local]: T };
-
-// Create a type-safe store for your locals
-export type LocalsKey<T> = BrandLocal<T> & {
+/**
+ * A type-safe key for `locals`. Carries the value type `T` as a phantom
+ * marker on the optional `__valueType` field so two keys with different
+ * value types are distinguishable at the type level.
+ *
+ * The phantom field is intentionally not anchored to a `unique symbol`:
+ * dual-package builds (`tshy`) emit separate `.d.ts` files for ESM and
+ * CJS outputs, and each `unique symbol` declaration in a `.d.ts` is its
+ * own nominal type. If a single compilation ever resolves `LocalsKey`
+ * from both the ESM and CJS paths — which happens under certain pnpm
+ * hoisting layouts — `unique symbol` brands produce structurally
+ * incompatible variants of the same type. A plain string brand avoids
+ * the hazard.
+ */
+export type LocalsKey<T> = {
   readonly id: string;
-  readonly __type: unique symbol;
+  readonly __type: symbol;
+  /** Phantom carrier for the value type — never read at runtime. */
+  readonly __valueType?: T;
 };
 
 export interface LocalsManager {


### PR DESCRIPTION
## Summary

`LocalsKey<T>` (the type returned by `locals.create()`) was branded with a
module-level `declare const __local: unique symbol`. Each such declaration
is its own nominal type, and `tshy` emits separate `.d.ts` files for the
ESM and CJS outputs — each gets its own `__local` symbol. Under certain
pnpm hoisting layouts a single TypeScript compilation can resolve
`LocalsKey` from both the ESM source path and the CJS dist path within
the same call site, producing two structurally-incompatible variants of
the same type. TS surfaces this as the misleading error:

```
Argument of type 'LocalsKey<X>' is not assignable to parameter of type
'LocalsKey<X>'. Property '[__local]' is missing in type 'LocalsKey<X>'
but required in type 'BrandLocal<X>'.
```

The error has been hitting CI on PRs opened since the chat.agent stack
landed (e.g. #3625 typecheck job), but doesn't reproduce on developer
machines where the pnpm node_modules layout was built up incrementally.

## Fix

Replace the `unique symbol` brand with an optional phantom field that
carries `T` at the type level:

```ts
// before
declare const __local: unique symbol;
type BrandLocal<T> = { [__local]: T };
export type LocalsKey<T> = BrandLocal<T> & {
  readonly id: string;
  readonly __type: unique symbol;
};

// after
export type LocalsKey<T> = {
  readonly id: string;
  readonly __type: symbol;
  /** Phantom carrier for the value type — never read at runtime. */
  readonly __valueType?: T;
};
```

The ESM and CJS `.d.ts` outputs now produce structurally identical types,
so cross-output resolution no longer produces a mismatch. `T` is still
carried at the type level via the optional phantom field. The runtime
shape is unchanged — `manager.ts` was already casting via `as unknown`,
which is no longer needed.

## Test plan

- [ ] `pnpm run typecheck --filter @trigger.dev/core --filter @trigger.dev/sdk`
- [ ] `pnpm run build --filter @trigger.dev/core --filter @trigger.dev/sdk`
      (clean rebuild) — confirms the ESM and CJS dist `.d.ts` outputs
      no longer carry distinct `unique symbol` declarations
- [ ] `pnpm --filter @trigger.dev/core test test/mockTaskContext.test.ts --run`
- [ ] `pnpm --filter @trigger.dev/sdk test test/mockChatAgent.test.ts --run`
