### PR TITLE
fix: validate email format on magic link login

### DIFF
--- a/.server-changes/magic-link-email-validation.md
+++ b/.server-changes/magic-link-email-validation.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Validate email format on the magic link login form.

--- a/apps/webapp/app/routes/login.magic/route.tsx
+++ b/apps/webapp/app/routes/login.magic/route.tsx
@@ -101,17 +101,32 @@ export async function action({ request }: ActionFunctionArgs) {
 
   const payload = Object.fromEntries(await clonedRequest.formData());
 
-  const data = z
+  const result = z
     .discriminatedUnion("action", [
       z.object({
         action: z.literal("send"),
-        email: z.string().trim().toLowerCase(),
+        email: z.string().trim().toLowerCase().email(),
       }),
       z.object({
         action: z.literal("reset"),
       }),
     ])
-    .parse(payload);
+    .safeParse(payload);
+
+  if (!result.success) {
+    const session = await getUserSession(request);
+    session.set("auth:error", {
+      message: "Please enter a valid email address.",
+    });
+
+    return redirect("/login/magic", {
+      headers: {
+        "Set-Cookie": await commitSession(session),
+      },
+    });
+  }
+
+  const data = result.data;
 
   switch (data.action) {
     case "send": {


### PR DESCRIPTION
Reject non-email strings at the magic link form instead of accepting any string and proceeding through rate-limit / authenticator steps.