### PR TITLE
fix: respect maxElapsed in ExponentialBackoff.execute

### DIFF
--- a/.changeset/respect-backoff-max-elapsed.md
+++ b/.changeset/respect-backoff-max-elapsed.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Stop `ExponentialBackoff.execute()` retries when callback execution time pushes the run past `maxElapsed`.

--- a/packages/core/src/v3/apps/backoff.ts
+++ b/packages/core/src/v3/apps/backoff.ts
@@ -98,7 +98,6 @@ export class ExponentialBackoff {
     return this.#clone(undefined, { maxRetries });
   }
 
-  // TODO: With .execute(), should this also include the time it takes to execute the callback?
   maxElapsed(maxElapsed?: number) {
     return this.#clone(undefined, { maxElapsed });
   }
@@ -339,6 +338,14 @@ export class ExponentialBackoff {
       } finally {
         elapsedMs += Date.now() - start;
         clearTimeout(attemptTimeout);
+      }
+
+      if (elapsedMs / 1000 > this.#maxElapsed) {
+        return {
+          success: false,
+          cause: "Timeout",
+          error: finalError,
+        };
       }
     }
 

--- a/packages/core/test/backoff.test.ts
+++ b/packages/core/test/backoff.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { ExponentialBackoff } from "../src/v3/apps/backoff.js";
+
+describe("ExponentialBackoff", () => {
+  it("stops execute retries when callback time exceeds maxElapsed", async () => {
+    const backoff = new ExponentialBackoff("NoJitter", {
+      factor: 0,
+      maxElapsed: 0.01,
+      maxRetries: 5,
+    });
+    const error = new Error("retryable");
+    let attempts = 0;
+
+    const result = await backoff.execute(async () => {
+      attempts++;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      throw error;
+    });
+
+    expect(result).toEqual({
+      success: false,
+      cause: "Timeout",
+      error,
+    });
+    expect(attempts).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #3726

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Ran the focused backoff test:

```bash
vitest run packages/core/test/backoff.test.ts --config vitest.temp.config.mjs
