### PR TITLE
ci: unblock changesets release PRs

### DIFF
--- a/.github/workflows/changesets-pr.yml
+++ b/.github/workflows/changesets-pr.yml
@@ -96,4 +96,4 @@ jobs:
             -f status=completed \
             -f conclusion=success \
             -f 'output[title]=Auto-pass for changeset release PR' \
-            -f 'output[summary]=Required check auto-satisfied for `changeset-release/main` PRs. Full CI ran on the underlying commits before they landed on main.'
+            -f 'output[summary]=Required check auto-satisfied for changeset-release/main PRs. Full CI ran on the underlying commits before they landed on main.'

--- a/.github/workflows/changesets-pr.yml
+++ b/.github/workflows/changesets-pr.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      checks: write
     if: github.repository == 'triggerdotdev/trigger.dev'
     steps:
       - name: Checkout
@@ -72,3 +73,27 @@ jobs:
                 -f body="$ENHANCED_BODY"
             fi
           fi
+
+      # The changesets bot authors release PRs with GITHUB_TOKEN, which by GitHub
+      # design cannot trigger downstream workflows. That leaves the required
+      # "All PR Checks" status permanently Expected and the PR unmergeable.
+      # The release PR only bumps package.json + lockfile + CHANGELOGs from
+      # changesets already on main, so we self-report the required check as
+      # success. If a human ever pushes to changeset-release/main, the real
+      # pr_checks.yml fires and its result overwrites this one (last write wins
+      # for the same context on the same SHA).
+      - name: Self-report "All PR Checks" success on release PR
+        if: steps.changesets.outputs.published != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(gh pr list --head changeset-release/main --json number --jq '.[0].number')
+          if [ -z "$PR_NUMBER" ]; then exit 0; fi
+          HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid')
+          gh api -X POST repos/${{ github.repository }}/check-runs \
+            -f name="All PR Checks" \
+            -f head_sha="$HEAD_SHA" \
+            -f status=completed \
+            -f conclusion=success \
+            -f 'output[title]=Auto-pass for changeset release PR' \
+            -f 'output[summary]=Required check auto-satisfied for `changeset-release/main` PRs. Full CI ran on the underlying commits before they landed on main.'

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -32,7 +32,8 @@ jobs:
       github.event.pull_request.author_association != 'OWNER' &&
       github.event.pull_request.author_association != 'COLLABORATOR' &&
       github.event.pull_request.user.login != 'devin-ai-integration[bot]' &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.user.login != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Close non-draft PR


### PR DESCRIPTION
## Summary

Two CI workflows were blocking the v4.5.0-rc.0 release PR (#3563) and would block every future changeset release PR.

### 1. `changesets-pr.yml` — self-report `All PR Checks`

The changesets bot pushes commits authored by `GITHUB_TOKEN`. By GitHub design, `GITHUB_TOKEN`-authored pushes can't trigger downstream workflows (loop-prevention). That means `pr_checks.yml` never fires on release-PR commits, leaving the required `All PR Checks` status permanently `Expected — Waiting for status to be reported`. The PR can't merge.

The fix: after `changesets/action` creates the PR, post a `success` check with the exact `All PR Checks` context onto the PR's head SHA. GitHub's required-check evaluation is satisfied by any check with the right context name — the source doesn't have to be `pr_checks.yml`.

**Why this is safe:** the release PR only mechanically bumps `package.json`, `pnpm-lock.yaml`, and `CHANGELOG.md` from changesets that were already on `main` (and already ran full CI when they merged). If a human ever pushes a commit to `changeset-release/main`, `pr_checks.yml` fires on that push (real user, not `GITHUB_TOKEN`) and posts its own `All PR Checks` status — last write wins for the same context on the same SHA, so the human-push result overrides the auto-success.

### 2. `vouch-check-pr.yml` — exempt `github-actions[bot]`

The `require-draft` job auto-closes any non-draft PR whose author is not a `MEMBER`/`OWNER`/`COLLABORATOR`, with an explicit allowlist for `devin-ai-integration[bot]` and `dependabot[bot]`. The changesets bot publishes as `github-actions[bot]` with `author_association: CONTRIBUTOR`, so every release PR was getting auto-closed on open with a "please re-open as draft" comment. Add `github-actions[bot]` to the exemption list.

## Test plan
- [ ] After merge, the next changeset bot push to `changeset-release/main` should post `All PR Checks: success` on the release PR's head SHA, and the PR should not get auto-closed by `Vouch - Check PR`.
- [ ] Confirm `pr_checks.yml` still fires + gates normal (human-authored) PRs to `main`.