### PR TITLE
ci: fix code path filter negation

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -17,16 +17,21 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      code: ${{ steps.code_filter.outputs.code }}
+      typecheck_self: ${{ steps.filter.outputs.typecheck_self }}
       webapp: ${{ steps.filter.outputs.webapp }}
       packages: ${{ steps.filter.outputs.packages }}
       internal: ${{ steps.filter.outputs.internal }}
       cli: ${{ steps.filter.outputs.cli }}
       sdk: ${{ steps.filter.outputs.sdk }}
     steps:
+      # `code` uses `every` semantics so the negation patterns actually subtract.
+      # With the default `some` quantifier, `**` matches every file and the
+      # subsequent `!...` patterns are no-ops (each pattern is OR'd, not AND'd).
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: filter
+        id: code_filter
         with:
+          predicate-quantifier: every
           filters: |
             code:
               - '**'
@@ -37,6 +42,11 @@ jobs:
               - '!references/**'
               - '!**/*.md'
               - '!**/.env.example'
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            typecheck_self:
               - '.github/workflows/pr_checks.yml'
               - '.github/workflows/typecheck.yml'
             webapp:
@@ -95,7 +105,7 @@ jobs:
 
   typecheck:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.typecheck_self == 'true'
     uses: ./.github/workflows/typecheck.yml
 
   webapp:


### PR DESCRIPTION
`dorny/paths-filter` defaults to OR semantics across the pattern array, so the leading `**` matched every file and the `!...` excludes were no-ops. The `code` filter has been returning `true` for every PR since #3615.

Split into two filter steps: `code` moves into its own step with `predicate-quantifier: every` so excludes actually subtract. The two re-include workflow files become a separate `typecheck_self` filter that the `typecheck` job ORs into its `if:`.

Side effect: workflow-file-only PRs that don't touch `pr_checks.yml` or `typecheck.yml` no longer trigger typecheck. Previously they did because the filter was broken-true.