### PR TITLE
fix(sdk): re-apply tool toModelOutput across chat.agent turns

### DIFF
--- a/.changeset/chat-agent-tools.md
+++ b/.changeset/chat-agent-tools.md
@@ -1,0 +1,15 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+Add a `tools` option to `chat.agent`. Declaring your tools here threads them into the SDK's internal `convertToModelMessages`, so each tool's `toModelOutput` is re-applied when prior-turn history is re-converted.
+
+```ts
+chat.agent({
+  tools: { readFile, search },
+  run: async ({ messages, tools, signal }) =>
+    streamText({ model, messages, tools, abortSignal: signal }),
+});
+```
+
+Also exports `InferChatUIMessageFromTools<typeof tools>` to derive the chat `UIMessage` type (typed tool parts) directly from a tool set.

--- a/packages/trigger-sdk/src/v3/ai-shared.ts
+++ b/packages/trigger-sdk/src/v3/ai-shared.ts
@@ -16,7 +16,7 @@
  */
 
 import type { Task, AnyTask } from "@trigger.dev/core/v3";
-import type { ModelMessage, UIMessage } from "ai";
+import type { InferUITools, ModelMessage, ToolSet, UIDataTypes, UIMessage } from "ai";
 
 /**
  * Message-part `type` value for the pending-message data part the agent
@@ -198,6 +198,26 @@ export type InferChatUIMessage<TTask extends AnyTask> = TTask extends Task<
 >
   ? TUIM
   : UIMessage;
+
+/**
+ * Derive the chat `UIMessage` type for a given tool set. The tool-part types
+ * (`tool-${name}` with typed input/output) are inferred from the tools. Use
+ * this to declare the message type from your tools (e.g. to pass to
+ * `chat.withUIMessage<...>()` or to type the frontend) without hand-writing
+ * the `UIMessage<unknown, UIDataTypes, InferUITools<...>>` triple.
+ *
+ * @example
+ * ```ts
+ * import type { InferChatUIMessageFromTools } from "@trigger.dev/sdk/ai";
+ * const tools = { search, readFile };
+ * type ChatUiMessage = InferChatUIMessageFromTools<typeof tools>;
+ * ```
+ */
+export type InferChatUIMessageFromTools<TTools extends ToolSet> = UIMessage<
+  unknown,
+  UIDataTypes,
+  InferUITools<TTools>
+>;
 
 /**
  * Upsert an incoming wire message into the customer's DB-backed chain

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -102,7 +102,16 @@ const METADATA_KEY = "tool.execute.options";
  * stopped/aborted conversations with partial tool parts.
  */
 function toModelMessages(messages: UIMessage[]): Promise<ModelMessage[]> {
-  return convertToModelMessages(messages, { ignoreIncompleteToolCalls: true });
+  // Pass the resolved per-turn `tools` (if any) so the AI SDK can look up each
+  // tool's `toModelOutput` and re-apply it to prior-turn tool results. Without
+  // `tools` it falls back to JSON-stringifying the raw output (TRI-10149). The
+  // conditional spread keeps the options object byte-identical to the no-tools
+  // path when nothing was declared.
+  const tools = locals.get(chatResolvedToolsKey);
+  return convertToModelMessages(messages, {
+    ignoreIncompleteToolCalls: true,
+    ...(tools ? { tools } : {}),
+  });
 }
 
 export type ToolCallExecutionOptions = {
@@ -1425,7 +1434,10 @@ export type ChatTaskSignals = {
  * The full payload passed to a `chatAgent` run function.
  * Extends `ChatTaskPayload` (the wire payload) with abort signals.
  */
-export type ChatTaskRunPayload<TClientData = unknown> = ChatTaskPayload<TClientData> &
+export type ChatTaskRunPayload<
+  TClientData = unknown,
+  TTools extends ToolSet = ToolSet,
+> = ChatTaskPayload<TClientData> &
   ChatTaskSignals & {
     /**
      * Task run context — same object as the `ctx` passed to a standard `task({ run })` handler’s second argument.
@@ -1436,6 +1448,21 @@ export type ChatTaskRunPayload<TClientData = unknown> = ChatTaskPayload<TClientD
     previousTurnUsage?: LanguageModelUsage;
     /** Cumulative token usage across all completed turns so far. */
     totalUsage: LanguageModelUsage;
+    /**
+     * The resolved tool set for this turn, the same `tools` you declared on
+     * `chat.agent({ tools })` (or the result of the per-turn `tools` function).
+     * Pass straight to `streamText({ tools })` so you don't redeclare them:
+     *
+     * ```ts
+     * run: ({ messages, tools, signal }) =>
+     *   streamText({ model, messages, tools, abortSignal: signal })
+     * ```
+     *
+     * Declaring `tools` on the config is also what lets the SDK re-run each
+     * tool's `toModelOutput` when it re-converts prior-turn history (see the
+     * `tools` option on `chat.agent`). Empty object when no `tools` were declared.
+     */
+    tools: TTools;
   };
 
 // Input streams for bidirectional chat communication
@@ -2366,6 +2393,20 @@ const chatPrepareMessagesKey =
   locals.create<(event: PrepareMessagesEvent<unknown>) => ModelMessage[] | Promise<ModelMessage[]>>(
     "chat.prepareMessages"
   );
+/**
+ * @internal The raw `tools` option from `chat.agent({ tools })`, either a
+ * static `ToolSet` or a per-turn function. Set once at boot.
+ */
+const chatToolsOptionKey = locals.create<
+  ToolSet | ((event: ResolveToolsEvent<unknown>) => ToolSet | Promise<ToolSet>)
+>("chat.toolsOption");
+/**
+ * @internal The concrete `ToolSet` resolved for the current turn. Read by
+ * `toModelMessages` so `convertToModelMessages` can re-run `toModelOutput` on
+ * prior-turn tool results. Unset when no `tools` were declared (preserves the
+ * exact pre-feature conversion behavior).
+ */
+const chatResolvedToolsKey = locals.create<ToolSet>("chat.resolvedTools");
 
 /** @internal Flag set by `chat.requestUpgrade()` to exit the loop after the current turn. */
 const chatUpgradeRequestedKey = locals.create<boolean>("chat.upgradeRequested");
@@ -2627,6 +2668,25 @@ export type PrepareMessagesEvent<TClientData = unknown> = {
 };
 
 /**
+ * Event passed to the per-turn `tools` function form on `chat.agent`.
+ *
+ * Use this when the active tool set depends on per-turn context (the user, a
+ * feature flag, etc.). Return the `ToolSet` to use for converting this turn's
+ * history. Only `inputSchema` and `toModelOutput` are read during conversion,
+ * so a lightweight map (no `execute`) is fine.
+ */
+export type ResolveToolsEvent<TClientData = unknown> = {
+  /** The chat session ID. */
+  chatId: string;
+  /** The current turn number (0-indexed). */
+  turn: number;
+  /** Whether this run is continuing an existing chat. */
+  continuation: boolean;
+  /** Custom data from the frontend. */
+  clientData?: TClientData;
+};
+
+/**
  * Data shape for `data-compaction` stream chunks emitted during compaction.
  * Use to type the `data` field when rendering compaction parts in the frontend.
  */
@@ -2798,6 +2858,40 @@ async function applyPrepareMessages(
       },
     }
   );
+}
+
+/**
+ * Resolve the `tools` option for the current turn and cache it in locals so
+ * `toModelMessages` can pass it to `convertToModelMessages`. For the function
+ * form, invokes the user function once per turn with the current turn context
+ * (which already has parsed `clientData`). No-op when no `tools` were declared.
+ * A throwing tools function logs and leaves the previously-resolved value in
+ * place rather than killing the turn.
+ * @internal
+ */
+async function resolveTurnTools(): Promise<void> {
+  const option = locals.get(chatToolsOptionKey);
+  if (!option) return;
+
+  if (typeof option !== "function") {
+    locals.set(chatResolvedToolsKey, option);
+    return;
+  }
+
+  const turnCtx = locals.get(chatTurnContextKey);
+  try {
+    const resolved = await option({
+      chatId: turnCtx?.chatId ?? "",
+      turn: turnCtx?.turn ?? 0,
+      continuation: turnCtx?.continuation ?? false,
+      clientData: turnCtx?.clientData,
+    });
+    locals.set(chatResolvedToolsKey, resolved);
+  } catch (error) {
+    logger.warn("chat.agent: tools() resolver threw; reusing previous tools for this turn", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 /**
@@ -4250,6 +4344,7 @@ export type ChatAgentOptions<
   TClientDataSchema extends TaskSchema | undefined = undefined,
   TUIMessage extends UIMessage = UIMessage,
   TActionSchema extends TaskSchema | undefined = undefined,
+  TTools extends ToolSet = ToolSet,
 > = Omit<
   TaskOptions<
     TIdentifier,
@@ -4361,6 +4456,41 @@ export type ChatAgentOptions<
   ) => Promise<unknown> | unknown;
 
   /**
+   * The tools available to this agent.
+   *
+   * `chat.agent` doesn't call the model for you. Your tools still go to
+   * `streamText({ tools })` inside `run()`. Declaring them here additionally
+   * lets the SDK re-run each tool's
+   * [`toModelOutput`](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling#tomodeloutput)
+   * when it re-converts persisted history on later turns. Without this, the
+   * AI SDK has no `tools` to look up `toModelOutput` against, so a tool's
+   * transformed result (e.g. raw image bytes → an image content part, or a
+   * sub-agent summary) silently degrades to its raw JSON output from turn 2
+   * onward.
+   *
+   * Only `inputSchema` and `toModelOutput` are read during conversion (never
+   * `execute`), so you may pass a lightweight map if you keep heavy execute
+   * deps out of this module.
+   *
+   * Pass either a static `ToolSet` or a function of per-turn context (for
+   * tools that depend on the user, a feature flag, etc.). The resolved set is
+   * available on the `run()` payload as `tools`.
+   *
+   * @example
+   * ```ts
+   * const tools = { read_file, search };
+   * chat.agent({
+   *   tools,
+   *   run: async ({ messages, tools, signal }) =>
+   *     streamText({ model, messages, tools, abortSignal: signal }),
+   * });
+   * ```
+   */
+  tools?:
+    | TTools
+    | ((event: ResolveToolsEvent<inferSchemaOut<TClientDataSchema>>) => TTools | Promise<TTools>);
+
+  /**
    * The run function for the chat task.
    *
    * Receives a `ChatTaskRunPayload` with the conversation messages, chat session ID,
@@ -4370,7 +4500,9 @@ export type ChatAgentOptions<
    * **Auto-piping:** If this function returns a value with `.toUIMessageStream()`,
    * the stream is automatically piped to the frontend.
    */
-  run: (payload: ChatTaskRunPayload<inferSchemaOut<TClientDataSchema>>) => Promise<unknown>;
+  run: (
+    payload: ChatTaskRunPayload<inferSchemaOut<TClientDataSchema>, TTools>
+  ) => Promise<unknown>;
 
   /**
    * Called once at the start of every run boot — for the initial run, for
@@ -4951,8 +5083,9 @@ function chatAgent<
   TClientDataSchema extends TaskSchema | undefined = undefined,
   TUIMessage extends UIMessage = UIMessage,
   TActionSchema extends TaskSchema | undefined = undefined,
+  TTools extends ToolSet = ToolSet,
 >(
-  options: ChatAgentOptions<TIdentifier, TClientDataSchema, TUIMessage, TActionSchema>
+  options: ChatAgentOptions<TIdentifier, TClientDataSchema, TUIMessage, TActionSchema, TTools>
 ): Task<TIdentifier, ChatTaskWirePayload<TUIMessage, inferSchemaIn<TClientDataSchema>>, unknown> {
   const {
     run: userRun,
@@ -4971,6 +5104,7 @@ function chatAgent<
     compaction,
     pendingMessages: pendingMessagesConfig,
     prepareMessages,
+    tools: toolsOption,
     onTurnComplete,
     maxTurns = 100,
     turnTimeout = "1h",
@@ -5047,6 +5181,25 @@ function chatAgent<
 
       if (prepareMessages) {
         locals.set(chatPrepareMessagesKey, prepareMessages);
+      }
+
+      if (toolsOption) {
+        // Cast: the option's function form is typed against the parsed
+        // `clientData` (`ResolveToolsEvent<inferSchemaOut<...>>`), but the
+        // locals key uses the erased `ResolveToolsEvent<unknown>`. The runtime
+        // value is identical; this mirrors how `prepareMessages` is stored.
+        locals.set(
+          chatToolsOptionKey,
+          toolsOption as
+            | ToolSet
+            | ((event: ResolveToolsEvent<unknown>) => ToolSet | Promise<ToolSet>)
+        );
+        // Static tools are usable immediately (e.g. the boot-time history
+        // seed before the first turn context exists). The function form is
+        // resolved per-turn once `clientData` is parsed (see resolveTurnTools).
+        if (typeof toolsOption !== "function") {
+          locals.set(chatResolvedToolsKey, toolsOption);
+        }
       }
 
       if (compaction) {
@@ -5958,6 +6111,11 @@ function chatAgent<
                     clientData,
                   });
 
+                  // Resolve the per-turn `tools` set now that turn context
+                  // (incl. parsed clientData) exists, so every toModelMessages
+                  // call this turn can re-apply tool `toModelOutput`.
+                  await resolveTurnTools();
+
                   // Per-turn stop controller (reset each turn)
                   const stopController = new AbortController();
                   currentStopController = stopController;
@@ -6613,6 +6771,7 @@ function chatAgent<
                         previousTurnUsage,
                         totalUsage: cumulativeUsage,
                         ctx,
+                        tools: locals.get(chatResolvedToolsKey) ?? {},
                         signal: combinedSignal,
                         cancelSignal,
                         stopSignal,
@@ -7512,11 +7671,11 @@ export interface ChatBuilder<
    * (backwards compatible).
    */
   agent: [TClientDataSchema] extends [undefined]
-  ? <TId extends string, TInfer extends TaskSchema | undefined = undefined, TAction extends TaskSchema | undefined = undefined>(
-    options: ChatAgentOptions<TId, TInfer, TUIMessage, TAction>
+  ? <TId extends string, TInfer extends TaskSchema | undefined = undefined, TAction extends TaskSchema | undefined = undefined, TTools extends ToolSet = ToolSet>(
+    options: ChatAgentOptions<TId, TInfer, TUIMessage, TAction, TTools>
   ) => Task<TId, ChatTaskWirePayload<TUIMessage, inferSchemaIn<TInfer>>, unknown>
-  : <TId extends string, TAction extends TaskSchema | undefined = undefined>(
-    options: Omit<ChatAgentOptions<TId, TClientDataSchema, TUIMessage, TAction>, "clientDataSchema">
+  : <TId extends string, TAction extends TaskSchema | undefined = undefined, TTools extends ToolSet = ToolSet>(
+    options: Omit<ChatAgentOptions<TId, TClientDataSchema, TUIMessage, TAction, TTools>, "clientDataSchema">
   ) => Task<TId, ChatTaskWirePayload<TUIMessage, inferSchemaIn<TClientDataSchema>>, unknown>;
 
   /**
@@ -9145,7 +9304,11 @@ function chatLocal<T extends Record<string, unknown>>(options: { id: string }): 
 // the browser graph. Re-exported here so `@trigger.dev/sdk/ai` consumers
 // still see them.
 import type { InferChatClientData, InferChatUIMessage } from "./ai-shared.js";
-export type { InferChatClientData, InferChatUIMessage } from "./ai-shared.js";
+export type {
+  InferChatClientData,
+  InferChatUIMessage,
+  InferChatUIMessageFromTools,
+} from "./ai-shared.js";
 
 /**
  * Options for {@link createChatStartSessionAction}.

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -2861,15 +2861,22 @@ async function applyPrepareMessages(
 }
 
 /**
- * Resolve the `tools` option for the current turn and cache it in locals so
+ * Resolve the `tools` option into a concrete `ToolSet` and cache it in locals so
  * `toModelMessages` can pass it to `convertToModelMessages`. For the function
- * form, invokes the user function once per turn with the current turn context
- * (which already has parsed `clientData`). No-op when no `tools` were declared.
- * A throwing tools function logs and leaves the previously-resolved value in
- * place rather than killing the turn.
+ * form, invokes the user function with the given context (or the current turn
+ * context when no override is passed). Pass an `override` for the boot-time
+ * history conversion, which runs before the per-turn context exists and uses
+ * the run/continuation payload's `clientData`.
+ *
+ * Fails closed: a throwing resolver propagates rather than carrying a prior
+ * turn's set forward. The function form can gate capabilities by user or flag,
+ * so reusing stale tools would leak capabilities. No-op when no `tools` were
+ * declared.
  * @internal
  */
-async function resolveTurnTools(): Promise<void> {
+async function resolveTurnTools(
+  override?: { chatId: string; turn: number; continuation: boolean; clientData: unknown }
+): Promise<void> {
   const option = locals.get(chatToolsOptionKey);
   if (!option) return;
 
@@ -2878,20 +2885,14 @@ async function resolveTurnTools(): Promise<void> {
     return;
   }
 
-  const turnCtx = locals.get(chatTurnContextKey);
-  try {
-    const resolved = await option({
-      chatId: turnCtx?.chatId ?? "",
-      turn: turnCtx?.turn ?? 0,
-      continuation: turnCtx?.continuation ?? false,
-      clientData: turnCtx?.clientData,
-    });
-    locals.set(chatResolvedToolsKey, resolved);
-  } catch (error) {
-    logger.warn("chat.agent: tools() resolver threw; reusing previous tools for this turn", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
+  const ctx = override ?? locals.get(chatTurnContextKey);
+  const resolved = await option({
+    chatId: ctx?.chatId ?? "",
+    turn: ctx?.turn ?? 0,
+    continuation: ctx?.continuation ?? false,
+    clientData: ctx?.clientData,
+  });
+  locals.set(chatResolvedToolsKey, resolved);
 }
 
 /**
@@ -5194,9 +5195,9 @@ function chatAgent<
             | ToolSet
             | ((event: ResolveToolsEvent<unknown>) => ToolSet | Promise<ToolSet>)
         );
-        // Static tools are usable immediately (e.g. the boot-time history
-        // seed before the first turn context exists). The function form is
-        // resolved per-turn once `clientData` is parsed (see resolveTurnTools).
+        // Static tools are usable immediately. The function form is resolved
+        // just before the boot history conversion (with the payload's
+        // clientData) and again per-turn (see resolveTurnTools).
         if (typeof toolsOption !== "function") {
           locals.set(chatResolvedToolsKey, toolsOption);
         }
@@ -5591,6 +5592,29 @@ function chatAgent<
         }
 
         if (accumulatedUIMessages.length > 0) {
+          // Resolve a function-form `tools` with the run/continuation payload's
+          // clientData so this conversion of the restored history applies each
+          // tool's toModelOutput (static tools were already seeded above). This
+          // only re-renders saved history, so it fails open: a resolver hiccup
+          // logs and converts without tools rather than blocking the resume.
+          // Per-turn resolveTurnTools still fails closed for live turns.
+          if (typeof toolsOption === "function") {
+            try {
+              await resolveTurnTools({
+                chatId: payload.chatId,
+                turn: 0,
+                continuation: payload.continuation ?? false,
+                clientData: parseClientData
+                  ? await parseClientData(payload.metadata)
+                  : payload.metadata,
+              });
+            } catch (error) {
+              logger.warn(
+                "chat.agent: tools() resolver threw at boot; restored history converted without toModelOutput",
+                { error: error instanceof Error ? error.message : String(error) }
+              );
+            }
+          }
           try {
             accumulatedMessages = await toModelMessages(accumulatedUIMessages);
           } catch (error) {

--- a/packages/trigger-sdk/test/mockChatAgent.test.ts
+++ b/packages/trigger-sdk/test/mockChatAgent.test.ts
@@ -2082,3 +2082,139 @@ describe("mockChatAgent", () => {
     });
   });
 });
+
+describe("mockChatAgent tools / toModelOutput (TRI-10149)", () => {
+  // A tool whose raw `execute`/output never contains the marker; the marker
+  // lives ONLY in `toModelOutput`. If the SDK re-converts prior-turn history
+  // without threading tools, `toModelOutput` is skipped and the marker is lost.
+  const makeVault = () =>
+    tool({
+      description: "Vault.",
+      inputSchema: z.object({}),
+      toModelOutput: () => ({ type: "text" as const, value: "MARKER-XYZ" }),
+    });
+
+  // Seed a prior assistant turn that already carries a resolved vault tool
+  // result whose raw output has NO marker.
+  const seedAssistantWithToolResult = {
+    id: "a-vault",
+    role: "assistant" as const,
+    parts: [
+      {
+        type: "tool-vault" as const,
+        toolCallId: "tc_vault",
+        state: "output-available" as const,
+        input: {},
+        output: { bytes: "raw-no-marker" },
+      },
+    ],
+  };
+
+  it("re-applies tool.toModelOutput when re-converting prior-turn history (static tools)", async () => {
+    const vault = makeVault();
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({ stream: textStream("ok") }),
+    });
+
+    const seenToolResults: string[] = [];
+    const agent = chat.agent({
+      id: "mockChatAgent.toModelOutput-static",
+      tools: { vault },
+      run: async ({ messages, tools, signal }) => {
+        // REUSE A: `tools` is threaded onto the run payload (typed concretely,
+        // not the broad `ToolSet`). The static-form type inference is validated
+        // end-to-end by the references/ai-chat typecheck; here we exercise the
+        // runtime behavior. (test/ is not part of the package's tsc pass.)
+        for (const m of messages) {
+          if (m.role === "tool") seenToolResults.push(JSON.stringify(m.content));
+        }
+        return streamText({ model, messages, tools, abortSignal: signal });
+      },
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "test-tmo-static" });
+    try {
+      // Turn 1 seeds the tool result; turn 2 forces a re-conversion of history.
+      await harness.sendMessage(seedAssistantWithToolResult as any);
+      await harness.sendMessage(userMessage("recall"));
+      await new Promise((r) => setTimeout(r, 20));
+
+      const all = seenToolResults.join("|");
+      // toModelOutput ran → transformed value present, raw output gone.
+      expect(all).toContain("MARKER-XYZ");
+      expect(all).not.toContain("raw-no-marker");
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("resolves the per-turn function form of tools and re-applies toModelOutput", async () => {
+    const vault = makeVault();
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({ stream: textStream("ok") }),
+    });
+
+    const seenToolResults: string[] = [];
+    let resolverCalls = 0;
+    const agent = chat.agent({
+      id: "mockChatAgent.toModelOutput-fn",
+      tools: () => {
+        resolverCalls++;
+        return { vault };
+      },
+      run: async ({ messages, tools, signal }) => {
+        for (const m of messages) {
+          if (m.role === "tool") seenToolResults.push(JSON.stringify(m.content));
+        }
+        return streamText({ model, messages, tools, abortSignal: signal });
+      },
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "test-tmo-fn" });
+    try {
+      await harness.sendMessage(seedAssistantWithToolResult as any);
+      await harness.sendMessage(userMessage("recall"));
+      await new Promise((r) => setTimeout(r, 20));
+
+      const all = seenToolResults.join("|");
+      expect(all).toContain("MARKER-XYZ");
+      expect(all).not.toContain("raw-no-marker");
+      // The resolver runs per turn (once each), not per conversion call.
+      expect(resolverCalls).toBeGreaterThanOrEqual(2);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("leaves conversion unchanged when no tools are declared (raw output passes through)", async () => {
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({ stream: textStream("ok") }),
+    });
+
+    const seenToolResults: string[] = [];
+    const agent = chat.agent({
+      id: "mockChatAgent.toModelOutput-none",
+      run: async ({ messages, signal }) => {
+        for (const m of messages) {
+          if (m.role === "tool") seenToolResults.push(JSON.stringify(m.content));
+        }
+        return streamText({ model, messages, abortSignal: signal });
+      },
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "test-tmo-none" });
+    try {
+      await harness.sendMessage(seedAssistantWithToolResult as any);
+      await harness.sendMessage(userMessage("recall"));
+      await new Promise((r) => setTimeout(r, 20));
+
+      // No tools declared → no toModelOutput lookup → raw output stringified
+      // (the pre-feature behavior, preserved for backward compatibility).
+      const all = seenToolResults.join("|");
+      expect(all).toContain("raw-no-marker");
+      expect(all).not.toContain("MARKER-XYZ");
+    } finally {
+      await harness.close();
+    }
+  });
+});

--- a/references/ai-chat/src/components/chat-sidebar.tsx
+++ b/references/ai-chat/src/components/chat-sidebar.tsx
@@ -119,6 +119,7 @@ export function ChatSidebar({
             <option value="upgrade-test">upgrade-test (requestUpgrade after 3 turns)</option>
             <option value="stress-emit">stress-emit (UI stress test)</option>
             <option value="cf-trust-test">cf-trust-test (Cloudflare proxy trust)</option>
+            <option value="tool-model-output-test">tool-model-output-test (toModelOutput cross-turn)</option>
           </select>
         </div>
         <label

--- a/references/ai-chat/src/lib/chat-tools-schemas.ts
+++ b/references/ai-chat/src/lib/chat-tools-schemas.ts
@@ -29,6 +29,7 @@
  */
 import { tool } from "ai";
 import type { InferUITools, UIDataTypes, UIMessage } from "ai";
+import type { InferChatUIMessageFromTools } from "@trigger.dev/sdk/ai";
 import { z } from "zod";
 
 export const inspectEnvironment = tool({
@@ -186,4 +187,5 @@ export const headStartTools = {
 
 type ChatToolSet = typeof headStartTools;
 export type ChatUiTools = InferUITools<ChatToolSet>;
-export type ChatUiMessage = UIMessage<unknown, UIDataTypes, ChatUiTools>;
+// Equivalent to `UIMessage<unknown, UIDataTypes, ChatUiTools>`, via the SDK helper.
+export type ChatUiMessage = InferChatUIMessageFromTools<ChatToolSet>;

--- a/references/ai-chat/src/trigger/chat.ts
+++ b/references/ai-chat/src/trigger/chat.ts
@@ -10,7 +10,8 @@ import {
   createProviderRegistry,
   validateUIMessages,
 } from "ai";
-import type { LanguageModel, LanguageModelUsage, UIMessage } from "ai";
+import type { LanguageModel, LanguageModelUsage, ModelMessage, UIMessage } from "ai";
+import { tool } from "ai";
 import { openai } from "@ai-sdk/openai";
 import { anthropic } from "@ai-sdk/anthropic";
 import { z } from "zod";
@@ -183,6 +184,12 @@ export const aiChat = chat
     id: "ai-chat",
     idleTimeoutInSeconds: 60,
     chatAccessTokenTTL: "1h",
+
+    // Declare tools on the config so the SDK threads them into its internal
+    // convertToModelMessages, so any tool `toModelOutput` is re-applied when
+    // prior-turn history is re-converted. The resolved set comes back, typed,
+    // on the run payload (used below instead of referencing `chatTools` again).
+    tools: chatTools,
 
     // #region Compaction — automatic context window management
     compaction: {
@@ -537,7 +544,7 @@ export const aiChat = chat
     // #endregion
 
     // #region run — just return streamText(), chat.agent handles everything else
-    run: async ({ messages, clientData, stopSignal }) => {
+    run: async ({ messages, clientData, stopSignal, tools }) => {
       userContext.messageCount++;
       if (clientData?.model) {
         userContext.preferredModel = clientData.model;
@@ -550,7 +557,8 @@ export const aiChat = chat
         ...chat.toStreamTextOptions({
           registry,
           telemetry: clientData?.userId ? { userId: clientData.userId } : undefined,
-          tools: chatTools,
+          // `tools` is the same `chatTools` set, handed back typed on the payload.
+          tools,
         }),
         model: languageModelForChatTurn(modelOverride),
         messages: messages,
@@ -1074,3 +1082,92 @@ export const cfTrustTestAgent = chat
       });
     },
   });
+
+// ============================================================================
+// tool-model-output-test: TRI-10149 regression
+//
+// A tool whose `toModelOutput` rewrites the result into a marker phrase that
+// the *raw* tool output never contains. The model only ever learns the
+// codeword through `toModelOutput`.
+//
+//   Turn 1: the model calls `vault`, sees the codeword via `toModelOutput`,
+//           but is told to reply with exactly "ACK", so the codeword never
+//           enters the assistant's text. The tool result is its only home in
+//           the persisted history.
+//   Turn 2: the model is asked to recall the codeword. The SDK re-converts the
+//           accumulated UIMessage history into the `messages: ModelMessage[]`
+//           handed to `run()`. If `tools` is threaded into that internal
+//           `convertToModelMessages` call, `toModelOutput` runs again and the
+//           model (and the `messages` we receive) see "GIRAFFE-7731". If not
+//           (the bug), the raw output is JSON-stringified and the codeword is
+//           gone.
+//
+// `run()` inspects its OWN incoming `messages` each turn and logs whether the
+// prior-turn tool result still carries the marker, a deterministic,
+// model-independent assertion point (this array is the literal output of the
+// `toModelMessages` wrapper under test). The model's turn-2 recall is a
+// secondary, user-facing signal.
+// ============================================================================
+
+const VAULT_CODEWORD = "GIRAFFE-7731";
+
+const vaultTool = tool({
+  description:
+    "Open the vault. You MUST call this tool to learn the codeword. The raw " +
+    "tool result is opaque bytes; only your model-side view reveals the codeword.",
+  inputSchema: z.object({}),
+  // Raw output deliberately omits the codeword. This is what streams to the
+  // frontend AND what gets JSON-stringified into the prompt when the history
+  // is re-converted WITHOUT tools (the bug this test guards against).
+  execute: async () => ({
+    kind: "vault-blob",
+    bytes: "9f3a8c1d7e2b40960aa5510fbe33cc77",
+    note: "raw vault bytes, not human readable",
+  }),
+  // Model-side view: the ONLY place the codeword appears. Skipped on turn 2+
+  // unless the SDK threads `tools` through its internal convertToModelMessages.
+  toModelOutput: () => ({
+    type: "text" as const,
+    value: `VAULT CONTENTS: the codeword is ${VAULT_CODEWORD}.`,
+  }),
+});
+
+/**
+ * Log whether each incoming tool-result message still carries the
+ * `toModelOutput` marker. `messages` is the exact output of the internal
+ * `toModelMessages` wrapper, so `containsCodeword` is the deterministic verdict
+ * for TRI-10149 on every turn after the tool has been called.
+ */
+function logVaultProbe(messages: ModelMessage[]) {
+  for (const m of messages) {
+    if (m.role !== "tool") continue;
+    const serialized = JSON.stringify(m.content);
+    logger.info("tool-model-output-test: incoming tool result", {
+      messageCount: messages.length,
+      containsCodeword: serialized.includes(VAULT_CODEWORD),
+      serialized: serialized.slice(0, 500),
+    });
+  }
+}
+
+export const toolModelOutputTest = chat.agent({
+  id: "tool-model-output-test",
+  idleTimeoutInSeconds: 60,
+  // Declaring tools on the config (TRI-10149) threads them into the SDK's
+  // internal convertToModelMessages so `toModelOutput` re-runs when prior-turn
+  // history is re-converted. `tools` is then handed back, typed, on the run payload.
+  tools: { vault: vaultTool },
+  run: async ({ messages, tools, signal }) => {
+    logVaultProbe(messages);
+    return streamText({
+      model: openai("gpt-4o-mini"),
+      system:
+        "You are a vault assistant. Follow the user's formatting instructions exactly. " +
+        "When the user asks for the codeword, answer with it directly.",
+      messages,
+      tools,
+      stopWhen: stepCountIs(5),
+      abortSignal: signal,
+    });
+  },
+});

--- a/references/ai-chat/src/trigger/chat.ts
+++ b/references/ai-chat/src/trigger/chat.ts
@@ -1150,6 +1150,10 @@ function logVaultProbe(messages: ModelMessage[]) {
   }
 }
 
+const vaultSystemPrompt =
+  "You are a vault assistant. Follow the user's formatting instructions exactly. " +
+  "When the user asks for the codeword, answer with it directly.";
+
 export const toolModelOutputTest = chat.agent({
   id: "tool-model-output-test",
   idleTimeoutInSeconds: 60,
@@ -1161,9 +1165,27 @@ export const toolModelOutputTest = chat.agent({
     logVaultProbe(messages);
     return streamText({
       model: openai("gpt-4o-mini"),
-      system:
-        "You are a vault assistant. Follow the user's formatting instructions exactly. " +
-        "When the user asks for the codeword, answer with it directly.",
+      system: vaultSystemPrompt,
+      messages,
+      tools,
+      stopWhen: stepCountIs(5),
+      abortSignal: signal,
+    });
+  },
+});
+
+// Same test, but with the per-turn function form of `tools`. Exercises the
+// resolver path: resolved per turn (and at boot, with the payload's clientData,
+// so a continuation's restored history still gets toModelOutput re-applied).
+export const toolModelOutputFnTest = chat.agent({
+  id: "tool-model-output-fn-test",
+  idleTimeoutInSeconds: 60,
+  tools: () => ({ vault: vaultTool }),
+  run: async ({ messages, tools, signal }) => {
+    logVaultProbe(messages);
+    return streamText({
+      model: openai("gpt-4o-mini"),
+      system: vaultSystemPrompt,
       messages,
       tools,
       stopWhen: stepCountIs(5),


### PR DESCRIPTION
## Summary

`chat.agent` now takes a `tools` option. Until now tools only went to `streamText` inside `run()`, so the SDK had no tools when it re-converted the persisted `UIMessage` history at the start of each turn. Any tool with a `toModelOutput` (raw image bytes into an image content part, or a sub-agent transcript compressed to a summary) had its transform applied on turn 1 and skipped from turn 2 onward, so the raw output got JSON-stringified back into the prompt and the model lost the transformed view.

Declaring `tools` on the config threads them into that conversion, so `toModelOutput` runs on every turn. The resolved set is handed back, typed, on the `run()` payload as `tools`:

```ts
const tools = { searchDocs, renderChart };

export const myChat = chat.agent({
  tools,
  run: async ({ messages, tools, signal }) =>
    streamText({ ...chat.toStreamTextOptions({ tools }), messages, abortSignal: signal }),
});
```

`tools` also accepts a per-turn function for tools that depend on the user or a feature flag. Only `inputSchema` and `toModelOutput` are read during conversion, never `execute`. Also exports `InferChatUIMessageFromTools<typeof tools>` to derive the chat `UIMessage` type from a tool set. No behavior change for agents that don't declare `tools`.
