### PR TITLE
perf(database): drop unused TaskRun(scheduleId, createdAt) index

### DIFF
--- a/.server-changes/drop-taskrun-scheduleid-createdat-idx.md
+++ b/.server-changes/drop-taskrun-scheduleid-createdat-idx.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+Reduce primary database write load on `TaskRun` by dropping an unused composite index on `(scheduleId, createdAt)`. The schedule list view reads from ClickHouse, so this Postgres index served no Prisma query while still being maintained on every `TaskRun` INSERT/UPDATE.

--- a/internal-packages/database/prisma/migrations/20260522150206_drop_task_run_schedule_id_created_at_idx/migration.sql
+++ b/internal-packages/database/prisma/migrations/20260522150206_drop_task_run_schedule_id_created_at_idx/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX CONCURRENTLY IF EXISTS "public"."TaskRun_scheduleId_createdAt_idx";

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -1084,8 +1084,6 @@ model TaskRun {
   // Run page inspector
   @@index([spanId])
   @@index([parentSpanId])
-  // Schedule list page
-  @@index([scheduleId, createdAt(sort: Desc)])
   // Finding runs in a batch
   @@index([runTags(ops: ArrayOps)], type: Gin)
   @@index([runtimeEnvironmentId, batchId])


### PR DESCRIPTION
## Summary

Drops the unused composite Postgres index `TaskRun_scheduleId_createdAt_idx`. The schedule list view reads from ClickHouse, so this index served no Prisma query while still being maintained on every `TaskRun` INSERT/UPDATE. Removing it reduces write amplification on the primary database.

Sibling to the prior drop of `TaskRun_scheduleId_idx` and the earlier removal of the `TaskRun.scheduleId` foreign key — all stemming from migrating schedule-aware reads to ClickHouse.

## Verification

- Sampled `pg_stat_user_indexes` for `TaskRun` over multiple hours — zero scans against this index.
- Grepped the codebase for any Prisma query filtering `TaskRun.scheduleId` — none found. All schedule-aware listing routes through `clickhouseRunsRepository`.