### PR TITLE
feat(sdk,core): offload large trigger payloads via object storage

### DIFF
--- a/.changeset/large-trigger-payload-offload.md
+++ b/.changeset/large-trigger-payload-offload.md
@@ -1,0 +1,8 @@
+---
+"@trigger.dev/core": patch
+"@trigger.dev/sdk": patch
+---
+
+Offload large trigger payloads to object storage before sending the trigger API request. The SDK uploads packets at or above the existing 128KB limit and sends an `application/store` pointer instead of embedding large JSON in the request body. `TriggerTaskRequestBody` now validates that `application/store` payloads are non-empty storage paths.
+
+Payload uploads use the same resolved `ApiClient` as the trigger call (including `requestOptions.clientConfig`), not only the global `apiClientManager.client` — so custom `baseURL`, access token, and preview branch apply to both presign and trigger.

--- a/packages/core/src/v3/schemas/api-type.test.ts
+++ b/packages/core/src/v3/schemas/api-type.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { InitializeDeploymentRequestBody } from "./api.js";
+import { InitializeDeploymentRequestBody, TriggerTaskRequestBody } from "./api.js";
 import type { InitializeDeploymentRequestBody as InitializeDeploymentRequestBodyType } from "./api.js";
 
 describe("InitializeDeploymentRequestBody", () => {
@@ -137,5 +137,43 @@ describe("InitializeDeploymentRequestBody", () => {
         expect(narrowed.contentHash).toBe("abc123");
       }
     });
+  });
+});
+
+describe("TriggerTaskRequestBody", () => {
+  it("accepts application/store payload as a non-empty string", () => {
+    const result = TriggerTaskRequestBody.safeParse({
+      payload: "packets/payloads/file.json",
+      context: {},
+      options: {
+        payloadType: "application/store",
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects application/store payload when payload is not a string", () => {
+    const result = TriggerTaskRequestBody.safeParse({
+      payload: { foo: "bar" },
+      context: {},
+      options: {
+        payloadType: "application/store",
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects application/store payload when payload is an empty string", () => {
+    const result = TriggerTaskRequestBody.safeParse({
+      payload: "",
+      context: {},
+      options: {
+        payloadType: "application/store",
+      },
+    });
+
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/core/src/v3/schemas/api.ts
+++ b/packages/core/src/v3/schemas/api.ts
@@ -161,83 +161,95 @@ export type IdempotencyKeyOptionsSchema = z.infer<typeof IdempotencyKeyOptionsSc
 // column is String?, so passing a number (a common foot-gun when callers do
 // `concurrencyKey: payload.userId`) used to fail at `prisma.taskRun.create`
 // with PrismaClientValidationError. Accept the intent and stringify here.
-const ConcurrencyKeySchema = z
-  .union([z.string(), z.number()])
-  .transform((value) => String(value));
+const ConcurrencyKeySchema = z.union([z.string(), z.number()]).transform((value) => String(value));
 
-export const TriggerTaskRequestBody = z.object({
-  payload: z.any(),
-  context: z.any(),
-  options: z
-    .object({
-      /** @deprecated engine v1 only */
-      dependentAttempt: z.string().optional(),
-      /** @deprecated engine v1 only */
-      parentAttempt: z.string().optional(),
-      /** @deprecated engine v1 only */
-      dependentBatch: z.string().optional(),
-      /**
-       * If triggered in a batch, this is the BatchTaskRun id
-       */
-      parentBatch: z.string().optional(),
-      /**
-       * RunEngine v2
-       * If triggered inside another run, the parentRunId is the friendly ID of the parent run.
-       */
-      parentRunId: z.string().optional(),
-      /**
-       * RunEngine v2
-       * Should be `true` if `triggerAndWait` or `batchTriggerAndWait`
-       */
-      resumeParentOnCompletion: z.boolean().optional(),
-      /**
-       * Locks the version to the passed value.
-       * Automatically set when using `triggerAndWait` or `batchTriggerAndWait`
-       */
-      lockToVersion: z.string().optional(),
+export const TriggerTaskRequestBody = z
+  .object({
+    payload: z.any(),
+    context: z.any(),
+    options: z
+      .object({
+        /** @deprecated engine v1 only */
+        dependentAttempt: z.string().optional(),
+        /** @deprecated engine v1 only */
+        parentAttempt: z.string().optional(),
+        /** @deprecated engine v1 only */
+        dependentBatch: z.string().optional(),
+        /**
+         * If triggered in a batch, this is the BatchTaskRun id
+         */
+        parentBatch: z.string().optional(),
+        /**
+         * RunEngine v2
+         * If triggered inside another run, the parentRunId is the friendly ID of the parent run.
+         */
+        parentRunId: z.string().optional(),
+        /**
+         * RunEngine v2
+         * Should be `true` if `triggerAndWait` or `batchTriggerAndWait`
+         */
+        resumeParentOnCompletion: z.boolean().optional(),
+        /**
+         * Locks the version to the passed value.
+         * Automatically set when using `triggerAndWait` or `batchTriggerAndWait`
+         */
+        lockToVersion: z.string().optional(),
 
-      queue: z
-        .object({
-          name: z.string(),
-          // @deprecated, this is now specified on the queue
-          concurrencyLimit: z.number().int().optional(),
-        })
-        .optional(),
-      concurrencyKey: ConcurrencyKeySchema.optional(),
-      delay: z.string().or(z.coerce.date()).optional(),
-      idempotencyKey: z
-        .string()
-        // Caps user-supplied keys before they reach the unique idempotency index
-        // on the underlying table — values past this fail at the database layer
-        // rather than returning a clean 400.
-        .max(2048, "idempotencyKey must be 2048 characters or less")
-        .optional(),
-      idempotencyKeyTTL: z.string().optional(),
-      /** The original user-provided idempotency key and scope */
-      idempotencyKeyOptions: IdempotencyKeyOptionsSchema.optional(),
-      machine: MachinePresetName.optional(),
-      maxAttempts: z.number().int().optional(),
-      maxDuration: z.number().optional(),
-      metadata: z.any(),
-      metadataType: z.string().optional(),
-      payloadType: z.string().optional(),
-      tags: RunTags.optional(),
-      test: z.boolean().optional(),
-      ttl: z.string().or(z.number().nonnegative().int()).optional(),
-      priority: z.number().optional(),
-      bulkActionId: z.string().optional(),
-      region: z.string().optional(),
-      debounce: z
-        .object({
-          key: z.string().max(512),
-          delay: z.string(),
-          mode: z.enum(["leading", "trailing"]).optional(),
-          maxDelay: z.string().optional(),
-        })
-        .optional(),
-    })
-    .optional(),
-});
+        queue: z
+          .object({
+            name: z.string(),
+            // @deprecated, this is now specified on the queue
+            concurrencyLimit: z.number().int().optional(),
+          })
+          .optional(),
+        concurrencyKey: ConcurrencyKeySchema.optional(),
+        delay: z.string().or(z.coerce.date()).optional(),
+        idempotencyKey: z
+          .string()
+          // Caps user-supplied keys before they reach the unique idempotency index
+          // on the underlying table — values past this fail at the database layer
+          // rather than returning a clean 400.
+          .max(2048, "idempotencyKey must be 2048 characters or less")
+          .optional(),
+        idempotencyKeyTTL: z.string().optional(),
+        /** The original user-provided idempotency key and scope */
+        idempotencyKeyOptions: IdempotencyKeyOptionsSchema.optional(),
+        machine: MachinePresetName.optional(),
+        maxAttempts: z.number().int().optional(),
+        maxDuration: z.number().optional(),
+        metadata: z.any(),
+        metadataType: z.string().optional(),
+        payloadType: z.string().optional(),
+        tags: RunTags.optional(),
+        test: z.boolean().optional(),
+        ttl: z.string().or(z.number().nonnegative().int()).optional(),
+        priority: z.number().optional(),
+        bulkActionId: z.string().optional(),
+        region: z.string().optional(),
+        debounce: z
+          .object({
+            key: z.string().max(512),
+            delay: z.string(),
+            mode: z.enum(["leading", "trailing"]).optional(),
+            maxDelay: z.string().optional(),
+          })
+          .optional(),
+      })
+      .optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.options?.payloadType !== "application/store") {
+      return;
+    }
+
+    if (typeof value.payload !== "string" || value.payload.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "payload must be a non-empty string when options.payloadType is application/store",
+        path: ["payload"],
+      });
+    }
+  });
 
 export type TriggerTaskRequestBody = z.infer<typeof TriggerTaskRequestBody>;
 
@@ -1658,9 +1670,7 @@ export const EndAndContinueSessionResponseBody = z.object({
    */
   swapped: z.boolean(),
 });
-export type EndAndContinueSessionResponseBody = z.infer<
-  typeof EndAndContinueSessionResponseBody
->;
+export type EndAndContinueSessionResponseBody = z.infer<typeof EndAndContinueSessionResponseBody>;
 
 export const UpdateSessionRequestBody = z.object({
   tags: z.array(z.string().max(128)).max(10).optional(),
@@ -1712,13 +1722,10 @@ export const ListSessionsQueryParams = z
     "filter[createdAt][from]": z.coerce.number().int().optional(),
     "filter[createdAt][to]": z.coerce.number().int().optional(),
   })
-  .refine(
-    (value) => !(value["page[after]"] && value["page[before]"]),
-    {
-      message: "Cannot pass both page[after] and page[before] on the same request",
-      path: ["page[before]"],
-    }
-  );
+  .refine((value) => !(value["page[after]"] && value["page[before]"]), {
+    message: "Cannot pass both page[after] and page[before] on the same request",
+    path: ["page[before]"],
+  });
 export type ListSessionsQueryParams = z.infer<typeof ListSessionsQueryParams>;
 
 /**
@@ -2111,7 +2118,9 @@ export type UpdatePromptOverrideRequestBody = z.infer<typeof UpdatePromptOverrid
 export const ReactivatePromptOverrideRequestBody = z.object({
   version: z.number().int().positive(),
 });
-export type ReactivatePromptOverrideRequestBody = z.infer<typeof ReactivatePromptOverrideRequestBody>;
+export type ReactivatePromptOverrideRequestBody = z.infer<
+  typeof ReactivatePromptOverrideRequestBody
+>;
 
 export const PromptOkResponseBody = z.object({ ok: z.boolean() });
 export type PromptOkResponseBody = z.infer<typeof PromptOkResponseBody>;

--- a/packages/core/src/v3/utils/ioSerialization.ts
+++ b/packages/core/src/v3/utils/ioSerialization.ts
@@ -100,22 +100,33 @@ export async function stringifyIO(value: any): Promise<IOPacket> {
   }
 }
 
+/**
+ * Offloads a packet to object storage when it exceeds the size limit.
+ *
+ * @param client - Optional API client to use for the upload presign request. When
+ * omitted, falls back to the global `apiClientManager.client`. Pass an explicit client
+ * (e.g. one built from a custom `clientConfig`) to ensure the payload is uploaded using
+ * the same configuration as the accompanying trigger API call.
+ */
 export async function conditionallyExportPacket(
   packet: IOPacket,
   pathPrefix: string,
-  tracer?: TriggerTracer
+  tracer?: TriggerTracer,
+  client?: ApiClient
 ): Promise<IOPacket> {
-  if (apiClientManager.client) {
+  const $client = client ?? apiClientManager.client;
+
+  if ($client) {
     const { needsOffloading, size } = packetRequiresOffloading(packet);
 
     if (needsOffloading) {
       if (!tracer) {
-        return await exportPacket(packet, pathPrefix);
+        return await exportPacket(packet, pathPrefix, $client);
       } else {
         const result = await tracer.startActiveSpan(
           "store.uploadOutput",
           async (span) => {
-            return await exportPacket(packet, pathPrefix);
+            return await exportPacket(packet, pathPrefix, $client);
           },
           {
             attributes: {
@@ -163,11 +174,15 @@ const ioRetryOptions = {
   randomize: true,
 } satisfies RetryOptions;
 
-async function exportPacket(packet: IOPacket, pathPrefix: string): Promise<IOPacket> {
+async function exportPacket(
+  packet: IOPacket,
+  pathPrefix: string,
+  client: ApiClient
+): Promise<IOPacket> {
   // Offload the output
   const filename = `${pathPrefix}.${getPacketExtension(packet.dataType)}`;
 
-  const presignedResponse = await apiClientManager.client!.createUploadPayloadUrl(filename);
+  const presignedResponse = await client.createUploadPayloadUrl(filename);
 
   if (!presignedResponse.storagePath) {
     throw new Error(

--- a/packages/core/test/ioSerialization.test.ts
+++ b/packages/core/test/ioSerialization.test.ts
@@ -1,4 +1,12 @@
-import { replaceSuperJsonPayload, prettyPrintPacket } from "../src/v3/utils/ioSerialization.js";
+import { createTestHttpServer } from "@epic-web/test-server/http";
+import {
+  replaceSuperJsonPayload,
+  prettyPrintPacket,
+  conditionallyExportPacket,
+  type IOPacket,
+} from "../src/v3/utils/ioSerialization.js";
+import { ApiClient } from "../src/v3/apiClient/index.js";
+import { apiClientManager } from "../src/v3/apiClientManager-api.js";
 
 describe("ioSerialization", () => {
   describe("replaceSuperJsonPayload", () => {
@@ -342,6 +350,144 @@ describe("ioSerialization", () => {
       const result = await prettyPrintPacket(data);
 
       expect(result).toBe(JSON.stringify(data, null, 2));
+    });
+  });
+
+  describe("conditionallyExportPacket", () => {
+    // A payload large enough to exceed OFFLOAD_IO_PACKET_LENGTH_LIMIT (128KB) so it offloads.
+    const largePayload = "x".repeat(200_000);
+    const largePacket: IOPacket = { data: largePayload, dataType: "text/plain" };
+
+    afterEach(() => {
+      // Clear any global client config set during a test.
+      apiClientManager.disable();
+    });
+
+    it("uses the provided client for the upload presign instead of the global client", async () => {
+      const globalPresignRequests: string[] = [];
+      const passedPresignRequests: string[] = [];
+      let uploadedBytes = 0;
+
+      // The global client points here — it must NOT be hit when a client is passed.
+      const globalServer = await createTestHttpServer({
+        defineRoutes(router) {
+          router.put("/api/v2/packets/:filename", async ({ req }) => {
+            globalPresignRequests.push(req.url);
+            return Response.json({ presignedUrl: "http://unused.local/upload" });
+          });
+        },
+      });
+
+      // The explicitly passed client points here — it MUST receive the presign + upload.
+      const passedServer = await createTestHttpServer({
+        defineRoutes(router) {
+          router.put("/api/v2/packets/:filename", async ({ req }) => {
+            passedPresignRequests.push(req.url);
+            return Response.json({
+              presignedUrl: `${passedServer.http.url().origin}/upload/payload`,
+              storagePath: "trigger/task/payload.txt",
+            });
+          });
+          router.put("/upload/payload", async ({ req }) => {
+            uploadedBytes = (await req.text()).length;
+            return new Response(null, { status: 200 });
+          });
+        },
+      });
+
+      try {
+        // Configure the global client to point at the global server.
+        apiClientManager.setGlobalAPIClientConfiguration({
+          baseURL: globalServer.http.url().origin,
+          accessToken: "tr-global",
+        });
+
+        const passedClient = new ApiClient(passedServer.http.url().origin, "tr-passed");
+
+        const result = await conditionallyExportPacket(
+          largePacket,
+          "trigger/task/payload",
+          undefined,
+          passedClient
+        );
+
+        expect(result.dataType).toBe("application/store");
+        expect(result.data).toBe("trigger/task/payload.txt");
+
+        // Upload went through the passed client only.
+        expect(passedPresignRequests).toHaveLength(1);
+        expect(globalPresignRequests).toHaveLength(0);
+        expect(uploadedBytes).toBe(largePayload.length);
+      } finally {
+        await globalServer.close();
+        await passedServer.close();
+      }
+    });
+
+    it("falls back to the global client when no client is provided", async () => {
+      const presignRequests: string[] = [];
+
+      const globalServer = await createTestHttpServer({
+        defineRoutes(router) {
+          router.put("/api/v2/packets/:filename", async ({ req }) => {
+            presignRequests.push(req.url);
+            return Response.json({
+              presignedUrl: `${globalServer.http.url().origin}/upload/payload`,
+              storagePath: "trigger/task/payload.txt",
+            });
+          });
+          router.put("/upload/payload", async () => new Response(null, { status: 200 }));
+        },
+      });
+
+      try {
+        apiClientManager.setGlobalAPIClientConfiguration({
+          baseURL: globalServer.http.url().origin,
+          accessToken: "tr-global",
+        });
+
+        const result = await conditionallyExportPacket(largePacket, "trigger/task/payload");
+
+        expect(result.dataType).toBe("application/store");
+        expect(result.data).toBe("trigger/task/payload.txt");
+        expect(presignRequests).toHaveLength(1);
+      } finally {
+        await globalServer.close();
+      }
+    });
+
+    it("returns the packet unchanged when no client is available", async () => {
+      apiClientManager.disable();
+
+      const result = await conditionallyExportPacket(largePacket, "trigger/task/payload");
+
+      expect(result).toEqual(largePacket);
+    });
+
+    it("does not offload small payloads even with a client", async () => {
+      const passedServer = await createTestHttpServer({
+        defineRoutes(router) {
+          router.put("/api/v2/packets/:filename", async () => {
+            throw new Error("presign should not be called for small payloads");
+          });
+        },
+      });
+
+      try {
+        const smallPacket: IOPacket = { data: "hello", dataType: "text/plain" };
+        const passedClient = new ApiClient(passedServer.http.url().origin, "tr-passed");
+
+        const result = await conditionallyExportPacket(
+          smallPacket,
+          "trigger/task/payload",
+          undefined,
+          passedClient
+        );
+
+        expect(result).toEqual(smallPacket);
+      } finally {
+        await passedServer.close();
+      }
     });
   });
 });

--- a/packages/trigger-sdk/src/v3/shared.ts
+++ b/packages/trigger-sdk/src/v3/shared.ts
@@ -2,9 +2,11 @@ import { SpanKind } from "@opentelemetry/api";
 import { SerializableJson } from "@trigger.dev/core";
 import {
   accessoryAttributes,
+  ApiClient,
   ApiError,
   apiClientManager,
   ApiRequestOptions,
+  conditionallyExportPacket,
   conditionallyImportPacket,
   convertToolParametersToSchema,
   createErrorTaskError,
@@ -25,6 +27,7 @@ import {
   sdkScope,
   SemanticInternalAttributes,
   stringifyIO,
+  type IOPacket,
   SubtaskUnwrapError,
   taskContext,
   TaskFromIdentifier,
@@ -2212,8 +2215,7 @@ async function trigger_internal<TRunTypes extends AnyRunTypes>(
   const apiClient = apiClientManager.clientOrThrow(requestOptions?.clientConfig);
 
   const parsedPayload = parsePayload ? await parsePayload(payload) : payload;
-
-  const payloadPacket = await stringifyIO(parsedPayload);
+  const triggerPayloadPacket = await prepareTriggerPayload(parsedPayload, apiClient, id);
 
   // Process idempotency key and extract options for storage
   const processedIdempotencyKey = await makeIdempotencyKey(options?.idempotencyKey);
@@ -2224,12 +2226,12 @@ async function trigger_internal<TRunTypes extends AnyRunTypes>(
   const handle = await apiClient.triggerTask(
     id,
     {
-      payload: payloadPacket.data,
+      payload: triggerPayloadPacket.data,
       options: {
         queue: options?.queue ? { name: options.queue } : undefined,
         concurrencyKey: options?.concurrencyKey,
         test: taskContext.ctx?.run.isTest,
-        payloadType: payloadPacket.dataType,
+        payloadType: triggerPayloadPacket.dataType,
         idempotencyKey: processedIdempotencyKey?.toString(),
         idempotencyKeyTTL: options?.idempotencyKeyTTL,
         idempotencyKeyOptions,
@@ -2468,8 +2470,7 @@ async function triggerAndWait_internal<TIdentifier extends string, TPayload, TOu
   const apiClient = apiClientManager.clientOrThrow(requestOptions?.clientConfig);
 
   const parsedPayload = parsePayload ? await parsePayload(payload) : payload;
-
-  const payloadPacket = await stringifyIO(parsedPayload);
+  const triggerPayloadPacket = await prepareTriggerPayload(parsedPayload, apiClient, id);
 
   // Process idempotency key and extract options for storage
   const processedIdempotencyKey = await makeIdempotencyKey(options?.idempotencyKey);
@@ -2483,13 +2484,13 @@ async function triggerAndWait_internal<TIdentifier extends string, TPayload, TOu
       const response = await apiClient.triggerTask(
         id,
         {
-          payload: payloadPacket.data,
+          payload: triggerPayloadPacket.data,
           options: {
             lockToVersion: taskContext.worker?.version, // Lock to current version because we're waiting for it to finish
             queue: options?.queue ? { name: options.queue } : undefined,
             concurrencyKey: options?.concurrencyKey,
             test: taskContext.ctx?.run.isTest,
-            payloadType: payloadPacket.dataType,
+            payloadType: triggerPayloadPacket.dataType,
             delay: options?.delay,
             ttl: options?.ttl,
             tags: options?.tags,
@@ -2555,7 +2556,7 @@ async function triggerAndSubscribe_internal<TIdentifier extends string, TPayload
   const apiClient = apiClientManager.clientOrThrow(requestOptions?.clientConfig);
 
   const parsedPayload = parsePayload ? await parsePayload(payload) : payload;
-  const payloadPacket = await stringifyIO(parsedPayload);
+  const triggerPayloadPacket = await prepareTriggerPayload(parsedPayload, apiClient, id);
 
   const processedIdempotencyKey = await makeIdempotencyKey(options?.idempotencyKey);
   const idempotencyKeyOptions = processedIdempotencyKey
@@ -2568,13 +2569,13 @@ async function triggerAndSubscribe_internal<TIdentifier extends string, TPayload
       const response = await apiClient.triggerTask(
         id,
         {
-          payload: payloadPacket.data,
+          payload: triggerPayloadPacket.data,
           options: {
             lockToVersion: taskContext.worker?.version,
             queue: options?.queue ? { name: options.queue } : undefined,
             concurrencyKey: options?.concurrencyKey,
             test: taskContext.ctx?.run.isTest,
-            payloadType: payloadPacket.dataType,
+            payloadType: triggerPayloadPacket.dataType,
             delay: options?.delay,
             ttl: options?.ttl,
             tags: options?.tags,
@@ -3073,4 +3074,23 @@ function registerTaskLifecycleHooks<
       fn: params.onCancel as AnyOnCancelHookFunction,
     });
   }
+}
+
+async function prepareTriggerPayload(
+  payload: unknown,
+  apiClient: ApiClient,
+  taskId: string
+): Promise<IOPacket> {
+  const payloadPacket = await stringifyIO(payload);
+  return await conditionallyExportPacket(
+    payloadPacket,
+    createTriggerPayloadPathPrefix(taskId),
+    undefined,
+    apiClient
+  );
+}
+
+function createTriggerPayloadPathPrefix(taskId: string): string {
+  const safeTaskId = encodeURIComponent(taskId);
+  return `trigger/${safeTaskId}/${Date.now()}-${Math.random().toString(36).slice(2)}/payload`;
 }


### PR DESCRIPTION
Adds backward-compatible support for large trigger payloads by reusing the existing object-storage packet flow.

Large payloads are uploaded to object storage before the trigger request is sent. The trigger API receives a small application/store pointer payload instead of embedding large JSON bodies in the request.

Small payload behavior is unchanged.

The runtime execution path is also unchanged — storage-backed payload packets are already supported. This change only removes large payload bytes from the trigger transport path, avoiding expensive full-body request parsing in the trigger endpoint.

## Testing

Automated:

- [x] cd packages/core && pnpm run test ./src/v3/schemas/api-type.test.ts --run passes
- [x] cd packages/core && pnpm run test ./src/v3/schemas/idempotencyKey.test.ts --run passes
- [x] pnpm run build --filter @trigger.dev/core --filter @trigger.dev/sdk passes

Manual smoke:

- [x] Upload a ~25MB payload via a presigned packet URL and trigger a task using payloadType: "application/store".
- [x] Trigger a task with a payload ≥128KB via the SDK and verify automatic offloading to object storage.
- [x] Trigger a task with a normal small payload and verify existing behavior is unchanged.
- [x] Verify runs complete successfully and storage-backed payloads are represented as application/store pointers rather than inline JSON.