### PR TITLE
fix(webapp): remove unused per-subsystem REDIS_READER env vars

### DIFF
--- a/.server-changes/remove-unused-per-subsystem-redis-reader-env-vars.md
+++ b/.server-changes/remove-unused-per-subsystem-redis-reader-env-vars.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+Remove 18 unused `*_REDIS_READER_HOST`/`PORT` env-var declarations from the webapp env schema. They were declared but never consumed by any Redis client. Self-hosters wanting a Redis read split should follow up via a separate issue.

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -175,17 +175,6 @@ const EnvironmentSchema = z
       .string()
       .optional()
       .transform((v) => v ?? process.env.REDIS_HOST),
-    RATE_LIMIT_REDIS_READER_HOST: z
-      .string()
-      .optional()
-      .transform((v) => v ?? process.env.REDIS_READER_HOST),
-    RATE_LIMIT_REDIS_READER_PORT: z.coerce
-      .number()
-      .optional()
-      .transform(
-        (v) =>
-          v ?? (process.env.REDIS_READER_PORT ? parseInt(process.env.REDIS_READER_PORT) : undefined)
-      ),
     RATE_LIMIT_REDIS_PORT: z.coerce
       .number()
       .optional()
@@ -207,17 +196,6 @@ const EnvironmentSchema = z
       .string()
       .optional()
       .transform((v) => v ?? process.env.REDIS_HOST),
-    CACHE_REDIS_READER_HOST: z
-      .string()
-      .optional()
-      .transform((v) => v ?? process.env.REDIS_READER_HOST),
-    CACHE_REDIS_READER_PORT: z.coerce
-      .number()
-      .optional()
-      .transform(
-        (v) =>
-          v ?? (process.env.REDIS_READER_PORT ? parseInt(process.env.REDIS_READER_PORT) : undefined)
-      ),
     CACHE_REDIS_PORT: z.coerce
       .number()
       .optional()
@@ -263,17 +241,6 @@ const EnvironmentSchema = z
       .string()
       .optional()
       .transform((v) => v ?? process.env.REDIS_HOST),
-    REALTIME_STREAMS_REDIS_READER_HOST: z
-      .string()
-      .optional()
-      .transform((v) => v ?? process.env.REDIS_READER_HOST),
-    REALTIME_STREAMS_REDIS_READER_PORT: z.coerce
-      .number()
-      .optional()
-      .transform(
-        (v) =>
-          v ?? (process.env.REDIS_READER_PORT ? parseInt(process.env.REDIS_READER_PORT) : undefined)
-      ),
     REALTIME_STREAMS_REDIS_PORT: z.coerce
       .number()
       .optional()
@@ -303,17 +270,6 @@ const EnvironmentSchema = z
       .string()
       .optional()
       .transform((v) => v ?? process.env.REDIS_HOST),
-    PUBSUB_REDIS_READER_HOST: z
-      .string()
-      .optional()
-      .transform((v) => v ?? process.env.REDIS_READER_HOST),
-    PUBSUB_REDIS_READER_PORT: z.coerce
-      .number()
-      .optional()
-      .transform(
-        (v) =>
-          v ?? (process.env.REDIS_READER_PORT ? parseInt(process.env.REDIS_READER_PORT) : undefined)
-      ),
     PUBSUB_REDIS_PORT: z.coerce
       .number()
       .optional()
@@ -567,17 +523,6 @@ const EnvironmentSchema = z
       .string()
       .optional()
       .transform((v) => v ?? process.env.REDIS_HOST),
-    ALERT_RATE_LIMITER_REDIS_READER_HOST: z
-      .string()
-      .optional()
-      .transform((v) => v ?? process.env.REDIS_READER_HOST),
-    ALERT_RATE_LIMITER_REDIS_READER_PORT: z.coerce
-      .number()
-      .optional()
-      .transform(
-        (v) =>
-          v ?? (process.env.REDIS_READER_PORT ? parseInt(process.env.REDIS_READER_PORT) : undefined)
-      ),
     ALERT_RATE_LIMITER_REDIS_PORT: z.coerce
       .number()
       .optional()
@@ -779,17 +724,6 @@ const EnvironmentSchema = z
       .string()
       .optional()
       .transform((v) => v ?? process.env.REDIS_HOST),
-    RUN_ENGINE_WORKER_REDIS_READER_HOST: z
-      .string()
-      .optional()
-      .transform((v) => v ?? process.env.REDIS_READER_HOST),
-    RUN_ENGINE_WORKER_REDIS_READER_PORT: z.coerce
-      .number()
-      .optional()
-      .transform(
-        (v) =>
-          v ?? (process.env.REDIS_READER_PORT ? parseInt(process.env.REDIS_READER_PORT) : undefined)
-      ),
     RUN_ENGINE_WORKER_REDIS_PORT: z.coerce
       .number()
       .optional()
@@ -812,17 +746,6 @@ const EnvironmentSchema = z
       .string()
       .optional()
       .transform((v) => v ?? process.env.REDIS_HOST),
-    RUN_ENGINE_RUN_QUEUE_REDIS_READER_HOST: z
-      .string()
-      .optional()
-      .transform((v) => v ?? process.env.REDIS_READER_HOST),
-    RUN_ENGINE_RUN_QUEUE_REDIS_READER_PORT: z.coerce
-      .number()
-      .optional()
-      .transform(
-        (v) =>
-          v ?? (process.env.REDIS_READER_PORT ? parseInt(process.env.REDIS_READER_PORT) : undefined)
-      ),
     RUN_ENGINE_RUN_QUEUE_REDIS_PORT: z.coerce
       .number()
       .optional()
@@ -845,17 +768,6 @@ const EnvironmentSchema = z
       .string()
       .optional()
       .transform((v) => v ?? process.env.REDIS_HOST),
-    RUN_ENGINE_RUN_LOCK_REDIS_READER_HOST: z
-      .string()
-      .optional()
-      .transform((v) => v ?? process.env.REDIS_READER_HOST),
-    RUN_ENGINE_RUN_LOCK_REDIS_READER_PORT: z.coerce
-      .number()
-      .optional()
-      .transform(
-        (v) =>
-          v ?? (process.env.REDIS_READER_PORT ? parseInt(process.env.REDIS_READER_PORT) : undefined)
-      ),
     RUN_ENGINE_RUN_LOCK_REDIS_PORT: z.coerce
       .number()
       .optional()
@@ -878,17 +790,6 @@ const EnvironmentSchema = z
       .string()
       .optional()
       .transform((v) => v ?? process.env.REDIS_HOST),
-    RUN_ENGINE_DEV_PRESENCE_REDIS_READER_HOST: z
-      .string()
-      .optional()
-      .transform((v) => v ?? process.env.REDIS_READER_HOST),
-    RUN_ENGINE_DEV_PRESENCE_REDIS_READER_PORT: z.coerce
-      .number()
-      .optional()
-      .transform(
-        (v) =>
-          v ?? (process.env.REDIS_READER_PORT ? parseInt(process.env.REDIS_READER_PORT) : undefined)
-      ),
     RUN_ENGINE_DEV_PRESENCE_REDIS_PORT: z.coerce
       .number()
       .optional()
@@ -980,17 +881,6 @@ const EnvironmentSchema = z
       .string()
       .optional()
       .transform((v) => v ?? process.env.REDIS_HOST),
-    LEGACY_RUN_ENGINE_WORKER_REDIS_READER_HOST: z
-      .string()
-      .optional()
-      .transform((v) => v ?? process.env.REDIS_READER_HOST),
-    LEGACY_RUN_ENGINE_WORKER_REDIS_READER_PORT: z.coerce
-      .number()
-      .optional()
-      .transform(
-        (v) =>
-          v ?? (process.env.REDIS_READER_PORT ? parseInt(process.env.REDIS_READER_PORT) : undefined)
-      ),
     LEGACY_RUN_ENGINE_WORKER_REDIS_PORT: z.coerce
       .number()
       .optional()
@@ -1026,17 +916,6 @@ const EnvironmentSchema = z
       .string()
       .optional()
       .transform((v) => v ?? process.env.REDIS_HOST),
-    COMMON_WORKER_REDIS_READER_HOST: z
-      .string()
-      .optional()
-      .transform((v) => v ?? process.env.REDIS_READER_HOST),
-    COMMON_WORKER_REDIS_READER_PORT: z.coerce
-      .number()
-      .optional()
-      .transform(
-        (v) =>
-          v ?? (process.env.REDIS_READER_PORT ? parseInt(process.env.REDIS_READER_PORT) : undefined)
-      ),
     COMMON_WORKER_REDIS_PORT: z.coerce
       .number()
       .optional()
@@ -1076,17 +955,6 @@ const EnvironmentSchema = z
       .string()
       .optional()
       .transform((v) => v ?? process.env.REDIS_HOST),
-    BATCH_TRIGGER_WORKER_REDIS_READER_HOST: z
-      .string()
-      .optional()
-      .transform((v) => v ?? process.env.REDIS_READER_HOST),
-    BATCH_TRIGGER_WORKER_REDIS_READER_PORT: z.coerce
-      .number()
-      .optional()
-      .transform(
-        (v) =>
-          v ?? (process.env.REDIS_READER_PORT ? parseInt(process.env.REDIS_READER_PORT) : undefined)
-      ),
     BATCH_TRIGGER_WORKER_REDIS_PORT: z.coerce
       .number()
       .optional()
@@ -1140,17 +1008,6 @@ const EnvironmentSchema = z
       .string()
       .optional()
       .transform((v) => v ?? process.env.REDIS_HOST),
-    ADMIN_WORKER_REDIS_READER_HOST: z
-      .string()
-      .optional()
-      .transform((v) => v ?? process.env.REDIS_READER_HOST),
-    ADMIN_WORKER_REDIS_READER_PORT: z.coerce
-      .number()
-      .optional()
-      .transform(
-        (v) =>
-          v ?? (process.env.REDIS_READER_PORT ? parseInt(process.env.REDIS_READER_PORT) : undefined)
-      ),
     ADMIN_WORKER_REDIS_PORT: z.coerce
       .number()
       .optional()
@@ -1181,17 +1038,6 @@ const EnvironmentSchema = z
       .string()
       .optional()
       .transform((v) => v ?? process.env.REDIS_HOST),
-    ALERTS_WORKER_REDIS_READER_HOST: z
-      .string()
-      .optional()
-      .transform((v) => v ?? process.env.REDIS_READER_HOST),
-    ALERTS_WORKER_REDIS_READER_PORT: z.coerce
-      .number()
-      .optional()
-      .transform(
-        (v) =>
-          v ?? (process.env.REDIS_READER_PORT ? parseInt(process.env.REDIS_READER_PORT) : undefined)
-      ),
     ALERTS_WORKER_REDIS_PORT: z.coerce
       .number()
       .optional()
@@ -1223,17 +1069,6 @@ const EnvironmentSchema = z
       .string()
       .optional()
       .transform((v) => v ?? process.env.REDIS_HOST),
-    SCHEDULE_WORKER_REDIS_READER_HOST: z
-      .string()
-      .optional()
-      .transform((v) => v ?? process.env.REDIS_READER_HOST),
-    SCHEDULE_WORKER_REDIS_READER_PORT: z.coerce
-      .number()
-      .optional()
-      .transform(
-        (v) =>
-          v ?? (process.env.REDIS_READER_PORT ? parseInt(process.env.REDIS_READER_PORT) : undefined)
-      ),
     SCHEDULE_WORKER_REDIS_PORT: z.coerce
       .number()
       .optional()
@@ -1274,17 +1109,6 @@ const EnvironmentSchema = z
       .string()
       .optional()
       .transform((v) => v ?? process.env.REDIS_HOST),
-    RUN_REPLICATION_REDIS_READER_HOST: z
-      .string()
-      .optional()
-      .transform((v) => v ?? process.env.REDIS_READER_HOST),
-    RUN_REPLICATION_REDIS_READER_PORT: z.coerce
-      .number()
-      .optional()
-      .transform(
-        (v) =>
-          v ?? (process.env.REDIS_READER_PORT ? parseInt(process.env.REDIS_READER_PORT) : undefined)
-      ),
     RUN_REPLICATION_REDIS_PORT: z.coerce
       .number()
       .optional()
@@ -1483,17 +1307,6 @@ const EnvironmentSchema = z
       .string()
       .optional()
       .transform((v) => v ?? process.env.REDIS_HOST),
-    REQUEST_IDEMPOTENCY_REDIS_READER_HOST: z
-      .string()
-      .optional()
-      .transform((v) => v ?? process.env.REDIS_READER_HOST),
-    REQUEST_IDEMPOTENCY_REDIS_READER_PORT: z.coerce
-      .number()
-      .optional()
-      .transform(
-        (v) =>
-          v ?? (process.env.REDIS_READER_PORT ? parseInt(process.env.REDIS_READER_PORT) : undefined)
-      ),
     REQUEST_IDEMPOTENCY_REDIS_PORT: z.coerce
       .number()
       .optional()


### PR DESCRIPTION
Fixes #3643.

## Problem

\`apps/webapp/app/env.server.ts\` declares six (actually 18 across all subsystems on closer inspection) per-subsystem \`*_REDIS_READER_HOST\` / \`*_REDIS_READER_PORT\` env vars that fall back to the global \`REDIS_READER_HOST\` / \`REDIS_READER_PORT\`. The docs at \`docs/self-hosting/env/webapp.mdx\` only document the global pair — and a grep confirms the per-subsystem names are referenced nowhere outside the env schema. They've been dead config since they landed.

## Fix (Option B in the linked plan — delete the unused declarations)

Remove the 36 per-subsystem zod entries from \`env.server.ts\` (host + port × 18 declarations + their corresponding documentation lines if applicable). Behavior-preserving for self-hosters: zod \`.parse()\` silently drops unknown keys.

### Why not Option A (wire them up)

Reader/writer split is not a pattern that exists elsewhere in the webapp. Several consumers (Upstash Ratelimit, GCRA limiter using Lua eval scripts) can't be cleanly split between reader/writer connections without a deeper architectural change. The issue author wrote \"would be useful to know if there's an intended design\" — that design is unsettled, and a drive-by contributor inventing it is the wrong move.

## Verification

- \`pnpm run typecheck --filter webapp\` passes locally.
- No behavior change for any self-hoster (deleted keys were never consumed).
- Docs left unchanged because they only document the global pair.

## Status

Marked draft per the project's contribution rules (CodeRabbit + CI must pass before marking ready). Vouch request opened in a separate issue.