### PR TITLE
fix(cli): stop the MCP waiting for every triggered run by default

### DIFF
--- a/.changeset/mcp-trigger-task-no-default-wait.md
+++ b/.changeset/mcp-trigger-task-no-default-wait.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+The MCP server no longer tells the AI agent to wait for a run to complete after every `trigger_task` call. Waiting is now opt-in: the agent only waits when you ask it to (for example "trigger and then wait for it to finish"). This avoids burning tokens polling runs you didn't need to block on and keeps responses clearer.

--- a/packages/cli-v3/src/mcp/config.ts
+++ b/packages/cli-v3/src/mcp/config.ts
@@ -62,7 +62,7 @@ export const toolsMetadata = {
     name: "trigger_task",
     title: "Trigger Task",
     description:
-      "Trigger a task in the project. Use the get_tasks tool to get a list of tasks and ask the user to select one if it's not clear which one to use. Use the wait_for_run_to_complete tool to wait for the run to complete.",
+      "Trigger a task in the project. Use the get_tasks tool to get a list of tasks and ask the user to select one if it's not clear which one to use. The run executes in the background, so only wait for it to complete (with the wait_for_run_to_complete tool) if the user asked you to.",
   },
   get_run_details: {
     name: "get_run_details",

--- a/packages/cli-v3/src/mcp/tools/tasks.ts
+++ b/packages/cli-v3/src/mcp/tools/tasks.ts
@@ -128,7 +128,7 @@ export const triggerTaskTool = {
     const contents = [
       `Task ${input.taskId} triggered and run with ID created: ${result.id}.`,
       `View the run in the dashboard: ${taskRunUrl}`,
-      `Use the ${toolsMetadata.wait_for_run_to_complete.name} tool to wait for the run to complete and the ${toolsMetadata.get_run_details.name} tool to get the details of the run.`,
+      `The run is now executing in the background. Do not wait for it to complete unless the user asked you to. If they did, use the ${toolsMetadata.wait_for_run_to_complete.name} tool. Otherwise, use the ${toolsMetadata.get_run_details.name} tool to check on it when needed.`,
     ];
 
     if (input.environment === "dev") {


### PR DESCRIPTION
## Summary

The Trigger.dev MCP server told the AI agent to wait for the run to complete after every `trigger_task` call. The agent followed that instruction even when the user only wanted to fire-and-forget, which burned tokens polling runs nobody needed to block on and made responses less clear.

Waiting is now opt-in. After triggering, the response tells the agent the run is executing in the background and to only wait if the user asked it to (for example "trigger and then wait for it to finish"). The `trigger_task` tool description is updated to match. The `wait_for_run_to_complete` tool itself is unchanged, so explicit waits still work.
