### PR TITLE
fix: Safari magic link redirect on MacOS

### DIFF
--- a/apps/webapp/app/services/sessionStorage.server.ts
+++ b/apps/webapp/app/services/sessionStorage.server.ts
@@ -11,7 +11,7 @@ export const DEFAULT_SESSION_DURATION_SECONDS = 31_556_952;
 export const sessionStorage = createCookieSessionStorage({
   cookie: {
     name: "__session",
-    sameSite: "lax",
+    sameSite: env.NODE_ENV === "production" ? "none" : "lax",
     path: "/",
     httpOnly: true,
     secrets: [env.SESSION_SECRET],


### PR DESCRIPTION
Fixes #1384

Safari's Intelligent Tracking Prevention (ITP) blocks session cookies set during OAuth/magic link redirect flows when the navigation originates from a cross-site context (e.g., clicking a magic link in an email).

The root cause was the session cookie's SameSite=Lax attribute. While Lax allows cookies on top-level GET navigations, Safari ITP can still block the setting of new cookies on the response during cross-site navigations where the user has no prior interaction with the domain.

Changed sameSite to "none" in production (where secure: true and HTTPS is used), which tells the browser to allow the cookie in cross-site contexts. Development on localhost retains "lax" since localhost does not have HTTPS (required for SameSite=None).

Changed file: apps/webapp/app/services/sessionStorage.server.ts
