### PR TITLE
fix: ClickHouse URL secure parameter handling in goose migrations and…

### DIFF
--- a/apps/webapp/app/routes/admin.api.v1.runs-replication.create.ts
+++ b/apps/webapp/app/routes/admin.api.v1.runs-replication.create.ts
@@ -57,8 +57,13 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 function createRunReplicationService(params: CreateRunReplicationServiceParams) {
+  const url = new URL(env.RUN_REPLICATION_CLICKHOUSE_URL);
+
+  // Remove secure param
+  url.searchParams.delete("secure");
+
   const clickhouse = new ClickHouse({
-    url: env.RUN_REPLICATION_CLICKHOUSE_URL,
+    url: url.toString(),
     name: params.name,
     keepAlive: {
       enabled: params.keepAliveEnabled,

--- a/apps/webapp/app/services/runsReplicationInstance.server.ts
+++ b/apps/webapp/app/services/runsReplicationInstance.server.ts
@@ -22,8 +22,13 @@ function initializeRunsReplicationInstance() {
 
   console.log("🗃️  Runs replication service enabled");
 
+  const url = new URL(env.RUN_REPLICATION_CLICKHOUSE_URL);
+
+  // Remove secure param
+  url.searchParams.delete("secure");
+
   const clickhouse = new ClickHouse({
-    url: env.RUN_REPLICATION_CLICKHOUSE_URL,
+    url: url.toString(),
     name: "runs-replication",
     keepAlive: {
       enabled: env.RUN_REPLICATION_KEEP_ALIVE_ENABLED === "1",

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -18,17 +18,12 @@ if [ -n "$CLICKHOUSE_URL" ] && [ "$SKIP_CLICKHOUSE_MIGRATIONS" != "1" ]; then
   echo "Running ClickHouse migrations..."
   export GOOSE_DRIVER=clickhouse
   
-  # Ensure secure=true is in the connection string
-  if echo "$CLICKHOUSE_URL" | grep -q "secure="; then
-    # secure parameter already exists, use as is
-    export GOOSE_DBSTRING="$CLICKHOUSE_URL"
-  elif echo "$CLICKHOUSE_URL" | grep -q "?"; then
-    # URL has query parameters, append secure=true
-    export GOOSE_DBSTRING="${CLICKHOUSE_URL}&secure=true"
-  else
-    # URL has no query parameters, add secure=true
-    export GOOSE_DBSTRING="${CLICKHOUSE_URL}?secure=true"
-  fi
+  # Strip secure parameter from URL before passing to goose
+  # The scheme (http:// vs https://) already encodes TLS choice, so secure param is redundant
+  export GOOSE_DBSTRING="$(echo "$CLICKHOUSE_URL" | sed 's/[?&]secure=[^&]*//g')"
+  
+  # Remove trailing ? or & if present after stripping secure param
+  export GOOSE_DBSTRING="$(echo "$GOOSE_DBSTRING" | sed 's/[?&]$//')"
   
   export GOOSE_MIGRATION_DIR=/triggerdotdev/internal-packages/clickhouse/schema
   /usr/local/bin/goose up


### PR DESCRIPTION
fix: ClickHouse URL secure parameter handling in goose migrations and replication clients

Closes #3674

✅ Checklist
 I have followed every step in the [contributing guide](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
 The PR title follows the convention.
 I ran and tested the code works


Testing
Manual testing scenarios:

1)    HTTP ClickHouse (no TLS)

Set [CLICKHOUSE_URL=http://default:password@clickhouse:8123](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Run docker compose up - webapp should start without restart loop
Goose migrations should complete successfully without "http with TLS specify" error


2 )    RUN_REPLICATION_CLICKHOUSE_URL with secure parameter

Set [RUN_REPLICATION_CLICKHOUSE_URL=http://default:password@clickhouse:8123?secure=false](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Runs replication service should initialize without "Unknown URL parameters: secure" error

3) HTTPS ClickHouse (with TLS)

Set [CLICKHOUSE_URL=https://default:password@clickhouse:8123](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Verify migrations and replication both work correctly


4) URLs with existing query parameters

Set [CLICKHOUSE_URL=http://default:password@clickhouse:8123?secure=true&custom_param=value](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Verify secure param is stripped while other params are preserved
Verify no trailing ? or & characters remain


Changelog
Fixed

Docker entrypoint no longer unconditionally appends ?secure=true to goose DSN, resolving startup failures on HTTP-only ClickHouse deployments
[RUN_REPLICATION_CLICKHOUSE_URL](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now has secure query parameter stripped before passing to @clickhouse/client, matching behavior for [QUERY_CLICKHOUSE_URL](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Consistent secure parameter handling across all ClickHouse client initialization points


Impact: Self-hosted deployments with HTTP ClickHouse can now upgrade to v4.4.6 without requiring workarounds or asymmetric configuration values.


Screenshots
N/A - Backend infrastructure fix

