### PR TITLE
fix: authenticate Docker Hub pulls to prevent anonymous rate limits #3741

### DIFF
--- a/.github/workflows/publish-webapp.yml
+++ b/.github/workflows/publish-webapp.yml
@@ -88,6 +88,12 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 🐋 Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: 🐳 Build image and push to GitHub Container Registry
         id: build_push
         uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0

--- a/.github/workflows/publish-worker-v4.yml
+++ b/.github/workflows/publish-worker-v4.yml
@@ -81,6 +81,12 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 🐋 Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: 🐳 Build image and push to GitHub Container Registry
         uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
         with:


### PR DESCRIPTION
Resolves #3741
/claim #3741

### Summary of Changes
Added authenticated Docker Hub logins using `docker/login-action@v3` right before the `depot/build-push-action` step in both the worker (`publish-worker-v4.yml`) and webapp (`publish-webapp.yml`) publish workflows. This ensures the automated image builder bypasses Docker Hub's anonymous-pull rate limits, resolving the 401 Unauthorized errors reported during deployment windows.