### PR TITLE
fix: prevent redactString RangeError and redactNumber NaN

### DIFF
--- a/packages/core/src/v3/runEngineWorker/supervisor/util.ts
+++ b/packages/core/src/v3/runEngineWorker/supervisor/util.ts
@@ -14,13 +14,13 @@ export function getDefaultWorkerHeaders(
 }
 
 function redactString(value: string, end = 10) {
-  return value.slice(0, end) + "*".repeat(value.length - end);
+  return value.slice(0, end) + "*".repeat(Math.max(0, value.length - end));
 }
 
 function redactNumber(value: number, end = 10) {
   const str = String(value);
   const redacted = redactString(str, end);
-  return Number(redacted);
+  return redacted;
 }
 
 export function redactKeys<T extends Record<string, any>>(obj: T, keys: Array<keyof T>): T {


### PR DESCRIPTION
## Summary

Fixes two bugs in `redactString` / `redactNumber` in `util.ts`:

1. `redactString` crashes with `RangeError` when `value.length < end`
2. `redactNumber` returned `NaN` because `Number("12345*****")` is invalid

## Changes

* Added `Math.max(0, ...)` safeguard to prevent negative repeat counts
* Changed `redactNumber` to return the redacted string directly

## Testing

Tested with:

```ts
redactString("abc")
redactNumber(42)
redactNumber(12345678901)
```

Verified:

* No RangeError
* No NaN output
* Proper redaction behavior
