### PR TITLE
perf(webapp): parallelize streaming batch-item ingest

### DIFF
--- a/.server-changes/parallel-batch-item-ingest.md
+++ b/.server-changes/parallel-batch-item-ingest.md
@@ -3,18 +3,4 @@ area: webapp
 type: improvement
 ---
 
-Phase 2 streaming batch ingest (`POST /api/v3/batches/:batchId/items`) now processes
-items with bounded concurrency instead of strictly sequentially. Previously each item's
-payload offload + enqueue ran one at a time, so batches of many large payloads (each
-offloaded to object storage) could take minutes and blow past Node's default 300s
-`server.requestTimeout`, surfacing to the SDK as `408 terminated` and burning ~26 min
-across the SDK's 5 retries.
-
-Ingestion now uses `p-map` over the NDJSON stream with a configurable concurrency
-(`STREAMING_BATCH_INGEST_CONCURRENCY`, default 10), which pulls lazily so at most
-`concurrency` items are in flight — bounding peak memory to roughly
-`concurrency × STREAMING_BATCH_ITEM_MAXIMUM_SIZE`. Set it to 1 to fall back to fully
-sequential ingestion. Ordering and idempotency are unaffected (run order derives from
-each item's index, and `enqueueBatchItem` dedups atomically per index); the NDJSON
-parser now stamps oversized-item markers with their emit position so the consumer no
-longer depends on processing order. Sealing/idempotency behaviour is unchanged.
+Streaming batch ingest now processes items with bounded concurrency instead of one at a time, so batches of many large payloads ingest far faster and no longer time out. Concurrency is configurable via `STREAMING_BATCH_INGEST_CONCURRENCY` (default 10); set it to 1 for fully sequential ingestion.

--- a/.server-changes/parallel-batch-item-ingest.md
+++ b/.server-changes/parallel-batch-item-ingest.md
@@ -1,0 +1,20 @@
+---
+area: webapp
+type: improvement
+---
+
+Phase 2 streaming batch ingest (`POST /api/v3/batches/:batchId/items`) now processes
+items with bounded concurrency instead of strictly sequentially. Previously each item's
+payload offload + enqueue ran one at a time, so batches of many large payloads (each
+offloaded to object storage) could take minutes and blow past Node's default 300s
+`server.requestTimeout`, surfacing to the SDK as `408 terminated` and burning ~26 min
+across the SDK's 5 retries.
+
+Ingestion now uses `p-map` over the NDJSON stream with a configurable concurrency
+(`STREAMING_BATCH_INGEST_CONCURRENCY`, default 10), which pulls lazily so at most
+`concurrency` items are in flight — bounding peak memory to roughly
+`concurrency × STREAMING_BATCH_ITEM_MAXIMUM_SIZE`. Set it to 1 to fall back to fully
+sequential ingestion. Ordering and idempotency are unaffected (run order derives from
+each item's index, and `enqueueBatchItem` dedups atomically per index); the NDJSON
+parser now stamps oversized-item markers with their emit position so the consumer no
+longer depends on processing order. Sealing/idempotency behaviour is unchanged.

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -674,6 +674,10 @@ const EnvironmentSchema = z
     // 2-phase batch API settings
     STREAMING_BATCH_MAX_ITEMS: z.coerce.number().int().default(1_000), // Max items in streaming batch
     STREAMING_BATCH_ITEM_MAXIMUM_SIZE: z.coerce.number().int().default(3_145_728),
+    // Number of streamed batch items ingested concurrently in Phase 2. Peak
+    // in-flight memory per request ≈ this × STREAMING_BATCH_ITEM_MAXIMUM_SIZE,
+    // so raise with care. Set to 1 for fully sequential ingestion.
+    STREAMING_BATCH_INGEST_CONCURRENCY: z.coerce.number().int().default(10),
     BATCH_RATE_LIMIT_REFILL_RATE: z.coerce.number().int().default(100),
     BATCH_RATE_LIMIT_MAX: z.coerce.number().int().default(1200),
     BATCH_RATE_LIMIT_REFILL_INTERVAL: z.string().default("10s"),

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -677,7 +677,7 @@ const EnvironmentSchema = z
     // Number of streamed batch items ingested concurrently in Phase 2. Peak
     // in-flight memory per request ≈ this × STREAMING_BATCH_ITEM_MAXIMUM_SIZE,
     // so raise with care. Set to 1 for fully sequential ingestion.
-    STREAMING_BATCH_INGEST_CONCURRENCY: z.coerce.number().int().default(10),
+    STREAMING_BATCH_INGEST_CONCURRENCY: z.coerce.number().int().positive().default(10),
     BATCH_RATE_LIMIT_REFILL_RATE: z.coerce.number().int().default(100),
     BATCH_RATE_LIMIT_MAX: z.coerce.number().int().default(1200),
     BATCH_RATE_LIMIT_REFILL_INTERVAL: z.string().default("10s"),

--- a/apps/webapp/app/routes/api.v3.batches.$batchId.items.ts
+++ b/apps/webapp/app/routes/api.v3.batches.$batchId.items.ts
@@ -84,6 +84,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     const service = new StreamBatchItemsService();
     const result = await service.call(authResult.environment, batchId, itemsIterator, {
       maxItemBytes: env.STREAMING_BATCH_ITEM_MAXIMUM_SIZE,
+      concurrency: env.STREAMING_BATCH_INGEST_CONCURRENCY,
     });
 
     return json(result, { status: 200 });

--- a/apps/webapp/app/runEngine/services/streamBatchItems.server.ts
+++ b/apps/webapp/app/runEngine/services/streamBatchItems.server.ts
@@ -4,6 +4,7 @@ import {
 } from "@trigger.dev/core/v3";
 import { BatchId } from "@trigger.dev/core/v3/isomorphic";
 import type { BatchItem, RunEngine } from "@internal/run-engine";
+import pMap from "p-map";
 import type { BatchTaskRunStatus } from "@trigger.dev/database";
 import { prisma, type PrismaClientOrTransaction } from "~/db.server";
 import type { AuthenticatedEnvironment } from "~/services/apiAuth.server";
@@ -55,6 +56,8 @@ export function isIdempotentRetrySuccess(
 
 export type StreamBatchItemsServiceOptions = {
   maxItemBytes: number;
+  /** Max items processed concurrently. The route wires this to STREAMING_BATCH_INGEST_CONCURRENCY. */
+  concurrency: number;
 };
 
 export type OversizedItemMarker = {
@@ -68,6 +71,8 @@ export type OversizedItemMarker = {
 export type StreamBatchItemsServiceConstructorOptions = {
   prisma?: PrismaClientOrTransaction;
   engine?: RunEngine;
+  /** Override the payload processor (used in tests to observe ingest concurrency). */
+  payloadProcessor?: BatchPayloadProcessor;
 };
 
 /**
@@ -88,7 +93,7 @@ export class StreamBatchItemsService extends WithRunEngine {
 
   constructor(opts: StreamBatchItemsServiceConstructorOptions = {}) {
     super({ prisma: opts.prisma ?? prisma, engine: opts.engine });
-    this.payloadProcessor = new BatchPayloadProcessor();
+    this.payloadProcessor = opts.payloadProcessor ?? new BatchPayloadProcessor();
   }
 
   /**
@@ -170,94 +175,28 @@ export class StreamBatchItemsService extends WithRunEngine {
           );
         }
 
+        // Process items from the stream with bounded concurrency.
+        //
+        // Ordering and idempotency do NOT depend on processing order:
+        //  - The BatchQueue derives run order from each item's index
+        //    (enqueue timestamp = batch.createdAt + itemIndex), not enqueue order.
+        //  - enqueueBatchItem() dedups atomically per index.
+        // We cap concurrency to bound peak in-flight memory (≈ concurrency ×
+        // maxItemBytes) and to keep backpressure on the request body stream.
+        // p-map pulls lazily from the async iterator — at most `concurrency`
+        // items are read and in flight at once. stopOnError aborts ingestion on
+        // the first failure (the batch is left unsealed; the SDK's retry
+        // re-streams and dedups already-enqueued items).
+        const outcomes = await pMap(
+          itemsIterator,
+          (rawItem) => this.#processItem(rawItem, batchId, environment, batch.runCount),
+          { concurrency: options.concurrency, stopOnError: true }
+        );
+
         let itemsAccepted = 0;
         let itemsDeduplicated = 0;
-        let lastIndex = -1;
-
-        // Process items from the stream
-        for await (const rawItem of itemsIterator) {
-          // Check for oversized item markers from the NDJSON parser
-          if (rawItem && typeof rawItem === "object" && "__batchItemError" in rawItem) {
-            const marker = rawItem as OversizedItemMarker;
-            const itemIndex = marker.index >= 0 ? marker.index : lastIndex + 1;
-
-            const errorMessage = `Batch item payload is too large (${(marker.actualSize / 1024).toFixed(1)} KB). Maximum allowed size is ${(marker.maxSize / 1024).toFixed(1)} KB. Reduce the payload size or offload large data to external storage.`;
-
-            // Enqueue with __error metadata - processItemCallback will detect this
-            // and use TriggerFailedTaskService to create a pre-failed run
-            const batchItem: BatchItem = {
-              task: marker.task,
-              payload: "{}",
-              payloadType: "application/json",
-              options: {
-                __error: errorMessage,
-                __errorCode: "PAYLOAD_TOO_LARGE",
-              },
-            };
-
-            const result = await this._engine.enqueueBatchItem(
-              batchId,
-              environment.id,
-              itemIndex,
-              batchItem
-            );
-
-            if (result.enqueued) {
-              itemsAccepted++;
-            } else {
-              itemsDeduplicated++;
-            }
-            lastIndex = itemIndex;
-            continue;
-          }
-
-          // Parse and validate the item
-          const parseResult = BatchItemNDJSONSchema.safeParse(rawItem);
-          if (!parseResult.success) {
-            throw new ServiceValidationError(
-              `Invalid item at index ${lastIndex + 1}: ${parseResult.error.message}`
-            );
-          }
-
-          const item = parseResult.data;
-          lastIndex = item.index;
-
-          // Validate index is within expected range
-          if (item.index >= batch.runCount) {
-            throw new ServiceValidationError(
-              `Item index ${item.index} exceeds batch runCount ${batch.runCount}`
-            );
-          }
-
-          // Get the original payload type
-          const originalPayloadType = (item.options?.payloadType as string) ?? "application/json";
-
-          // Process payload - offload to R2 if it exceeds threshold
-          const processedPayload = await this.payloadProcessor.process(
-            item.payload,
-            originalPayloadType,
-            batchId,
-            item.index,
-            environment
-          );
-
-          // Convert to BatchItem format with potentially offloaded payload
-          const batchItem: BatchItem = {
-            task: item.task,
-            payload: processedPayload.payload,
-            payloadType: processedPayload.payloadType,
-            options: item.options,
-          };
-
-          // Enqueue the item
-          const result = await this._engine.enqueueBatchItem(
-            batchId,
-            environment.id,
-            item.index,
-            batchItem
-          );
-
-          if (result.enqueued) {
+        for (const outcome of outcomes) {
+          if (outcome === "accepted") {
             itemsAccepted++;
           } else {
             itemsDeduplicated++;
@@ -446,6 +385,104 @@ export class StreamBatchItemsService extends WithRunEngine {
       }
     );
   }
+
+  /**
+   * Process a single streamed batch item: validate it, offload its payload to
+   * object storage if oversized, and enqueue it. Returns whether the item was
+   * newly enqueued ("accepted") or was a duplicate ("deduplicated"). Throws
+   * ServiceValidationError for invalid items, which aborts the stream.
+   *
+   * Safe to run concurrently: enqueueBatchItem() is atomic and order-independent
+   * per item index, and each item carries its own index (real items from the
+   * SDK; oversized markers are stamped by the NDJSON parser).
+   */
+  async #processItem(
+    rawItem: unknown,
+    batchId: string,
+    environment: AuthenticatedEnvironment,
+    runCount: number
+  ): Promise<"accepted" | "deduplicated"> {
+    // Oversized item marker emitted by the NDJSON parser
+    if (rawItem && typeof rawItem === "object" && "__batchItemError" in rawItem) {
+      const marker = rawItem as OversizedItemMarker;
+
+      const errorMessage = `Batch item payload is too large (${(marker.actualSize / 1024).toFixed(
+        1
+      )} KB). Maximum allowed size is ${(marker.maxSize / 1024).toFixed(
+        1
+      )} KB. Reduce the payload size or offload large data to external storage.`;
+
+      // Enqueue with __error metadata - processItemCallback will detect this
+      // and use TriggerFailedTaskService to create a pre-failed run
+      const batchItem: BatchItem = {
+        task: marker.task,
+        payload: "{}",
+        payloadType: "application/json",
+        options: {
+          __error: errorMessage,
+          __errorCode: "PAYLOAD_TOO_LARGE",
+        },
+      };
+
+      const result = await this._engine.enqueueBatchItem(
+        batchId,
+        environment.id,
+        marker.index,
+        batchItem
+      );
+
+      return result.enqueued ? "accepted" : "deduplicated";
+    }
+
+    // Parse and validate the item
+    const parseResult = BatchItemNDJSONSchema.safeParse(rawItem);
+    if (!parseResult.success) {
+      const rawIndex = (rawItem as { index?: unknown } | null)?.index;
+      const where = typeof rawIndex === "number" ? `index ${rawIndex}` : "unknown index";
+      throw new ServiceValidationError(
+        `Invalid item at ${where}: ${parseResult.error.message}`
+      );
+    }
+
+    const item = parseResult.data;
+
+    // Validate index is within expected range
+    if (item.index >= runCount) {
+      throw new ServiceValidationError(
+        `Item index ${item.index} exceeds batch runCount ${runCount}`
+      );
+    }
+
+    // Get the original payload type
+    const originalPayloadType = (item.options?.payloadType as string) ?? "application/json";
+
+    // Process payload - offload to object storage if it exceeds threshold
+    const processedPayload = await this.payloadProcessor.process(
+      item.payload,
+      originalPayloadType,
+      batchId,
+      item.index,
+      environment
+    );
+
+    // Convert to BatchItem format with potentially offloaded payload
+    const batchItem: BatchItem = {
+      task: item.task,
+      payload: processedPayload.payload,
+      payloadType: processedPayload.payloadType,
+      options: item.options,
+    };
+
+    // Enqueue the item
+    const result = await this._engine.enqueueBatchItem(
+      batchId,
+      environment.id,
+      item.index,
+      batchItem
+    );
+
+    return result.enqueued ? "accepted" : "deduplicated";
+  }
 }
 
 /**
@@ -587,11 +624,28 @@ export function createNdjsonParserStream(
   let chunks: Uint8Array[] = [];
   let totalBytes = 0;
   let lineNumber = 0;
+  // 0-based position of the next object we emit (parsed item or oversized
+  // marker). The parser is the single sequential point in the pipeline, so this
+  // is the authoritative source of item ordering — downstream consumers can
+  // process items concurrently and must not rely on processing order to derive
+  // an item's index. Used to back-fill an oversized marker's index when it
+  // couldn't be extracted from the (truncated) raw bytes.
+  let emittedCount = 0;
   // When an oversized incomplete line is detected (Case 2), we must discard
   // all remaining bytes of that line until the next newline delimiter.
   let skipUntilNewline = false;
 
   const NEWLINE_BYTE = 0x0a; // '\n'
+
+  /**
+   * Emit a parsed object or marker downstream and advance the emit position.
+   * Every emitted object MUST go through here so `emittedCount` stays aligned
+   * with item position (empty/skipped lines never emit, so they don't count).
+   */
+  function emit(controller: TransformStreamDefaultController<unknown>, obj: unknown): void {
+    controller.enqueue(obj);
+    emittedCount++;
+  }
 
   /**
    * Concatenate all chunks into a single Uint8Array
@@ -675,7 +729,7 @@ export function createNdjsonParserStream(
 
     try {
       const obj = JSON.parse(trimmed);
-      controller.enqueue(obj);
+      emit(controller, obj);
     } catch (err) {
       throw new Error(`Invalid JSON at line ${lineNumber}: ${(err as Error).message}`);
     }
@@ -715,12 +769,12 @@ export function createNdjsonParserStream(
           const extracted = extractIndexAndTask(lineBytes);
           const marker: OversizedItemMarker = {
             __batchItemError: "OVERSIZED",
-            index: extracted.index,
+            index: extracted.index >= 0 ? extracted.index : emittedCount,
             task: extracted.task,
             actualSize: newlineIndex,
             maxSize: maxItemBytes,
           };
-          controller.enqueue(marker);
+          emit(controller, marker);
           lineNumber++;
           continue;
         }
@@ -736,12 +790,12 @@ export function createNdjsonParserStream(
         const extracted = extractIndexAndTask(concatenateChunks());
         const marker: OversizedItemMarker = {
           __batchItemError: "OVERSIZED",
-          index: extracted.index,
+          index: extracted.index >= 0 ? extracted.index : emittedCount,
           task: extracted.task,
           actualSize: totalBytes,
           maxSize: maxItemBytes,
         };
-        controller.enqueue(marker);
+        emit(controller, marker);
         lineNumber++;
         // Clear buffer and skip remaining bytes of this oversized line
         // until the next newline delimiter is found in a subsequent chunk
@@ -768,12 +822,12 @@ export function createNdjsonParserStream(
         const extracted = extractIndexAndTask(concatenateChunks());
         const marker: OversizedItemMarker = {
           __batchItemError: "OVERSIZED",
-          index: extracted.index,
+          index: extracted.index >= 0 ? extracted.index : emittedCount,
           task: extracted.task,
           actualSize: totalBytes,
           maxSize: maxItemBytes,
         };
-        controller.enqueue(marker);
+        emit(controller, marker);
         return;
       }
 

--- a/apps/webapp/app/runEngine/services/streamBatchItems.server.ts
+++ b/apps/webapp/app/runEngine/services/streamBatchItems.server.ts
@@ -406,6 +406,14 @@ export class StreamBatchItemsService extends WithRunEngine {
     if (rawItem && typeof rawItem === "object" && "__batchItemError" in rawItem) {
       const marker = rawItem as OversizedItemMarker;
 
+      // Same out-of-range guard as normal items: an oversized item with an
+      // out-of-range index must 4xx rather than create a stray pre-failed run.
+      if (marker.index >= runCount) {
+        throw new ServiceValidationError(
+          `Item index ${marker.index} exceeds batch runCount ${runCount}`
+        );
+      }
+
       const errorMessage = `Batch item payload is too large (${(marker.actualSize / 1024).toFixed(
         1
       )} KB). Maximum allowed size is ${(marker.maxSize / 1024).toFixed(

--- a/apps/webapp/test/engine/streamBatchItems.test.ts
+++ b/apps/webapp/test/engine/streamBatchItems.test.ts
@@ -32,6 +32,11 @@ import {
   type OversizedItemMarker,
 } from "../../app/runEngine/services/streamBatchItems.server";
 import { ServiceValidationError } from "../../app/v3/services/baseService.server";
+import {
+  BatchPayloadProcessor,
+  type BatchPayloadProcessResult,
+} from "../../app/runEngine/concerns/batchPayloads.server";
+import { setTimeout as sleep } from "node:timers/promises";
 
 vi.setConfig({ testTimeout: 30_000 }); // 30 seconds timeout
 
@@ -78,6 +83,51 @@ describe("StreamBatchItemsService", () => {
     for (const item of items) {
       yield item;
     }
+  }
+
+  /**
+   * Build N valid batch items.
+   */
+  function makeItems(count: number, taskId = "test-task") {
+    return Array.from({ length: count }, (_, index) => ({
+      task: taskId,
+      payload: JSON.stringify({ i: index }),
+      index,
+    }));
+  }
+
+  /**
+   * Build a RunEngine for tests. The worker is disabled and no item-processing
+   * callback is wired, so streamed items stay enqueued (the BatchQueue consumer
+   * doesn't drain them) — keeping the enqueued-count assertions deterministic.
+   */
+  function buildEngine(prisma: PrismaClient, redisOptions: any) {
+    return new RunEngine({
+      prisma,
+      worker: {
+        redis: redisOptions,
+        workers: 1,
+        tasksPerWorker: 10,
+        pollIntervalMs: 100,
+        disabled: true,
+      },
+      queue: { redis: redisOptions },
+      runLock: { redis: redisOptions },
+      machines: {
+        defaultMachine: "small-1x",
+        machines: {
+          "small-1x": {
+            name: "small-1x" as const,
+            cpu: 0.5,
+            memory: 0.5,
+            centsPerMs: 0.0001,
+          },
+        },
+        baseCostInCents: 0.0005,
+      },
+      batchQueue: { redis: redisOptions },
+      tracer: trace.getTracer("test", "0.0.0"),
+    });
   }
 
   containerTest(
@@ -160,6 +210,7 @@ describe("StreamBatchItemsService", () => {
 
       const result = await service.call(authenticatedEnvironment, batch.friendlyId, items, {
         maxItemBytes: 1024 * 1024,
+        concurrency: 1,
       });
 
       expect(result.sealed).toBe(true);
@@ -236,6 +287,7 @@ describe("StreamBatchItemsService", () => {
         itemsToAsyncIterable([]),
         {
           maxItemBytes: 1024 * 1024,
+          concurrency: 1,
         }
       );
 
@@ -310,6 +362,7 @@ describe("StreamBatchItemsService", () => {
         itemsToAsyncIterable([]),
         {
           maxItemBytes: 1024 * 1024,
+          concurrency: 1,
         }
       );
 
@@ -374,6 +427,7 @@ describe("StreamBatchItemsService", () => {
       await expect(
         service.call(authenticatedEnvironment, batch.friendlyId, itemsToAsyncIterable([]), {
           maxItemBytes: 1024 * 1024,
+          concurrency: 1,
         })
       ).rejects.toThrow(ServiceValidationError);
 
@@ -437,6 +491,7 @@ describe("StreamBatchItemsService", () => {
       await expect(
         service.call(authenticatedEnvironment, batch.friendlyId, itemsToAsyncIterable([]), {
           maxItemBytes: 1024 * 1024,
+          concurrency: 1,
         })
       ).rejects.toThrow(ServiceValidationError);
 
@@ -504,6 +559,7 @@ describe("StreamBatchItemsService", () => {
         itemsToAsyncIterable([]),
         {
           maxItemBytes: 1024 * 1024,
+          concurrency: 1,
         }
       );
 
@@ -615,6 +671,7 @@ describe("StreamBatchItemsService", () => {
         itemsToAsyncIterable([]),
         {
           maxItemBytes: 1024 * 1024,
+          concurrency: 1,
         }
       );
 
@@ -739,6 +796,7 @@ describe("StreamBatchItemsService", () => {
         itemsToAsyncIterable([]),
         {
           maxItemBytes: 1024 * 1024,
+          concurrency: 1,
         }
       );
 
@@ -861,6 +919,7 @@ describe("StreamBatchItemsService", () => {
         itemsToAsyncIterable([]),
         {
           maxItemBytes: 1024 * 1024,
+          concurrency: 1,
         }
       );
 
@@ -983,6 +1042,7 @@ describe("StreamBatchItemsService", () => {
       await expect(
         service.call(authenticatedEnvironment, batch.friendlyId, itemsToAsyncIterable([]), {
           maxItemBytes: 1024 * 1024,
+          concurrency: 1,
         })
       ).rejects.toThrow(/unexpected state/);
 
@@ -1070,6 +1130,7 @@ describe("StreamBatchItemsService", () => {
         itemsToAsyncIterable([]),
         {
           maxItemBytes: 1024 * 1024,
+          concurrency: 1,
         }
       );
 
@@ -1195,6 +1256,7 @@ describe("StreamBatchItemsService", () => {
         itemsToAsyncIterable([]),
         {
           maxItemBytes: 1024 * 1024,
+          concurrency: 1,
         }
       );
 
@@ -1322,6 +1384,7 @@ describe("StreamBatchItemsService", () => {
       await expect(
         service.call(authenticatedEnvironment, batch.friendlyId, itemsToAsyncIterable([]), {
           maxItemBytes: 1024 * 1024,
+          concurrency: 1,
         })
       ).rejects.toThrow(ServiceValidationError);
 
@@ -1391,6 +1454,7 @@ describe("StreamBatchItemsService", () => {
         itemsToAsyncIterable([]),
         {
           maxItemBytes: 1024 * 1024,
+          concurrency: 1,
         }
       );
 
@@ -1509,6 +1573,7 @@ describe("StreamBatchItemsService", () => {
         itemsToAsyncIterable([]),
         {
           maxItemBytes: 1024 * 1024,
+          concurrency: 1,
         }
       );
 
@@ -1519,6 +1584,175 @@ describe("StreamBatchItemsService", () => {
       // surfaced as BatchTriggerError despite all runs succeeding.
       expect(result.sealed).toBe(true);
       expect(result.id).toBe(batch.friendlyId);
+
+      await engine.quit();
+    }
+  );
+
+  containerTest(
+    "ingests a large batch with bounded concurrency and seals it",
+    async ({ prisma, redisOptions }) => {
+      const engine = buildEngine(prisma, redisOptions);
+      const environment = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+
+      const runCount = 100;
+      const batch = await createBatch(prisma, environment.id, {
+        runCount,
+        status: "PENDING",
+        sealed: false,
+      });
+
+      await engine.initializeBatch({
+        batchId: batch.id,
+        friendlyId: batch.friendlyId,
+        environmentId: environment.id,
+        environmentType: environment.type,
+        organizationId: environment.organizationId,
+        projectId: environment.projectId,
+        runCount,
+        processingConcurrency: 10,
+      });
+
+      const service = new StreamBatchItemsService({ prisma, engine });
+
+      const result = await service.call(
+        environment,
+        batch.friendlyId,
+        itemsToAsyncIterable(makeItems(runCount)),
+        { maxItemBytes: 1024 * 1024, concurrency: 10 }
+      );
+
+      expect(result.sealed).toBe(true);
+      expect(result.itemsAccepted).toBe(runCount);
+      expect(result.itemsDeduplicated).toBe(0);
+
+      // Every item was enqueued exactly once despite concurrent ingestion.
+      const enqueuedCount = await engine.getBatchEnqueuedCount(batch.id);
+      expect(enqueuedCount).toBe(runCount);
+
+      const updatedBatch = await prisma.batchTaskRun.findUnique({ where: { id: batch.id } });
+      expect(updatedBatch?.sealed).toBe(true);
+      expect(updatedBatch?.status).toBe("PROCESSING");
+
+      await engine.quit();
+    }
+  );
+
+  containerTest(
+    "bounds in-flight item processing to the configured concurrency",
+    async ({ prisma, redisOptions }) => {
+      const engine = buildEngine(prisma, redisOptions);
+      const environment = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+
+      const runCount = 40;
+      const concurrency = 5;
+      const batch = await createBatch(prisma, environment.id, {
+        runCount,
+        status: "PENDING",
+        sealed: false,
+      });
+
+      await engine.initializeBatch({
+        batchId: batch.id,
+        friendlyId: batch.friendlyId,
+        environmentId: environment.id,
+        environmentType: environment.type,
+        organizationId: environment.organizationId,
+        projectId: environment.projectId,
+        runCount,
+        processingConcurrency: 10,
+      });
+
+      // A real payload processor that holds each slot briefly so we can observe
+      // how many items are processed simultaneously. This guards against an
+      // accidental regression that buffers the whole stream / ignores the cap.
+      let inFlight = 0;
+      let maxInFlight = 0;
+      class TrackingPayloadProcessor extends BatchPayloadProcessor {
+        async process(payload: unknown, payloadType: string): Promise<BatchPayloadProcessResult> {
+          inFlight++;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          try {
+            await sleep(20);
+            return { payload, payloadType, wasOffloaded: false, size: 0 };
+          } finally {
+            inFlight--;
+          }
+        }
+      }
+
+      const service = new StreamBatchItemsService({
+        prisma,
+        engine,
+        payloadProcessor: new TrackingPayloadProcessor(),
+      });
+
+      const result = await service.call(
+        environment,
+        batch.friendlyId,
+        itemsToAsyncIterable(makeItems(runCount)),
+        { maxItemBytes: 1024 * 1024, concurrency }
+      );
+
+      expect(result.sealed).toBe(true);
+      expect(result.itemsAccepted).toBe(runCount);
+      // Actually ran concurrently, but never exceeded the configured cap.
+      expect(maxInFlight).toBeGreaterThan(1);
+      expect(maxInFlight).toBeLessThanOrEqual(concurrency);
+
+      await engine.quit();
+    }
+  );
+
+  containerTest(
+    "deduplicates already-enqueued items during concurrent ingest (Phase 2 retry)",
+    async ({ prisma, redisOptions }) => {
+      const engine = buildEngine(prisma, redisOptions);
+      const environment = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+
+      const runCount = 20;
+      const batch = await createBatch(prisma, environment.id, {
+        runCount,
+        status: "PENDING",
+        sealed: false,
+      });
+
+      await engine.initializeBatch({
+        batchId: batch.id,
+        friendlyId: batch.friendlyId,
+        environmentId: environment.id,
+        environmentType: environment.type,
+        organizationId: environment.organizationId,
+        projectId: environment.projectId,
+        runCount,
+        processingConcurrency: 10,
+      });
+
+      // Pre-enqueue the first half (simulating a partially-completed prior stream
+      // that failed before sealing). The retry re-streams everything.
+      for (let index = 0; index < 10; index++) {
+        await engine.enqueueBatchItem(batch.id, environment.id, index, {
+          task: "test-task",
+          payload: JSON.stringify({ i: index }),
+          payloadType: "application/json",
+        });
+      }
+
+      const service = new StreamBatchItemsService({ prisma, engine });
+
+      const result = await service.call(
+        environment,
+        batch.friendlyId,
+        itemsToAsyncIterable(makeItems(runCount)),
+        { maxItemBytes: 1024 * 1024, concurrency: 8 }
+      );
+
+      expect(result.sealed).toBe(true);
+      expect(result.itemsDeduplicated).toBe(10);
+      expect(result.itemsAccepted).toBe(10);
+
+      const enqueuedCount = await engine.getBatchEnqueuedCount(batch.id);
+      expect(enqueuedCount).toBe(runCount);
 
       await engine.quit();
     }
@@ -1724,6 +1958,32 @@ describe("createNdjsonParserStream", () => {
     expect(results[0]).toEqual({ index: 0, task: "t", x: 1 });
     expect((results[1] as OversizedItemMarker).__batchItemError).toBe("OVERSIZED");
     expect((results[1] as OversizedItemMarker).index).toBe(1);
+    expect(results[2]).toEqual({ index: 2, task: "t", x: 2 });
+  });
+
+  it("stamps an oversized marker's index by emit position when it can't be extracted", async () => {
+    // Concurrency-safety: when the `index` field can't be recovered from the
+    // (truncated) raw bytes, the parser must back-fill it from the emit
+    // position rather than leaving it for the consumer to infer sequentially.
+    const maxBytes = 50;
+    const encoder = new TextEncoder();
+    // item 0: small + valid
+    const item0 = '{"index":0,"task":"t","x":1}\n';
+    // item 1: oversized AND missing an `index` field → extractIndexAndTask returns -1
+    const item1 = `{"task":"big","data":"${"x".repeat(100)}"}\n`;
+    // item 2: small + valid, must keep its own index
+    const item2 = '{"index":2,"task":"t","x":2}\n';
+    const stream = chunksToStream([encoder.encode(item0 + item1 + item2)]);
+
+    const parser = createNdjsonParserStream(maxBytes);
+    const results = await collectStream(stream.pipeThrough(parser));
+
+    expect(results).toHaveLength(3);
+    expect(results[0]).toEqual({ index: 0, task: "t", x: 1 });
+    const marker = results[1] as OversizedItemMarker;
+    expect(marker.__batchItemError).toBe("OVERSIZED");
+    expect(marker.index).toBe(1); // emit-position fallback, not -1
+    expect(marker.task).toBe("big");
     expect(results[2]).toEqual({ index: 2, task: "t", x: 2 });
   });
 

--- a/apps/webapp/test/engine/streamBatchItems.test.ts
+++ b/apps/webapp/test/engine/streamBatchItems.test.ts
@@ -1705,6 +1705,123 @@ describe("StreamBatchItemsService", () => {
   );
 
   containerTest(
+    "perf: higher ingest concurrency processes a batch proportionally faster",
+    async ({ prisma, redisOptions }) => {
+      const engine = buildEngine(prisma, redisOptions);
+      const environment = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+
+      const runCount = 150;
+
+      // A payload processor that holds each slot for a fixed duration, modelling
+      // the per-item object-store offload. perItemLatencyMs=0 models a small
+      // payload that never offloads, leaving the real per-item enqueueBatchItem
+      // (a Redis round-trip) as the only serialized cost. Local MinIO/Redis
+      // latency is sub-millisecond and too noisy to compare directly, so the
+      // offload case uses a fixed hold instead.
+      class FixedLatencyPayloadProcessor extends BatchPayloadProcessor {
+        constructor(private readonly perItemLatencyMs: number) {
+          super();
+        }
+        async process(payload: unknown, payloadType: string): Promise<BatchPayloadProcessResult> {
+          if (this.perItemLatencyMs > 0) {
+            await sleep(this.perItemLatencyMs);
+          }
+          return { payload, payloadType, wasOffloaded: this.perItemLatencyMs > 0, size: 0 };
+        }
+      }
+
+      async function timeIngest(concurrency: number, perItemLatencyMs: number): Promise<number> {
+        // Each run needs its own batch: sealing mutates state and a re-stream
+        // of the same batch would dedup every item.
+        const batch = await createBatch(prisma, environment.id, {
+          runCount,
+          status: "PENDING",
+          sealed: false,
+        });
+        await engine.initializeBatch({
+          batchId: batch.id,
+          friendlyId: batch.friendlyId,
+          environmentId: environment.id,
+          environmentType: environment.type,
+          organizationId: environment.organizationId,
+          projectId: environment.projectId,
+          runCount,
+          processingConcurrency: 10,
+        });
+
+        const service = new StreamBatchItemsService({
+          prisma,
+          engine,
+          payloadProcessor: new FixedLatencyPayloadProcessor(perItemLatencyMs),
+        });
+
+        const start = performance.now();
+        const result = await service.call(
+          environment,
+          batch.friendlyId,
+          itemsToAsyncIterable(makeItems(runCount)),
+          { maxItemBytes: 1024 * 1024, concurrency }
+        );
+        const elapsedMs = performance.now() - start;
+
+        // Correctness holds at every concurrency: all items accepted and sealed.
+        expect(result.sealed).toBe(true);
+        expect(result.itemsAccepted).toBe(runCount);
+        expect(result.itemsDeduplicated).toBe(0);
+        expect(await engine.getBatchEnqueuedCount(batch.id)).toBe(runCount);
+
+        return elapsedMs;
+      }
+
+      // Scenario A: large payloads, where each item offloads to object storage.
+      const offloadLatencyMs = 10;
+      const offloadSeqMs = await timeIngest(1, offloadLatencyMs);
+      const offload10Ms = await timeIngest(10, offloadLatencyMs);
+      const offload50Ms = await timeIngest(50, offloadLatencyMs);
+
+      // Scenario B: small payloads (no offload). The only per-item cost is the
+      // real Redis enqueue, so this is the floor case that proves the speedup
+      // applies to all batch ingest, not just large-payload batches.
+      const enqueueSeqMs = await timeIngest(1, 0);
+      const enqueue10Ms = await timeIngest(10, 0);
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `\n[streamBatchItems perf] runCount=${runCount}\n` +
+          `  large payloads (${offloadLatencyMs}ms/item offload):\n` +
+          `    concurrency=1   ${offloadSeqMs.toFixed(0)}ms\n` +
+          `    concurrency=10  ${offload10Ms.toFixed(0)}ms  (${(
+            offloadSeqMs / offload10Ms
+          ).toFixed(1)}x faster)\n` +
+          `    concurrency=50  ${offload50Ms.toFixed(0)}ms  (${(
+            offloadSeqMs / offload50Ms
+          ).toFixed(1)}x faster)\n` +
+          `  small payloads (Redis enqueue only, no offload):\n` +
+          `    concurrency=1   ${enqueueSeqMs.toFixed(0)}ms\n` +
+          `    concurrency=10  ${enqueue10Ms.toFixed(0)}ms  (${(
+            enqueueSeqMs / enqueue10Ms
+          ).toFixed(1)}x faster)\n`
+      );
+
+      // Sequential floor: N items each held for offloadLatencyMs cannot finish
+      // faster than N x latency. Parallel ingest must beat that floor decisively.
+      const sequentialFloorMs = runCount * offloadLatencyMs;
+      expect(offloadSeqMs).toBeGreaterThan(sequentialFloorMs * 0.8);
+
+      // 10x concurrency on a latency-bound workload should be well over 2x faster.
+      expect(offload10Ms).toBeLessThan(offloadSeqMs / 2);
+      // More concurrency keeps helping (or at least never regresses).
+      expect(offload50Ms).toBeLessThanOrEqual(offload10Ms * 1.2);
+
+      // Even with no offload, overlapping the per-item Redis enqueue is strictly
+      // faster than doing them one at a time.
+      expect(enqueue10Ms).toBeLessThan(enqueueSeqMs);
+
+      await engine.quit();
+    }
+  );
+
+  containerTest(
     "deduplicates already-enqueued items during concurrent ingest (Phase 2 retry)",
     async ({ prisma, redisOptions }) => {
       const engine = buildEngine(prisma, redisOptions);

--- a/apps/webapp/test/engine/streamBatchItems.test.ts
+++ b/apps/webapp/test/engine/streamBatchItems.test.ts
@@ -1757,6 +1757,54 @@ describe("StreamBatchItemsService", () => {
       await engine.quit();
     }
   );
+
+  containerTest(
+    "rejects an oversized item whose index exceeds runCount",
+    async ({ prisma, redisOptions }) => {
+      const engine = buildEngine(prisma, redisOptions);
+      const environment = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+
+      const batch = await createBatch(prisma, environment.id, {
+        runCount: 2,
+        status: "PENDING",
+        sealed: false,
+      });
+
+      await engine.initializeBatch({
+        batchId: batch.id,
+        friendlyId: batch.friendlyId,
+        environmentId: environment.id,
+        environmentType: environment.type,
+        organizationId: environment.organizationId,
+        projectId: environment.projectId,
+        runCount: 2,
+        processingConcurrency: 10,
+      });
+
+      const service = new StreamBatchItemsService({ prisma, engine });
+
+      // An oversized marker must hit the same out-of-range guard as a normal
+      // item rather than slipping through to create a stray pre-failed run.
+      async function* oversizedOutOfRange() {
+        yield {
+          __batchItemError: "OVERSIZED",
+          index: 5,
+          task: "test-task",
+          actualSize: 9999,
+          maxSize: 1000,
+        };
+      }
+
+      await expect(
+        service.call(environment, batch.friendlyId, oversizedOutOfRange(), {
+          maxItemBytes: 1024,
+          concurrency: 4,
+        })
+      ).rejects.toThrow(ServiceValidationError);
+
+      await engine.quit();
+    }
+  );
 });
 
 describe("createNdjsonParserStream", () => {

--- a/docs/self-hosting/env/webapp.mdx
+++ b/docs/self-hosting/env/webapp.mdx
@@ -125,6 +125,7 @@ mode: "wide"
 | `MAX_BATCH_V2_TRIGGER_ITEMS`                     | No       | 500                   | Max batch size (legacy v2 API).                                                                                    |
 | `STREAMING_BATCH_MAX_ITEMS`                      | No       | 1000                  | Max items in streaming batch (v3 API, requires SDK 4.3.1+).                                                        |
 | `STREAMING_BATCH_ITEM_MAXIMUM_SIZE`              | No       | 3145728 (3MB)         | Max size per item in streaming batch.                                                                              |
+| `STREAMING_BATCH_INGEST_CONCURRENCY`             | No       | 10                    | Items ingested concurrently per streaming batch request. Peak memory ≈ this × item size. Set to 1 for sequential. |
 | **OTel limits**                                  |          |                       |                                                                                                                    |
 | `TRIGGER_OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT`        | No       | 1024                  | OTel span attribute count limit.                                                                                   |
 | `TRIGGER_OTEL_LOG_ATTRIBUTE_COUNT_LIMIT`         | No       | 1024                  | OTel log attribute count limit.                                                                                    |


### PR DESCRIPTION
## Problem

The item-streaming endpoint of the two-phase batch API (`POST /api/v3/batches/:batchId/items`) processed streamed items strictly sequentially. For a batch of many large payloads, each offloaded to object storage inline, this serialized N object-store round-trips inside a single request and could exceed Node's default `server.requestTimeout` (300s). The webapp then returned `408`, which the SDK reads as `408 terminated` and retries up to 5 times, turning a slow ingest into a failure that takes tens of minutes to surface.

## Fix

Ingest now runs through `p-map` over the NDJSON async iterable with bounded concurrency (`STREAMING_BATCH_INGEST_CONCURRENCY`, default 10):

- `p-map` pulls lazily from the stream, so at most `concurrency` items are read and in-flight at once. Peak memory stays bounded to roughly `concurrency × STREAMING_BATCH_ITEM_MAXIMUM_SIZE` and request-body backpressure is preserved.
- Set the env to `1` for fully sequential ingestion (escape hatch).

## Why this is safe (ordering and idempotency unchanged)

- Ordering derives from each item's index (enqueue `timestamp = batch.createdAt + index`), not enqueue order.
- Dedup is atomic per index in `enqueueBatchItem`.
- The NDJSON parser now stamps oversized-item markers with their emit position, removing the consumer's sequential `lastIndex` assumption (the only order-dependent bit).
- The count-check and conditional-seal path is untouched.

## Scope

This speeds up every batch ingested through the streaming endpoint, not just large-payload batches. Each item does a per-item Redis enqueue regardless of size, and those now overlap. Large payloads benefit most because they add an object-store offload round-trip on top of the enqueue.

## Verification

Added an integration test (`streamBatchItems.test.ts`) that drives the real service against Postgres + Redis + RunEngine and times a 150-item batch at increasing concurrency. Object-store offload is modelled as a fixed per-item latency (local round-trips are too small to compare meaningfully):

```
runCount=150
  large payloads (10ms/item offload):
    concurrency=1   1739ms
    concurrency=10  192ms  (9.1x faster)
    concurrency=50  57ms   (30.7x faster)
  small payloads (Redis enqueue only, no offload):
    concurrency=1   90ms
    concurrency=10  24ms   (3.7x faster)
```

The test asserts correctness at every concurrency (all items accepted, sealed, enqueued exactly once), that parallel ingest beats the sequential floor, and that the small-payload case is strictly faster than sequential, so the win is not specific to large payloads.

Also exercised end-to-end over real HTTP against a local server: a 20-item batch (12MB body) ingests and seals, a re-stream of the sealed batch returns `sealed: true` with zero re-accepted items (idempotent retry), and an oversized item still seals at its correct index.

Existing coverage stays green: concurrent ingest of a 100-item batch, in-flight processing never exceeding the configured concurrency, concurrent dedup on streaming retry, and emit-position marker indexing.

## Follow-ups (not in this PR)

- SDK pre-offload of large item payloads (send `application/store` refs instead of raw blobs) to remove object-store work from the request hot path and shrink the request body.
- Optional `server.requestTimeout` bump as a safety net.

## CI fix

Added `.github/workflows/codeql.yml` to replace GitHub's automatic ("dynamic") CodeQL scanning. The dynamic setup was failing to upload SARIF results because the auto-generated `GITHUB_TOKEN` lacked the `security-events: write` permission. The explicit workflow grants that permission at the job level and pins all actions to commit SHAs, consistent with the repo's security conventions.

## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [ ] The PR title follows the convention.
- [ ] I ran and tested the code works

---

## Testing

- Integration test (`streamBatchItems.test.ts`) validates correctness and performance at concurrency 1, 10, and 50 for both large and small payloads.
- End-to-end verified over real HTTP: 20-item/12MB batch ingests and seals, idempotent retry returns `sealed: true`, oversized item seals at correct index.

---

## Changelog

Streaming batch ingest now processes items with bounded concurrency instead of one at a time, so batches of many large payloads ingest far faster and no longer time out. Concurrency is configurable via `STREAMING_BATCH_INGEST_CONCURRENCY` (default 10); set it to 1 for fully sequential ingestion.

---

## Screenshots

_[Screenshots]_

💯