### PR TITLE
fix(core,cli): stop chat.agent uncaught exception on mid-stream abort

### DIFF
--- a/.changeset/s2-batch-transform-linger-fix.md
+++ b/.changeset/s2-batch-transform-linger-fix.md
@@ -1,0 +1,6 @@
+---
+"@trigger.dev/core": patch
+"trigger.dev": patch
+---
+
+Bump `@s2-dev/streamstore` to `0.22.10` to fix a `TASK_RUN_UNCAUGHT_EXCEPTION` ("Invalid state: Unable to enqueue") when a `chat.agent` turn is aborted mid-stream.

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -112,7 +112,7 @@
     "@remix-run/serve": "2.17.4",
     "@remix-run/server-runtime": "2.17.4",
     "@remix-run/v1-meta": "^0.1.3",
-    "@s2-dev/streamstore": "^0.22.5",
+    "@s2-dev/streamstore": "^0.22.10",
     "@sentry/remix": "9.46.0",
     "@slack/web-api": "7.9.1",
     "@socket.io/redis-adapter": "^8.3.0",

--- a/packages/cli-v3/package.json
+++ b/packages/cli-v3/package.json
@@ -94,7 +94,7 @@
     "@opentelemetry/resources": "2.0.1",
     "@opentelemetry/sdk-trace-node": "2.0.1",
     "@opentelemetry/semantic-conventions": "1.36.0",
-    "@s2-dev/streamstore": "^0.22.5",
+    "@s2-dev/streamstore": "^0.22.10",
     "@trigger.dev/build": "workspace:4.5.0-rc.3",
     "@trigger.dev/core": "workspace:4.5.0-rc.3",
     "@trigger.dev/schema-to-json": "workspace:4.5.0-rc.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -206,7 +206,7 @@
     "@opentelemetry/sdk-trace-base": "2.0.1",
     "@opentelemetry/sdk-trace-node": "2.0.1",
     "@opentelemetry/semantic-conventions": "1.36.0",
-    "@s2-dev/streamstore": "0.22.5",
+    "@s2-dev/streamstore": "0.22.10",
     "dequal": "^2.0.3",
     "eventsource": "^3.0.5",
     "eventsource-parser": "^3.0.0",

--- a/packages/core/src/v3/realtimeStreams/streamsWriterV2.test.ts
+++ b/packages/core/src/v3/realtimeStreams/streamsWriterV2.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { AppendRecord, BatchTransform } from "@s2-dev/streamstore";
 
 import { ChatChunkTooLargeError, isChatChunkTooLargeError } from "../errors.js";
 import { encodeChunkOrError } from "./streamsWriterV2.js";
@@ -74,67 +73,5 @@ describe("isChatChunkTooLargeError", () => {
     expect(isChatChunkTooLargeError(new Error("nope"))).toBe(false);
     expect(isChatChunkTooLargeError("string")).toBe(false);
     expect(isChatChunkTooLargeError(undefined)).toBe(false);
-  });
-});
-
-// Regression guard for the `@s2-dev/streamstore` linger-timer race that
-// surfaced as `TASK_RUN_UNCAUGHT_EXCEPTION` ("Invalid state: Unable to
-// enqueue") in `chat.agent`. `StreamsWriterV2` pipes records through a
-// `BatchTransform` into S2's `session.writable`. When a run aborts mid-turn
-// while a record is still buffered in the linger window, the writable is
-// aborted and the transform's readable controller errors — but the pending
-// linger `setTimeout` still fires and calls `controller.enqueue()` on the
-// now-dead controller, throwing from a timer callback (so it's uncaught).
-//
-// Fixed upstream in `@s2-dev/streamstore@0.22.10` by wrapping the linger
-// flush in a try/catch that discards the closed-controller `TypeError`. This
-// test exercises the *real* `BatchTransform` (no mock) and fails if the
-// dependency is ever downgraded below the fix.
-describe("BatchTransform linger-timer abort safety (s2 dependency contract)", () => {
-  it("does not throw an uncaught error when the controller dies before the linger fires", async () => {
-    const lingerDurationMillis = 50;
-    const captured: unknown[] = [];
-    const onUncaught = (err: unknown) => captured.push(err);
-
-    // Intercept uncaught errors from the linger timer for the duration of the
-    // test — the throw happens in a `setTimeout`, so it can't be caught with a
-    // surrounding try/catch.
-    const prevUncaught = process.listeners("uncaughtException");
-    const prevUnhandled = process.listeners("unhandledRejection");
-    process.removeAllListeners("uncaughtException");
-    process.removeAllListeners("unhandledRejection");
-    process.on("uncaughtException", onUncaught);
-    process.on("unhandledRejection", onUncaught);
-
-    try {
-      // Mirror the StreamsWriterV2 pipeline shape: source -> BatchTransform ->
-      // session.writable. The downstream never acks, so the buffered record
-      // stays in the linger window until we abort.
-      const batcher = new BatchTransform({ lingerDurationMillis });
-      const downstream = new WritableStream({
-        write() {
-          return new Promise(() => {});
-        },
-      });
-      batcher.readable.pipeTo(downstream).catch(() => {});
-
-      const writer = batcher.writable.getWriter();
-      // Buffer a record — this arms the linger setTimeout.
-      await writer.write(AppendRecord.string({ body: "hello" }));
-      // Abort the downstream before the linger fires (== run suspend/abort ->
-      // session.writable.abort()), which errors the transform's readable side.
-      await downstream.abort?.("aborted").catch(() => {});
-      writer.abort("aborted").catch(() => {});
-      // Wait past the linger window so the pending timer fires on the dead
-      // controller.
-      await new Promise((r) => setTimeout(r, lingerDurationMillis + 150));
-    } finally {
-      process.removeListener("uncaughtException", onUncaught);
-      process.removeListener("unhandledRejection", onUncaught);
-      prevUncaught.forEach((l) => process.on("uncaughtException", l));
-      prevUnhandled.forEach((l) => process.on("unhandledRejection", l));
-    }
-
-    expect(captured).toEqual([]);
   });
 });

--- a/packages/core/src/v3/realtimeStreams/streamsWriterV2.test.ts
+++ b/packages/core/src/v3/realtimeStreams/streamsWriterV2.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { AppendRecord, BatchTransform } from "@s2-dev/streamstore";
 
 import { ChatChunkTooLargeError, isChatChunkTooLargeError } from "../errors.js";
 import { encodeChunkOrError } from "./streamsWriterV2.js";
@@ -73,5 +74,67 @@ describe("isChatChunkTooLargeError", () => {
     expect(isChatChunkTooLargeError(new Error("nope"))).toBe(false);
     expect(isChatChunkTooLargeError("string")).toBe(false);
     expect(isChatChunkTooLargeError(undefined)).toBe(false);
+  });
+});
+
+// Regression guard for the `@s2-dev/streamstore` linger-timer race that
+// surfaced as `TASK_RUN_UNCAUGHT_EXCEPTION` ("Invalid state: Unable to
+// enqueue") in `chat.agent`. `StreamsWriterV2` pipes records through a
+// `BatchTransform` into S2's `session.writable`. When a run aborts mid-turn
+// while a record is still buffered in the linger window, the writable is
+// aborted and the transform's readable controller errors — but the pending
+// linger `setTimeout` still fires and calls `controller.enqueue()` on the
+// now-dead controller, throwing from a timer callback (so it's uncaught).
+//
+// Fixed upstream in `@s2-dev/streamstore@0.22.10` by wrapping the linger
+// flush in a try/catch that discards the closed-controller `TypeError`. This
+// test exercises the *real* `BatchTransform` (no mock) and fails if the
+// dependency is ever downgraded below the fix.
+describe("BatchTransform linger-timer abort safety (s2 dependency contract)", () => {
+  it("does not throw an uncaught error when the controller dies before the linger fires", async () => {
+    const lingerDurationMillis = 50;
+    const captured: unknown[] = [];
+    const onUncaught = (err: unknown) => captured.push(err);
+
+    // Intercept uncaught errors from the linger timer for the duration of the
+    // test — the throw happens in a `setTimeout`, so it can't be caught with a
+    // surrounding try/catch.
+    const prevUncaught = process.listeners("uncaughtException");
+    const prevUnhandled = process.listeners("unhandledRejection");
+    process.removeAllListeners("uncaughtException");
+    process.removeAllListeners("unhandledRejection");
+    process.on("uncaughtException", onUncaught);
+    process.on("unhandledRejection", onUncaught);
+
+    try {
+      // Mirror the StreamsWriterV2 pipeline shape: source -> BatchTransform ->
+      // session.writable. The downstream never acks, so the buffered record
+      // stays in the linger window until we abort.
+      const batcher = new BatchTransform({ lingerDurationMillis });
+      const downstream = new WritableStream({
+        write() {
+          return new Promise(() => {});
+        },
+      });
+      batcher.readable.pipeTo(downstream).catch(() => {});
+
+      const writer = batcher.writable.getWriter();
+      // Buffer a record — this arms the linger setTimeout.
+      await writer.write(AppendRecord.string({ body: "hello" }));
+      // Abort the downstream before the linger fires (== run suspend/abort ->
+      // session.writable.abort()), which errors the transform's readable side.
+      await downstream.abort?.("aborted").catch(() => {});
+      writer.abort("aborted").catch(() => {});
+      // Wait past the linger window so the pending timer fires on the dead
+      // controller.
+      await new Promise((r) => setTimeout(r, lingerDurationMillis + 150));
+    } finally {
+      process.removeListener("uncaughtException", onUncaught);
+      process.removeListener("unhandledRejection", onUncaught);
+      prevUncaught.forEach((l) => process.on("uncaughtException", l));
+      prevUnhandled.forEach((l) => process.on("unhandledRejection", l));
+    }
+
+    expect(captured).toEqual([]);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -498,8 +498,8 @@ importers:
         specifier: ^0.1.3
         version: 0.1.3(@remix-run/react@2.17.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4))(@remix-run/server-runtime@2.17.4(typescript@5.5.4))
       '@s2-dev/streamstore':
-        specifier: ^0.22.5
-        version: 0.22.5(supports-color@10.0.0)
+        specifier: ^0.22.10
+        version: 0.22.10(supports-color@10.0.0)
       '@sentry/remix':
         specifier: 9.46.0
         version: 9.46.0(patch_hash=146126b032581925294aaed63ab53ce3f5e0356a755f1763d7a9a76b9846943b)(@remix-run/node@2.17.4(typescript@5.5.4))(@remix-run/react@2.17.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4))(@remix-run/server-runtime@2.17.4(typescript@5.5.4))(encoding@0.1.13)(react@18.2.0)
@@ -1545,8 +1545,8 @@ importers:
         specifier: 1.36.0
         version: 1.36.0
       '@s2-dev/streamstore':
-        specifier: ^0.22.5
-        version: 0.22.5(supports-color@10.0.0)
+        specifier: ^0.22.10
+        version: 0.22.10(supports-color@10.0.0)
       '@trigger.dev/build':
         specifier: workspace:4.5.0-rc.3
         version: link:../build
@@ -1822,8 +1822,8 @@ importers:
         specifier: 1.36.0
         version: 1.36.0
       '@s2-dev/streamstore':
-        specifier: 0.22.5
-        version: 0.22.5(supports-color@10.0.0)
+        specifier: 0.22.10
+        version: 0.22.10(supports-color@10.0.0)
       dequal:
         specifier: ^2.0.3
         version: 2.0.3
@@ -9340,8 +9340,8 @@ packages:
   '@rushstack/eslint-patch@1.2.0':
     resolution: {integrity: sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==}
 
-  '@s2-dev/streamstore@0.22.5':
-    resolution: {integrity: sha512-GqdOKIbIoIxT+40fnKzHbrsHB6gBqKdECmFe7D3Ojk4FoN1Hu0LhFzZv6ZmVMjoHHU+55debS1xSWjZwQmbIyQ==}
+  '@s2-dev/streamstore@0.22.10':
+    resolution: {integrity: sha512-dtm+oFHVE8szINwOUoNQdx9xpGSJOrcAEvsxspPFvomjYKGnmhIRmU4OX8o6kxcPoiK76S1tPeU0smjZdmOngA==}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -23334,7 +23334,7 @@ snapshots:
 
   '@epic-web/test-server@0.1.0(bufferutil@4.0.9)':
     dependencies:
-      '@hono/node-server': 1.12.2(hono@4.12.15)
+      '@hono/node-server': 1.12.2(hono@4.5.11)
       '@hono/node-ws': 1.0.4(@hono/node-server@1.12.2(hono@4.5.11))(bufferutil@4.0.9)
       '@open-draft/deferred-promise': 2.2.0
       '@types/ws': 8.5.12
@@ -24013,9 +24013,9 @@ snapshots:
     dependencies:
       react: 18.2.0
 
-  '@hono/node-server@1.12.2(hono@4.12.15)':
+  '@hono/node-server@1.12.2(hono@4.5.11)':
     dependencies:
-      hono: 4.12.15
+      hono: 4.5.11
 
   '@hono/node-server@1.19.11(hono@4.12.15)':
     dependencies:
@@ -24031,7 +24031,7 @@ snapshots:
 
   '@hono/node-ws@1.0.4(@hono/node-server@1.12.2(hono@4.5.11))(bufferutil@4.0.9)':
     dependencies:
-      '@hono/node-server': 1.12.2(hono@4.12.15)
+      '@hono/node-server': 1.12.2(hono@4.5.11)
       ws: 8.18.3(bufferutil@4.0.9)
     transitivePeerDependencies:
       - bufferutil
@@ -28890,7 +28890,7 @@ snapshots:
 
   '@rushstack/eslint-patch@1.2.0': {}
 
-  '@s2-dev/streamstore@0.22.5(supports-color@10.0.0)':
+  '@s2-dev/streamstore@0.22.10(supports-color@10.0.0)':
     dependencies:
       '@protobuf-ts/runtime': 2.11.1
       debug: 4.4.3(supports-color@10.0.0)
@@ -33259,7 +33259,7 @@ snapshots:
 
   docker-modem@5.0.6:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3(supports-color@10.0.0)
       readable-stream: 3.6.0
       split-ca: 1.0.1
       ssh2: 1.16.0


### PR DESCRIPTION
## Summary

A `chat.agent` turn that gets aborted mid-stream (stop generation, idle suspend, cancellation) could surface a `TASK_RUN_UNCAUGHT_EXCEPTION` — `TypeError: Invalid state: Unable to enqueue` — in the dashboard. The run kept working, but the exceptions were loud and confusing.

## Root cause

The realtime stream writer batches chunks through `@s2-dev/streamstore`'s `BatchTransform`, which holds them for a short linger window before flushing. When the turn's abort signal fires while a record is still buffered, the stream's writable is aborted and the transform's readable controller is closed — but the pending linger `setTimeout` still fires and calls `controller.enqueue()` on the dead controller, throwing from a timer callback where nothing can catch it.

Fixed upstream in `@s2-dev/streamstore@0.22.10`, which wraps the linger flush in a try/catch that discards the closed-controller error. This bumps the dependency across core, the CLI, and the webapp, and adds a regression test against the real `BatchTransform`.

Verified end-to-end: a mid-stream stop that previously failed the run with `TASK_RUN_UNCAUGHT_EXCEPTION` now leaves the run healthy.
