### PR TITLE
chore: vouch ConProgramming

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -22,3 +22,4 @@ bharathkumar39293
 bhekanik
 jrossi
 ThullyoCunha
+ConProgramming


### PR DESCRIPTION
Vouches GitHub user [`ConProgramming`](https://github.com/ConProgramming) (Conner) as an outside contributor by adding them to `.github/VOUCHED.td`, so their PRs aren't auto-closed by the vouch check.

Done as a direct edit rather than via the issue flow because they have no open Vouch Request issue to comment `vouch` on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)