### PR TITLE
feat(webapp,supervisor): isolate scheduled runs on a dedicated worker queue

### DIFF
--- a/.server-changes/scheduled-worker-queue-split.md
+++ b/.server-changes/scheduled-worker-queue-split.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: feature
+---
+
+Scheduled runs and their descendants can be routed to a dedicated worker queue and processed by a separate worker fleet, isolating standard and agent run startup latency from scheduled-cron bursts. Off by default, enabled per organization via a feature flag.

--- a/apps/supervisor/src/env.ts
+++ b/apps/supervisor/src/env.ts
@@ -34,6 +34,10 @@ const Env = z
 
     // Dequeue settings (provider mode)
     TRIGGER_DEQUEUE_ENABLED: BoolEnv.default(true),
+    // Which worker-queue class this supervisor fleet serves. "default" pulls the
+    // region queue (standard/agent runs); "scheduled" pulls the dedicated
+    // scheduled-lineage queue. Run a separate fleet per class for isolation.
+    TRIGGER_WORKER_QUEUE_CLASS: z.enum(["default", "scheduled"]).default("default"),
     TRIGGER_DEQUEUE_INTERVAL_MS: z.coerce.number().int().default(250),
     TRIGGER_DEQUEUE_IDLE_INTERVAL_MS: z.coerce.number().int().default(1000),
     TRIGGER_DEQUEUE_MAX_RUN_COUNT: z.coerce.number().int().default(1),

--- a/apps/supervisor/src/index.ts
+++ b/apps/supervisor/src/index.ts
@@ -190,6 +190,7 @@ class ManagedSupervisor {
       dequeueIdleIntervalMs: env.TRIGGER_DEQUEUE_IDLE_INTERVAL_MS,
       queueConsumerEnabled: env.TRIGGER_DEQUEUE_ENABLED,
       maxRunCount: env.TRIGGER_DEQUEUE_MAX_RUN_COUNT,
+      queueClass: env.TRIGGER_WORKER_QUEUE_CLASS,
       metricsRegistry: register,
       scaling: {
         strategy: env.TRIGGER_DEQUEUE_SCALING_STRATEGY,

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -1059,6 +1059,16 @@ const EnvironmentSchema = z
     COMMON_WORKER_REDIS_TLS_DISABLED: z.string().default(process.env.REDIS_TLS_DISABLED ?? "false"),
     COMMON_WORKER_REDIS_CLUSTER_MODE_ENABLED: z.string().default("0"),
 
+    // Global default for the scheduled worker-queue split. When "1", runs in a
+    // scheduled lineage (rootTriggerSource === "schedule") are routed to a
+    // dedicated `<region>:scheduled` worker queue so a separate consumer fleet
+    // can dequeue them independently of standard/agent runs. The per-org
+    // `workerQueueScheduledSplitEnabled` feature flag overrides this default in
+    // BOTH directions (an org set to false stays on the single queue even when
+    // this is "1"; an org set to true splits even when this is "0"). Never
+    // applies to DEVELOPMENT environments.
+    TRIGGER_WORKER_QUEUE_SCHEDULED_SPLIT_ENABLED: z.string().default("0"),
+
     TRIGGER_MOLLIFIER_ENABLED: z.string().default("0"),
     // Separate switch for the drainer (consumer side) so it can be split
     // off onto a dedicated worker service. Unset → inherits

--- a/apps/webapp/app/routes/engine.v1.worker-actions.dequeue.ts
+++ b/apps/webapp/app/routes/engine.v1.worker-actions.dequeue.ts
@@ -7,12 +7,13 @@ import { createActionWorkerApiRoute } from "~/services/routeBuilders/apiBuilder.
 
 export const action = createActionWorkerApiRoute(
   {
-    body: WorkerApiDequeueRequestBody, // Even though we don't use it, we need to keep it for backwards compatibility
+    body: WorkerApiDequeueRequestBody,
   },
   async ({
     authenticatedWorker,
     runnerId,
+    body,
   }): Promise<TypedResponse<WorkerApiDequeueResponseBody>> => {
-    return json(await authenticatedWorker.dequeue({ runnerId }));
+    return json(await authenticatedWorker.dequeue({ runnerId, queueClass: body.queueClass }));
   }
 );

--- a/apps/webapp/app/runEngine/concerns/workerQueueSplit.server.ts
+++ b/apps/webapp/app/runEngine/concerns/workerQueueSplit.server.ts
@@ -1,0 +1,90 @@
+import type { WorkerQueueClass } from "@trigger.dev/core/v3/workers";
+import { FEATURE_FLAG, FeatureFlagCatalog } from "~/v3/featureFlags";
+
+/**
+ * Suffix appended to a region's worker queue name to route scheduled-lineage
+ * runs onto their own Redis list (e.g. `us-nyc-3` -> `us-nyc-3:scheduled`). A
+ * dedicated consumer fleet dequeues the suffixed list so the top-of-hour
+ * scheduled-cron herd can't starve standard/agent run startup. The worker queue
+ * name is opaque everywhere downstream (it's only ever `:`-joined into a Redis
+ * key and persisted on the run), so encoding the class in the suffix needs no
+ * Lua, envelope, or resolver changes.
+ */
+export const SCHEDULED_WORKER_QUEUE_SUFFIX = ":scheduled";
+
+/** `TriggerSource` value used for runs originating from a schedule. */
+const SCHEDULE_TRIGGER_SOURCE = "schedule";
+
+/**
+ * Resolve whether the scheduled worker-queue split is enabled for a run, reading
+ * only the in-memory org feature-flags JSON (already loaded on the authenticated
+ * environment) — never a DB query, so it is safe on the trigger hot path.
+ *
+ * Precedence: a per-org override wins in BOTH directions; the global default is
+ * used only when the org has not set the flag.
+ */
+export function resolveScheduledQueueSplitEnabled({
+  orgFeatureFlags,
+  globalDefault,
+}: {
+  orgFeatureFlags: Record<string, unknown> | null | undefined;
+  globalDefault: boolean;
+}): boolean {
+  const override = orgFeatureFlags?.[FEATURE_FLAG.workerQueueScheduledSplitEnabled];
+
+  if (override !== undefined) {
+    const parsed =
+      FeatureFlagCatalog[FEATURE_FLAG.workerQueueScheduledSplitEnabled].safeParse(override);
+
+    if (parsed.success) {
+      return parsed.data;
+    }
+  }
+
+  return globalDefault;
+}
+
+/**
+ * Pick the worker queue a run should be enqueued onto. Runs in a scheduled
+ * lineage (`rootTriggerSource === "schedule"`, which propagates from a scheduled
+ * root down to every descendant) route to the suffixed list when the split is
+ * enabled; everything else is unchanged. Idempotent — never double-suffixes.
+ */
+export function workerQueueForRun({
+  workerQueue,
+  rootTriggerSource,
+  splitEnabled,
+}: {
+  workerQueue: string;
+  rootTriggerSource: string | undefined;
+  splitEnabled: boolean;
+}): string {
+  if (
+    !splitEnabled ||
+    rootTriggerSource !== SCHEDULE_TRIGGER_SOURCE ||
+    workerQueue.endsWith(SCHEDULED_WORKER_QUEUE_SUFFIX)
+  ) {
+    return workerQueue;
+  }
+
+  return `${workerQueue}${SCHEDULED_WORKER_QUEUE_SUFFIX}`;
+}
+
+/**
+ * Consumer-side counterpart to {@link workerQueueForRun}: given a worker's base
+ * (region) queue and the requested queue class, return the worker queue to
+ * dequeue from. `"scheduled"` targets the suffixed list; anything else is the
+ * base queue. The server always derives this from the authenticated worker's
+ * own `masterQueue`, so a token can only ever reach its own region's queues.
+ * Idempotent — never double-suffixes.
+ */
+export function workerQueueForClass(
+  masterQueue: string,
+  queueClass: WorkerQueueClass | undefined
+): string {
+  if (queueClass === "scheduled" && !masterQueue.endsWith(SCHEDULED_WORKER_QUEUE_SUFFIX)) {
+    return `${masterQueue}${SCHEDULED_WORKER_QUEUE_SUFFIX}`;
+  }
+
+  return masterQueue;
+}

--- a/apps/webapp/app/runEngine/services/triggerTask.server.ts
+++ b/apps/webapp/app/runEngine/services/triggerTask.server.ts
@@ -35,6 +35,10 @@ import {
   type ClaimedIdempotency,
 } from "../concerns/idempotencyKeys.server";
 import {
+  resolveScheduledQueueSplitEnabled,
+  workerQueueForRun,
+} from "../concerns/workerQueueSplit.server";
+import {
   publishClaim as publishMollifierClaim,
   releaseClaim as releaseMollifierClaim,
 } from "~/v3/mollifier/idempotencyClaim.server";
@@ -351,7 +355,7 @@ export class RunEngineTriggerTaskService {
             environment,
             body.options?.region
           );
-          const workerQueue = workerQueueResult?.masterQueue;
+          const baseWorkerQueue = workerQueueResult?.masterQueue;
           const enableFastPath = workerQueueResult?.enableFastPath ?? false;
 
           // Build annotations for this run
@@ -365,6 +369,30 @@ export class RunEngineTriggerTaskService {
             rootScheduleId: parentAnnotations?.rootScheduleId || options.scheduleId || undefined,
             taskKind: taskKind ?? "STANDARD",
           };
+
+          // Route runs in a scheduled lineage (the scheduled run itself and every
+          // descendant, via the propagated rootTriggerSource) to a dedicated
+          // `<region>:scheduled` worker queue so a separate consumer fleet can
+          // dequeue them independently of standard/agent runs. Gated per-org with
+          // a global default, never applied to dev. Reads only the in-memory org
+          // flags already on the environment — no DB query on the hot path.
+          const scheduledQueueSplitEnabled =
+            environment.type !== "DEVELOPMENT" &&
+            resolveScheduledQueueSplitEnabled({
+              orgFeatureFlags: environment.organization.featureFlags as Record<
+                string,
+                unknown
+              > | null,
+              globalDefault: env.TRIGGER_WORKER_QUEUE_SCHEDULED_SPLIT_ENABLED === "1",
+            });
+          const workerQueue =
+            baseWorkerQueue !== undefined
+              ? workerQueueForRun({
+                  workerQueue: baseWorkerQueue,
+                  rootTriggerSource: annotations.rootTriggerSource,
+                  splitEnabled: scheduledQueueSplitEnabled,
+                })
+              : baseWorkerQueue;
 
           try {
             return await this.traceEventConcern.traceRun(

--- a/apps/webapp/app/v3/featureFlags.ts
+++ b/apps/webapp/app/v3/featureFlags.ts
@@ -9,6 +9,7 @@ export const FEATURE_FLAG = {
   hasComputeAccess: "hasComputeAccess",
   hasPrivateConnections: "hasPrivateConnections",
   mollifierEnabled: "mollifierEnabled",
+  workerQueueScheduledSplitEnabled: "workerQueueScheduledSplitEnabled",
 } as const;
 
 export const FeatureFlagCatalog = {
@@ -20,6 +21,7 @@ export const FeatureFlagCatalog = {
   [FEATURE_FLAG.hasComputeAccess]: z.coerce.boolean(),
   [FEATURE_FLAG.hasPrivateConnections]: z.coerce.boolean(),
   [FEATURE_FLAG.mollifierEnabled]: z.coerce.boolean(),
+  [FEATURE_FLAG.workerQueueScheduledSplitEnabled]: z.coerce.boolean(),
 };
 
 export type FeatureFlagKey = keyof typeof FeatureFlagCatalog;

--- a/apps/webapp/app/v3/services/worker/workerGroupTokenService.server.ts
+++ b/apps/webapp/app/v3/services/worker/workerGroupTokenService.server.ts
@@ -10,7 +10,7 @@ import {
   TaskRunExecutionResult,
 } from "@trigger.dev/core/v3";
 import { fromFriendlyId } from "@trigger.dev/core/v3/isomorphic";
-import { WORKER_HEADERS } from "@trigger.dev/core/v3/workers";
+import { WORKER_HEADERS, type WorkerQueueClass } from "@trigger.dev/core/v3/workers";
 import {
   Prisma,
   RuntimeEnvironment,
@@ -27,6 +27,7 @@ import { defaultMachine } from "~/services/platform.v3.server";
 import { singleton } from "~/utils/singleton";
 import { resolveVariablesForEnvironment } from "~/v3/environmentVariables/environmentVariablesRepository.server";
 import { machinePresetFromName } from "~/v3/machinePresets.server";
+import { workerQueueForClass } from "~/runEngine/concerns/workerQueueSplit.server";
 import { WithRunEngine, WithRunEngineOptions } from "../baseService.server";
 
 const authenticatedWorkerInstanceCache = singleton(
@@ -369,10 +370,18 @@ export class AuthenticatedWorkerInstance extends WithRunEngine {
     });
   }
 
-  async dequeue({ runnerId }: { runnerId?: string }): Promise<DequeuedMessage[]> {
+  async dequeue({
+    runnerId,
+    queueClass,
+  }: {
+    runnerId?: string;
+    queueClass?: WorkerQueueClass;
+  }): Promise<DequeuedMessage[]> {
+    // Derive the actual queue from this worker's own masterQueue + class, so a
+    // token can only ever reach its own region's queues (default or :scheduled).
     return await this._engine.dequeueFromWorkerQueue({
       consumerId: this.workerInstanceId,
-      workerQueue: this.masterQueue,
+      workerQueue: workerQueueForClass(this.masterQueue, queueClass),
       workerId: this.workerInstanceId,
       runnerId,
     });

--- a/apps/webapp/test/engine/triggerTask.test.ts
+++ b/apps/webapp/test/engine/triggerTask.test.ts
@@ -267,6 +267,124 @@ describe("RunEngineTriggerTaskService", () => {
     await engine.quit();
   });
 
+  containerTest(
+    "routes scheduled-lineage runs to a separate worker queue that dequeues independently",
+    async ({ prisma, redisOptions }) => {
+      const engine = new RunEngine({
+        prisma,
+        worker: {
+          redis: redisOptions,
+          workers: 1,
+          tasksPerWorker: 10,
+          pollIntervalMs: 100,
+        },
+        queue: {
+          redis: redisOptions,
+          // Disable the background master-queue consumers so our manual
+          // processMasterQueueForEnvironment + dequeue calls are deterministic.
+          masterQueueConsumersDisabled: true,
+          processWorkerQueueDebounceMs: 50,
+        },
+        runLock: { redis: redisOptions },
+        machines: {
+          defaultMachine: "small-1x",
+          machines: {
+            "small-1x": {
+              name: "small-1x" as const,
+              cpu: 0.5,
+              memory: 0.5,
+              centsPerMs: 0.0001,
+            },
+          },
+          baseCostInCents: 0.0005,
+        },
+        tracer: trace.getTracer("test", "0.0.0"),
+      });
+
+      try {
+        const authenticatedEnvironment = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+
+        // Turn the per-org split flag on in-memory — the resolver reads this
+        // object directly (no DB round-trip on the trigger hot path).
+        (authenticatedEnvironment.organization as { featureFlags?: unknown }).featureFlags = {
+          workerQueueScheduledSplitEnabled: true,
+        };
+
+        const taskIdentifier = "test-task";
+        await setupBackgroundWorker(engine, authenticatedEnvironment, taskIdentifier);
+
+        const triggerTaskService = new RunEngineTriggerTaskService({
+          engine,
+          prisma,
+          payloadProcessor: new MockPayloadProcessor(),
+          queueConcern: new DefaultQueueManager(prisma, engine),
+          idempotencyKeyConcern: new IdempotencyKeyConcern(
+            prisma,
+            engine,
+            new MockTraceEventConcern()
+          ),
+          validator: new MockTriggerTaskValidator(),
+          traceEventConcern: new MockTraceEventConcern(),
+          tracer: trace.getTracer("test", "0.0.0"),
+          metadataMaximumSize: 1024 * 1024 * 1,
+        });
+
+        // A standard run (default triggerSource) stays on the region queue.
+        const standardResult = await triggerTaskService.call({
+          taskId: taskIdentifier,
+          environment: authenticatedEnvironment,
+          body: { payload: { kind: "standard" } },
+        });
+        assertNonNullable(standardResult);
+
+        // A scheduled run routes to the `<region>:scheduled` queue. Descendants
+        // would too, via rootTriggerSource propagation.
+        const scheduledResult = await triggerTaskService.call({
+          taskId: taskIdentifier,
+          environment: authenticatedEnvironment,
+          body: { payload: { kind: "scheduled" } },
+          options: { triggerSource: "schedule" },
+        });
+        assertNonNullable(scheduledResult);
+
+        const standardRun = await prisma.taskRun.findUniqueOrThrow({
+          where: { id: standardResult.run.id },
+        });
+        const scheduledRun = await prisma.taskRun.findUniqueOrThrow({
+          where: { id: scheduledResult.run.id },
+        });
+
+        // Producer routing: the persisted worker queue carries the class.
+        const baseWorkerQueue = standardRun.workerQueue;
+        expect(scheduledRun.workerQueue).toBe(`${baseWorkerQueue}:scheduled`);
+
+        // Move both runs from the env queue onto their respective worker queues.
+        await engine.runQueue.processMasterQueueForEnvironment(authenticatedEnvironment.id, 10);
+        await setTimeout(500);
+
+        // Dequeue isolation: the scheduled queue yields only the scheduled run...
+        const dequeuedScheduled = await engine.dequeueFromWorkerQueue({
+          consumerId: "test-scheduled-consumer",
+          workerQueue: `${baseWorkerQueue}:scheduled`,
+        });
+        expect(dequeuedScheduled.length).toBe(1);
+        assertNonNullable(dequeuedScheduled[0]);
+        expect(dequeuedScheduled[0].run.id).toBe(scheduledResult.run.id);
+
+        // ...and the base queue yields only the standard run.
+        const dequeuedStandard = await engine.dequeueFromWorkerQueue({
+          consumerId: "test-standard-consumer",
+          workerQueue: baseWorkerQueue,
+        });
+        expect(dequeuedStandard.length).toBe(1);
+        assertNonNullable(dequeuedStandard[0]);
+        expect(dequeuedStandard[0].run.id).toBe(standardResult.run.id);
+      } finally {
+        await engine.quit();
+      }
+    }
+  );
+
   // The BatchQueue worker rebuilds body.options from Redis-stored items
   // (Record<string, unknown>), so the Phase-2 schema coercion doesn't apply
   // to in-flight items enqueued before the schema fix. The defensive

--- a/apps/webapp/test/workerQueueSplit.test.ts
+++ b/apps/webapp/test/workerQueueSplit.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveScheduledQueueSplitEnabled,
+  workerQueueForRun,
+  workerQueueForClass,
+  SCHEDULED_WORKER_QUEUE_SUFFIX,
+} from "~/runEngine/concerns/workerQueueSplit.server";
+import { FEATURE_FLAG } from "~/v3/featureFlags";
+
+const FLAG = FEATURE_FLAG.workerQueueScheduledSplitEnabled;
+
+describe("resolveScheduledQueueSplitEnabled", () => {
+  it("falls back to the global default when the org has no override", () => {
+    expect(resolveScheduledQueueSplitEnabled({ orgFeatureFlags: null, globalDefault: false })).toBe(
+      false
+    );
+    expect(
+      resolveScheduledQueueSplitEnabled({ orgFeatureFlags: undefined, globalDefault: true })
+    ).toBe(true);
+    expect(resolveScheduledQueueSplitEnabled({ orgFeatureFlags: {}, globalDefault: true })).toBe(
+      true
+    );
+  });
+
+  it("per-org true overrides a global default of false (beta opt-in)", () => {
+    expect(
+      resolveScheduledQueueSplitEnabled({
+        orgFeatureFlags: { [FLAG]: true },
+        globalDefault: false,
+      })
+    ).toBe(true);
+  });
+
+  it("per-org false overrides a global default of true (escape hatch)", () => {
+    expect(
+      resolveScheduledQueueSplitEnabled({
+        orgFeatureFlags: { [FLAG]: false },
+        globalDefault: true,
+      })
+    ).toBe(false);
+  });
+
+  it("ignores unrelated org flags", () => {
+    expect(
+      resolveScheduledQueueSplitEnabled({
+        orgFeatureFlags: { somethingElse: true },
+        globalDefault: false,
+      })
+    ).toBe(false);
+  });
+
+  it("coerces a present override to boolean (z.coerce.boolean semantics)", () => {
+    // The catalog type is z.coerce.boolean(), matching the mollifier flag, so any
+    // present value is coerced rather than rejected. The admin routes validate
+    // against the same catalog on write, so stored values are real JSON booleans;
+    // this just documents that a present override always wins over the default.
+    expect(
+      resolveScheduledQueueSplitEnabled({
+        orgFeatureFlags: { [FLAG]: 0 as unknown as boolean },
+        globalDefault: true,
+      })
+    ).toBe(false);
+  });
+});
+
+describe("workerQueueForRun", () => {
+  const region = "us-nyc-3";
+  const scheduled = `${region}${SCHEDULED_WORKER_QUEUE_SUFFIX}`;
+
+  it("suffixes scheduled-lineage runs when the split is enabled", () => {
+    expect(
+      workerQueueForRun({ workerQueue: region, rootTriggerSource: "schedule", splitEnabled: true })
+    ).toBe(scheduled);
+  });
+
+  it("leaves standard/agent runs on the base queue", () => {
+    for (const rootTriggerSource of ["api", "sdk", "dashboard", "cli", "mcp", undefined]) {
+      expect(
+        workerQueueForRun({ workerQueue: region, rootTriggerSource, splitEnabled: true })
+      ).toBe(region);
+    }
+  });
+
+  it("never suffixes when the split is disabled, even for scheduled runs", () => {
+    expect(
+      workerQueueForRun({ workerQueue: region, rootTriggerSource: "schedule", splitEnabled: false })
+    ).toBe(region);
+  });
+
+  it("is idempotent — does not double-suffix an already-scheduled queue", () => {
+    expect(
+      workerQueueForRun({
+        workerQueue: scheduled,
+        rootTriggerSource: "schedule",
+        splitEnabled: true,
+      })
+    ).toBe(scheduled);
+  });
+});
+
+describe("workerQueueForClass", () => {
+  const region = "us-nyc-3";
+  const scheduled = `${region}${SCHEDULED_WORKER_QUEUE_SUFFIX}`;
+
+  it("returns the base queue for the default class or no class", () => {
+    expect(workerQueueForClass(region, "default")).toBe(region);
+    expect(workerQueueForClass(region, undefined)).toBe(region);
+  });
+
+  it("returns the suffixed queue for the scheduled class", () => {
+    expect(workerQueueForClass(region, "scheduled")).toBe(scheduled);
+  });
+
+  it("is idempotent — does not double-suffix", () => {
+    expect(workerQueueForClass(scheduled, "scheduled")).toBe(scheduled);
+  });
+
+  it("round-trips with workerQueueForRun: a scheduled run lands on the queue its class targets", () => {
+    const enqueued = workerQueueForRun({
+      workerQueue: region,
+      rootTriggerSource: "schedule",
+      splitEnabled: true,
+    });
+    expect(workerQueueForClass(region, "scheduled")).toBe(enqueued);
+  });
+});

--- a/packages/core/src/v3/runEngineWorker/supervisor/queueConsumer.ts
+++ b/packages/core/src/v3/runEngineWorker/supervisor/queueConsumer.ts
@@ -1,6 +1,6 @@
 import { SimpleStructuredLogger } from "../../utils/structuredLogger.js";
 import { SupervisorHttpClient } from "./http.js";
-import { WorkerApiDequeueResponseBody } from "./schemas.js";
+import { WorkerApiDequeueResponseBody, WorkerQueueClass } from "./schemas.js";
 import { PreDequeueFn, PreSkipFn } from "./types.js";
 
 export interface QueueConsumer {
@@ -15,6 +15,8 @@ export type RunQueueConsumerOptions = {
   preDequeue?: PreDequeueFn;
   preSkip?: PreSkipFn;
   maxRunCount?: number;
+  /** Which worker-queue class this consumer pulls from. Defaults to the worker's region queue. */
+  queueClass?: WorkerQueueClass;
   onDequeue: (messages: WorkerApiDequeueResponseBody, timing?: { dequeueResponseMs: number; pollingIntervalMs: number }) => Promise<void>;
 };
 
@@ -23,6 +25,7 @@ export class RunQueueConsumer implements QueueConsumer {
   private readonly preDequeue?: PreDequeueFn;
   private readonly preSkip?: PreSkipFn;
   private readonly maxRunCount?: number;
+  private readonly queueClass?: WorkerQueueClass;
   private readonly onDequeue: (messages: WorkerApiDequeueResponseBody, timing?: { dequeueResponseMs: number; pollingIntervalMs: number }) => Promise<void>;
 
   private readonly logger = new SimpleStructuredLogger("queue-consumer");
@@ -39,6 +42,7 @@ export class RunQueueConsumer implements QueueConsumer {
     this.preDequeue = opts.preDequeue;
     this.preSkip = opts.preSkip;
     this.maxRunCount = opts.maxRunCount;
+    this.queueClass = opts.queueClass;
     this.lastScheduledIntervalMs = opts.idleIntervalMs;
     this.onDequeue = opts.onDequeue;
     this.client = opts.client;
@@ -117,6 +121,7 @@ export class RunQueueConsumer implements QueueConsumer {
       const response = await this.client.dequeue({
         maxResources: preDequeueResult?.maxResources,
         maxRunCount: this.maxRunCount,
+        queueClass: this.queueClass,
       });
       const dequeueResponseMs = Math.round(performance.now() - dequeueStart);
 

--- a/packages/core/src/v3/runEngineWorker/supervisor/schemas.ts
+++ b/packages/core/src/v3/runEngineWorker/supervisor/schemas.ts
@@ -64,9 +64,20 @@ export const WorkerApiConnectResponseBody = z.object({
 });
 export type WorkerApiConnectResponseBody = z.infer<typeof WorkerApiConnectResponseBody>;
 
+export const WorkerQueueClass = z.enum(["default", "scheduled"]);
+export type WorkerQueueClass = z.infer<typeof WorkerQueueClass>;
+
 export const WorkerApiDequeueRequestBody = z.object({
   maxResources: MachineResources.optional(),
   maxRunCount: z.number().optional(),
+  /**
+   * Which class of worker queue this consumer pulls from. Absent or "default" =
+   * the worker group's region queue. "scheduled" targets the dedicated
+   * scheduled-lineage queue so a separate fleet can drain it independently. The
+   * server derives the actual queue name from the token, so this only ever
+   * selects between the authenticated worker's own queues.
+   */
+  queueClass: WorkerQueueClass.optional(),
 });
 export type WorkerApiDequeueRequestBody = z.infer<typeof WorkerApiDequeueRequestBody>;
 

--- a/packages/core/src/v3/runEngineWorker/supervisor/session.ts
+++ b/packages/core/src/v3/runEngineWorker/supervisor/session.ts
@@ -1,6 +1,10 @@
 import { SupervisorHttpClient } from "./http.js";
 import { PreDequeueFn, PreSkipFn, SupervisorClientCommonOptions } from "./types.js";
-import { WorkerApiDequeueResponseBody, WorkerApiHeartbeatRequestBody } from "./schemas.js";
+import {
+  WorkerApiDequeueResponseBody,
+  WorkerApiHeartbeatRequestBody,
+  WorkerQueueClass,
+} from "./schemas.js";
 import { RunQueueConsumerPool, ScalingOptions } from "./consumerPool.js";
 import { WorkerEvents } from "./events.js";
 import EventEmitter from "events";
@@ -21,6 +25,8 @@ type SupervisorSessionOptions = SupervisorClientCommonOptions & {
   preDequeue?: PreDequeueFn;
   preSkip?: PreSkipFn;
   maxRunCount?: number;
+  /** Which worker-queue class this supervisor's consumers pull from. Defaults to the region queue. */
+  queueClass?: WorkerQueueClass;
   sendRunDebugLogs?: boolean;
   scaling: ScalingOptions;
   metricsRegistry?: Registry;
@@ -56,6 +62,7 @@ export class SupervisorSession extends EventEmitter<WorkerEvents> {
         intervalMs: opts.dequeueIntervalMs,
         idleIntervalMs: opts.dequeueIdleIntervalMs,
         maxRunCount: opts.maxRunCount,
+        queueClass: opts.queueClass,
       },
       scaling: opts.scaling,
       metricsRegistry: opts.metricsRegistry,


### PR DESCRIPTION
## Summary

Scheduled runs and their descendants can now be routed to a dedicated per-region worker queue, processed by a separate worker fleet, so a burst of scheduled crons no longer competes with standard and agent runs for the same queue and inflates their startup latency. It is off by default and enabled per organization via a feature flag (with a global default), so nothing changes until it is turned on.

## Design

At trigger time, any run whose lineage originates from a schedule (`rootTriggerSource === "schedule"`, which already propagates from a scheduled run down to all of its children) gets its worker queue suffixed with `:scheduled`. The worker queue name is an opaque string persisted on the run and used verbatim by enqueue and dequeue, so this needs no Lua, message-envelope, or concurrency changes. Concurrency stays keyed by environment and queue, not by worker queue.

On the consumer side, the dequeue endpoint gains an optional `queueClass` selector. A supervisor sends `queueClass: "scheduled"` and the server derives the actual queue from the worker's own group, so a token can only ever reach its own region's queues. A fleet picks its class with the `TRIGGER_WORKER_QUEUE_CLASS` env var (`default` or `scheduled`), so a dedicated scheduled fleet can run alongside the standard one.

Verified end to end against a local managed-worker setup: scheduled runs route to the dedicated queue, are drained only by the scheduled fleet, and standard runs are left untouched.
