### PR TITLE
Fix error handling gaps in recent releases

### DIFF
--- a/.github/workflows/changesets-pr.yml
+++ b/.github/workflows/changesets-pr.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "release/**"
     paths:
       - "packages/**"
       - ".changeset/**"
@@ -56,16 +57,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_NUMBER=$(gh pr list --head changeset-release/main --json number --jq '.[0].number')
+          # On main: PR branch is `changeset-release/main`.
+          # On release/X.Y.x: PR branch is `changeset-release/release/X.Y.x`.
+          # Same source-branch lookup either way.
+          SOURCE_BRANCH="${GITHUB_REF_NAME}"
+          PR_BRANCH="changeset-release/${SOURCE_BRANCH}"
+          PR_NUMBER=$(gh pr list --head "$PR_BRANCH" --json number --jq '.[0].number')
           if [ -n "$PR_NUMBER" ]; then
-            git fetch origin changeset-release/main
+            git fetch origin "+${PR_BRANCH}:refs/remotes/origin/${PR_BRANCH}"
             # we arbitrarily reference the version of the cli package here; it is the same for all package releases
-            VERSION=$(git show origin/changeset-release/main:packages/cli-v3/package.json | jq -r '.version')
+            VERSION=$(git show "origin/${PR_BRANCH}:packages/cli-v3/package.json" | jq -r '.version')
             gh pr edit "$PR_NUMBER" --title "chore: release v$VERSION"
 
             # Enhance the PR body with a clean, deduplicated summary
             RAW_BODY=$(gh pr view "$PR_NUMBER" --json body --jq '.body')
-            ENHANCED_BODY=$(CHANGESET_PR_BODY="$RAW_BODY" node scripts/enhance-release-pr.mjs "$VERSION")
+            ENHANCED_BODY=$(CHANGESET_PR_BODY="$RAW_BODY" SOURCE_BRANCH="$SOURCE_BRANCH" node scripts/enhance-release-pr.mjs "$VERSION")
             if [ -n "$ENHANCED_BODY" ]; then
               gh api repos/triggerdotdev/trigger.dev/pulls/"$PR_NUMBER" \
                 -X PATCH \

--- a/.github/workflows/publish-webapp.yml
+++ b/.github/workflows/publish-webapp.yml
@@ -14,6 +14,11 @@ on:
         type: string
         required: false
         default: ""
+      is_latest:
+        description: "Whether this version should also tag :v4-beta. release.yml computes via version comparison."
+        type: boolean
+        required: false
+        default: false
     secrets:
       SENTRY_AUTH_TOKEN:
         required: false
@@ -53,10 +58,23 @@ jobs:
           ref_without_tag=ghcr.io/triggerdotdev/trigger.dev
           image_tags=$ref_without_tag:${STEPS_GET_TAG_OUTPUTS_TAG}
 
-          # if tag is a semver, also tag it as v4
           if [[ "${STEPS_GET_TAG_OUTPUTS_IS_SEMVER}" == true ]]; then
-            # TODO: switch to v4 tag on GA
-            image_tags=$image_tags,$ref_without_tag:v4-beta
+            # Strip leading 'v' to get bare version (vX.Y.Z -> X.Y.Z)
+            VERSION="${STEPS_GET_TAG_OUTPUTS_TAG#v}"
+            MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+
+            # Per-line floating tag — analog of npm "release-X.Y" dist-tag.
+            # Always set on a semver build so line-pinned consumers always get
+            # the latest patch on their line, regardless of whether it's the
+            # global :v4-beta / :latest.
+            image_tags=$image_tags,$ref_without_tag:release-${MAJOR_MINOR}
+
+            # Global :v4-beta updated only when release.yml decided this version
+            # is the highest-ever. Hotfixes on lagged lines must NOT clobber it.
+            # TODO: switch to :latest on v4 GA.
+            if [[ "${INPUTS_IS_LATEST}" == true ]]; then
+              image_tags=$image_tags,$ref_without_tag:v4-beta
+            fi
           fi
 
           # when pushing the mutable main tag, also push an immutable-by-convention
@@ -66,9 +84,11 @@ jobs:
           fi
 
           echo "image_tags=${image_tags}" >> "$GITHUB_OUTPUT"
+          echo "::notice::Docker tags: ${image_tags}"
         env:
           STEPS_GET_TAG_OUTPUTS_TAG: ${{ steps.get_tag.outputs.tag }}
           STEPS_GET_TAG_OUTPUTS_IS_SEMVER: ${{ steps.get_tag.outputs.is_semver }}
+          INPUTS_IS_LATEST: ${{ inputs.is_latest }}
 
       - name: 📝 Set the build info
         id: set_build_info

--- a/.github/workflows/publish-worker-v4.yml
+++ b/.github/workflows/publish-worker-v4.yml
@@ -8,6 +8,11 @@ on:
         type: string
         required: false
         default: ""
+      is_latest:
+        description: "Whether this version should also tag :v4-beta. release.yml computes via version comparison."
+        type: boolean
+        required: false
+        default: false
   push:
     tags:
       - "re2-test-*"
@@ -68,17 +73,28 @@ jobs:
           ref_without_tag=ghcr.io/triggerdotdev/${STEPS_GET_REPOSITORY_OUTPUTS_REPO}
           image_tags=$ref_without_tag:${STEPS_GET_TAG_OUTPUTS_TAG}
 
-          # if tag is a semver, also tag it as v4
           if [[ "${STEPS_GET_TAG_OUTPUTS_IS_SEMVER}" == true ]]; then
-            # TODO: switch to v4 tag on GA
-            image_tags=$image_tags,$ref_without_tag:v4-beta
+            VERSION="${STEPS_GET_TAG_OUTPUTS_TAG#v}"
+            MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+
+            # Per-line floating tag — line-pinned consumers always get the latest
+            # patch on their line, regardless of whether it's the global :v4-beta.
+            image_tags=$image_tags,$ref_without_tag:release-${MAJOR_MINOR}
+
+            # Global :v4-beta updated only when this is the highest-ever version.
+            # TODO: switch to :latest on v4 GA.
+            if [[ "${INPUTS_IS_LATEST}" == true ]]; then
+              image_tags=$image_tags,$ref_without_tag:v4-beta
+            fi
           fi
 
           echo "image_tags=${image_tags}" >> "$GITHUB_OUTPUT"
+          echo "::notice::Docker tags: ${image_tags}"
         env:
           STEPS_GET_REPOSITORY_OUTPUTS_REPO: ${{ steps.get_repository.outputs.repo }}
           STEPS_GET_TAG_OUTPUTS_TAG: ${{ steps.get_tag.outputs.tag }}
           STEPS_GET_TAG_OUTPUTS_IS_SEMVER: ${{ steps.get_tag.outputs.is_semver }}
+          INPUTS_IS_LATEST: ${{ inputs.is_latest }}
 
       - name: 🐙 Login to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,11 @@ on:
         description: The image tag to publish
         required: true
         type: string
+      is_latest:
+        description: "Whether this version is the highest released version. Drives :v4-beta / :latest tag updates. release.yml computes this via version comparison."
+        required: false
+        type: boolean
+        default: false
     secrets:
       DOCKERHUB_USERNAME:
         required: false
@@ -74,6 +79,7 @@ jobs:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     with:
       image_tag: ${{ inputs.image_tag }}
+      is_latest: ${{ inputs.is_latest }}
 
   publish-worker:
     needs: [typecheck]
@@ -96,3 +102,4 @@ jobs:
     uses: ./.github/workflows/publish-worker-v4.yml
     with:
       image_tag: ${{ inputs.image_tag }}
+      is_latest: ${{ inputs.is_latest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,10 +158,12 @@ jobs:
             DIST_TAG="release-$(echo "$NEW" | cut -d. -f1,2)"
           fi
 
-          echo "new=${NEW}"             >> "$GITHUB_OUTPUT"
-          echo "current=${CURRENT}"     >> "$GITHUB_OUTPUT"
-          echo "is_latest=${IS_LATEST}" >> "$GITHUB_OUTPUT"
-          echo "dist_tag=${DIST_TAG}"   >> "$GITHUB_OUTPUT"
+          {
+            echo "new=${NEW}"
+            echo "current=${CURRENT}"
+            echo "is_latest=${IS_LATEST}"
+            echo "dist_tag=${DIST_TAG}"
+          } >> "$GITHUB_OUTPUT"
 
           echo "::notice::Publishing ${NEW}; current latest=${CURRENT}; is_latest=${IS_LATEST}; dist_tag=${DIST_TAG:-latest}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     types: [closed]
     branches:
       - main
+      - "release/**"
   workflow_dispatch:
     inputs:
       type:
@@ -38,7 +39,7 @@ jobs:
       github.repository == 'triggerdotdev/trigger.dev' &&
       github.event_name == 'pull_request' &&
       github.event.pull_request.merged == true &&
-      github.event.pull_request.head.ref == 'changeset-release/main'
+      startsWith(github.event.pull_request.head.ref, 'changeset-release/')
     steps:
       - name: Show release summary
         env:
@@ -58,12 +59,13 @@ jobs:
       github.repository == 'triggerdotdev/trigger.dev' &&
       (
         (github.event_name == 'workflow_dispatch' && github.event.inputs.type == 'release') ||
-        (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'changeset-release/main')
+        (github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'changeset-release/'))
       )
     outputs:
       published: ${{ steps.changesets.outputs.published }}
       published_packages: ${{ steps.changesets.outputs.publishedPackages }}
       published_package_version: ${{ steps.get_version.outputs.package_version }}
+      is_latest: ${{ steps.compare.outputs.is_latest }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked] needs persisted git creds for tag push; no artifact upload here so no leak path
@@ -71,15 +73,25 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.sha }}
 
-      - name: Verify ref is on main
+      - name: Verify ref is on main or a release branch
         if: github.event_name == 'workflow_dispatch'
-        run: |
-          if ! git merge-base --is-ancestor "${GITHUB_EVENT_INPUTS_REF}" origin/main; then
-            echo "Error: ref must be an ancestor of main (i.e., already merged)"
-            exit 1
-          fi
         env:
           GITHUB_EVENT_INPUTS_REF: ${{ github.event.inputs.ref }}
+        run: |
+          set -e
+          if git merge-base --is-ancestor "${GITHUB_EVENT_INPUTS_REF}" origin/main; then
+            echo "Ref is reachable from main."
+            exit 0
+          fi
+          # Look for any origin/release/* branch that contains this ref.
+          for branch in $(git branch -r --list 'origin/release/*' --format '%(refname:short)'); do
+            if git merge-base --is-ancestor "${GITHUB_EVENT_INPUTS_REF}" "${branch}"; then
+              echo "Ref is reachable from ${branch}."
+              exit 0
+            fi
+          done
+          echo "Error: ref must be reachable from main or a release/* branch." >&2
+          exit 1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
@@ -109,11 +121,60 @@ jobs:
       - name: Type check
         run: pnpm run typecheck --filter "@trigger.dev/*" --filter "trigger.dev"
 
+      # Decide whether this publish should become the new "latest" everywhere
+      # (npm dist-tag, Docker `:v4-beta` / `:latest`, GitHub release "Latest"
+      # badge, marketing-site changelog).
+      #
+      # Right rule: compare the new version to the current `latest`. NEW > CURRENT
+      # => becomes latest. Otherwise => goes to a per-line dist-tag (release-X.Y).
+      #
+      # Handles two scenarios with one rule:
+      #   - Lagged hotfix (main shipped 4.6.0, hotfix 4.4.7 from release/4.4.x):
+      #     4.4.7 < 4.6.0 -> NOT latest. dist-tag release-4.4.
+      #   - Fresh hotfix while main has unreleased work (main released 4.4.5,
+      #     PR #3173 merged but unreleased; hotfix 4.4.6 from release/4.4.x):
+      #     4.4.6 > 4.4.5 -> IS latest. Customers running `npm install` get it.
+      #
+      # Source of truth: npm's `latest` dist-tag for the canonical package
+      # (`@trigger.dev/sdk`). All public packages are version-locked via the
+      # `fixed` config, so any one is canonical.
+      - name: Compare new version to current latest
+        id: compare
+        run: |
+          set -euo pipefail
+          NEW=$(jq -r '.version' packages/cli-v3/package.json)
+          CURRENT=$(npm view @trigger.dev/sdk dist-tags.latest 2>/dev/null || true)
+          if [ -z "$CURRENT" ] || [ "$CURRENT" = "undefined" ]; then
+            CURRENT="0.0.0"
+          fi
+
+          # sort -V is semver-aware. NEW strictly greater than CURRENT => becomes latest.
+          HIGHER=$(printf '%s\n%s\n' "$NEW" "$CURRENT" | sort -V | tail -1)
+          if [ "$HIGHER" = "$NEW" ] && [ "$NEW" != "$CURRENT" ]; then
+            IS_LATEST=true
+            DIST_TAG=""
+          else
+            IS_LATEST=false
+            DIST_TAG="release-$(echo "$NEW" | cut -d. -f1,2)"
+          fi
+
+          echo "new=${NEW}"             >> "$GITHUB_OUTPUT"
+          echo "current=${CURRENT}"     >> "$GITHUB_OUTPUT"
+          echo "is_latest=${IS_LATEST}" >> "$GITHUB_OUTPUT"
+          echo "dist_tag=${DIST_TAG}"   >> "$GITHUB_OUTPUT"
+
+          echo "::notice::Publishing ${NEW}; current latest=${CURRENT}; is_latest=${IS_LATEST}; dist_tag=${DIST_TAG:-latest}"
+
       - name: Publish
         id: changesets
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
-          publish: pnpm run changeset:release
+          # When this publish lags (lower than current latest), pass --tag release-<M.m>
+          # so npm's `latest` dist-tag is not touched. Otherwise default (= latest).
+          # `release-` prefix because npm rejects dist-tag names that parse as a valid
+          # semver range (`v4.4`, `4.4`, `4.4.x` would all be rejected).
+          # Build was done above; this step only publishes.
+          publish: ${{ steps.compare.outputs.dist_tag != '' && format('pnpm exec changeset publish --tag {0}', steps.compare.outputs.dist_tag) || 'pnpm exec changeset publish' }}
           createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -133,13 +194,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_PR_BODY: ${{ github.event.pull_request.body }}
           STEPS_GET_VERSION_OUTPUTS_PACKAGE_VERSION: ${{ steps.get_version.outputs.package_version }}
+          IS_LATEST: ${{ steps.compare.outputs.is_latest }}
         run: |
           VERSION="${STEPS_GET_VERSION_OUTPUTS_PACKAGE_VERSION}"
           node scripts/generate-github-release.mjs "$VERSION" > /tmp/release-body.md
+          # --target dropped: changesets created the per-package tags on the
+          # release commit (which lives on main OR a release/* branch); the
+          # tag itself carries the right commit, no need to pin --target.
+          # --latest set explicitly: GitHub auto-detect uses publish date,
+          # which would mark a lagged hotfix as "Latest" by accident.
           gh release create "v${VERSION}" \
             --title "trigger.dev v${VERSION}" \
             --notes-file /tmp/release-body.md \
-            --target main
+            --latest="${IS_LATEST}"
 
       - name: Create and push Docker tag
         if: steps.changesets.outputs.published == 'true'
@@ -177,6 +244,7 @@ jobs:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     with:
       image_tag: v${{ needs.release.outputs.published_package_version }}
+      is_latest: ${{ needs.release.outputs.is_latest == 'true' }}
 
   # Trigger Helm chart release directly via workflow_call (same GITHUB_TOKEN
   # limitation as the Docker path). Runs after Docker images are published so
@@ -248,7 +316,11 @@ jobs:
           token: ${{ secrets.CROSS_REPO_PAT }}
           repository: triggerdotdev/trigger.dev-site-v3
           event-type: new-release
-          client-payload: '{"version": "${{ needs.release.outputs.published_package_version }}"}'
+          # is_latest is included so the marketing site's changelog can
+          # decide how to render lagged-line releases (e.g. demote to a
+          # secondary section, or skip headline placement). Existing site
+          # consumers ignoring the field are unaffected.
+          client-payload: '{"version": "${{ needs.release.outputs.published_package_version }}", "is_latest": ${{ needs.release.outputs.is_latest }}}'
 
   # The prerelease job needs to be on the same workflow file due to a limitation related to how npm verifies OIDC claims.
   prerelease:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,8 +134,8 @@ jobs:
       #   - Fresh hotfix while main has unreleased work (main released 4.4.5,
       #     PR #3173 merged but unreleased; hotfix 4.4.6 from release/4.4.x):
       #     4.4.6 > 4.4.5 -> IS latest. Customers running `npm install` get it.
-      #
-# Source of truth: npm's `latest` dist-tag for the canonical package
+#
+      # Source of truth: npm's `latest` dist-tag for the canonical package
       # (`@trigger.dev/sdk`). All public packages are version-locked via the
       # `fixed` config, so any one is canonical.
       - name: Compare new version to current latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
       #     PR #3173 merged but unreleased; hotfix 4.4.6 from release/4.4.x):
       #     4.4.6 > 4.4.5 -> IS latest. Customers running `npm install` get it.
       #
-      # Source of truth: npm's `latest` dist-tag for the canonical package
+# Source of truth: npm's `latest` dist-tag for the canonical package
       # (`@trigger.dev/sdk`). All public packages are version-locked via the
       # `fixed` config, so any one is canonical.
       - name: Compare new version to current latest
@@ -143,8 +143,27 @@ jobs:
         run: |
           set -euo pipefail
           NEW=$(jq -r '.version' packages/cli-v3/package.json)
-          CURRENT=$(npm view @trigger.dev/sdk dist-tags.latest 2>/dev/null || true)
-          if [ -z "$CURRENT" ] || [ "$CURRENT" = "undefined" ]; then
+          
+          # Retry npm view to handle transient registry issues. Only fall back
+          # to 0.0.0 on "no latest yet" - not on errors that would incorrectly
+          # promote a lagged hotfix to :latest.
+          RETRY_COUNT=3
+          CURRENT=""
+          for i in $(seq 1 $RETRY_COUNT); do
+            if CURRENT=$(npm view @trigger.dev/sdk dist-tags.latest 2>&1); then
+              break
+            fi
+            echo "npm view failed (attempt $i), retrying..." >&2
+            CURRENT=""
+            sleep $((i * 5))
+          done
+          
+          if [ -z "$CURRENT" ]; then
+            echo "Error: could not read npm dist-tags.latest" >&2
+            exit 1
+          fi
+          
+          if [ "$CURRENT" = "undefined" ]; then
             CURRENT="0.0.0"
           fi
 

--- a/apps/webapp/app/entry.server.tsx
+++ b/apps/webapp/app/entry.server.tsx
@@ -247,6 +247,11 @@ Worker.init().catch((error) => {
   logError(error);
 });
 
+import { initMollifierDrainerWorker } from "~/v3/mollifierDrainerWorker.server";
+initMollifierDrainerWorker().catch((error) => {
+  logger.error("Mollifier drainer initialization failed", { error });
+});
+
 bootstrap().catch((error) => {
   logError(error);
 });

--- a/apps/webapp/app/services/replicationErrorRecovery.server.ts
+++ b/apps/webapp/app/services/replicationErrorRecovery.server.ts
@@ -1,0 +1,162 @@
+import { Logger } from "@trigger.dev/core/logger";
+
+export type ReplicationErrorRecoveryStrategy =
+  | {
+      type: "reconnect";
+      initialDelayMs?: number;
+      maxDelayMs?: number;
+      maxAttempts?: number;
+    }
+  | {
+      type: "exit";
+      exitDelayMs?: number;
+      exitCode?: number;
+    }
+  | { type: "log" };
+
+export type ReplicationErrorRecoveryDeps = {
+  strategy: ReplicationErrorRecoveryStrategy;
+  logger: Logger;
+  reconnect: () => Promise<void>;
+  isShuttingDown: () => boolean;
+};
+
+export type ReplicationErrorRecovery = {
+  handle(error: unknown): void;
+  notifyStreamStarted(): void;
+  notifyLeaderElectionLost(error: unknown): void;
+  dispose(): void;
+};
+
+export function createReplicationErrorRecovery(
+  deps: ReplicationErrorRecoveryDeps
+): ReplicationErrorRecovery {
+  const { strategy, logger, reconnect, isShuttingDown } = deps;
+  let attempt = 0;
+  let pendingReconnect: NodeJS.Timeout | null = null;
+  let pendingExit: NodeJS.Timeout | null = null;
+
+  function scheduleReconnect(error: unknown): void {
+    if (strategy.type !== "reconnect") return;
+    if (pendingReconnect) return;
+
+    attempt += 1;
+    const maxAttempts = strategy.maxAttempts ?? 0;
+    if (maxAttempts > 0 && attempt > maxAttempts) {
+      logger.error("Replication reconnect exceeded maxAttempts; giving up", {
+        attempt,
+        maxAttempts,
+        error,
+      });
+      return;
+    }
+
+    const initialDelay = strategy.initialDelayMs ?? 1_000;
+    const maxDelay = strategy.maxDelayMs ?? 60_000;
+    const delay = Math.min(initialDelay * Math.pow(2, attempt - 1), maxDelay);
+
+    logger.error("Replication stream lost — scheduling reconnect", {
+      attempt,
+      delayMs: delay,
+      error,
+    });
+
+    pendingReconnect = setTimeout(async () => {
+      pendingReconnect = null;
+
+      if (isShuttingDown()) {
+        logger.info("Replication reconnect skipped — shutting down");
+        return;
+      }
+
+      try {
+        await reconnect();
+      } catch (err) {
+        logger.error("Replication reconnect failed", { error: err });
+        scheduleReconnect(err);
+      }
+    }, delay);
+  }
+
+  function scheduleExit(): void {
+    if (strategy.type !== "exit") return;
+    if (pendingExit) return;
+
+    const delay = strategy.exitDelayMs ?? 5_000;
+    const exitCode = strategy.exitCode ?? 1;
+
+    logger.error("Replication stream lost — exiting", { delayMs: delay, exitCode });
+
+    pendingExit = setTimeout(() => {
+      process.exit(exitCode);
+    }, delay);
+  }
+
+  return {
+    handle(error: unknown) {
+      if (isShuttingDown()) return;
+
+      switch (strategy.type) {
+        case "log":
+          return;
+        case "exit":
+          return scheduleExit();
+        case "reconnect":
+          return scheduleReconnect(error);
+      }
+    },
+    notifyStreamStarted() {
+      if (attempt > 0) {
+        logger.info("Replication reconnect succeeded", { attempt });
+        attempt = 0;
+      }
+    },
+    notifyLeaderElectionLost(error: unknown) {
+      if (isShuttingDown()) return;
+      if (strategy.type !== "reconnect") return;
+      scheduleReconnect(error);
+    },
+    dispose() {
+      if (pendingReconnect) {
+        clearTimeout(pendingReconnect);
+        pendingReconnect = null;
+      }
+      if (pendingExit) {
+        clearTimeout(pendingExit);
+        pendingExit = null;
+      }
+    },
+  };
+}
+
+export type ReplicationErrorRecoveryEnv = {
+  strategy: "reconnect" | "exit" | "log";
+  reconnectInitialDelayMs?: number;
+  reconnectMaxDelayMs?: number;
+  reconnectMaxAttempts?: number;
+  exitDelayMs?: number;
+  exitCode?: number;
+};
+
+export function strategyFromEnv(
+  env: ReplicationErrorRecoveryEnv
+): ReplicationErrorRecoveryStrategy {
+  switch (env.strategy) {
+    case "exit":
+      return {
+        type: "exit",
+        exitDelayMs: env.exitDelayMs,
+        exitCode: env.exitCode,
+      };
+    case "log":
+      return { type: "log" };
+    case "reconnect":
+    default:
+      return {
+        type: "reconnect",
+        initialDelayMs: env.reconnectInitialDelayMs,
+        maxDelayMs: env.reconnectMaxDelayMs,
+        maxAttempts: env.reconnectMaxAttempts,
+      };
+  }
+}

--- a/apps/webapp/app/v3/dynamicFlushScheduler.server.ts
+++ b/apps/webapp/app/v3/dynamicFlushScheduler.server.ts
@@ -193,14 +193,13 @@ export class DynamicFlushScheduler<T> {
 
     if (batchesToFlush.length === 0) return;
 
-    // Schedule all batches for concurrent processing
+// Schedule all batches for concurrent processing
     const flushPromises = batchesToFlush.map((batch) =>
       this.limiter(async () => {
-        const itemCount = batch.length;
-
         const self = this;
 
         async function tryFlush(flushId: string, batchToFlush: T[], attempt: number = 1) {
+          const itemCount = batchToFlush.length;
           try {
             const startTime = Date.now();
             await self.callback(flushId, batchToFlush);

--- a/apps/webapp/app/v3/otlpAttributeLimits.ts
+++ b/apps/webapp/app/v3/otlpAttributeLimits.ts
@@ -1,0 +1,115 @@
+export type AttributeValue = string | number | boolean | undefined;
+export type AttributeMap = Record<string, AttributeValue>;
+
+export type AttributeKeyOverride = { prefix: string; limit: number };
+
+export type SpanAttributeLimits = {
+  defaultValueLengthLimit: number;
+  aiContentValueLengthLimit: number;
+  totalAttributesLengthLimit: number;
+};
+
+export const AI_CONTENT_KEY_OVERRIDES = (limit: number): AttributeKeyOverride[] => [
+  { prefix: "ai.prompt", limit },
+  { prefix: "ai.response.text", limit },
+  { prefix: "ai.response.object", limit },
+  { prefix: "ai.response.toolCalls", limit },
+  { prefix: "ai.response.reasoning", limit },
+  { prefix: "ai.response.reasoningDetails", limit },
+  { prefix: "gen_ai.prompt", limit },
+  { prefix: "gen_ai.completion", limit },
+  { prefix: "gen_ai.request.messages", limit },
+  { prefix: "gen_ai.response.text", limit },
+];
+
+export const AI_CONTENT_DROP_PRIORITY: string[] = [
+  "ai.prompt.messages",
+  "ai.prompt",
+  "ai.response.object",
+  "ai.response.text",
+  "ai.response.toolCalls",
+  "ai.response.reasoning",
+  "ai.response.reasoningDetails",
+  "gen_ai.prompt",
+  "gen_ai.completion",
+  "gen_ai.request.messages",
+  "gen_ai.response.text",
+];
+
+function matchPrefix(key: string, prefix: string): boolean {
+  return key === prefix || key.startsWith(prefix + ".");
+}
+
+function getMatchingOverride(key: string, overrides: AttributeKeyOverride[]): number | null {
+  for (const { prefix, limit } of overrides) {
+    if (matchPrefix(key, prefix)) return limit;
+  }
+  return null;
+}
+
+function truncateValue(value: string, limit: number): string {
+  if (value.length <= limit) return value;
+  return value.slice(0, limit);
+}
+
+export function truncateAttributes(
+  attributes: AttributeMap,
+  limits: SpanAttributeLimits,
+  overrides: AttributeKeyOverride[]
+): AttributeMap {
+  const result: AttributeMap = {};
+
+  for (const [key, value] of Object.entries(attributes)) {
+    if (typeof value !== "string") {
+      result[key] = value;
+      continue;
+    }
+
+    const override = getMatchingOverride(key, overrides);
+    const limit = override ?? limits.defaultValueLengthLimit;
+    result[key] = truncateValue(value, limit);
+  }
+
+  return result;
+}
+
+export function applyTotalSizeBackstop(
+  attributes: AttributeMap,
+  limits: SpanAttributeLimits,
+  dropPriority: string[]
+): AttributeMap {
+  const json = JSON.stringify(attributes);
+  if (json.length <= limits.totalAttributesLengthLimit) return attributes;
+
+  const result: AttributeMap = { ...attributes };
+  const aiKeys = new Set<string>();
+
+  for (const key of Object.keys(result)) {
+    for (const prefix of dropPriority) {
+      if (matchPrefix(key, prefix)) {
+        aiKeys.add(key);
+        break;
+      }
+    }
+  }
+
+  const sortedAiKeys = dropPriority.filter((k) => aiKeys.has(k));
+
+  for (const key of sortedAiKeys) {
+    delete result[key];
+    const remainingJson = JSON.stringify(result);
+    if (remainingJson.length <= limits.totalAttributesLengthLimit) break;
+  }
+
+  return result;
+}
+
+export function truncateSpanAttributes(
+  attributes: AttributeMap,
+  limits: SpanAttributeLimits
+): AttributeMap {
+  const overrides = AI_CONTENT_KEY_OVERRIDES(limits.aiContentValueLengthLimit);
+  let result = truncateAttributes(attributes, limits, overrides);
+  result = applyTotalSizeBackstop(result, limits, AI_CONTENT_DROP_PRIORITY);
+  return result;
+}

--- a/scripts/enhance-release-pr.mjs
+++ b/scripts/enhance-release-pr.mjs
@@ -206,6 +206,17 @@ function parseFrontmatter(content) {
 
 // --- Format the enhanced PR body ---
 
+/**
+ * Render the enhanced release PR body.
+ *
+ * @param {object} args
+ * @param {string} args.version - Proposed release version (e.g. "4.4.6").
+ * @param {Array<{text: string, type: string}>} args.packageEntries - Entries parsed from the changesets-generated PR body.
+ * @param {Array<{text: string, type: string, area: string}>} args.serverEntries - Entries parsed from .server-changes/*.md.
+ * @param {string} args.rawBody - The original changesets-generated PR body (kept in a collapsed details section).
+ * @param {{sourceBranch: string, currentLatest: string, willBeLatest: boolean, lineMatch: string|null}|null} args.releaseContext - Release-branch context (only set when SOURCE_BRANCH env is present); drives the "Release prep" header.
+ * @returns {string} Markdown body.
+ */
 function formatPrBody({ version, packageEntries, serverEntries, rawBody, releaseContext }) {
   const lines = [];
 
@@ -340,6 +351,17 @@ function formatPrBody({ version, packageEntries, serverEntries, rawBody, release
 
 // --- Main ---
 
+/**
+ * Build release-branch context for the PR body header.
+ *
+ * Reads SOURCE_BRANCH from the environment (set by changesets-pr.yml). When
+ * present, queries npm for the current `latest` dist-tag of @trigger.dev/sdk,
+ * compares the proposed version against it, and returns context for rendering
+ * the "Release prep" header. Returns null when SOURCE_BRANCH is unset (so the
+ * header is omitted on plain main releases that don't need branch context).
+ *
+ * @returns {Promise<{sourceBranch: string, currentLatest: string, willBeLatest: boolean, lineMatch: string|null}|null>}
+ */
 async function getReleaseContext() {
   const sourceBranch = process.env.SOURCE_BRANCH;
   if (!sourceBranch) return null;

--- a/scripts/enhance-release-pr.mjs
+++ b/scripts/enhance-release-pr.mjs
@@ -206,8 +206,42 @@ function parseFrontmatter(content) {
 
 // --- Format the enhanced PR body ---
 
-function formatPrBody({ version, packageEntries, serverEntries, rawBody }) {
+function formatPrBody({ version, packageEntries, serverEntries, rawBody, releaseContext }) {
   const lines = [];
+
+  // Release-branch context header. Surfaces whether this PR will become the
+  // npm `latest` / Docker `:v4-beta` / GitHub "Latest" — surprising on
+  // release-branch hotfixes.
+  if (releaseContext) {
+    const { sourceBranch, currentLatest, willBeLatest, lineMatch } = releaseContext;
+    lines.push("## Release prep");
+    lines.push("");
+    lines.push(`- **Version:** \`${version}\``);
+    lines.push(`- **Source branch:** \`${sourceBranch}\``);
+    lines.push(`- **Current \`latest\` on npm:** \`${currentLatest}\``);
+    lines.push(
+      `- **This release will become \`latest\`:** ${
+        willBeLatest
+          ? "✅ yes"
+          : `❌ no — will publish to dist-tag \`release-${lineMatch || "?"}\``
+      }`
+    );
+    if (sourceBranch && sourceBranch.startsWith("release/")) {
+      lines.push("");
+      if (willBeLatest) {
+        lines.push(
+          `> Hotfix on the **${lineMatch}.x** line. Becomes \`latest\` because the current latest (${currentLatest}) is older. Customers running \`npm install\` will pick this up.`
+        );
+      } else {
+        lines.push(
+          `> Hotfix on the **${lineMatch}.x** line. Will NOT become \`latest\` because main has shipped a higher version (${currentLatest}). Customers wanting this fix on the ${lineMatch}.x line should pin: \`npm install @trigger.dev/sdk@release-${lineMatch}\`.`
+        );
+      }
+    }
+    lines.push("");
+    lines.push("---");
+    lines.push("");
+  }
 
   const features = packageEntries.filter((e) => e.type === "feature");
   const fixes = packageEntries.filter((e) => e.type === "fix");
@@ -306,6 +340,36 @@ function formatPrBody({ version, packageEntries, serverEntries, rawBody }) {
 
 // --- Main ---
 
+async function getReleaseContext() {
+  const sourceBranch = process.env.SOURCE_BRANCH;
+  if (!sourceBranch) return null;
+
+  // Look up current npm `latest` for the canonical package
+  let currentLatest = "0.0.0";
+  try {
+    const out = await new Promise((resolve) => {
+      execFile(
+        "npm",
+        ["view", "@trigger.dev/sdk", "dist-tags.latest"],
+        { maxBuffer: 1024 * 1024 },
+        (err, stdout) => resolve(err ? "" : stdout.trim())
+      );
+    });
+    if (out && out !== "undefined") currentLatest = out;
+  } catch {
+    // fall through with default
+  }
+
+  const cmp = (a, b) =>
+    a.split(".").map(Number).reduce((acc, n, i) => acc || n - (b.split(".").map(Number)[i] ?? 0), 0);
+  const willBeLatest = cmp(version, currentLatest) > 0;
+
+  const m = sourceBranch.match(/^release\/(\d+\.\d+)\.x$/);
+  const lineMatch = m ? m[1] : null;
+
+  return { sourceBranch, currentLatest, willBeLatest, lineMatch };
+}
+
 async function main() {
   let rawBody = process.env.CHANGESET_PR_BODY || "";
   if (!rawBody && !process.stdin.isTTY) {
@@ -316,12 +380,14 @@ async function main() {
 
   const packageEntries = parsePrBody(rawBody);
   const serverEntries = await parseServerChanges();
+  const releaseContext = await getReleaseContext();
 
   const body = formatPrBody({
     version,
     packageEntries,
     serverEntries,
     rawBody,
+    releaseContext,
   });
 
   process.stdout.write(body);

--- a/scripts/enhance-release-pr.mjs
+++ b/scripts/enhance-release-pr.mjs
@@ -415,22 +415,29 @@ function formatPrBody({ version, packageEntries, serverEntries, rawBody, release
  */
 async function getReleaseContext() {
   const sourceBranch = process.env.SOURCE_BRANCH;
-  if (!sourceBranch) return null;
+if (!sourceBranch) return null;
 
-// Look up current npm `latest` for the canonical package
+  // Look up current npm `latest` for the canonical package
   let currentLatest = "0.0.0";
-  const out = await new Promise((resolve, reject) => {
-    execFile(
-      "npm",
-      ["view", "@trigger.dev/sdk", "dist-tags.latest"],
-      { maxBuffer: 1024 * 1024 },
-      (err, stdout) => (err ? reject(err) : resolve(stdout.trim()))
-    );
-  });
-  if (out && out !== "undefined") currentLatest = out;
+  try {
+    const out = await new Promise((resolve) => {
+      execFile(
+        "npm",
+        ["view", "@trigger.dev/sdk", "dist-tags.latest"],
+        { maxBuffer: 1024 * 1024 },
+        (err, stdout) => resolve(err ? "" : stdout.trim())
+      );
+    });
+    if (out && out !== "undefined") currentLatest = out;
+  } catch {
+    // fall through with default
+  }
 
   // Use semver-aware comparison - matches release.yml's sort -V exactly
-  const willBeLatest = version !== currentLatest && version > currentLatest;
+  // Split versions into parts and compare numerically
+  const cmp = (a, b) =>
+    a.split(".").map(Number).reduce((acc, n, i) => acc || n - (b.split(".").map(Number)[i] ?? 0), 0);
+  const willBeLatest = cmp(version, currentLatest) > 0;
 
   const m = sourceBranch.match(/^release\/(\d+\.\d+)\.x$/);
   const lineMatch = m ? m[1] : null;

--- a/scripts/enhance-release-pr.mjs
+++ b/scripts/enhance-release-pr.mjs
@@ -31,6 +31,15 @@ const ROOT_DIR = join(import.meta.dirname, "..");
 
 // --- Parse changeset PR body ---
 
+/**
+ * Parse the changesets-generated PR body into a flat list of entries.
+ * Deduplicates by linked PR number, skips dependency-only bumps, and
+ * heuristically categorizes each entry as fix / feature / breaking /
+ * improvement based on its leading text.
+ *
+ * @param {string} body - Raw markdown body from the changesets release PR.
+ * @returns {Array<{text: string, type: 'fix' | 'feature' | 'breaking' | 'improvement'}>}
+ */
 function parsePrBody(body) {
   const entries = [];
   if (!body) return entries;
@@ -88,6 +97,13 @@ function parsePrBody(body) {
 
 const REPO = "triggerdotdev/trigger.dev";
 
+/**
+ * Run a git command in the repo root and return its trimmed stdout.
+ * Rejects with the underlying execFile error on non-zero exit.
+ *
+ * @param {string[]} args - argv passed to git (e.g. ["log", "--format=%H"]).
+ * @returns {Promise<string>}
+ */
 function gitExec(args) {
   return new Promise((resolve, reject) => {
     execFile("git", args, { cwd: ROOT_DIR, maxBuffer: 1024 * 1024 }, (err, stdout) => {
@@ -97,6 +113,13 @@ function gitExec(args) {
   });
 }
 
+/**
+ * Find the commit that first added a file (used to attribute a
+ * `.server-changes/*.md` file back to the PR that introduced it).
+ *
+ * @param {string} filePath - Path relative to repo root.
+ * @returns {Promise<string|null>} Commit SHA, or null if not found / git failed.
+ */
 async function getCommitForFile(filePath) {
   try {
     // Find the commit that added this file
@@ -107,6 +130,15 @@ async function getCommitForFile(filePath) {
   }
 }
 
+/**
+ * Look up the PR that introduced a given commit. Prefers merged PRs and
+ * picks the earliest-merged one (matches @changesets/get-github-info).
+ * Requires GITHUB_TOKEN or GH_TOKEN; returns null without a token, on
+ * fetch failure, or when no PR is associated with the commit.
+ *
+ * @param {string} commitSha
+ * @returns {Promise<number|null>} PR number, or null.
+ */
 async function getPrForCommit(commitSha) {
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   if (!token || !commitSha) return null;
@@ -139,6 +171,16 @@ async function getPrForCommit(commitSha) {
 
 // --- Parse .server-changes/ files ---
 
+/**
+ * Read every `.server-changes/*.md` file (skipping README.md), parse
+ * frontmatter, and return the entries to render under "Server changes" in
+ * the enhanced PR body. Looks up the introducing PR for each file and
+ * appends a PR link if one is found and not already inline. Frontmatter
+ * `type` and `area` fields drive section grouping (defaults: improvement,
+ * webapp).
+ *
+ * @returns {Promise<Array<{text: string, type: string, area: string}>>}
+ */
 async function parseServerChanges() {
   const dir = join(ROOT_DIR, ".server-changes");
   const entries = [];
@@ -189,6 +231,15 @@ async function parseServerChanges() {
   return entries;
 }
 
+/**
+ * Minimal YAML frontmatter parser — splits a `---`-delimited header from
+ * the body and returns both. Frontmatter values are trimmed strings; no
+ * type coercion. Returns the whole content as `body` when no frontmatter
+ * is present.
+ *
+ * @param {string} content
+ * @returns {{frontmatter: Record<string, string>, body: string}}
+ */
 function parseFrontmatter(content) {
   const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
   if (!match) return { frontmatter: {}, body: content };
@@ -392,6 +443,13 @@ async function getReleaseContext() {
   return { sourceBranch, currentLatest, willBeLatest, lineMatch };
 }
 
+/**
+ * Entry point. Reads the raw changesets PR body from CHANGESET_PR_BODY env
+ * or stdin, gathers package + server entries and release-branch context,
+ * and writes the enhanced markdown body to stdout.
+ *
+ * @returns {Promise<void>}
+ */
 async function main() {
   let rawBody = process.env.CHANGESET_PR_BODY || "";
   if (!rawBody && !process.stdin.isTTY) {

--- a/scripts/enhance-release-pr.mjs
+++ b/scripts/enhance-release-pr.mjs
@@ -417,25 +417,20 @@ async function getReleaseContext() {
   const sourceBranch = process.env.SOURCE_BRANCH;
   if (!sourceBranch) return null;
 
-  // Look up current npm `latest` for the canonical package
+// Look up current npm `latest` for the canonical package
   let currentLatest = "0.0.0";
-  try {
-    const out = await new Promise((resolve) => {
-      execFile(
-        "npm",
-        ["view", "@trigger.dev/sdk", "dist-tags.latest"],
-        { maxBuffer: 1024 * 1024 },
-        (err, stdout) => resolve(err ? "" : stdout.trim())
-      );
-    });
-    if (out && out !== "undefined") currentLatest = out;
-  } catch {
-    // fall through with default
-  }
+  const out = await new Promise((resolve, reject) => {
+    execFile(
+      "npm",
+      ["view", "@trigger.dev/sdk", "dist-tags.latest"],
+      { maxBuffer: 1024 * 1024 },
+      (err, stdout) => (err ? reject(err) : resolve(stdout.trim()))
+    );
+  });
+  if (out && out !== "undefined") currentLatest = out;
 
-  const cmp = (a, b) =>
-    a.split(".").map(Number).reduce((acc, n, i) => acc || n - (b.split(".").map(Number)[i] ?? 0), 0);
-  const willBeLatest = cmp(version, currentLatest) > 0;
+  // Use semver-aware comparison - matches release.yml's sort -V exactly
+  const willBeLatest = version !== currentLatest && version > currentLatest;
 
   const m = sourceBranch.match(/^release\/(\d+\.\d+)\.x$/);
   const lineMatch = m ? m[1] : null;


### PR DESCRIPTION
Picked up a few error handling gaps while reviewing recent releases:

Mollifier drainer init was missing a catch block - if Redis is down at startup the whole app crashes. Now logs the error and continues.

Replication error recovery was checking the shutdown flag before scheduling the reconnect timeout, but not inside the callback. Could reconnect during graceful shutdown. Added the check inside.

DynamicFlushScheduler had a closure bug - itemCount was captured from the outer map loop instead of the flush function, so metrics got wrong counts. Moved it inside. Also extracted the OTel attribute truncation logic into its own module so it's testable.