### PR TITLE
chore(core,sdk): make the ai-v7 typecheck pass deterministic

### DIFF
--- a/packages/core/tsconfig.ai-v7.json
+++ b/packages/core/tsconfig.ai-v7.json
@@ -6,6 +6,10 @@
   // file-direct rationale.
   "extends": "./tsconfig.src.json",
   "compilerOptions": {
+    // noEmit-only gate: disable composite/incremental so this pass never writes or
+    // reads a .tsbuildinfo and can't replay stale module resolution across runs.
+    "composite": false,
+    "incremental": false,
     "baseUrl": ".",
     "paths": {
       "ai": ["./node_modules/ai-v7/dist/index.d.ts"]

--- a/packages/trigger-sdk/tsconfig.ai-v7.json
+++ b/packages/trigger-sdk/tsconfig.ai-v7.json
@@ -9,6 +9,10 @@
   // real installed `ai`, which would make this pass a no-op.
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // noEmit-only gate: disable composite/incremental so this pass never writes or
+    // reads a .tsbuildinfo and can't replay stale module resolution across runs.
+    "composite": false,
+    "incremental": false,
     "baseUrl": ".",
     "paths": {
       "ai": ["./node_modules/ai-v7/dist/index.d.ts"]


### PR DESCRIPTION
## Summary

The SDK and core packages run a second, forward-compat typecheck pass (`tsc --noEmit -p tsconfig.ai-v7.json`) that remaps the `"ai"` import to the ESM-only AI SDK 7 canary, so we catch source that only compiles against one major. That pass inherited `composite: true` from the base tsconfig, which makes `tsc` write a `.tsbuildinfo` even under `--noEmit`.

Incremental buildinfo caches each file's resolved module format (CJS vs ESM) and module resolution. When that state goes stale or is replayed, the v7 pass can report spurious `TS1479` ("CommonJS module ... cannot `require` an ECMAScript module") errors on the `"ai"` import even though the source is fine in a clean checkout. Because this pass shares the typecheck job that gates the Docker image publish, a spurious failure there blocks publishing.

## Fix

Set `composite: false` and `incremental: false` on both `tsconfig.ai-v7.json` files. The pass is `--noEmit` only, so it never needed incremental state. Now each run is a clean, full check that writes no buildinfo and can't replay stale resolution.

Verified: both `@trigger.dev/sdk` and `@trigger.dev/core` typecheck green, and neither writes an ai-v7 `.tsbuildinfo` anymore.
