### PR TITLE
fix(webapp): scope team-member removal to the caller's org

### DIFF
--- a/.server-changes/remove-team-member-org-scope.md
+++ b/.server-changes/remove-team-member-org-scope.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Scope the `removeTeamMember` delete to the resolved organization so a member can only be deleted from the org they belong to. Previously the delete was keyed by `OrgMember.id` alone, letting a privileged caller in one org delete members of an unrelated org by id (cross-org IDOR).

--- a/apps/webapp/app/models/member.server.ts
+++ b/apps/webapp/app/models/member.server.ts
@@ -76,6 +76,7 @@ export async function removeTeamMember({
   return prisma.orgMember.delete({
     where: {
       id: memberId,
+      organizationId: org.id,
     },
     include: {
       organization: true,


### PR DESCRIPTION
Closes #nothing

## ✅ Checklist

- [X] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [X] The PR title follows the convention.
- [X] I ran and tested the code works

---

## Testing
- `pnpm run typecheck --filter webapp` passes
- Traced the only caller (`_app.orgs.$organizationSlug.settings.team/route.tsx`): the rendered `memberId` always comes from the org-scoped loader, so every legitimate request (self-leave or removing a same-org member) still matches and succeeds
- A cross-org `memberId` now resolves to no record; the delete throws P2025, which the route already catches and returns as a 400, so no crash

---

## Changelog

Scope `removeTeamMember` deletes to the caller's organization, fixing a cross-org member-deletion IDOR

Previously, a member of any org could delete a row from any other org, if they knew their id. And they do know their ID, since `OrgMember.id` is rendered into a hidden form input on the team-settings page.

Note that I previously opened this as a private PR about a month ago, [here](https://github.com/triggerdotdev/trigger.dev-ghsa-58mc-m3qq-6qrh/pull/1). But I think this is safe to open publicly, since it doesn't reveal the other steps needed to exploit the full account take over (which I documented in [GHSA-58mc-m3qq-6qrh](github.com/triggerdotdev/trigger.dev/security/advisories/GHSA-58mc-m3qq-6qrh).

I submitted a vouch request in #3539 - could you take a look please?

---

## Screenshots

N/A — server-side authorization fix

💯
