### PR TITLE
fix(webapp): log Google auth conflict as warn instead of error

### DIFF
--- a/.server-changes/google-auth-conflict-warn.md
+++ b/.server-changes/google-auth-conflict-warn.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+Downgrade the "Google auth conflict" log from `error` to `warn`. This branch handles an expected user-state mismatch (Google ID belongs to one user, email is on another) by returning the existing auth user — there's no exception to chase, so it shouldn't page on the Sentry error channel.

--- a/apps/webapp/app/models/user.server.ts
+++ b/apps/webapp/app/models/user.server.ts
@@ -233,7 +233,7 @@ export async function findOrCreateGoogleUser({
     // Check if email user and auth user are the same
     if (existingEmailUser.id !== existingUser.id) {
       // Different users: email is taken by one user, Google auth belongs to another
-      logger.error(
+      logger.warn(
         `Google auth conflict: Google ID ${authenticationProfile.id} belongs to user ${existingUser.id} but email ${email} is taken by user ${existingEmailUser.id}`,
         {
           email,


### PR DESCRIPTION
## Summary

A "Google auth conflict" Sentry alert fires whenever a user signs in via Google whose Google account is linked to one user row but whose Google-provided email is now on a *different* user row. The handler in `apps/webapp/app/models/user.server.ts:236` already does the right thing — it returns the existing auth-linked user and skips the update path so neither row gets mutated — but it logs the situation with `logger.error`, which routes to Sentry as an exception and pages the on-call channel.

There's no exception to chase here: the branch is the intended outcome for a known data shape (user changed their email on one account after originally signing up via Google on another). Downgrading the call to `logger.warn` keeps the diagnostic record in our logs (with all the same context fields — email, both user IDs, authIdentifier) but stops it firing the production error alert.

## Change

- `logger.error` → `logger.warn` for the conflict branch in `findOrCreateGoogleUser`. Context payload is unchanged.

## Test plan

- [x] Typecheck only — there's no behavioural change to test, the log level is the entire diff.