### PR TITLE
throw on duplicate task ids in resource catalog

### DIFF
--- a/packages/core/src/v3/resource-catalog/standardResourceCatalog.ts
+++ b/packages/core/src/v3/resource-catalog/standardResourceCatalog.ts
@@ -77,6 +77,21 @@ export class StandardResourceCatalog implements ResourceCatalog {
       return;
     }
 
+    const existingFileMetadata = this._taskFileMetadata.get(task.id);
+
+    if (
+      existingFileMetadata &&
+      (existingFileMetadata.filePath !== this._currentFileContext.filePath ||
+        existingFileMetadata.entryPoint !== this._currentFileContext.entryPoint)
+    ) {
+      throw new Error(
+        `Duplicate Trigger.dev task id "${task.id}" found:\n` +
+          `- ${existingFileMetadata.filePath} (${existingFileMetadata.entryPoint})\n` +
+          `- ${this._currentFileContext.filePath} (${this._currentFileContext.entryPoint})\n\n` +
+          "Task ids must be unique inside a project. Rename or remove one of these task definitions."
+      );
+    }
+
     this._taskFileMetadata.set(task.id, {
       ...this._currentFileContext,
     });

--- a/packages/core/test/taskCatalog.test.ts
+++ b/packages/core/test/taskCatalog.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { StandardResourceCatalog } from "../src/v3/resource-catalog/standardResourceCatalog.js";
+import type { TaskMetadataWithFunctions } from "../src/v3/types/index.js";
+
+function task(id: string, maxDuration = 60): TaskMetadataWithFunctions {
+  return {
+    id,
+    maxDuration,
+    fns: {
+      run: async () => undefined,
+    },
+  } as TaskMetadataWithFunctions;
+}
+
+describe("StandardResourceCatalog — tasks", () => {
+  it("throws when the same task id is registered from different files", () => {
+    const catalog = new StandardResourceCatalog();
+
+    catalog.setCurrentFileContext("trigger/first.ts", "first");
+    catalog.registerTaskMetadata(task("duplicate-task", 1800));
+
+    catalog.setCurrentFileContext("trigger/second.ts", "second");
+
+    let error: unknown;
+
+    try {
+      catalog.registerTaskMetadata(task("duplicate-task", 7200));
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(
+      'Duplicate Trigger.dev task id "duplicate-task" found'
+    );
+    expect((error as Error).message).toContain("trigger/first.ts (first)");
+    expect((error as Error).message).toContain("trigger/second.ts (second)");
+    expect((error as Error).message).toContain(
+      "Task ids must be unique inside a project"
+    );
+  });
+
+  it("allows re-registering the same task id from the same file context", () => {
+    const catalog = new StandardResourceCatalog();
+
+    catalog.setCurrentFileContext("trigger/task.ts", "task");
+    catalog.registerTaskMetadata(task("same-task", 1800));
+    catalog.registerTaskMetadata(task("same-task", 7200));
+
+    expect(catalog.getTaskManifest("same-task")).toMatchObject({
+      id: "same-task",
+      maxDuration: 7200,
+      filePath: "trigger/task.ts",
+      entryPoint: "task",
+    });
+  });
+});


### PR DESCRIPTION
this fixes #3654.

right now, if two tasks are registered with the same id, the later one silently overwrites the earlier entry in the resource catalog. this makes trigger.dev throw when the same task id is registered from a different file context.

the error includes the duplicate task id and both file contexts, so it should be clear which task files need to be renamed or removed.

i also added a small regression test for duplicate task ids, plus a test that keeps re-registering the same task from the same file context working.

verified with:

npm exec --yes pnpm@10.33.2 -- vitest run packages/core/test/taskCatalog.test.ts packages/core/test/skillCatalog.test.ts

8 tests passed.