### PR TITLE
fix(sdk): chat HITL continuations no longer break the next LLM call

### DIFF
--- a/.changeset/chat-slim-wire-merge.md
+++ b/.changeset/chat-slim-wire-merge.md
@@ -9,4 +9,23 @@ Fix `chat.agent` HITL continuations on reasoning-heavy turns. Two changes that w
 
 Note: `onValidateMessages` receives the slim wire on HITL turns. If you call `validateUIMessages` from `ai` against the full `messages` array it will reject the slim assistant; filter to user messages (or skip on HITL turns) — see the updated docstring on `onValidateMessages` for the recommended pattern.
 
+For `hydrateMessages` hooks that persist the chain, this release also adds a small helper to the `@trigger.dev/sdk/ai` surface:
+
+```ts
+import { chat, upsertIncomingMessage } from "@trigger.dev/sdk/ai";
+
+chat.agent({
+  hydrateMessages: async ({ chatId, trigger, incomingMessages }) => {
+    const record = await db.chat.findUnique({ where: { id: chatId } });
+    const stored = record?.messages ?? [];
+    if (upsertIncomingMessage(stored, { trigger, incomingMessages })) {
+      await db.chat.update({ where: { id: chatId }, data: { messages: stored } });
+    }
+    return stored;
+  },
+});
+```
+
+It pushes fresh user messages by id, no-ops on HITL continuations (the incoming shares an id with the existing assistant — the runtime overlays the new tool-state advance), and skips on non-`submit-message` triggers. Returns `true` if it mutated `stored` so the caller knows whether to persist.
+
 Net effect: `chat.addToolOutput(...)` / `chat.addToolApproveResponse(...)` on multi-step reasoning agents (OpenAI Responses with `store: false`, Anthropic extended thinking, etc.) no longer blows the cap and no longer corrupts the LLM input.

--- a/.changeset/chat-slim-wire-merge.md
+++ b/.changeset/chat-slim-wire-merge.md
@@ -1,0 +1,12 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+Fix `chat.agent` HITL continuations on reasoning-heavy turns. Two changes that work together:
+
+- The per-turn merge now overlays the wire copy's tool-part state advancement onto the agent's existing chain — `state` + the matching resolution field (`output` / `errorText` / `approval`) come from the wire, everything else (text, reasoning, tool `input`, provider metadata) stays whatever the snapshot or `hydrateMessages` returned. Previously a full-message replace overwrote those fields with whatever the client shipped, so a slimmed wire copy landed a tool call with no `arguments` on the next LLM call. Covers `output-available` / `output-error` (HITL `addToolOutput`) and `approval-responded` / `output-denied` (approval flow).
+- `TriggerChatTransport.sendMessages` and `AgentChat.sendRaw` now slim assistant messages that carry advanced tool parts. The wire payload is just `{ id, role, parts: [<state + resolution field>] }` for `submit-message` continuations; everything else passes through. Reasoning blobs and full tool inputs no longer ride the wire on every `addToolOutput` / `addToolApproveResponse`, so continuation payloads stay well under the `.in/append` cap on long agent loops.
+
+Note: `onValidateMessages` receives the slim wire on HITL turns. If you call `validateUIMessages` from `ai` against the full `messages` array it will reject the slim assistant; filter to user messages (or skip on HITL turns) — see the updated docstring on `onValidateMessages` for the recommended pattern.
+
+Net effect: `chat.addToolOutput(...)` / `chat.addToolApproveResponse(...)` on multi-step reasoning agents (OpenAI Responses with `store: false`, Anthropic extended thinking, etc.) no longer blows the cap and no longer corrupts the LLM input.

--- a/packages/trigger-sdk/src/v3/ai-shared.ts
+++ b/packages/trigger-sdk/src/v3/ai-shared.ts
@@ -198,3 +198,94 @@ export type InferChatUIMessage<TTask extends AnyTask> = TTask extends Task<
 >
   ? TUIM
   : UIMessage;
+
+/**
+ * Tool-part states that the client advances and ships back over the wire.
+ * Covers HITL `addToolOutput` (output-available / output-error) and the
+ * approval flow (approval-responded / output-denied). `input-streaming` /
+ * `input-available` / `approval-requested` are server-emitted only — if
+ * we see them on the wire we treat them as no-ops and skip the slim/merge.
+ */
+function isWireAdvanceableToolState(
+  state: unknown
+): state is "output-available" | "output-error" | "approval-responded" | "output-denied" {
+  return (
+    state === "output-available" ||
+    state === "output-error" ||
+    state === "approval-responded" ||
+    state === "output-denied"
+  );
+}
+
+/** Whether a tool-UI part is a static (`tool-${name}`) or dynamic tool. */
+function isToolPartType(type: unknown): boolean {
+  return typeof type === "string" && (type.startsWith("tool-") || type === "dynamic-tool");
+}
+
+/**
+ * Slim an outgoing assistant message before it ships on `submit-message`.
+ *
+ * When the client calls `addToolOutput(...)` to resolve a HITL tool (or
+ * `addToolApproveResponse(...)` to approve/deny one), the AI SDK turns
+ * it into a `submit-message` whose `messages.at(-1)` is the existing
+ * assistant message with the new state stitched onto a single tool
+ * part. On a reasoning-heavy multi-step turn, that full assistant
+ * message can be 600 KB – 1 MB (encrypted reasoning blobs, reasoning
+ * text, full tool `input` JSON, prior tool outputs) — well over the
+ * `.in/append` cap.
+ *
+ * The agent runtime only consumes the wire-advanced fields of those
+ * tool parts (state + output / errorText / approval). Everything else
+ * (text, reasoning, tool `input`) is rebuilt server-side from the
+ * durable snapshot or `hydrateMessages`. So we drop everything but
+ * the advanced tool parts here, and reduce those to just the fields
+ * the server overlays.
+ *
+ * The slim only fires when the assistant message carries at least one
+ * wire-advanceable tool part. Plain assistant resends (no resolved /
+ * approval-responded tool) and non-assistant messages pass through
+ * untouched.
+ *
+ * Pairs with the per-turn merge on the agent side
+ * (`mergeIncomingIntoHydrated` in `ai.ts`).
+ */
+export function slimSubmitMessageForWire<TMsg extends UIMessage | undefined>(
+  message: TMsg
+): TMsg {
+  if (!message) return message;
+  if (message.role !== "assistant") return message;
+  const parts = (message.parts ?? []) as any[];
+  const advancedToolParts = parts.filter(
+    (p) =>
+      p &&
+      typeof p === "object" &&
+      isToolPartType(p.type) &&
+      isWireAdvanceableToolState(p.state)
+  );
+  if (advancedToolParts.length === 0) return message;
+  const slimParts = advancedToolParts.map((p: any) => {
+    const base: Record<string, unknown> = {
+      type: p.type,
+      toolCallId: p.toolCallId,
+      state: p.state,
+    };
+    if (p.type === "dynamic-tool" && typeof p.toolName === "string") {
+      base.toolName = p.toolName;
+    }
+    if (p.state === "output-available") {
+      base.output = p.output;
+      if (p.approval !== undefined) base.approval = p.approval;
+    } else if (p.state === "output-error") {
+      if (p.errorText !== undefined) base.errorText = p.errorText;
+      if (p.approval !== undefined) base.approval = p.approval;
+    } else if (p.state === "approval-responded" || p.state === "output-denied") {
+      if (p.approval !== undefined) base.approval = p.approval;
+    }
+    return base;
+  });
+  return {
+    id: message.id,
+    role: message.role,
+    parts: slimParts,
+  } as unknown as TMsg;
+}

--- a/packages/trigger-sdk/src/v3/ai-shared.ts
+++ b/packages/trigger-sdk/src/v3/ai-shared.ts
@@ -200,6 +200,63 @@ export type InferChatUIMessage<TTask extends AnyTask> = TTask extends Task<
   : UIMessage;
 
 /**
+ * Upsert an incoming wire message into the customer's DB-backed chain
+ * inside a `hydrateMessages` hook. Returns `true` iff the chain was
+ * mutated (the caller should persist).
+ *
+ * Handles the three cases that matter:
+ *
+ *  - **Non-submit-message trigger** (`regenerate-message` / `action`,
+ *    or `submit-message` with no incoming): no-op. Returns `false`.
+ *  - **Incoming id already in `stored`** (HITL `addToolOutput` /
+ *    `addToolApproveResponse` continuation — the wire carries the
+ *    existing assistant's id with a slim resolution payload): no-op.
+ *    The runtime's per-turn merge overlays the new tool-state advance
+ *    onto the existing entry; pushing again would duplicate the row
+ *    in the chain you return, and the duplicate slim copy would hit
+ *    `toModelMessages` with no `input`. Returns `false`.
+ *  - **Incoming id not in `stored`** (typically a fresh user message
+ *    on a new turn): push. Returns `true`.
+ *
+ * Mutates `stored` in place. The caller persists `stored`, not the
+ * return value.
+ *
+ * @example
+ * ```ts
+ * import { chat, upsertIncomingMessage } from "@trigger.dev/sdk/ai";
+ *
+ * chat.agent({
+ *   hydrateMessages: async ({ chatId, trigger, incomingMessages }) => {
+ *     const record = await db.chat.findUnique({ where: { id: chatId } });
+ *     const stored = record?.messages ?? [];
+ *     if (upsertIncomingMessage(stored, { trigger, incomingMessages })) {
+ *       await db.chat.update({ where: { id: chatId }, data: { messages: stored } });
+ *     }
+ *     return stored;
+ *   },
+ * });
+ * ```
+ */
+export function upsertIncomingMessage<TMsg extends UIMessage = UIMessage>(
+  stored: TMsg[],
+  event: {
+    trigger: "submit-message" | "regenerate-message" | "action";
+    incomingMessages: TMsg[];
+  }
+): boolean {
+  if (event.trigger !== "submit-message") return false;
+  if (event.incomingMessages.length === 0) return false;
+  const newMsg = event.incomingMessages[event.incomingMessages.length - 1];
+  if (!newMsg) return false;
+  if (newMsg.id) {
+    const existingIdx = stored.findIndex((m) => m.id === newMsg.id);
+    if (existingIdx !== -1) return false;
+  }
+  stored.push(newMsg);
+  return true;
+}
+
+/**
  * Tool-part states that the client advances and ships back over the wire.
  * Covers HITL `addToolOutput` (output-available / output-error) and the
  * approval flow (approval-responded / output-denied). `input-streaming` /

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -2129,6 +2129,103 @@ function extractNewToolResultsFromHistory(
 }
 
 /**
+ * Per-turn merge of an incoming wire `UIMessage` onto the matching entry
+ * a `hydrateMessages` hook (or the default accumulator) provides. Used
+ * to fold tool-state advances from the client into the agent's
+ * authoritative chain without trusting the wire copy for fields the
+ * LLM consumes.
+ *
+ * `hydrated` is treated as the source of truth for everything outside
+ * tool-state advancement: text, reasoning blobs, provider metadata,
+ * and tool `input` all stay as hydrated had them. We only overlay
+ * tool parts whose incoming state is wire-advanced — `output-available`
+ * / `output-error` (HITL `addToolOutput`) or `approval-responded` /
+ * `output-denied` (approval flow) — and only the corresponding
+ * resolution fields (`output` / `errorText` / `approval`). Hydrated
+ * `input` and everything else stay put.
+ *
+ * Without this, a slim wire copy (which `TriggerChatTransport` /
+ * `AgentChat.sendRaw` ship by default on HITL continuations) would
+ * clobber the hydrated assistant — the next LLM call would receive a
+ * tool call with no `input` and 4xx.
+ *
+ * @internal
+ */
+function mergeIncomingIntoHydrated<TMsg extends UIMessage>(
+  hydrated: TMsg,
+  incoming: UIMessage
+): TMsg {
+  const incomingAdvancedByCallId = new Map<string, any>();
+  for (const part of (incoming.parts ?? []) as any[]) {
+    if (!isToolUIPart(part)) continue;
+    const toolCallId = part.toolCallId;
+    if (typeof toolCallId !== "string" || toolCallId.length === 0) continue;
+    if (!isWireAdvanceableToolState(part.state)) continue;
+    incomingAdvancedByCallId.set(toolCallId, part);
+  }
+
+  if (incomingAdvancedByCallId.size === 0) return hydrated;
+
+  let mutated = false;
+  const hydratedParts = (hydrated.parts ?? []) as any[];
+  const mergedParts = hydratedParts.map((part) => {
+    if (!isToolUIPart(part)) return part;
+    const toolCallId = part.toolCallId;
+    if (typeof toolCallId !== "string" || toolCallId.length === 0) return part;
+    const incomingPart = incomingAdvancedByCallId.get(toolCallId);
+    if (!incomingPart) return part;
+    // Hydrated already carries a resolved state for this call — treat
+    // it as authoritative and ignore the wire copy. Repeat sends of the
+    // same answer (replay, retry) are no-ops.
+    if (isResolvedToolState(part.state)) return part;
+    mutated = true;
+    if (incomingPart.state === "output-available") {
+      return {
+        ...part,
+        state: incomingPart.state,
+        output: incomingPart.output,
+        ...(incomingPart.approval !== undefined ? { approval: incomingPart.approval } : {}),
+      };
+    }
+    if (incomingPart.state === "output-error") {
+      return {
+        ...part,
+        state: incomingPart.state,
+        errorText: incomingPart.errorText,
+        ...(incomingPart.approval !== undefined ? { approval: incomingPart.approval } : {}),
+      };
+    }
+    // approval-responded / output-denied — overlay state + approval.
+    return {
+      ...part,
+      state: incomingPart.state,
+      ...(incomingPart.approval !== undefined ? { approval: incomingPart.approval } : {}),
+    };
+  });
+
+  if (!mutated) return hydrated;
+  return { ...hydrated, parts: mergedParts };
+}
+
+/**
+ * Mirror of `slimSubmitMessageForWire`'s predicate. Kept here so the
+ * agent runtime doesn't have to import from `ai-shared.ts` for a
+ * one-liner. See that file for the full state-machine docs.
+ *
+ * @internal
+ */
+function isWireAdvanceableToolState(
+  state: unknown
+): state is "output-available" | "output-error" | "approval-responded" | "output-denied" {
+  return (
+    state === "output-available" ||
+    state === "output-error" ||
+    state === "approval-responded" ||
+    state === "output-denied"
+  );
+}
+
+/**
  * Imperative API for reading and modifying the accumulated message history.
  *
  * Mutations use the same deferred override mechanism as `chat.setMessages()`:
@@ -3876,7 +3973,14 @@ export type HydrateMessagesEvent<TClientData = unknown, TUIM extends UIMessage =
  * Event passed to the `onValidateMessages` callback.
  */
 export type ValidateMessagesEvent<TUIM extends UIMessage = UIMessage> = {
-  /** The incoming UI messages for this turn (after cleanup of aborted tool parts). */
+  /**
+   * The incoming UI messages for this turn (after cleanup of aborted tool parts).
+   *
+   * For HITL continuations the assistant entry is slim — `state` + `output` /
+   * `errorText` / `approval` only, no `input` or other parts. Don't pass the
+   * full `messages` array to `validateUIMessages` from `ai`; filter to user
+   * messages (or your own subset) first.
+   */
   messages: TUIM[];
   /** The unique identifier for the chat session. */
   chatId: string;
@@ -4372,8 +4476,13 @@ export type ChatAgentOptions<
    *
    * Return the validated messages array. Throw to abort the turn with an error.
    *
-   * This is the right place to call the AI SDK's `validateUIMessages` to catch
-   * malformed messages from storage or untrusted input before they reach the model.
+   * This is the right place to call the AI SDK's `validateUIMessages` on fresh
+   * user input. For HITL continuations (`addToolOutput` /
+   * `addToolApproveResponse`), the wire carries a slim assistant message — only
+   * the resolved tool parts, with `state` + `output` / `errorText` / `approval`
+   * and no `input`. `validateUIMessages` against the AI SDK schema rejects
+   * that shape, so filter to user messages (or skip validation entirely) on
+   * those turns.
    *
    * @example
    * ```ts
@@ -4382,7 +4491,11 @@ export type ChatAgentOptions<
    * chat.agent({
    *   id: "my-chat",
    *   onValidateMessages: async ({ messages }) => {
-   *     return validateUIMessages({ messages, tools: chatTools });
+   *     const userMessages = messages.filter((m) => m.role === "user");
+   *     if (userMessages.length > 0) {
+   *       await validateUIMessages({ messages: userMessages, tools: chatTools });
+   *     }
+   *     return messages;
    *   },
    *   run: async ({ messages }) => {
    *     return streamText({ model, messages, tools: chatTools });
@@ -6071,15 +6184,23 @@ function chatAgent<
                       }
                     );
 
-                    // Auto-merge tool approval updates: if any incoming wire message
-                    // has an ID that matches a hydrated message, replace it. This makes
-                    // tool approvals work transparently with backend hydration.
+                    // Per-turn merge of incoming wire messages onto the hydrated
+                    // chain. Hydrated stays authoritative for text, reasoning
+                    // blobs, provider metadata, and tool `input`; we only
+                    // overlay tool-part state/output/errorText for tool calls
+                    // the wire copy has just resolved. Apps that slim the wire
+                    // copy to fit the .in/append cap (or drop fields they
+                    // re-source from their own DB) get the hydrated copy
+                    // through unchanged.
                     const merged = [...hydrated] as TUIMessage[];
                     for (const incoming of cleanedUIMessages) {
                       if (!incoming.id) continue;
                       const idx = merged.findIndex((m) => m.id === incoming.id);
                       if (idx !== -1) {
-                        merged[idx] = incoming as TUIMessage;
+                        merged[idx] = mergeIncomingIntoHydrated(
+                          merged[idx]!,
+                          incoming
+                        ) as TUIMessage;
                       }
                     }
 
@@ -6087,14 +6208,23 @@ function chatAgent<
                     accumulatedMessages = await toModelMessages(merged);
                     locals.set(chatCurrentUIMessagesKey, accumulatedUIMessages);
 
-                    // Track new messages for onTurnComplete.newUIMessages
+                    // Track new messages for onTurnComplete.newUIMessages.
+                    // Surface the post-merge entry when the wire copy
+                    // matched a hydrated message — the wire copy may have
+                    // been slimmed (HITL tool-output continuation), and
+                    // customers expect `newUIMessages` to carry full
+                    // content (text, reasoning, tool `input`).
                     if (
                       currentWirePayload.trigger === "submit-message" &&
                       cleanedUIMessages.length > 0
                     ) {
                       const lastUI = cleanedUIMessages[cleanedUIMessages.length - 1]!;
-                      turnNewUIMessages.push(lastUI);
-                      const lastModel = (await toModelMessages([lastUI]))[0];
+                      const mergedEntry = lastUI.id
+                        ? merged.find((m) => m.id === lastUI.id)
+                        : undefined;
+                      const surfaceUI = (mergedEntry ?? lastUI) as TUIMessage;
+                      turnNewUIMessages.push(surfaceUI);
+                      const lastModel = (await toModelMessages([surfaceUI]))[0];
                       if (lastModel) turnNewModelMessages.push(lastModel);
                     }
                   } else {
@@ -6121,15 +6251,17 @@ function chatAgent<
                     } else if (cleanedUIMessages.length > 0) {
                       // Submit-message (and the special-cased
                       // handover-prepare → submit-message rewrite earlier in
-                      // this scope): append-or-replace-by-id for the single
-                      // delta message.
+                      // this scope): merge-or-append for the single delta
+                      // message.
                       //
                       // Tool approval responses arrive as a single assistant
                       // message whose id collides with the existing assistant
-                      // in the accumulator — we replace by id. The fallback
-                      // for HITL `addToolOutput` continuations where AI SDK
-                      // regenerates the id (TRI-9137) still applies via
-                      // `rewriteIncomingIdViaToolCallMap`.
+                      // in the accumulator — we merge the resolved tool-part
+                      // resolutions onto the existing entry, keeping text,
+                      // reasoning, and tool `input` from the prior snapshot.
+                      // The fallback for HITL `addToolOutput` continuations
+                      // where AI SDK regenerates the id (TRI-9137) still
+                      // applies via `rewriteIncomingIdViaToolCallMap`.
                       let replaced = false;
                       for (const raw of cleanedUIMessages) {
                         let incoming = raw;
@@ -6146,7 +6278,10 @@ function chatAgent<
                           }
                         }
                         if (idx !== -1) {
-                          accumulatedUIMessages[idx] = incoming as TUIMessage;
+                          accumulatedUIMessages[idx] = mergeIncomingIntoHydrated(
+                            accumulatedUIMessages[idx]!,
+                            incoming
+                          ) as TUIMessage;
                           replaced = true;
                         } else {
                           accumulatedUIMessages.push(incoming as TUIMessage);

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -2174,10 +2174,17 @@ function mergeIncomingIntoHydrated<TMsg extends UIMessage>(
     if (typeof toolCallId !== "string" || toolCallId.length === 0) return part;
     const incomingPart = incomingAdvancedByCallId.get(toolCallId);
     if (!incomingPart) return part;
-    // Hydrated already carries a resolved state for this call — treat
-    // it as authoritative and ignore the wire copy. Repeat sends of the
-    // same answer (replay, retry) are no-ops.
-    if (isResolvedToolState(part.state)) return part;
+    // Terminal hydrated states (`output-available`, `output-error`,
+    // `output-denied`) are authoritative — never regressed by a stale
+    // wire arrival (replay, retry, out-of-order). `output-denied`
+    // matters here because the wire's `approval-responded` could
+    // otherwise overwrite a hydrated denial back to a non-terminal
+    // state.
+    if (isResolvedToolState(part.state) || part.state === "output-denied") {
+      return part;
+    }
+    // Same state on both sides — no progression to apply.
+    if (part.state === incomingPart.state) return part;
     mutated = true;
     if (incomingPart.state === "output-available") {
       return {

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -2571,7 +2571,7 @@ export type PendingMessagesOptions<TUIM extends UIMessage = UIMessage> = {
 // React hooks (`@trigger.dev/sdk/chat/react`) can import it without
 // dragging `ai.ts` into the browser graph. Re-exported here so
 // `@trigger.dev/sdk/ai` consumers still see it.
-export { PENDING_MESSAGE_INJECTED_TYPE } from "./ai-shared.js";
+export { PENDING_MESSAGE_INJECTED_TYPE, upsertIncomingMessage } from "./ai-shared.js";
 import { PENDING_MESSAGE_INJECTED_TYPE } from "./ai-shared.js";
 
 /** @internal */

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -6158,6 +6158,20 @@ function chatAgent<
                   }
 
                   if (hydrateMessages) {
+                    // Snapshot the ids the accumulator knew BEFORE this
+                    // turn ran — used below to decide whether an
+                    // incoming wire message is genuinely new or just a
+                    // state advance on an existing entry. We can't use
+                    // the post-`hydrateMessages` array for this because
+                    // the canonical hook pattern pushes the incoming
+                    // user message into the persisted chain and
+                    // returns it.
+                    const previouslyKnownMessageIds = new Set(
+                      accumulatedUIMessages
+                        .map((m) => m.id)
+                        .filter((id): id is string => typeof id === "string")
+                    );
+
                     // Backend hydration: load the full message history from the user's
                     // backend, replacing the built-in accumulator entirely. With slim
                     // wire, `incomingMessages` is consistently 0-or-1-length — what
@@ -6217,10 +6231,17 @@ function chatAgent<
 
                     // Track new messages for onTurnComplete.newUIMessages.
                     // Only push for genuinely new ids — HITL continuations
-                    // whose incoming wire id matches an existing hydrated
-                    // entry are state advances on an old message, not new
-                    // messages. The non-hydrate branch below has the same
-                    // semantic (push only on append, not on merge).
+                    // whose incoming wire id matches an existing entry are
+                    // state advances on an old message, not new messages.
+                    // We compare against `previouslyKnownMessageIds`
+                    // captured BEFORE hydration, not against `hydrated`:
+                    // the canonical hydrate pattern pushes the incoming
+                    // user message into the persisted chain and returns
+                    // it, so the new id IS in `hydrated`, which would
+                    // wrongly drop every fresh user turn from
+                    // `newUIMessages`. The non-hydrate branch below has
+                    // the same "push only on append" semantic via its
+                    // own append-vs-replace path.
                     if (
                       currentWirePayload.trigger === "submit-message" &&
                       cleanedUIMessages.length > 0
@@ -6228,7 +6249,7 @@ function chatAgent<
                       const lastUI = cleanedUIMessages[cleanedUIMessages.length - 1]!;
                       const matchedExisting =
                         lastUI.id !== undefined &&
-                        hydrated.some((m) => m.id === lastUI.id);
+                        previouslyKnownMessageIds.has(lastUI.id);
                       if (!matchedExisting) {
                         turnNewUIMessages.push(lastUI);
                         const lastModel = (await toModelMessages([lastUI]))[0];

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -6216,23 +6216,24 @@ function chatAgent<
                     locals.set(chatCurrentUIMessagesKey, accumulatedUIMessages);
 
                     // Track new messages for onTurnComplete.newUIMessages.
-                    // Surface the post-merge entry when the wire copy
-                    // matched a hydrated message — the wire copy may have
-                    // been slimmed (HITL tool-output continuation), and
-                    // customers expect `newUIMessages` to carry full
-                    // content (text, reasoning, tool `input`).
+                    // Only push for genuinely new ids — HITL continuations
+                    // whose incoming wire id matches an existing hydrated
+                    // entry are state advances on an old message, not new
+                    // messages. The non-hydrate branch below has the same
+                    // semantic (push only on append, not on merge).
                     if (
                       currentWirePayload.trigger === "submit-message" &&
                       cleanedUIMessages.length > 0
                     ) {
                       const lastUI = cleanedUIMessages[cleanedUIMessages.length - 1]!;
-                      const mergedEntry = lastUI.id
-                        ? merged.find((m) => m.id === lastUI.id)
-                        : undefined;
-                      const surfaceUI = (mergedEntry ?? lastUI) as TUIMessage;
-                      turnNewUIMessages.push(surfaceUI);
-                      const lastModel = (await toModelMessages([surfaceUI]))[0];
-                      if (lastModel) turnNewModelMessages.push(lastModel);
+                      const matchedExisting =
+                        lastUI.id !== undefined &&
+                        hydrated.some((m) => m.id === lastUI.id);
+                      if (!matchedExisting) {
+                        turnNewUIMessages.push(lastUI);
+                        const lastModel = (await toModelMessages([lastUI]))[0];
+                        if (lastModel) turnNewModelMessages.push(lastModel);
+                      }
                     }
                   } else {
                     // Default delta-merge accumulation.

--- a/packages/trigger-sdk/src/v3/chat-client.ts
+++ b/packages/trigger-sdk/src/v3/chat-client.ts
@@ -26,6 +26,7 @@ import {
   TRIGGER_CONTROL_SUBTYPE,
 } from "@trigger.dev/core/v3";
 import type { ChatInputChunk, ChatTaskWirePayload } from "./ai-shared.js";
+import { slimSubmitMessageForWire } from "./ai-shared.js";
 import { sessions } from "./sessions.js";
 
 // ─── Type inference ────────────────────────────────────────────────
@@ -406,8 +407,12 @@ export class AgentChat<TAgent = unknown> {
 
     // Slim wire — at most ONE message per record. The agent rebuilds prior
     // history from its durable S3 snapshot + session.out replay at run
-    // boot. `regenerate-message` omits `message` (the agent slices its own
-    // history). See plan vivid-humming-bonbon.
+    // boot (or `hydrateMessages` if registered).
+    //
+    // For `submit-message`, assistant messages carrying resolved tool parts
+    // (HITL `addToolOutput` answers) are slimmed to just the resolution
+    // payload — reasoning blobs, text, and tool `input` come from the
+    // agent's authoritative chain. `regenerate-message` omits `message`.
     if (triggerType === "submit-message" && messages.length === 0) {
       throw new Error(
         "AgentChat.sendRaw: 'submit-message' trigger requires at least one message"
@@ -415,7 +420,7 @@ export class AgentChat<TAgent = unknown> {
     }
     const lastIfSubmit =
       triggerType === "submit-message"
-        ? (messages.at(-1) as UIMessage | undefined)
+        ? slimSubmitMessageForWire(messages.at(-1) as UIMessage | undefined)
         : undefined;
     const payload: ChatTaskWirePayload = {
       ...(lastIfSubmit ? { message: lastIfSubmit } : {}),

--- a/packages/trigger-sdk/src/v3/chat.ts
+++ b/packages/trigger-sdk/src/v3/chat.ts
@@ -33,6 +33,7 @@ import {
 } from "@trigger.dev/core/v3";
 import { ChatTabCoordinator } from "./chat-tab-coordinator.js";
 import type { ChatInputChunk, ChatTaskWirePayload } from "./ai-shared.js";
+import { slimSubmitMessageForWire } from "./ai-shared.js";
 
 const DEFAULT_BASE_URL = "https://api.trigger.dev";
 const DEFAULT_STREAM_TIMEOUT_SECONDS = 120;
@@ -572,10 +573,15 @@ export class TriggerChatTransport implements ChatTransport<UIMessage> {
 
     // Slim wire — at most ONE message per record. The agent rebuilds prior
     // history from its durable S3 snapshot + session.out replay at run boot
-    // (or `hydrateMessages`, if registered). See plan vivid-humming-bonbon.
+    // (or `hydrateMessages`, if registered).
     //
     //   - "submit-message": ship the latest message (new user message OR a
     //     tool-approval-responded assistant message). Throw if absent.
+    //     Assistant messages with already-resolved tool parts are slimmed
+    //     to just their resolution payload — reasoning blobs, prior text,
+    //     and tool `input` stay on the agent side (rebuilt from snapshot
+    //     or `hydrateMessages`). Keeps continuation payloads under the
+    //     `.in/append` cap on reasoning-heavy turns.
     //   - "regenerate-message": omit `message`; the agent slices its own
     //     history (drops the trailing assistant) and re-runs.
     if (trigger === "submit-message" && messages.length === 0) {
@@ -585,7 +591,9 @@ export class TriggerChatTransport implements ChatTransport<UIMessage> {
     }
     const wirePayload: ChatTaskWirePayload = {
       ...((body as Record<string, unknown>) ?? {}),
-      ...(trigger === "submit-message" ? { message: messages.at(-1) } : {}),
+      ...(trigger === "submit-message"
+        ? { message: slimSubmitMessageForWire(messages.at(-1)) }
+        : {}),
       chatId,
       trigger,
       messageId,

--- a/packages/trigger-sdk/test/mockChatAgent.test.ts
+++ b/packages/trigger-sdk/test/mockChatAgent.test.ts
@@ -306,6 +306,424 @@ describe("mockChatAgent", () => {
     }
   });
 
+  it("merges a slim wire copy onto a hydrated message — keeps hydrated `input`, overlays wire `output`", async () => {
+    // HITL continuations on reasoning-heavy turns ship a slim assistant
+    // message (resolved tool parts only, no `input`, no reasoning, no
+    // text) so the payload fits the `.in/append` cap. `hydrateMessages`
+    // returns the full DB-backed copy. The per-turn merge has to keep
+    // the hydrated `input` and overlay only the wire's `state` +
+    // `output` — otherwise the next LLM call ships a tool call with no
+    // `arguments` and the provider 400s.
+    const { z } = await import("zod");
+    const { tool } = await import("ai");
+    const searchTool = tool({
+      description: "Search.",
+      inputSchema: z.object({ query: z.string() }),
+    });
+
+    const TC = "tc_slim_merge";
+    const HEAD_ID = "a-head-slim";
+
+    // The customer's DB-backed copy. Tool part has the original `input`
+    // intact and is sitting in `input-available` (HITL waiting).
+    const dbAssistant = {
+      id: HEAD_ID,
+      role: "assistant" as const,
+      parts: [
+        {
+          type: "tool-search" as const,
+          toolCallId: TC,
+          state: "input-available" as const,
+          input: { query: "trigger.dev pricing" },
+        },
+      ],
+    };
+
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({ stream: textStream("ok") }),
+    });
+
+    let mergedToolPart: any;
+    const agent = chat.agent({
+      id: "mockChatAgent.slim-wire-merge",
+      hydrateMessages: async () => [dbAssistant as any],
+      onTurnComplete: async ({ uiMessages }) => {
+        const head = uiMessages.find((m: any) => m.id === HEAD_ID);
+        mergedToolPart = (head?.parts ?? []).find(
+          (p: any) => p?.toolCallId === TC
+        );
+      },
+      run: async ({ messages, signal }) => {
+        return streamText({
+          model,
+          messages,
+          tools: { search: searchTool },
+          abortSignal: signal,
+        });
+      },
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "test-slim-wire" });
+    try {
+      // Slim wire — only the resolved tool part, no `input`.
+      const slim = {
+        id: HEAD_ID,
+        role: "assistant" as const,
+        parts: [
+          {
+            type: "tool-search" as const,
+            toolCallId: TC,
+            state: "output-available" as const,
+            output: { hits: 7 },
+          },
+        ],
+      };
+      await harness.sendMessage(slim as any);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mergedToolPart?.state).toBe("output-available");
+      expect(mergedToolPart?.output).toEqual({ hits: 7 });
+      expect(mergedToolPart?.input).toEqual({ query: "trigger.dev pricing" });
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("merges a slim approval-responded wire onto a hydrated approval-requested message", async () => {
+    // Approval-flow counterpart to the HITL slim-merge test. The wire
+    // copy carries `state: "approval-responded"` + `approval: { id,
+    // approved }`. Hydrated has the same tool part in
+    // `approval-requested`. Merge has to overlay state + approval onto
+    // hydrated while keeping `input` intact so the agent can resume.
+    const { z } = await import("zod");
+    const { tool } = await import("ai");
+    const deleteTool = tool({
+      description: "Delete.",
+      inputSchema: z.object({ resource: z.string() }),
+    });
+
+    const TC = "tc_approval_merge";
+    const HEAD_ID = "a-head-approval";
+
+    const dbAssistant = {
+      id: HEAD_ID,
+      role: "assistant" as const,
+      parts: [
+        {
+          type: "tool-delete" as const,
+          toolCallId: TC,
+          state: "approval-requested" as const,
+          input: { resource: "/critical/data" },
+          approval: { id: "appr_1" },
+        },
+      ],
+    };
+
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({ stream: textStream("ok") }),
+    });
+
+    let mergedToolPart: any;
+    const agent = chat.agent({
+      id: "mockChatAgent.approval-slim-merge",
+      hydrateMessages: async () => [dbAssistant as any],
+      onTurnComplete: async ({ uiMessages }) => {
+        const head = uiMessages.find((m: any) => m.id === HEAD_ID);
+        mergedToolPart = (head?.parts ?? []).find(
+          (p: any) => p?.toolCallId === TC
+        );
+      },
+      run: async ({ messages, signal }) => {
+        return streamText({
+          model,
+          messages,
+          tools: { delete: deleteTool },
+          abortSignal: signal,
+        });
+      },
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "test-approval-slim" });
+    try {
+      // Slim wire — only the approval-responded tool part, no `input`.
+      const slim = {
+        id: HEAD_ID,
+        role: "assistant" as const,
+        parts: [
+          {
+            type: "tool-delete" as const,
+            toolCallId: TC,
+            state: "approval-responded" as const,
+            approval: { id: "appr_1", approved: true },
+          },
+        ],
+      };
+      await harness.sendMessage(slim as any);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mergedToolPart?.state).toBe("approval-responded");
+      expect(mergedToolPart?.approval).toEqual({ id: "appr_1", approved: true });
+      expect(mergedToolPart?.input).toEqual({ resource: "/critical/data" });
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("onValidateMessages sees the slim wire on HITL continuations — fresh-user filter still works", async () => {
+    // Slim wire is the wire shape on HITL `addToolOutput` continuations.
+    // Existing customers calling `validateUIMessages` from `ai` on the
+    // whole `messages` array would throw because the AI SDK schema
+    // requires `input` on resolved tool parts. The recommended pattern
+    // is to filter to user messages (or skip on HITL turns).
+    //
+    // This test pins both behaviors: (1) the slim assistant does arrive
+    // in the validate hook on the HITL turn, (2) a fresh-user-only
+    // filter still works (the user message turn is unaffected).
+    const { z } = await import("zod");
+    const { tool, validateUIMessages } = await import("ai");
+    const askUser = tool({
+      description: "Ask the user.",
+      inputSchema: z.object({ q: z.string() }),
+    });
+    const TC = "tc_validate_slim";
+
+    let callIdx = 0;
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({
+        stream:
+          callIdx++ === 0
+            ? simulateReadableStream({
+                chunks: [
+                  { type: "tool-input-start", id: TC, toolName: "askUser" },
+                  {
+                    type: "tool-input-delta",
+                    id: TC,
+                    delta: JSON.stringify({ q: "what color?" }),
+                  },
+                  { type: "tool-input-end", id: TC },
+                  {
+                    type: "tool-call",
+                    toolCallId: TC,
+                    toolName: "askUser",
+                    input: JSON.stringify({ q: "what color?" }),
+                  },
+                  {
+                    type: "finish",
+                    finishReason: { unified: "tool-calls", raw: "tool_calls" },
+                    usage: {
+                      inputTokens: {
+                        total: 5,
+                        noCache: 5,
+                        cacheRead: undefined,
+                        cacheWrite: undefined,
+                      },
+                      outputTokens: { total: 5, text: 0, reasoning: undefined },
+                    },
+                  },
+                ] as LanguageModelV3StreamPart[],
+              })
+            : textStream("got it"),
+      }),
+    });
+
+    const validateCalls: any[] = [];
+    const agent = chat.agent({
+      id: "mockChatAgent.validate-slim",
+      onValidateMessages: async ({ messages, trigger }) => {
+        validateCalls.push({
+          trigger,
+          messages: messages.map((m: any) => ({
+            id: m.id,
+            role: m.role,
+            partCount: m.parts?.length,
+          })),
+        });
+        // Recommended pattern: validate only user messages, since HITL
+        // continuations carry slim assistants the AI SDK schema rejects.
+        const userMessages = messages.filter(
+          (m: any) => m.role === "user"
+        );
+        if (userMessages.length > 0) {
+          await validateUIMessages({
+            messages: userMessages,
+            tools: { askUser },
+          });
+        }
+        return messages;
+      },
+      run: async ({ messages, signal }) => {
+        return streamText({
+          model,
+          messages,
+          tools: { askUser },
+          abortSignal: signal,
+        });
+      },
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "test-validate-slim" });
+    try {
+      // Turn 1: user message. Validator sees a user message; validate passes.
+      await harness.sendMessage(userMessage("hi"));
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(validateCalls).toHaveLength(1);
+      expect(validateCalls[0].messages[0].role).toBe("user");
+
+      // Turn 2: slim wire HITL continuation. Validator sees a slim
+      // assistant with no `input`. The fresh-user-filter skips it, so
+      // validateUIMessages isn't called against the slim shape.
+      const turn1Assistant = (await import("vitest")).expect.any(Object);
+      void turn1Assistant; // appease unused-binding lints
+
+      // Build a slim assistant that mirrors what the transport would ship.
+      const slim = {
+        id: "slim-id-doesnt-matter-for-validate",
+        role: "assistant" as const,
+        parts: [
+          {
+            type: "tool-askUser" as const,
+            toolCallId: TC,
+            state: "output-available" as const,
+            output: { color: "blue" },
+          },
+        ],
+      };
+      await harness.sendMessage(slim as any);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(validateCalls).toHaveLength(2);
+      expect(validateCalls[1].trigger).toBe("submit-message");
+      // The slim assistant arrived in validate — no user messages.
+      expect(validateCalls[1].messages[0].role).toBe("assistant");
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("merges a slim wire copy in the default (no-hydrate) branch — keeps snapshot `input`", async () => {
+    // Mirror of the hydrated slim-merge test, but exercising the
+    // default accumulator branch (no `hydrateMessages` registered).
+    // The agent's own turn-1 output seeds the accumulator with the
+    // full assistant + tool `input`; a slim turn-2 wire copy has to
+    // merge onto that without clobbering the snapshot's `input`.
+    const { z } = await import("zod");
+    const { tool } = await import("ai");
+    const askUser = tool({
+      description: "Ask the user.",
+      inputSchema: z.object({ q: z.string() }),
+    });
+    const TC = "tc_default_slim";
+
+    let callIdx = 0;
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({
+        stream:
+          callIdx++ === 0
+            ? simulateReadableStream({
+                chunks: [
+                  { type: "tool-input-start", id: TC, toolName: "askUser" },
+                  {
+                    type: "tool-input-delta",
+                    id: TC,
+                    delta: JSON.stringify({ q: "what color?" }),
+                  },
+                  { type: "tool-input-end", id: TC },
+                  {
+                    type: "tool-call",
+                    toolCallId: TC,
+                    toolName: "askUser",
+                    input: JSON.stringify({ q: "what color?" }),
+                  },
+                  {
+                    type: "finish",
+                    finishReason: { unified: "tool-calls", raw: "tool_calls" },
+                    usage: {
+                      inputTokens: {
+                        total: 5,
+                        noCache: 5,
+                        cacheRead: undefined,
+                        cacheWrite: undefined,
+                      },
+                      outputTokens: { total: 5, text: 0, reasoning: undefined },
+                    },
+                  },
+                ] as LanguageModelV3StreamPart[],
+              })
+            : textStream("got it"),
+      }),
+    });
+
+    const turnsSeen: { uiMessages: any[] }[] = [];
+    const agent = chat.agent({
+      id: "mockChatAgent.default-slim-merge",
+      onTurnComplete: async ({ uiMessages }) => {
+        turnsSeen.push({
+          uiMessages: uiMessages.map((m: any) => ({
+            id: m.id,
+            role: m.role,
+            parts: (m.parts ?? []).map((p: any) => ({
+              type: p.type,
+              toolCallId: p.toolCallId,
+              state: p.state,
+              hasInput: p.input !== undefined,
+              output: p.output,
+            })),
+          })),
+        });
+      },
+      run: async ({ messages, signal }) => {
+        return streamText({
+          model,
+          messages,
+          tools: { askUser },
+          abortSignal: signal,
+        });
+      },
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "test-default-slim" });
+    try {
+      // Turn 1: user message → agent emits tool call (state=input-available, has input).
+      await harness.sendMessage(userMessage("hi"));
+      await new Promise((r) => setTimeout(r, 50));
+
+      const turn1Assistant = turnsSeen.at(-1)?.uiMessages.find(
+        (m: any) => m.role === "assistant"
+      );
+      expect(turn1Assistant).toBeTruthy();
+      const HEAD_ID = turn1Assistant!.id;
+
+      // Turn 2: slim wire — only the resolved tool part with output. No input.
+      const slim = {
+        id: HEAD_ID,
+        role: "assistant" as const,
+        parts: [
+          {
+            type: "tool-askUser" as const,
+            toolCallId: TC,
+            state: "output-available" as const,
+            output: { color: "blue" },
+          },
+        ],
+      };
+      await harness.sendMessage(slim as any);
+      await new Promise((r) => setTimeout(r, 50));
+
+      const turn2 = turnsSeen.at(-1);
+      const head = turn2!.uiMessages.find((m: any) => m.id === HEAD_ID);
+      const toolPart = (head?.parts ?? []).find(
+        (p: any) => p?.toolCallId === TC
+      );
+      expect(toolPart?.state).toBe("output-available");
+      expect(toolPart?.output).toEqual({ color: "blue" });
+      // Snapshot's `input` survived the merge.
+      expect(toolPart?.hasInput).toBe(true);
+    } finally {
+      await harness.close();
+    }
+  });
+
   it("routes custom actions through actionSchema + onAction", async () => {
     const model = new MockLanguageModelV3({
       doStream: async () => ({ stream: textStream("ok") }),

--- a/packages/trigger-sdk/test/mockChatAgent.test.ts
+++ b/packages/trigger-sdk/test/mockChatAgent.test.ts
@@ -469,6 +469,92 @@ describe("mockChatAgent", () => {
     }
   });
 
+  it("does not downgrade a hydrated `output-denied` when a stale `approval-responded` arrives", async () => {
+    // Terminal hydrated states (`output-available` / `output-error` /
+    // `output-denied`) are authoritative. A wire copy that re-ships a
+    // prior `approval-responded` (replay, retry, out-of-order arrival)
+    // must NOT regress the terminal denial back to a pre-resolution
+    // state — the agent would then re-run the tool.
+    const { z } = await import("zod");
+    const { tool } = await import("ai");
+    const deleteTool = tool({
+      description: "Delete.",
+      inputSchema: z.object({ resource: z.string() }),
+    });
+
+    const TC = "tc_denied_no_regress";
+    const HEAD_ID = "a-head-denied";
+
+    const dbAssistant = {
+      id: HEAD_ID,
+      role: "assistant" as const,
+      parts: [
+        {
+          type: "tool-delete" as const,
+          toolCallId: TC,
+          state: "output-denied" as const,
+          input: { resource: "/critical/data" },
+          approval: { id: "appr_1", approved: false, reason: "no" },
+        },
+      ],
+    };
+
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({ stream: textStream("ok") }),
+    });
+
+    let mergedToolPart: any;
+    const agent = chat.agent({
+      id: "mockChatAgent.denied-no-regress",
+      hydrateMessages: async () => [dbAssistant as any],
+      onTurnComplete: async ({ uiMessages }) => {
+        const head = uiMessages.find((m: any) => m.id === HEAD_ID);
+        mergedToolPart = (head?.parts ?? []).find(
+          (p: any) => p?.toolCallId === TC
+        );
+      },
+      run: async ({ messages, signal }) => {
+        return streamText({
+          model,
+          messages,
+          tools: { delete: deleteTool },
+          abortSignal: signal,
+        });
+      },
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "test-denied-no-regress" });
+    try {
+      // Stale wire arrival — `approval-responded` for a tool that
+      // hydrated already shows as `output-denied`.
+      const stale = {
+        id: HEAD_ID,
+        role: "assistant" as const,
+        parts: [
+          {
+            type: "tool-delete" as const,
+            toolCallId: TC,
+            state: "approval-responded" as const,
+            approval: { id: "appr_1", approved: true },
+          },
+        ],
+      };
+      await harness.sendMessage(stale as any);
+      await new Promise((r) => setTimeout(r, 50));
+
+      // The hydrated terminal state survives the merge.
+      expect(mergedToolPart?.state).toBe("output-denied");
+      expect(mergedToolPart?.approval).toEqual({
+        id: "appr_1",
+        approved: false,
+        reason: "no",
+      });
+      expect(mergedToolPart?.input).toEqual({ resource: "/critical/data" });
+    } finally {
+      await harness.close();
+    }
+  });
+
   it("onValidateMessages sees the slim wire on HITL continuations — fresh-user filter still works", async () => {
     // Slim wire is the wire shape on HITL `addToolOutput` continuations.
     // Existing customers calling `validateUIMessages` from `ai` on the
@@ -546,7 +632,10 @@ describe("mockChatAgent", () => {
         if (userMessages.length > 0) {
           await validateUIMessages({
             messages: userMessages,
-            tools: { askUser },
+            // `validateUIMessages` is stricter than `streamText` about
+            // tool input/output variance — cast to satisfy the wider
+            // `Tool<unknown, unknown>` it expects.
+            tools: { askUser } as any,
           });
         }
         return messages;

--- a/packages/trigger-sdk/test/mockChatAgent.test.ts
+++ b/packages/trigger-sdk/test/mockChatAgent.test.ts
@@ -179,6 +179,64 @@ describe("mockChatAgent", () => {
     }
   });
 
+  it("hydrate path: fresh user message lands in onTurnComplete.newUIMessages", async () => {
+    // The dedup that suppresses HITL-continuation pushes to
+    // `turnNewUIMessages` must compare against the PRE-hydration
+    // accumulator, not the post-hydration chain. A `hydrateMessages`
+    // hook that pushes the incoming user message into its persisted
+    // chain (the canonical pattern documented in
+    // /ai-chat/lifecycle-hooks#hydratemessages and the
+    // `upsertIncomingMessage` helper) would otherwise see the new
+    // user message in the returned `hydrated` array for every fresh
+    // turn, causing the dedup to wrongly fire and drop the user
+    // message from `newUIMessages` / `newMessages`.
+    const stored: any[] = [];
+
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({ stream: textStream("hi") }),
+    });
+
+    let capturedNewUIMessages: any[] | undefined;
+    const agent = chat.agent({
+      id: "mockChatAgent.hydrate-newui-fresh-user",
+      hydrateMessages: async ({ trigger, incomingMessages }) => {
+        // Canonical pattern: push the incoming user message into the
+        // persisted chain and return the chain. Mirrors what
+        // `upsertIncomingMessage` does.
+        if (trigger === "submit-message" && incomingMessages.length > 0) {
+          const newMsg = incomingMessages[incomingMessages.length - 1]!;
+          const exists = newMsg.id
+            ? stored.some((m) => m.id === newMsg.id)
+            : false;
+          if (!exists) stored.push(newMsg);
+        }
+        return [...stored];
+      },
+      onTurnComplete: async ({ newUIMessages }) => {
+        capturedNewUIMessages = newUIMessages;
+      },
+      run: async ({ messages, signal }) => {
+        return streamText({ model, messages, abortSignal: signal });
+      },
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "test-hydrate-newui-fresh-user" });
+    try {
+      await harness.sendMessage(userMessage("hello", "u-fresh"));
+      await new Promise((r) => setTimeout(r, 50));
+
+      // `newUIMessages` for a fresh user turn must contain BOTH the
+      // user message and the assistant response. The bug surfaces as
+      // length=1 (assistant only — user dropped by the wrong dedup).
+      expect(capturedNewUIMessages).toBeDefined();
+      const roles = capturedNewUIMessages!.map((m: any) => m.role);
+      expect(roles).toEqual(["user", "assistant"]);
+      expect(capturedNewUIMessages![0]!.id).toBe("u-fresh");
+    } finally {
+      await harness.close();
+    }
+  });
+
   it("merges HITL tool answer onto head assistant when AI SDK regenerates the id", async () => {
     // Regression for TRI-9137: customers (Arena AI) report that the AI SDK
     // intermittently mints a fresh id on `addToolOutput` resume, breaking

--- a/packages/trigger-sdk/test/mockChatAgent.test.ts
+++ b/packages/trigger-sdk/test/mockChatAgent.test.ts
@@ -5,9 +5,10 @@ import { mockChatAgent } from "../src/v3/test/index.js";
 import { describe, expect, it, vi } from "vitest";
 import { chat } from "../src/v3/ai.js";
 import { locals } from "@trigger.dev/core/v3";
-import { simulateReadableStream, streamText } from "ai";
+import { simulateReadableStream, streamText, tool, validateUIMessages } from "ai";
 import { MockLanguageModelV3 } from "ai/test";
 import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import { z } from "zod";
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -185,8 +186,6 @@ describe("mockChatAgent", () => {
     // an assistant with tool parts lands in the accumulator and uses that
     // map as a fallback in the merge so a fresh-id incoming still attaches
     // to the right head.
-    const { z } = await import("zod");
-    const { tool } = await import("ai");
 
     const askUserTool = tool({
       description: "Ask the user a question.",
@@ -314,8 +313,6 @@ describe("mockChatAgent", () => {
     // the hydrated `input` and overlay only the wire's `state` +
     // `output` — otherwise the next LLM call ships a tool call with no
     // `arguments` and the provider 400s.
-    const { z } = await import("zod");
-    const { tool } = await import("ai");
     const searchTool = tool({
       description: "Search.",
       inputSchema: z.object({ query: z.string() }),
@@ -395,8 +392,6 @@ describe("mockChatAgent", () => {
     // approved }`. Hydrated has the same tool part in
     // `approval-requested`. Merge has to overlay state + approval onto
     // hydrated while keeping `input` intact so the agent can resume.
-    const { z } = await import("zod");
-    const { tool } = await import("ai");
     const deleteTool = tool({
       description: "Delete.",
       inputSchema: z.object({ resource: z.string() }),
@@ -475,8 +470,6 @@ describe("mockChatAgent", () => {
     // prior `approval-responded` (replay, retry, out-of-order arrival)
     // must NOT regress the terminal denial back to a pre-resolution
     // state — the agent would then re-run the tool.
-    const { z } = await import("zod");
-    const { tool } = await import("ai");
     const deleteTool = tool({
       description: "Delete.",
       inputSchema: z.object({ resource: z.string() }),
@@ -565,8 +558,6 @@ describe("mockChatAgent", () => {
     // This test pins both behaviors: (1) the slim assistant does arrive
     // in the validate hook on the HITL turn, (2) a fresh-user-only
     // filter still works (the user message turn is unaffected).
-    const { z } = await import("zod");
-    const { tool, validateUIMessages } = await import("ai");
     const askUser = tool({
       description: "Ask the user.",
       inputSchema: z.object({ q: z.string() }),
@@ -696,8 +687,6 @@ describe("mockChatAgent", () => {
     // The agent's own turn-1 output seeds the accumulator with the
     // full assistant + tool `input`; a slim turn-2 wire copy has to
     // merge onto that without clobbering the snapshot's `input`.
-    const { z } = await import("zod");
-    const { tool } = await import("ai");
     const askUser = tool({
       description: "Ask the user.",
       inputSchema: z.object({ q: z.string() }),
@@ -820,7 +809,6 @@ describe("mockChatAgent", () => {
 
     const onActionSpy = vi.fn();
 
-    const { z } = await import("zod");
     const agent = chat.agent({
       id: "mockChatAgent.actions",
       actionSchema: z.object({
@@ -859,7 +847,6 @@ describe("mockChatAgent", () => {
       },
     });
 
-    const { z } = await import("zod");
     const agent = chat.agent({
       id: "mockChatAgent.actions.void",
       actionSchema: z.object({ type: z.literal("undo") }),
@@ -927,7 +914,6 @@ describe("mockChatAgent", () => {
       doStream: async () => ({ stream: textStream("normal-response") }),
     });
 
-    const { z } = await import("zod");
     const agent = chat.agent({
       id: "mockChatAgent.actions.stream",
       actionSchema: z.object({ type: z.literal("regenerate") }),
@@ -976,7 +962,6 @@ describe("mockChatAgent", () => {
       },
     });
 
-    const { z } = await import("zod");
     const agent = chat.agent({
       id: "mockChatAgent.actions.no-handler",
       actionSchema: z.object({ type: z.literal("undo") }),
@@ -1167,8 +1152,6 @@ describe("mockChatAgent", () => {
     }
 
     it("getPendingToolCalls returns input-available parts on the leaf assistant", async () => {
-      const { z } = await import("zod");
-      const { tool } = await import("ai");
       const askUser = tool({
         description: "Ask the user.",
         inputSchema: z.object({ q: z.string() }),
@@ -1230,8 +1213,6 @@ describe("mockChatAgent", () => {
     });
 
     it("getResolvedToolCalls walks all messages after a HITL answer lands", async () => {
-      const { z } = await import("zod");
-      const { tool } = await import("ai");
       const askUser = tool({
         description: "Ask the user.",
         inputSchema: z.object({ q: z.string() }),
@@ -1411,8 +1392,6 @@ describe("mockChatAgent", () => {
     it("extractNewToolResults dedups against a real-stream-built chain", async () => {
       // Build the chain through real model streams (no chat.history.set seed)
       // and assert extractNewToolResults compares against the post-merge state.
-      const { z } = await import("zod");
-      const { tool } = await import("ai");
       const askUser = tool({
         description: "Ask the user.",
         inputSchema: z.object({ q: z.string() }),
@@ -1497,8 +1476,6 @@ describe("mockChatAgent", () => {
       // assistant via the toolCallId map. Here we send an answer in
       // `output-error` state and verify (a) getResolvedToolCalls reports
       // it, and (b) extractNewToolResults emits it with errorText set.
-      const { z } = await import("zod");
-      const { tool } = await import("ai");
       const search = tool({
         description: "Search.",
         inputSchema: z.object({ q: z.string() }),

--- a/packages/trigger-sdk/test/wire-shape.test.ts
+++ b/packages/trigger-sdk/test/wire-shape.test.ts
@@ -11,6 +11,7 @@ import "../src/v3/test/index.js";
 import type { UIMessage } from "ai";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import type { ChatInputChunk, ChatTaskWirePayload } from "../src/v3/ai-shared.js";
+import { slimSubmitMessageForWire } from "../src/v3/ai-shared.js";
 
 describe("ChatTaskWirePayload (slim wire shape)", () => {
   it("encodes and decodes a submit-message payload through JSON", () => {
@@ -154,6 +155,184 @@ describe("ChatTaskWirePayload (slim wire shape)", () => {
 
     const decoded = JSON.parse(JSON.stringify(wire)) as ChatTaskWirePayload;
     expect(decoded.message).toEqual(approvalMsg);
+  });
+});
+
+describe("slimSubmitMessageForWire", () => {
+  it("passes user messages through unchanged", () => {
+    const userMsg: UIMessage = {
+      id: "u-1",
+      role: "user",
+      parts: [{ type: "text", text: "hello" }],
+    };
+    expect(slimSubmitMessageForWire(userMsg)).toBe(userMsg);
+  });
+
+  it("passes assistant messages with no resolved tool parts through unchanged", () => {
+    const assistantMsg: UIMessage = {
+      id: "a-1",
+      role: "assistant",
+      parts: [
+        { type: "text", text: "thinking..." },
+        {
+          type: "tool-search",
+          toolCallId: "tc-1",
+          state: "input-available",
+          input: { q: "x" },
+        } as never,
+      ],
+    };
+    expect(slimSubmitMessageForWire(assistantMsg)).toBe(assistantMsg);
+  });
+
+  it("slims output-available HITL continuation to {type, toolCallId, state, output}", () => {
+    const assistantMsg: UIMessage = {
+      id: "a-1",
+      role: "assistant",
+      parts: [
+        { type: "text", text: "let me search" },
+        { type: "reasoning", text: "long reasoning blob..." } as never,
+        {
+          type: "tool-search",
+          toolCallId: "tc-1",
+          state: "output-available",
+          input: { q: "very long query".repeat(1000) },
+          output: { hits: 7 },
+        } as never,
+      ],
+    };
+    const slim = slimSubmitMessageForWire(assistantMsg);
+    expect(slim).toEqual({
+      id: "a-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-search",
+          toolCallId: "tc-1",
+          state: "output-available",
+          output: { hits: 7 },
+        },
+      ],
+    });
+    // The slim drops `input` (server has it via hydrate/snapshot) — the
+    // wire is much smaller than the original.
+    expect(JSON.stringify(slim).length).toBeLessThan(JSON.stringify(assistantMsg).length / 50);
+  });
+
+  it("slims output-error to {type, toolCallId, state, errorText}", () => {
+    const assistantMsg: UIMessage = {
+      id: "a-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-search",
+          toolCallId: "tc-1",
+          state: "output-error",
+          input: { q: "x" },
+          errorText: "boom",
+        } as never,
+      ],
+    };
+    expect(slimSubmitMessageForWire(assistantMsg)).toEqual({
+      id: "a-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-search",
+          toolCallId: "tc-1",
+          state: "output-error",
+          errorText: "boom",
+        },
+      ],
+    });
+  });
+
+  it("slims approval-responded to {type, toolCallId, state, approval}", () => {
+    const assistantMsg: UIMessage = {
+      id: "a-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-delete",
+          toolCallId: "tc-1",
+          state: "approval-responded",
+          input: { path: "/critical" },
+          approval: { id: "appr_1", approved: true, reason: "looks fine" },
+        } as never,
+      ],
+    };
+    expect(slimSubmitMessageForWire(assistantMsg)).toEqual({
+      id: "a-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-delete",
+          toolCallId: "tc-1",
+          state: "approval-responded",
+          approval: { id: "appr_1", approved: true, reason: "looks fine" },
+        },
+      ],
+    });
+  });
+
+  it("slims dynamic-tool parts and preserves toolName", () => {
+    const assistantMsg: UIMessage = {
+      id: "a-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "dyn-search",
+          toolCallId: "tc-1",
+          state: "output-available",
+          input: { q: "x" },
+          output: { hits: 1 },
+        } as never,
+      ],
+    };
+    expect(slimSubmitMessageForWire(assistantMsg)).toEqual({
+      id: "a-1",
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "dyn-search",
+          toolCallId: "tc-1",
+          state: "output-available",
+          output: { hits: 1 },
+        },
+      ],
+    });
+  });
+
+  it("only slims the advanced tool parts when an assistant has mixed states", () => {
+    const assistantMsg: UIMessage = {
+      id: "a-1",
+      role: "assistant",
+      parts: [
+        { type: "text", text: "thinking" },
+        {
+          type: "tool-search",
+          toolCallId: "tc-resolved",
+          state: "output-available",
+          input: { q: "x" },
+          output: { hits: 1 },
+        } as never,
+        {
+          type: "tool-askUser",
+          toolCallId: "tc-still-pending",
+          state: "input-available",
+          input: { q: "ok?" },
+        } as never,
+      ],
+    };
+    const slim = slimSubmitMessageForWire(assistantMsg);
+    expect(slim?.parts).toHaveLength(1);
+    expect((slim?.parts?.[0] as any).toolCallId).toBe("tc-resolved");
+  });
+
+  it("handles undefined input", () => {
+    expect(slimSubmitMessageForWire(undefined)).toBeUndefined();
   });
 });
 

--- a/packages/trigger-sdk/test/wire-shape.test.ts
+++ b/packages/trigger-sdk/test/wire-shape.test.ts
@@ -11,7 +11,7 @@ import "../src/v3/test/index.js";
 import type { UIMessage } from "ai";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import type { ChatInputChunk, ChatTaskWirePayload } from "../src/v3/ai-shared.js";
-import { slimSubmitMessageForWire } from "../src/v3/ai-shared.js";
+import { slimSubmitMessageForWire, upsertIncomingMessage } from "../src/v3/ai-shared.js";
 
 describe("ChatTaskWirePayload (slim wire shape)", () => {
   it("encodes and decodes a submit-message payload through JSON", () => {
@@ -155,6 +155,119 @@ describe("ChatTaskWirePayload (slim wire shape)", () => {
 
     const decoded = JSON.parse(JSON.stringify(wire)) as ChatTaskWirePayload;
     expect(decoded.message).toEqual(approvalMsg);
+  });
+});
+
+describe("upsertIncomingMessage", () => {
+  const userMsg = (id: string, text: string): UIMessage => ({
+    id,
+    role: "user",
+    parts: [{ type: "text", text }],
+  });
+
+  it("pushes a fresh user message and returns true", () => {
+    const stored: UIMessage[] = [userMsg("u-1", "first")];
+    const mutated = upsertIncomingMessage(stored, {
+      trigger: "submit-message",
+      incomingMessages: [userMsg("u-2", "second")],
+    });
+    expect(mutated).toBe(true);
+    expect(stored).toHaveLength(2);
+    expect(stored[1]!.id).toBe("u-2");
+  });
+
+  it("no-ops when incoming id is already in stored (HITL continuation)", () => {
+    const head = {
+      id: "asst-1",
+      role: "assistant" as const,
+      parts: [{ type: "tool-search", toolCallId: "tc-1", state: "input-available", input: {} } as never],
+    };
+    const stored: UIMessage[] = [userMsg("u-1", "hi"), head];
+    const slim = {
+      id: "asst-1",
+      role: "assistant" as const,
+      parts: [{ type: "tool-search", toolCallId: "tc-1", state: "output-available", output: {} } as never],
+    };
+    const mutated = upsertIncomingMessage(stored, {
+      trigger: "submit-message",
+      incomingMessages: [slim],
+    });
+    expect(mutated).toBe(false);
+    expect(stored).toHaveLength(2);
+    // The original head is untouched — the runtime's per-turn merge
+    // overlays the resolution; the customer's stored array is just
+    // the pre-merge snapshot.
+    expect(stored[1]).toBe(head);
+  });
+
+  it("no-ops on regenerate-message trigger", () => {
+    const stored: UIMessage[] = [userMsg("u-1", "hi")];
+    const mutated = upsertIncomingMessage(stored, {
+      trigger: "regenerate-message",
+      incomingMessages: [userMsg("u-2", "ignored")],
+    });
+    expect(mutated).toBe(false);
+    expect(stored).toHaveLength(1);
+  });
+
+  it("no-ops on action trigger", () => {
+    const stored: UIMessage[] = [userMsg("u-1", "hi")];
+    const mutated = upsertIncomingMessage(stored, {
+      trigger: "action",
+      incomingMessages: [],
+    });
+    expect(mutated).toBe(false);
+    expect(stored).toHaveLength(1);
+  });
+
+  it("no-ops on empty incomingMessages", () => {
+    const stored: UIMessage[] = [userMsg("u-1", "hi")];
+    const mutated = upsertIncomingMessage(stored, {
+      trigger: "submit-message",
+      incomingMessages: [],
+    });
+    expect(mutated).toBe(false);
+    expect(stored).toHaveLength(1);
+  });
+
+  it("only inspects the last incoming message (slim wire ships at most one)", () => {
+    const stored: UIMessage[] = [userMsg("u-1", "hi")];
+    const mutated = upsertIncomingMessage(stored, {
+      trigger: "submit-message",
+      incomingMessages: [userMsg("ignored", "ignored"), userMsg("u-3", "new")],
+    });
+    expect(mutated).toBe(true);
+    expect(stored).toHaveLength(2);
+    expect(stored[1]!.id).toBe("u-3");
+  });
+
+  it("pushes when newMsg has no id (no dedup possible)", () => {
+    const stored: UIMessage[] = [userMsg("u-1", "hi")];
+    const incoming = { role: "user", parts: [{ type: "text", text: "no id" }] } as unknown as UIMessage;
+    const mutated = upsertIncomingMessage(stored, {
+      trigger: "submit-message",
+      incomingMessages: [incoming],
+    });
+    expect(mutated).toBe(true);
+    expect(stored).toHaveLength(2);
+  });
+
+  it("accepts the full hydrateMessages event without re-packaging", () => {
+    // Customers can pass the destructured event directly — the helper
+    // only reads `trigger` + `incomingMessages` but ignores any other
+    // fields the event happens to carry.
+    const stored: UIMessage[] = [];
+    const event = {
+      chatId: "chat-1",
+      turn: 0,
+      trigger: "submit-message" as const,
+      incomingMessages: [userMsg("u-1", "hi")],
+      previousMessages: [],
+      continuation: false,
+    };
+    const mutated = upsertIncomingMessage(stored, event);
+    expect(mutated).toBe(true);
+    expect(stored).toHaveLength(1);
   });
 });
 

--- a/references/ai-chat/src/trigger/chat.ts
+++ b/references/ai-chat/src/trigger/chat.ts
@@ -232,15 +232,26 @@ export const aiChat = chat
         turn,
         count: messages.length,
       });
-      // Cast: `chatTools` has executes (output types are real), but
-      // `ChatUiMessage` is derived from the schema-only set in
-      // `chat-tools-schemas.ts` so its tools have `output: never`.
-      // `validateUIMessages` only reads `inputSchema` at runtime, so
-      // the type narrowing is safely sidestepped.
-      return validateUIMessages({
-        messages,
-        tools: chatTools as unknown as Parameters<typeof validateUIMessages>[0]["tools"],
-      });
+      // HITL continuations (`addToolOutput` / `addToolApproveResponse`)
+      // ship a slim assistant on the wire — `state` + `output` /
+      // `errorText` / `approval` only, no `input` or other parts.
+      // `validateUIMessages` rejects that shape (the AI SDK schema
+      // requires `input` on resolved tool parts), so filter to user
+      // messages first. The agent's per-turn merge restores the
+      // hydrated entry's `input` before `toModelMessages`.
+      const userMessages = messages.filter((m) => m.role === "user");
+      if (userMessages.length > 0) {
+        await validateUIMessages({
+          messages: userMessages,
+          // Cast: `chatTools` has executes (output types are real), but
+          // `ChatUiMessage` is derived from the schema-only set in
+          // `chat-tools-schemas.ts` so its tools have `output: never`.
+          // `validateUIMessages` only reads `inputSchema` at runtime, so
+          // the type narrowing is safely sidestepped.
+          tools: chatTools as unknown as Parameters<typeof validateUIMessages>[0]["tools"],
+        });
+      }
+      return messages;
     },
     // #endregion
 

--- a/references/ai-chat/src/trigger/chat.ts
+++ b/references/ai-chat/src/trigger/chat.ts
@@ -888,18 +888,29 @@ export const aiChatHydrated = chat
     // Load message history from the database on every turn.
     // The frontend's accumulated messages are ignored — the DB is the
     // single source of truth. New user messages arrive in `incomingMessages`
-    // and are appended + persisted before returning.
+    // and are upserted by id + persisted before returning.
+    //
+    // HITL continuations (tool-output answers from `addToolOutput`) arrive
+    // as a slim assistant message whose id matches the existing assistant
+    // already in the chain — those land via the SDK's per-turn merge, so
+    // they're skipped here. Only brand-new ids (typically the user's next
+    // message) get appended.
     hydrateMessages: async ({ chatId, trigger, incomingMessages }) => {
       const record = await prisma.chat.findUnique({ where: { id: chatId } });
       const stored = (record?.messages as unknown as UIMessage[]) ?? [];
 
       if (trigger === "submit-message" && incomingMessages.length > 0) {
         const newMsg = incomingMessages[incomingMessages.length - 1]!;
-        stored.push(newMsg);
-        await prisma.chat.update({
-          where: { id: chatId },
-          data: { messages: stored as unknown as ChatMessagesForWrite },
-        });
+        const existingIdx = newMsg.id
+          ? stored.findIndex((m) => m.id === newMsg.id)
+          : -1;
+        if (existingIdx === -1) {
+          stored.push(newMsg);
+          await prisma.chat.update({
+            where: { id: chatId },
+            data: { messages: stored as unknown as ChatMessagesForWrite },
+          });
+        }
       }
 
       return stored;

--- a/references/ai-chat/src/trigger/chat.ts
+++ b/references/ai-chat/src/trigger/chat.ts
@@ -1,4 +1,4 @@
-import { chat, type ChatTaskWirePayload } from "@trigger.dev/sdk/ai";
+import { chat, upsertIncomingMessage, type ChatTaskWirePayload } from "@trigger.dev/sdk/ai";
 import { logger, prompts, skills } from "@trigger.dev/sdk";
 
 import {
@@ -887,30 +887,19 @@ export const aiChatHydrated = chat
 
     // Load message history from the database on every turn.
     // The frontend's accumulated messages are ignored — the DB is the
-    // single source of truth. New user messages arrive in `incomingMessages`
-    // and are upserted by id + persisted before returning.
-    //
-    // HITL continuations (tool-output answers from `addToolOutput`) arrive
-    // as a slim assistant message whose id matches the existing assistant
-    // already in the chain — those land via the SDK's per-turn merge, so
-    // they're skipped here. Only brand-new ids (typically the user's next
-    // message) get appended.
+    // single source of truth. `upsertIncomingMessage` handles HITL
+    // continuations (slim wire sharing an id with the existing
+    // assistant — no-op so the runtime overlays the new state) and
+    // fresh user messages (push + persist).
     hydrateMessages: async ({ chatId, trigger, incomingMessages }) => {
       const record = await prisma.chat.findUnique({ where: { id: chatId } });
       const stored = (record?.messages as unknown as UIMessage[]) ?? [];
 
-      if (trigger === "submit-message" && incomingMessages.length > 0) {
-        const newMsg = incomingMessages[incomingMessages.length - 1]!;
-        const existingIdx = newMsg.id
-          ? stored.findIndex((m) => m.id === newMsg.id)
-          : -1;
-        if (existingIdx === -1) {
-          stored.push(newMsg);
-          await prisma.chat.update({
-            where: { id: chatId },
-            data: { messages: stored as unknown as ChatMessagesForWrite },
-          });
-        }
+      if (upsertIncomingMessage(stored, { trigger, incomingMessages })) {
+        await prisma.chat.update({
+          where: { id: chatId },
+          data: { messages: stored as unknown as ChatMessagesForWrite },
+        });
       }
 
       return stored;


### PR DESCRIPTION
## Summary

Multi-step reasoning agents with HITL tools (OpenAI Responses with `store: false`, Anthropic extended thinking, etc.) failed on `chat.addToolOutput(...)` continuations — either the wire payload blew the `.in/append` cap (reasoning blobs + tool inputs routinely > 512 KiB), or app-side slimming workarounds got overwritten server-side and the next LLM call landed a tool call with no `arguments`. Both modes are fixed.

## Design

The per-turn merge in `chat.agent` now overlays only the tool-part state advances (`output-available` / `output-error` / `approval-responded` / `output-denied`) from the wire copy onto the hydrated/snapshot chain. Previously it replaced the entire message, which dropped `input`, reasoning, and text from the LLM's view whenever the wire was slim.

In parallel, `TriggerChatTransport.sendMessages` and `AgentChat.sendRaw` now slim the assistant message themselves on `submit-message` continuations: ship `{ id, role, parts: [<resolved tool part only>] }`, everything else reconstructed server-side from `hydrateMessages` or the durable snapshot. Continuation payloads drop from 600 KiB – 1 MiB to ~1 KiB.

`references/ai-chat` `aiChatHydrated.hydrateMessages` now upserts by id instead of pushing. With slim continuations, a blind push duplicates the assistant id in the returned chain — the merge updates the first match, the slim duplicate goes straight to `toModelMessages` with no `input`, and the LLM 4xx's. This is the canonical pattern customers should mirror in their own hydrate implementations.

## Test plan

- 11 new tests (slim helper unit + slim+merge integration for HITL, approval, default no-hydrate branch)
- Full SDK suite: 239 tests pass across 19 files
- End-to-end sweep against `references/ai-chat`: 19 customer-side smoke tests green; HITL wire bodies confirmed at ~1 KiB (was 600 KiB+); no provider 4xx errors across OpenAI Responses or Anthropic