### PR TITLE
Fix ClickHouse migration DSN handling for HTTP URLs in the webapp entrypoint

### DIFF
--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -17,18 +17,10 @@ if [ -n "$CLICKHOUSE_URL" ] && [ "$SKIP_CLICKHOUSE_MIGRATIONS" != "1" ]; then
   # Run ClickHouse migrations
   echo "Running ClickHouse migrations..."
   export GOOSE_DRIVER=clickhouse
-  
-  # Ensure secure=true is in the connection string
-  if echo "$CLICKHOUSE_URL" | grep -q "secure="; then
-    # secure parameter already exists, use as is
-    export GOOSE_DBSTRING="$CLICKHOUSE_URL"
-  elif echo "$CLICKHOUSE_URL" | grep -q "?"; then
-    # URL has query parameters, append secure=true
-    export GOOSE_DBSTRING="${CLICKHOUSE_URL}&secure=true"
-  else
-    # URL has no query parameters, add secure=true
-    export GOOSE_DBSTRING="${CLICKHOUSE_URL}?secure=true"
-  fi
+
+  # Goose derives TLS from the URL scheme. Strip any existing secure query
+  # parameter and only set secure=true for https URLs.
+  export GOOSE_DBSTRING="$(node -e 'const url = new URL(process.env.CLICKHOUSE_URL); url.searchParams.delete("secure"); if (url.protocol === "https:") { url.searchParams.set("secure", "true"); } process.stdout.write(url.toString());')"
   
   export GOOSE_MIGRATION_DIR=/triggerdotdev/internal-packages/clickhouse/schema
   /usr/local/bin/goose up


### PR DESCRIPTION
This PR fixes the startup failure reported in issue [#3674](vscode-file://vscode-app/c:/Users/patel/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for self-hosted Docker setups using ClickHouse over HTTP.

The bug was in [entrypoint.sh](vscode-file://vscode-app/c:/Users/patel/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html), where the ClickHouse migration DSN was being built with secure=true appended unconditionally unless the URL already contained a secure parameter. That caused Goose to reject valid http:// ClickHouse URLs with an error like: clickhouse [dsn parse]: http with TLS specify

As a result, the webapp container failed during startup and entered a restart loop.

This change makes the DSN construction scheme-aware:

It strips any existing secure query parameter.
It only adds secure=true when the ClickHouse URL uses https://.
For http:// URLs, it leaves the URL unmodified so Goose can parse it correctly.
In short, the fix removes the mismatch between the URL scheme and the forced TLS flag, which was the root cause of the startup failure.