### PR TITLE
chore(database): drop unused TaskRun status composite index

### DIFF
--- a/.server-changes/drop-taskrun-status-composite-idx.md
+++ b/.server-changes/drop-taskrun-status-composite-idx.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+Reduce primary database write load on `TaskRun` by dropping an unused composite index on `(status, runtimeEnvironmentId, createdAt, id)`. After gating the legacy `WAITING_FOR_DEPLOY` drain to V1-engine workers only, no V2 Prisma query uses this index while it was still being maintained on every `TaskRun` INSERT/UPDATE.

--- a/internal-packages/database/prisma/migrations/20260525083555_drop_task_run_status_runtime_environment_id_created_at_id_idx/migration.sql
+++ b/internal-packages/database/prisma/migrations/20260525083555_drop_task_run_status_runtime_environment_id_created_at_id_idx/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX CONCURRENTLY IF EXISTS "public"."TaskRun_status_runtimeEnvironmentId_createdAt_id_idx";

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -1089,7 +1089,6 @@ model TaskRun {
   @@index([runtimeEnvironmentId, batchId])
   @@index([runtimeEnvironmentId, createdAt(sort: Desc)])
   @@index([createdAt], type: Brin)
-  @@index([status, runtimeEnvironmentId, createdAt, id(sort: Desc)])
 }
 
 model TaskRunTemplate {


### PR DESCRIPTION
## Summary

Drops the `TaskRun_status_runtimeEnvironmentId_createdAt_id_idx` index from the `TaskRun` table. After #3742 gated the legacy `WAITING_FOR_DEPLOY` drain to V1-engine workers only, this index sees zero scans on both writer and reader replicas. Removing it cuts index maintenance on every `TaskRun` INSERT/UPDATE.

## Why

The index existed to support `WHERE status = X AND runtimeEnvironmentId = Y` queries from `ExecuteTasksWaitingForDeployService`, which is V1-only and no longer triggered on V2 deployments. A code grep across `apps/webapp` and `internal-packages/run-engine` confirmed no V2 production query uses this access pattern — every other `status:` filter on `TaskRun` is paired with `id`/`friendlyId`/`parentSpanId` and uses a different index.

Dropping it also unlocks HOT updates on the dequeue path. The dequeue `UPDATE` modifies `status` (`QUEUED` -> `DEQUEUED`), and `status` is the leading column of this index — its presence blocked HOT eligibility for every `TaskRun` UPDATE. With the index gone, dequeue UPDATEs can become HOT, reducing WAL bytes and removing the B-tree page contention on this index's right-edge leaves.

Uses `DROP INDEX CONCURRENTLY` to avoid blocking writes during the drop.

## Sequencing

Should only ship once #3742 has soaked long enough to confirm the index is genuinely cold (24h+ of zero scans on `pg_stat_user_indexes`).