### PR TITLE
fix(core): retry TASK_MIDDLEWARE_ERROR under the task's retry policy

### DIFF
--- a/.changeset/retry-middleware-errors.md
+++ b/.changeset/retry-middleware-errors.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Retry `TASK_MIDDLEWARE_ERROR` under the task's retry policy instead of failing the run on the first attempt. The error was already classified as retryable by `shouldRetryError`, but `shouldLookupRetrySettings` did not include it, so the retry flow fell through to `fail_run`. Fixes #3231.

--- a/packages/core/src/v3/errors.ts
+++ b/packages/core/src/v3/errors.ts
@@ -427,6 +427,7 @@ export function shouldLookupRetrySettings(error: TaskRunError): boolean {
         case "TASK_PROCESS_SIGTERM":
         case "TASK_PROCESS_SIGSEGV":
         case "TASK_RUN_UNCAUGHT_EXCEPTION":
+        case "TASK_MIDDLEWARE_ERROR":
           return true;
 
         default:

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -263,6 +263,12 @@ describe("shouldRetryError + shouldLookupRetrySettings", () => {
     expect(shouldLookupRetrySettings(err)).toBe(true);
   });
 
+  it("retries TASK_MIDDLEWARE_ERROR using the task's retry settings", () => {
+    const err = internal("TASK_MIDDLEWARE_ERROR");
+    expect(shouldRetryError(err)).toBe(true);
+    expect(shouldLookupRetrySettings(err)).toBe(true);
+  });
+
   it("still does not retry SIGKILL timeout", () => {
     expect(shouldRetryError(internal("TASK_PROCESS_SIGKILL_TIMEOUT"))).toBe(false);
   });


### PR DESCRIPTION
Retries `TASK_MIDDLEWARE_ERROR` under the task's retry policy. `shouldRetryError` already classed it as retryable, but `shouldLookupRetrySettings` did not, so the run fell through to `fail_run` on attempt 1 instead of using the task's `retry` config. 
Fixes #3231.