### PR TITLE
fix: subscribeToBatch Zod stream crash on partial shape updates (#3510)

### DIFF
--- a/packages/core/src/v3/apiClient/stream.ts
+++ b/packages/core/src/v3/apiClient/stream.ts
@@ -62,8 +62,10 @@ export function zodShapeStream<TShapeSchema extends z.ZodTypeAny>(
 
         if (result.success) {
           controller.enqueue(result.data);
-        } else {
-          controller.error(new Error(`Unable to parse shape: ${result.error.message}`));
+        } else if (typeof console !== "undefined") {
+          console.warn(
+            `[zodShapeStream] Skipping unparseable shape chunk: ${result.error.message}`
+          );
         }
       },
     })


### PR DESCRIPTION
When ElectricSQL sends partial shape updates during initial sync (where not all columns are present in every message), zodShapeStream would crash the entire ReadableStream by calling controller.error(). This killed the subscription for all downstream consumers.

Fixes the issue by logging a warning and skipping unparseable chunks instead of terminating the stream. The RowState in ReadableShapeStream correctly accumulates full row data across insert/update messages and only emits when up-to-date, but edge cases during reconnection or initial sync could emit incomplete rows.