### PR TITLE
fix(cli): avoid O(n^2) hang in truncateMessage during deploy

### DIFF
--- a/.changeset/fix-cli-deploy-truncatemessage-on2.md
+++ b/.changeset/fix-cli-deploy-truncatemessage-on2.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Fix `trigger deploy` hanging at 100% CPU in non-TTY CI environments. The deploy spinner ran every build-log message through `truncateMessage()`, which truncated large messages one character at a time while re-scanning the whole string with two ANSI regexes on each iteration (O(n²)), and truncated even when there was no terminal width to fit to. On the large messages a deploy emits this pegged a CPU core for many minutes on slower CI runners, so the deploy appeared to hang at "Deploying project". `truncateMessage` now returns the message unchanged when there is no terminal width (no TTY and no explicit max) and truncates in a single O(n) forward pass that preserves ANSI escape sequences.

--- a/packages/cli-v3/src/utilities/windows.ts
+++ b/packages/cli-v3/src/utilities/windows.ts
@@ -18,8 +18,21 @@ function getVisibleLength(str: string): number {
   );
 }
 
+// Matches a single ANSI escape sequence (terminal hyperlink or CSI sequence)
+// at the regex's lastIndex. Used to skip escape codes while counting visible
+// characters during truncation.
+const ANSI_SEQUENCE = /\u001b]8;;[^\u0007]*\u0007|\x1b\[[0-9;]*[a-zA-Z]/y;
+
 function truncateMessage(msg: string, maxLength?: number): string {
-  const terminalWidth = maxLength ?? process.stdout.columns ?? 80;
+  // When there is no explicit max and no TTY (e.g. a non-interactive CI shell),
+  // `process.stdout.columns` is undefined and there is no terminal width to fit
+  // to, so leave the message untouched. This also avoids the work below on the
+  // large messages emitted during a deploy.
+  const terminalWidth = maxLength ?? process.stdout.columns;
+  if (terminalWidth == null) {
+    return msg;
+  }
+
   const availableWidth = terminalWidth - 5; // Reserve some space for the spinner and padding
   const visibleLength = getVisibleLength(msg);
 
@@ -27,14 +40,32 @@ function truncateMessage(msg: string, maxLength?: number): string {
     return msg;
   }
 
-  // We need to truncate based on visible characters, but preserve ANSI sequences
-  // Simple approach: truncate character by character until we fit
-  let truncated = msg;
-  while (getVisibleLength(truncated) > availableWidth - 3) {
-    truncated = truncated.slice(0, -1);
+  // Truncate based on visible characters while preserving ANSI sequences, in a
+  // single forward pass. The previous implementation removed one character at a
+  // time and re-scanned the whole string with two regexes on every iteration --
+  // O(n^2) -- which pegged the CPU for minutes on the large messages a deploy
+  // emits, especially in CI where the message isn't a short live-updating line.
+  const limit = Math.max(availableWidth - 3, 0);
+  let result = "";
+  let visible = 0;
+  let index = 0;
+
+  while (index < msg.length && visible < limit) {
+    ANSI_SEQUENCE.lastIndex = index;
+    const match = ANSI_SEQUENCE.exec(msg);
+
+    if (match) {
+      // Escape sequences don't count toward the visible width.
+      result += match[0];
+      index += match[0].length;
+    } else {
+      result += msg[index];
+      visible += 1;
+      index += 1;
+    }
   }
 
-  return truncated + "...";
+  return result + "...";
 }
 
 const wrappedClackSpinner = () => {


### PR DESCRIPTION
## Summary

`trigger deploy` hangs at `┌ Deploying project` with one CPU core pegged near 100% for many minutes in non-interactive (CI) environments, eventually timing out.

## Root cause

The deploy spinner runs every build-log message through `truncateMessage()` in `packages/cli-v3/src/utilities/windows.ts`. In a non-TTY shell `process.stdout.columns` is `undefined`, so it falls back to a width of 80 and truncates the message **one character at a time**, re-scanning the whole string with two ANSI regexes (`getVisibleLength`) on every iteration — **O(n²)**. On the large messages a deploy emits, this pegs a CPU core for minutes. A fast machine finishes in ~1s, but slower CI runners do not, so the deploy appears to hang. Profiling with `node --prof` shows ~92% of CPU in `RegExpReplace` / `StringPrototypeReplace` / `truncateMessage`.

## Fix

- Return the message unchanged when there is no terminal width to fit to (no TTY and no explicit `maxLength`) — truncation is meaningless there, and this avoids the scan entirely in CI.
- When truncation is needed, do it in a single O(n) forward pass that copies whole ANSI escape sequences (which don't count toward the visible width) and stops once the visible limit is reached, instead of removing one character at a time and re-scanning the whole string each step.

## Testing

- Short messages and messages that already fit are returned unchanged.
- ANSI-styled messages keep their escape sequences and the visible width is computed correctly.
- A ~24 MB message now truncates in ~125 ms; previously the same input took minutes (effectively hanging the deploy).

Fixes #3826
