### PR TITLE
ci(release): exit changeset pre mode before snapshot prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,6 +302,13 @@ jobs:
       - name: Generate Prisma Client
         run: pnpm run generate
 
+      - name: Exit changeset pre mode (if active)
+        run: |
+          if [ -f .changeset/pre.json ]; then
+            echo "Repo is in changeset pre mode; exiting so snapshot release can run"
+            pnpm exec changeset pre exit
+          fi
+
       - name: Snapshot version
         run: pnpm exec changeset version --snapshot "${GITHUB_EVENT_INPUTS_PRERELEASE_TAG}"
         env:


### PR DESCRIPTION
## Summary

The prerelease (snapshot) path of the release workflow fails immediately whenever `main` carries an active `.changeset/pre.json` (i.e. during an in-progress RC cycle, like the current v4 RC):

```
🦋 error Snapshot release is not allowed in pre mode
🦋 To resolve this exit the pre mode by running `changeset pre exit`
```

This blocks `chat-prerelease` snapshots from main even though the snapshots are unrelated to the RC cycle.

Adds a conditional `changeset pre exit` step right before `Snapshot version` in the prerelease job. The job runs on a checkout with `persist-credentials: false`, so the `pre.json` deletion stays on the runner's working tree — main's persisted pre-mode state is untouched, and v4 RC publishes keep working normally.

## Test plan

- [ ] Re-run the `🦋 Changesets Release` workflow with `type=prerelease`, `ref=main`, `prerelease_tag=chat-prerelease` and confirm it gets past the snapshot step and publishes.
- [ ] Confirm `.changeset/pre.json` on `main` is unchanged after the run.
