### PR TITLE
fix(clickhouse): renumber task_kind migration 029 → 031

### DIFF
--- a/internal-packages/clickhouse/schema/029_add_task_kind_to_task_runs_v2.sql
+++ b/internal-packages/clickhouse/schema/029_add_task_kind_to_task_runs_v2.sql
@@ -1,7 +1,0 @@
--- +goose Up
-ALTER TABLE trigger_dev.task_runs_v2
-  ADD COLUMN task_kind LowCardinality(String) DEFAULT '';
-
--- +goose Down
-ALTER TABLE trigger_dev.task_runs_v2
-  DROP COLUMN task_kind;

--- a/internal-packages/clickhouse/schema/031_add_task_kind_to_task_runs_v2.sql
+++ b/internal-packages/clickhouse/schema/031_add_task_kind_to_task_runs_v2.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- IF NOT EXISTS is required because this migration was previously numbered
+-- 029 and may have been applied in environments where goose accepted it
+-- before 030_create_sessions_v1 advanced the version counter. Renaming to
+-- 031 makes goose treat this as new everywhere, so the DDL must tolerate
+-- the column already being present.
+ALTER TABLE trigger_dev.task_runs_v2
+  ADD COLUMN IF NOT EXISTS task_kind LowCardinality(String) DEFAULT '';
+
+-- +goose Down
+ALTER TABLE trigger_dev.task_runs_v2
+  DROP COLUMN IF EXISTS task_kind;


### PR DESCRIPTION
## Summary

Renumber `029_add_task_kind_to_task_runs_v2.sql` → `031_add_task_kind_to_task_runs_v2.sql` to fix a deploy-blocking out-of-order migration, and make the DDL idempotent with `ADD COLUMN IF NOT EXISTS` / `DROP COLUMN IF EXISTS`.

## Root cause

- Migration `030_create_sessions_v1.sql` landed on main on 2026-04-28 (PR #3417) and was applied to test cloud ClickHouse on a subsequent deploy. Current goose version on test ClickHouse: **30**.
- Migration `029_add_task_kind_to_task_runs_v2.sql` was authored later on 2026-05-10 as part of the Sessions primitive PR series (`be1a6cf8`).
- The next test cloud deploy failed because goose strict-mode refused to apply a missing version *before* the current version:

```
goose run: error: found 1 missing migrations before current version 30:
  version 29: 029_add_task_kind_to_task_runs_v2.sql
```

## Fix

1. **Rename to `031_*`** (next available number after 030). Goose now treats it as a new migration after 030 and applies it cleanly on test/prod where the column does not yet exist.
2. **Make the DDL idempotent** (`ADD COLUMN IF NOT EXISTS`). The original 029 may have been applied in environments that ran goose with `--allow-missing` (e.g. some local dev databases) — those would have the column already, and the rename causes goose to see 031 as new and re-attempt the ADD. Idempotent DDL keeps that path safe. The `Down` mirrors with `DROP COLUMN IF EXISTS`.

## Test plan

- [ ] Test cloud deploy (after this lands) successfully runs the ClickHouse migration step
- [ ] `task_kind` column shows up on `trigger_dev.task_runs_v2` post-migration
- [ ] Local environments that had previously applied 029 do not error on the next `goose up`