### PR TITLE
chore: default local dev event store to ClickHouse in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ NODE_ENV=development
 CLICKHOUSE_URL=http://default:password@localhost:8123
 RUN_REPLICATION_CLICKHOUSE_URL=http://default:password@localhost:8123
 RUN_REPLICATION_ENABLED=1
+# Store task run spans/traces in ClickHouse so the dashboard trace view is
+# populated in local dev. The local stack is ClickHouse-backed (see above), so
+# leaving this unset falls back to the "postgres" store and dev run traces show
+# up empty even though the run itself appears.
+EVENT_REPOSITORY_DEFAULT_STORE=clickhouse_v2
 
 # Set this to UTC because Node.js uses the system timezone
 TZ="UTC"


### PR DESCRIPTION
## Summary

A fresh clone running `trigger dev` against the local webapp shows the run in the dashboard but an empty trace view. `EVENT_REPOSITORY_DEFAULT_STORE` was unset in `.env.example`, so span ingestion fell back to the `postgres` store while the rest of the local stack (run replication, `CLICKHOUSE_URL`) is ClickHouse-backed. Defaulting it to `clickhouse_v2` makes dev run traces show up out of the box.
