### PR TITLE
fix: prevent nanosecond precision loss in OTLP timestamp conversion

### DIFF
--- a/apps/webapp/app/v3/eventRepository/common.server.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.ts
@@ -21,7 +21,7 @@ export function extractContextFromCarrier(carrier: Record<string, unknown>) {
 }
 
 export function getNowInNanoseconds(): bigint {
-  return BigInt(new Date().getTime() * 1_000_000);
+  return BigInt(new Date().getTime()) * BigInt(1_000_000);
 }
 
 export function getDateFromNanoseconds(nanoseconds: bigint): Date {
@@ -35,7 +35,7 @@ export function calculateDurationFromStart(
 ) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  const duration = Number(BigInt($endtime.getTime() * 1_000_000) - startTime);
+  const duration = Number(BigInt($endtime.getTime()) * BigInt(1_000_000) - startTime);
 
   if (minimumDuration && duration < minimumDuration) {
     return minimumDuration;

--- a/apps/webapp/app/v3/eventRepository/index.server.ts
+++ b/apps/webapp/app/v3/eventRepository/index.server.ts
@@ -262,7 +262,7 @@ async function recordRunEvent(
         runId: foundRun.friendlyId,
         ...attributes,
       },
-      startTime: BigInt((startTime?.getTime() ?? Date.now()) * 1_000_000),
+      startTime: BigInt(startTime?.getTime() ?? Date.now()) * BigInt(1_000_000),
       ...optionsRest,
     });
 


### PR DESCRIPTION
## Summary

Fixes #3292 - OTLP nanosecond timestamp overflow due to IEEE 754 precision loss.

### Problem

Several places multiply epoch milliseconds by 1,000,000 **before** converting to BigInt. Since epoch-ms * 1e6 is ~1.7e18 (exceeds `Number.MAX_SAFE_INTEGER` ~9e15), this causes ~256ns precision errors in ~0.2% of cases.

### Fix

Convert to BigInt **before** multiplication, using the same pattern already established in `convertDateToNanoseconds()` in the same file:

`	ypescript
// Before (precision loss):
BigInt(new Date().getTime() * 1_000_000)

// After (correct):
BigInt(new Date().getTime()) * BigInt(1_000_000)
`

### Changed Files

- `apps/webapp/app/v3/eventRepository/common.server.ts` - `getNowInNanoseconds()` and `calculateDurationFromStart()`
- `apps/webapp/app/v3/eventRepository/index.server.ts` - `recordRunDebugLog()` startTime

### Notes

- The 4th location mentioned in the issue (`runEngineHandlers.server.ts`) no longer contains the pattern (likely already fixed)
- Zero behavior change for correct-precision cases; only fixes the ~0.2% edge case
- Follows the existing `convertDateToNanoseconds()` pattern exactly