### PR TITLE
chore: enter prerelease mode (rc) to ship v4.5.0-rc.0

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,22 @@
+{
+  "mode": "pre",
+  "tag": "rc",
+  "initialVersions": {
+    "coordinator": "0.0.1",
+    "docker-provider": "0.0.1",
+    "kubernetes-provider": "0.0.1",
+    "supervisor": "0.0.1",
+    "webapp": "1.0.0",
+    "@trigger.dev/build": "4.4.6",
+    "trigger.dev": "4.4.6",
+    "@trigger.dev/core": "4.4.6",
+    "@trigger.dev/plugins": "4.4.6",
+    "@trigger.dev/python": "4.4.6",
+    "@trigger.dev/react-hooks": "4.4.6",
+    "@trigger.dev/redis-worker": "4.4.6",
+    "@trigger.dev/rsc": "4.4.6",
+    "@trigger.dev/schema-to-json": "4.4.6",
+    "@trigger.dev/sdk": "4.4.6"
+  },
+  "changesets": []
+}


### PR DESCRIPTION
## Summary

Adds `.changeset/pre.json` to put the repo into changesets pre mode with dist-tag `rc`. After this merges, the changesets bot regenerates the existing release PR as `chore: release v4.5.0-rc.0`. Merging that PR publishes the first release candidate of 4.5.0 to npm under `@rc`.

The pre-mode plumbing landed in #3628. The release content (chat.agent + sessions + ai prompts + dashboard server-changes) landed in #3629.

## What ships when the bot PR merges

Under dist-tag `rc`:
- `@trigger.dev/{sdk,core,build,react-hooks,redis-worker,plugins,python,rsc,schema-to-json}@4.5.0-rc.0`
- `trigger.dev@4.5.0-rc.0`

Plus:
- Docker image `ghcr.io/triggerdotdev/trigger.dev:v4.5.0-rc.0` (immutable tag only — `:v4-beta` is not touched)
- Helm chart `oci://ghcr.io/triggerdotdev/charts/trigger.dev:4.5.0-rc.0`
- GitHub release `v4.5.0-rc.0` marked as Pre-release (no Latest badge)

What does NOT happen:
- npm `latest` stays at 4.4.6
- No marketing-site changelog PR (gated on `is_prerelease != 'true'`)
- Docker `:latest` not touched (we never push it anyway in this repo)

## Iteration

For subsequent rc.N: add a regular changeset to main, bot regenerates the release PR as `v4.5.0-rc.N`. Merge to ship.

## Exiting pre mode

When ready to ship stable: `pnpm exec changeset pre exit`, push, merge regenerated PR. That publishes `4.5.0` under `latest` and fires the marketing-site dispatch.