### PR TITLE
chore(webapp): make HTTP keep-alive timeout configurable

### DIFF
--- a/.server-changes/configurable-http-keepalive-timeout.md
+++ b/.server-changes/configurable-http-keepalive-timeout.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+Make the Express server's `keepAliveTimeout` configurable via `HTTP_KEEPALIVE_TIMEOUT_MS` (defaults to the previous hardcoded 65000 ms).

--- a/apps/webapp/server.ts
+++ b/apps/webapp/server.ts
@@ -19,6 +19,10 @@ const ENABLE_CLUSTER = process.env.ENABLE_CLUSTER === "1";
 const cpuCount = os.availableParallelism();
 const WORKERS =
   Number.parseInt(process.env.WEB_CONCURRENCY || process.env.CLUSTER_WORKERS || "", 10) || cpuCount;
+// Must be greater than the upstream load balancer's idle timeout to avoid the
+// LB pipelining a request onto a connection Node has already closed (→ 502).
+const HTTP_KEEPALIVE_TIMEOUT_MS =
+  Number.parseInt(process.env.HTTP_KEEPALIVE_TIMEOUT_MS || "", 10) || 65 * 1000;
 
 function forkWorkers() {
   for (let i = 0; i < WORKERS; i++) {
@@ -200,7 +204,7 @@ if (ENABLE_CLUSTER && cluster.isPrimary) {
       }
     });
 
-    server.keepAliveTimeout = 65 * 1000;
+    server.keepAliveTimeout = HTTP_KEEPALIVE_TIMEOUT_MS;
     // Mitigate against https://github.com/triggerdotdev/trigger.dev/security/dependabot/128
     // by not allowing 2000+ headers to be sent and causing a DoS
     // headers will instead be limited by the maxHeaderSize


### PR DESCRIPTION
Make the Express server's `keepAliveTimeout` configurable via `HTTP_KEEPALIVE_TIMEOUT_MS`. Default preserved at 65000 ms — no behavior change if unset.