### PR TITLE
fix: remove duplicate-word typos across SDK error, run-engine docs, and schemaTask doc

### DIFF
--- a/.changeset/fix-ai-task-tool-error-typo.md
+++ b/.changeset/fix-ai-task-tool-error-typo.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+Fix duplicated word in `assertTaskUsableAsTool` error message: "to to a tool" → "to a tool".

--- a/docs/tasks/schemaTask.mdx
+++ b/docs/tasks/schemaTask.mdx
@@ -24,7 +24,7 @@ const myTask = schemaTask({
 });
 ```
 
-`schemaTask` takes all the same options as [task](/tasks/overview), with the addition of a `schema` field. The `schema` field is a schema parser function from a schema library or or a custom parser function.
+`schemaTask` takes all the same options as [task](/tasks/overview), with the addition of a `schema` field. The `schema` field is a schema parser function from a schema library or a custom parser function.
 
 <Note>
   We will probably eventually combine `task` and `schemaTask` into a single function, but because

--- a/internal-packages/run-engine/README.md
+++ b/internal-packages/run-engine/README.md
@@ -189,7 +189,7 @@ Wait for a future time, then continue. We should add the option to pass an `idem
 
 ```ts
 //Note if the idempotency key is a string, it will get prefixed with the run id.
-//you can explicitly pass in an idempotency key created with the the global scope.
+//you can explicitly pass in an idempotency key created with the global scope.
 await wait.until(new Date("2022-01-01T00:00:00Z"), { idempotencyKey: "first-wait" });
 await wait.until(new Date("2022-01-01T00:00:00Z"), { idempotencyKey: "second-wait" });
 ```

--- a/internal-packages/run-engine/src/engine/index.ts
+++ b/internal-packages/run-engine/src/engine/index.ts
@@ -1584,7 +1584,7 @@ export class RunEngine {
   }
 
   /**
-  Send a heartbeat to signal the the run is still executing.
+  Send a heartbeat to signal the run is still executing.
   If a heartbeat isn't received, after a while the run is considered "stalled"
   and some logic will be run to try recover it.
   @returns The ExecutionResult, which could be a different snapshot.

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -858,7 +858,7 @@ type ToolSetCompatible<T extends Tool<any, any>> = T & NonNullable<ToolSet[strin
 function assertTaskUsableAsTool(task: AnyTask): void {
   if (("schema" in task && !task.schema) || ("jsonSchema" in task && !task.jsonSchema)) {
     throw new Error(
-      "Cannot convert this task to to a tool because the task has no schema. Make sure to either use schemaTask or a task with an input jsonSchema."
+      "Cannot convert this task to a tool because the task has no schema. Make sure to either use schemaTask or a task with an input jsonSchema."
     );
   }
 }


### PR DESCRIPTION
## Summary

Four small duplicated-word typos:

| File:line | Fix |
|---|---|
| \`packages/trigger-sdk/src/v3/ai.ts:861\` | \`Cannot convert this task to to a tool\` → \`Cannot convert this task to a tool\` (user-facing error message thrown by \`assertTaskUsableAsTool\`) |
| \`internal-packages/run-engine/src/engine/index.ts:1587\` | JSDoc: \`Send a heartbeat to signal the the run is still executing.\` → \`...the run is still executing.\` |
| \`internal-packages/run-engine/README.md:192\` | \`created with the the global scope\` → \`created with the global scope\` |
| \`docs/tasks/schemaTask.mdx:27\` | \`a schema parser function from a schema library or or a custom parser function\` → \`...or a custom parser function\` |

Diff is exactly 4 lines + 1 changeset entry (patch for \`@trigger.dev/sdk\` since \`ai.ts\` is in a public package).

## Novelty

\`gh pr list --search\` for each phrase across the repo returned no open PRs touching these lines. No open typo PR at all.

## Test plan

- [x] All edits are JSDoc/comment/error-string/doc-only — no runtime/type behaviour change.
- [x] \`grep -rn 'the the \\|to to a tool\\|or or a custom'\` across the changed files returns no matches after the fix.