### PR TITLE
Preserve OTLP nanosecond timestamp precision

### DIFF
--- a/apps/webapp/app/v3/eventRepository/common.server.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.ts
@@ -21,7 +21,7 @@ export function extractContextFromCarrier(carrier: Record<string, unknown>) {
 }
 
 export function getNowInNanoseconds(): bigint {
-  return BigInt(new Date().getTime() * 1_000_000);
+  return convertDateToNanoseconds(new Date());
 }
 
 export function getDateFromNanoseconds(nanoseconds: bigint): Date {
@@ -35,7 +35,7 @@ export function calculateDurationFromStart(
 ) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  const duration = Number(BigInt($endtime.getTime() * 1_000_000) - startTime);
+  const duration = Number(convertDateToNanoseconds($endtime) - startTime);
 
   if (minimumDuration && duration < minimumDuration) {
     return minimumDuration;

--- a/apps/webapp/app/v3/eventRepository/index.server.ts
+++ b/apps/webapp/app/v3/eventRepository/index.server.ts
@@ -7,6 +7,7 @@ import { FEATURE_FLAG } from "../featureFlags";
 import { flag } from "../featureFlags.server";
 import { getTaskEventStore } from "../taskEventStore.server";
 import { clickhouseFactory } from "~/services/clickhouse/clickhouseFactoryInstance.server";
+import { convertDateToNanoseconds } from "./common.server";
 
 export const EVENT_STORE_TYPES = {
   POSTGRES: "postgres",
@@ -28,10 +29,7 @@ export type EventStoreType = (typeof EVENT_STORE_TYPES)[keyof typeof EVENT_STORE
  * directly and gate startup on `clickhouseFactory.isReady()`. Everything else
  * should use {@link getEventRepositoryForStore}, the async variant below.
  */
-function resolveEventRepositoryForStore(
-  store: string,
-  organizationId: string
-): IEventRepository {
+function resolveEventRepositoryForStore(store: string, organizationId: string): IEventRepository {
   if (store === EVENT_STORE_TYPES.CLICKHOUSE || store === EVENT_STORE_TYPES.CLICKHOUSE_V2) {
     return clickhouseFactory.getEventRepositoryForOrganizationSync(store, organizationId)
       .repository;
@@ -262,7 +260,7 @@ async function recordRunEvent(
         runId: foundRun.friendlyId,
         ...attributes,
       },
-      startTime: BigInt((startTime?.getTime() ?? Date.now()) * 1_000_000),
+      startTime: convertDateToNanoseconds(startTime ?? new Date()),
       ...optionsRest,
     });
 

--- a/apps/webapp/app/v3/runEngineHandlers.server.ts
+++ b/apps/webapp/app/v3/runEngineHandlers.server.ts
@@ -16,7 +16,10 @@ import { MetadataTooLargeError } from "~/utils/packets";
 import { QueueSizeLimitExceededError } from "~/v3/services/common.server";
 import { TriggerTaskService } from "~/v3/services/triggerTask.server";
 import { tracer } from "~/v3/tracer.server";
-import { createExceptionPropertiesFromError } from "./eventRepository/common.server";
+import {
+  convertDateToNanoseconds,
+  createExceptionPropertiesFromError,
+} from "./eventRepository/common.server";
 import { getEventRepositoryForStore, recordRunDebugLog } from "./eventRepository/index.server";
 import { roomFromFriendlyRunId, socketIo } from "./handleSocketIo.server";
 import { engine } from "./runEngine.server";
@@ -464,7 +467,7 @@ export function registerRunEngineEventBusHandlers() {
         );
 
         await eventRepository.recordEvent(retryMessage, {
-          startTime: BigInt(time.getTime() * 1000000),
+          startTime: convertDateToNanoseconds(time),
           taskSlug: run.taskIdentifier,
           environment,
           attributes: {

--- a/apps/webapp/test/eventRepositoryNanoseconds.test.ts
+++ b/apps/webapp/test/eventRepositoryNanoseconds.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  calculateDurationFromStart,
+  convertDateToNanoseconds,
+  getNowInNanoseconds,
+} from "~/v3/eventRepository/common.server";
+
+describe("event repository nanosecond conversion", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("converts epoch milliseconds to nanoseconds after BigInt conversion", () => {
+    const date = new Date(1_700_000_000_001);
+
+    expect(convertDateToNanoseconds(date)).toBe(1_700_000_000_001_000_000n);
+  });
+
+  it("uses precise nanosecond conversion for current time and durations", () => {
+    const startTime = convertDateToNanoseconds(new Date(1_700_000_000_001));
+    const endTime = new Date(1_700_000_000_003);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(endTime);
+
+    expect(getNowInNanoseconds()).toBe(1_700_000_000_003_000_000n);
+    expect(calculateDurationFromStart(startTime)).toBe(2_000_000);
+  });
+});


### PR DESCRIPTION
## Summary
- reuse `convertDateToNanoseconds()` anywhere the webapp converts epoch milliseconds into OTLP nanosecond timestamps
- move the remaining event repository and retry-event paths off float-first multiplication
- add a regression test with an epoch millisecond value that loses precision when multiplied before `BigInt` conversion

## Why
Fixes #3292. Multiplying epoch milliseconds by `1_000_000` before converting to `BigInt` crosses `Number.MAX_SAFE_INTEGER` and can introduce small nanosecond-level errors. Converting to `BigInt` first preserves exact span timestamps and duration calculations.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check apps/webapp/app/v3/eventRepository/common.server.ts apps/webapp/app/v3/eventRepository/index.server.ts apps/webapp/app/v3/runEngineHandlers.server.ts apps/webapp/test/eventRepositoryNanoseconds.test.ts`
- `git diff --check`
- `node` repro check confirms `BigInt(ms * 1_000_000)` differs from `BigInt(ms) * 1_000_000n` for `1_700_000_000_001`

## Local test note
I tried `pnpm --filter webapp exec vitest run test/eventRepositoryNanoseconds.test.ts`, but local collection is blocked before tests run because `@trigger.dev/core/v3/isomorphic` is not available until workspace packages are generated/built. Attempting `pnpm --filter @trigger.dev/core build` is currently blocked by existing generated database artifacts (`../generated/prisma`) plus an unrelated `sharedRuntimeManager.ts` exhaustiveness error.
