### PR TITLE
fix(sdk): cache realtime-stream create response per (runId, key)

### DIFF
--- a/.changeset/realtime-streams-creds-cache.md
+++ b/.changeset/realtime-streams-creds-cache.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Cache the `PUT /realtime/v1/streams/:runId/self/:key` response per `(runId, key)` so repeated `streams.pipe()` / `chat.response.write` / `chat.stream.writer` calls reuse the same S2 credentials instead of issuing a fresh PUT (and the `realtimeStreams || $1` array push it triggers on `TaskRun`) for every chunk. Hot-loop writers, most notably `chat.response.write` called per chunk inside a `chat.agent` turn, now do one PUT per `(run, stream-key)` instead of one per write, eliminating the writer-pool lock contention that scaled with the customer's chunk rate. S2 v2 access tokens are scoped to the org basin with a 1-day server-side TTL so reusing them across calls within a single run is safe; the cache evicts on `createStream` failure and on `manager.reset()`.

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "vite-tsconfig-paths": "^4.0.5",
     "vitest": "3.1.4"
   },
-  "packageManager": "pnpm@10.23.0",
+  "packageManager": "pnpm@10.33.2",
   "dependencies": {
     "@changesets/cli": "2.26.2",
     "@remix-run/changelog-github": "^0.0.5",

--- a/packages/core/src/v3/realtimeStreams/manager.ts
+++ b/packages/core/src/v3/realtimeStreams/manager.ts
@@ -1,7 +1,8 @@
 import { ApiClient } from "../apiClient/index.js";
 import { ensureAsyncIterable, ensureReadableStream } from "../streams/asyncIterableStream.js";
+import { AnyZodFetchOptions } from "../zodfetch.js";
 import { taskContext } from "../task-context-api.js";
-import { StreamInstance } from "./streamInstance.js";
+import { CreateStreamResponseLike, StreamInstance } from "./streamInstance.js";
 import {
   RealtimeStreamInstance,
   RealtimeStreamOperationOptions,
@@ -21,8 +22,39 @@ export class StandardRealtimeStreamsManager implements RealtimeStreamsManager {
     abortController: AbortController;
   }>();
 
+  // Cache of in-flight / resolved `createStream` responses, keyed by
+  // `${runId}:${key}`. S2 v2 access tokens are scoped to the org basin
+  // (default 1-day TTL server-side) so reusing them across repeated
+  // `pipe()` calls for the same `(runId, key)` is safe, and avoids the
+  // per-call PUT that pushes `streamId` onto `TaskRun.realtimeStreams`,
+  // which under chat-agent-style hot-loop writers caused row-lock
+  // contention on the writer DB.
+  private createStreamCache = new Map<string, Promise<CreateStreamResponseLike>>();
+
   reset(): void {
     this.activeStreams.clear();
+    this.createStreamCache.clear();
+  }
+
+  private getCachedCreateStream(
+    runId: string,
+    key: string,
+    requestOptions: AnyZodFetchOptions | undefined
+  ): Promise<CreateStreamResponseLike> {
+    const cacheKey = `${runId}:${key}`;
+    const cached = this.createStreamCache.get(cacheKey);
+    if (cached) return cached;
+
+    const promise = this.apiClient.createStream(runId, "self", key, requestOptions);
+    this.createStreamCache.set(cacheKey, promise);
+    // Evict on failure so the next call retries instead of returning a
+    // poisoned cache entry forever.
+    promise.catch(() => {
+      if (this.createStreamCache.get(cacheKey) === promise) {
+        this.createStreamCache.delete(cacheKey);
+      }
+    });
+    return promise;
   }
 
   public pipe<T>(
@@ -58,6 +90,7 @@ export class StandardRealtimeStreamsManager implements RealtimeStreamsManager {
       requestOptions: options?.requestOptions,
       target: options?.target,
       debug: this.debug,
+      createStream: () => this.getCachedCreateStream(runId, key, options?.requestOptions),
     });
 
     // Register this stream

--- a/packages/core/src/v3/realtimeStreams/streamInstance.ts
+++ b/packages/core/src/v3/realtimeStreams/streamInstance.ts
@@ -5,6 +5,11 @@ import { StreamsWriterV1 } from "./streamsWriterV1.js";
 import { StreamsWriterV2 } from "./streamsWriterV2.js";
 import { StreamsWriter, StreamWriteResult } from "./types.js";
 
+export type CreateStreamResponseLike = {
+  version: string;
+  headers?: Record<string, string>;
+};
+
 export type StreamInstanceOptions<T> = {
   apiClient: ApiClient;
   baseUrl: string;
@@ -15,6 +20,14 @@ export type StreamInstanceOptions<T> = {
   requestOptions?: AnyZodFetchOptions;
   target?: "self" | "parent" | "root" | string;
   debug?: boolean;
+  /**
+   * Optional override for the create-stream call. Defaults to
+   * `apiClient.createStream(runId, "self", key, requestOptions)`. The
+   * manager passes a cached version so repeated `pipe()` calls for the
+   * same `(runId, key)` share a single PUT instead of hammering the
+   * server on every chunk.
+   */
+  createStream?: () => Promise<CreateStreamResponseLike>;
 };
 
 type StreamsWriterInstance<T> = StreamsWriterV1<T> | StreamsWriterV2<T>;
@@ -27,12 +40,17 @@ export class StreamInstance<T> implements StreamsWriter {
   }
 
   private async initializeWriter(): Promise<StreamsWriterInstance<T>> {
-    const { version, headers } = await this.options.apiClient.createStream(
-      this.options.runId,
-      "self",
-      this.options.key,
-      this.options?.requestOptions
-    );
+    const createStreamFn =
+      this.options.createStream ??
+      (() =>
+        this.options.apiClient.createStream(
+          this.options.runId,
+          "self",
+          this.options.key,
+          this.options?.requestOptions
+        ));
+
+    const { version, headers } = await createStreamFn();
 
     const parsedResponse = parseCreateStreamResponse(version, headers);
 


### PR DESCRIPTION
## Summary

Stops `chat.response.write` / `streams.writer` hot-loops from issuing a fresh `PUT /realtime/v1/streams/:runId/self/:key` (and the `realtimeStreams || $1` array push on `TaskRun` that goes with it) for every chunk.

### Root cause

Each call into `streams.pipe()` constructs a brand-new `StreamInstance`, which calls `apiClient.createStream(runId, "self", key)`. The server route handler unconditionally runs `prisma.taskRun.update({ data: { realtimeStreams: { push: streamId } } })` to record the stream in the run's tracking array, then mints an S2 access token and returns it. For S2/v2 streams the access token is scoped to the org basin (1-day server-side TTL) and the stream name is deterministic from `(runId, streamId)`, so every PUT for the same `(runId, streamId)` returns equivalent credentials. The only thing differing per call is the array push.

`chat.response.write(part)` opens a one-shot stream per chunk via `streams.writer(CHAT_STREAM_KEY, { execute: ({ write }) => write(part) })`. Customers running per-chunk writers inside a `chat.agent` turn end up doing hundreds-to-thousands of PUTs against the same TaskRun row, with each PUT rewriting an ever-growing TOAST'd array. Under concurrency this monopolised the writer pool with `Lock:tuple` contention on the writer DB.

### Fix

`StandardRealtimeStreamsManager` now keeps a `Map<string, Promise<CreateStreamResponseLike>>` keyed by `${runId}:${key}`. First call PUTs as before; subsequent calls reuse the cached promise and construct a fresh `StreamsWriterV2` straight from the cached access token / basin / stream name. Net effect for hot-loop writers is **one PUT per `(run, stream-key)`** for the lifetime of the SDK process.

`StreamInstance` grows an optional `createStream` callback so the manager can inject the cached resolver while preserving the standalone-construction path used by tests.

### Risk & invalidation

- S2 v2 access tokens default to a 1-day server-side TTL (`accessTokenExpirationInMs`). The server SWR-caches them per `(basin, streamPrefix)` so the value the SDK gets is always a live token; reusing it within a single run is safe.
- Cache evicts on `createStream` failure (poisoned-promise guard).
- Cache clears on `manager.reset()` for parity with the existing `activeStreams` behaviour.
- v1 streams also benefit incidentally: subsequent `pipe()` calls for the same `(runId, key)` skip the array push, so the run's `realtimeStreams` no longer accumulates duplicates of the same id.

## Test plan

- [ ] Vitest suite for `realtimeStreams` still passes (`pnpm run test --filter @trigger.dev/core`).
- [ ] Cut a chat-prerelease snapshot from this branch and run a `chat.agent` reference task that emits N `chat.response.write` calls in a tight loop; verify exactly **one** `PUT /realtime/v1/streams/...` lands on the server and the run's `TaskRun.realtimeStreams` ends with exactly one entry per stream key.
- [ ] Confirm the run's S2 stream still receives all N chunks (writer reuse, no data loss).
- [ ] Confirm `streams.pipe()` for multiple distinct keys in the same run each gets its own PUT (cache scoped per `(runId, key)`).