### PR TITLE
fix(cli): match bundleSkills indexer env with main worker indexer

### DIFF
--- a/.changeset/bundle-skills-env.md
+++ b/.changeset/bundle-skills-env.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Pass `TRIGGER_API_URL` and `TRIGGER_SECRET_KEY` to the `bundleSkills` indexer pass in dev so it matches the env the main worker indexer gets. Without this, task files that read CLI-injected env vars at module top level threw on import in the skill-discovery pass while succeeding in the real worker, surfacing as a spurious `[bundleSkills] skill discovery failed, skipping skill bundling: Failed to import some task files` warning on every dev rebuild for any project that doesn't duplicate `TRIGGER_API_URL` into its `.env`.

--- a/packages/cli-v3/src/dev/devSession.ts
+++ b/packages/cli-v3/src/dev/devSession.ts
@@ -121,6 +121,10 @@ export async function startDevSession({
 
     // Built-in skill bundling — copies registered skill folders into
     // `.trigger/skills/{id}/` so `skill.local()` works at dev runtime.
+    // The indexer pass must match the main worker indexer's env (see
+    // devSupervisor.#getEnvVars) — otherwise task files that read
+    // CLI-injected vars (TRIGGER_API_URL, TRIGGER_SECRET_KEY) at module
+    // top level throw on import here while succeeding in the real worker.
     try {
       const buildManifestPath = join(
         workerDir?.path ?? destination.path,
@@ -131,7 +135,11 @@ export async function startDevSession({
         buildManifest,
         buildManifestPath,
         workingDir: rawConfig.workingDir,
-        env: process.env,
+        env: {
+          ...process.env,
+          TRIGGER_API_URL: client.apiURL,
+          TRIGGER_SECRET_KEY: client.accessToken ?? undefined,
+        },
         logger: buildContext.logger,
       });
       buildManifest = skillsResult.buildManifest;


### PR DESCRIPTION
## Summary

The `bundleSkills` step (new in 4.5.0-rc.0) runs an extra indexer pass to discover registered Agent Skills so it can copy their folders into `.trigger/skills/{id}/` before the worker starts. It runs in a child process that imports every task file.

The child was getting `env: process.env`, while the main worker indexer at `backgroundWorker.ts:62` gets the merged env from `devSupervisor.#getEnvVars` — which injects `TRIGGER_API_URL` and `TRIGGER_SECRET_KEY` from the active CLI profile.

So any task file that reads `process.env.TRIGGER_API_URL` (or related CLI-injected vars) at module top level imported fine in the real worker but threw on import in the `bundleSkills` indexer, surfacing as a spurious warning on every dev rebuild for any project that doesn't duplicate `TRIGGER_API_URL` into its `.env`:

```
[bundleSkills] skill discovery failed, skipping skill bundling: Failed to import some task files
```

The user's code is fine — the dev worker comes up green and tasks execute normally — but skill discovery is silently skipped, which is a real (if quiet) functional gap for any project that uses both `chat.agent` + skills AND relies on the CLI to inject `TRIGGER_API_URL` from the profile.

## Fix

Thread `TRIGGER_API_URL` + `TRIGGER_SECRET_KEY` from the `client` into the `bundleSkills` env in `devSession.ts`, so the two indexer passes see the same environment. The deploy path (`buildWorker.ts`) is unaffected — those vars aren't meaningful at build time.

## Follow-up

The cleanest architectural fix is to eliminate the duplicate indexer pass entirely — the main worker indexer already returns `workerManifest.skills`, so `bundleSkills` could read from there instead of running its own indexer. Tracked separately; this PR is the surgical fix for the symptom.

## Test plan

- [ ] Reproduce: `trigger dev` in a project that (a) reads `process.env.TRIGGER_API_URL` at module top level in a task file and (b) doesn't have `TRIGGER_API_URL` in its `.env`. Confirm the `[bundleSkills] skill discovery failed` warning appears.
- [ ] With this PR applied, the same project should start clean — no warning.
- [ ] Sanity: existing projects (ai-chat reference, hello-world) still start clean.