### PR TITLE
fix(webapp): skip V1 WAITING_FOR_DEPLOY drain on V2 promotes

### DIFF
--- a/.server-changes/skip-waiting-for-deploy-on-v2-promotes.md
+++ b/.server-changes/skip-waiting-for-deploy-on-v2-promotes.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Skip the legacy V1 `WAITING_FOR_DEPLOY` drain on V2 deployment promotions. A new `LEGACY_RUN_ENGINE_WAITING_FOR_DEPLOY_DISABLED` env var also acts as a kill-switch for any already-enqueued jobs.

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -1016,6 +1016,7 @@ const EnvironmentSchema = z
 
     LEGACY_RUN_ENGINE_WAITING_FOR_DEPLOY_BATCH_SIZE: z.coerce.number().int().default(100),
     LEGACY_RUN_ENGINE_WAITING_FOR_DEPLOY_BATCH_STAGGER_MS: z.coerce.number().int().default(1_000),
+    LEGACY_RUN_ENGINE_WAITING_FOR_DEPLOY_DISABLED: z.string().default("0"),
 
     COMMON_WORKER_ENABLED: z.string().default(process.env.WORKER_ENABLED ?? "true"),
     COMMON_WORKER_CONCURRENCY_WORKERS: z.coerce.number().int().default(2),

--- a/apps/webapp/app/v3/services/changeCurrentDeployment.server.ts
+++ b/apps/webapp/app/v3/services/changeCurrentDeployment.server.ts
@@ -175,7 +175,17 @@ export class ChangeCurrentDeploymentService extends BaseService {
       });
     }
 
-    await ExecuteTasksWaitingForDeployService.enqueue(deployment.workerId);
+    // Only V1 engine workers need the WAITING_FOR_DEPLOY drain — V2 runs sit
+    // in PENDING_VERSION and are handled out of band, so enqueuing here for V2
+    // just produces empty scans of the TaskRun status index.
+    const worker = await this._prisma.backgroundWorker.findFirst({
+      where: { id: deployment.workerId },
+      select: { engine: true },
+    });
+
+    if (worker?.engine === "V1") {
+      await ExecuteTasksWaitingForDeployService.enqueue(deployment.workerId);
+    }
   }
 
   async #syncSchedulesForDeployment(deployment: WorkerDeployment) {

--- a/apps/webapp/app/v3/services/executeTasksWaitingForDeploy.ts
+++ b/apps/webapp/app/v3/services/executeTasksWaitingForDeploy.ts
@@ -7,6 +7,12 @@ import { BaseService } from "./baseService.server";
 
 export class ExecuteTasksWaitingForDeployService extends BaseService {
   public async call(backgroundWorkerId: string) {
+    // Kill-switch for the legacy V1 WAITING_FOR_DEPLOY drain. Set to "1" to
+    // neuter any jobs already enqueued (V2 has its own PENDING_VERSION path).
+    if (env.LEGACY_RUN_ENGINE_WAITING_FOR_DEPLOY_DISABLED === "1") {
+      return;
+    }
+
     const backgroundWorker = await this._prisma.backgroundWorker.findFirst({
       where: {
         id: backgroundWorkerId,


### PR DESCRIPTION
## Summary

Stops the legacy V1 `WAITING_FOR_DEPLOY` drain from running on every V2 deployment promotion. The drain queries `TaskRun` by `status='WAITING_FOR_DEPLOY'`, which only V1-engine runs ever have — V2 runs use `PENDING_VERSION` and are handled out of band. Calling the drain on V2 promotes produced empty queries against the status index and unnecessary reader-DB load.

## Fix

Two layers:

1. Gate the enqueue at the call site in `ChangeCurrentDeploymentService` so it only fires when the deployment's worker is on engine V1.
2. Add a `LEGACY_RUN_ENGINE_WAITING_FOR_DEPLOY_DISABLED` env var (default `0`). When set to `1`, the service returns immediately from `call()` — neuters any jobs already sitting in the worker queue from before the deploy lands.

V1 customers see no change; V2 promotes no longer trigger the drain.