### PR TITLE
fix(database): include the Prisma CLI in production builds

### DIFF
--- a/.server-changes/include-prisma-cli-in-prod-image.md
+++ b/.server-changes/include-prisma-cli-in-prod-image.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Fix database migrations failing to run in the production image because the Prisma CLI was missing from the build.

--- a/internal-packages/database/package.json
+++ b/internal-packages/database/package.json
@@ -6,11 +6,11 @@
   "types": "./dist/index.d.ts",
   "dependencies": {
     "@prisma/client": "6.14.0",
-    "decimal.js": "^10.6.0"
+    "decimal.js": "^10.6.0",
+    "prisma": "6.14.0"
   },
   "devDependencies": {
     "@types/decimal.js": "^7.4.3",
-    "prisma": "6.14.0",
     "rimraf": "6.0.1"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1133,13 +1133,13 @@ importers:
       decimal.js:
         specifier: ^10.6.0
         version: 10.6.0
+      prisma:
+        specifier: 6.14.0
+        version: 6.14.0(magicast@0.3.5)(typescript@5.5.4)
     devDependencies:
       '@types/decimal.js':
         specifier: ^7.4.3
         version: 7.4.3
-      prisma:
-        specifier: 6.14.0
-        version: 6.14.0(magicast@0.3.5)(typescript@5.5.4)
       rimraf:
         specifier: 6.0.1
         version: 6.0.1


### PR DESCRIPTION
## Summary

The Prisma CLI was missing from production builds of the webapp image, so anything that shells out to `prisma` at startup failed. The container entrypoint and the standalone migration step both run `prisma migrate deploy` / `prisma migrate status`, and those broke with `Command "prisma" not found`.

## Fix

`prisma` was a `devDependency` of `@trigger.dev/database`. It had only been landing in the pruned `--prod` install as a side effect of pnpm auto-installing it as a peer of `@prisma/client`. A recent dependency change shifted peer resolution so prisma stopped being materialized into the production tree, and the CLI disappeared from the image.

Moving `prisma` into `dependencies` of `@trigger.dev/database` makes the CLI an explicit part of production installs. It lands in the webapp image only: the separately deployed supervisor, coordinator, and provider images don't reach the database package in their production trees (`core` only `devDepends` on it, so it isn't transitive), so they're unaffected.

Verified against a locally built production image: `pnpm --filter @trigger.dev/database exec prisma --version` now resolves the CLI and the schema engine instead of failing.
