### PR TITLE
chore(core,sdk): move the AI SDK v7 forward-compat typecheck out of CI

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -182,7 +182,8 @@
     "bundle-vendor": "node scripts/bundle-superjson.mjs",
     "build": "pnpm run bundle-vendor && tshy && node scripts/bundle-superjson.mjs --copy && pnpm run update-version",
     "dev": "pnpm run bundle-vendor && tshy --watch",
-    "typecheck": "pnpm run bundle-vendor && tsc --noEmit -p tsconfig.src.json && tsc --noEmit -p tsconfig.ai-v7.json",
+    "typecheck": "pnpm run bundle-vendor && tsc --noEmit -p tsconfig.src.json",
+    "typecheck:ai-v7": "pnpm run bundle-vendor && tsc --noEmit -p tsconfig.ai-v7.json",
     "pretest": "pnpm run bundle-vendor",
     "test": "vitest",
     "check-exports": "attw --pack ."

--- a/packages/trigger-sdk/package.json
+++ b/packages/trigger-sdk/package.json
@@ -65,7 +65,8 @@
     "clean": "rimraf dist .tshy .tshy-build .turbo",
     "build": "tshy && pnpm run update-version",
     "dev": "tshy --watch",
-    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.ai-v7.json",
+    "typecheck": "tsc --noEmit",
+    "typecheck:ai-v7": "tsc --noEmit -p tsconfig.ai-v7.json",
     "test": "vitest",
     "update-version": "tsx ../../scripts/updateVersion.ts",
     "check-exports": "attw --pack ."


### PR DESCRIPTION
## Summary

The SDK and core packages run a second, forward-compat typecheck pass (`tsc --noEmit -p tsconfig.ai-v7.json`) that remaps the `ai` import to the ESM-only AI SDK 7 canary so we catch source that only compiles against one major. Because it resolves `ai` through tsconfig `paths`, it's uniquely sensitive to how dependencies are laid out on disk: a clean install and a restored dependency cache can resolve the canary's module format differently, and when they diverge the pass emits spurious `TS1479` ("CommonJS module cannot require an ECMAScript module") errors on the `ai` import even though the source is fine in a clean checkout.

That pass shares the typecheck job that gates the Docker image publish, so a spurious failure there blocks publishing on an otherwise green tree.

This moves the pass out of the gating `typecheck` script in both packages and into a standalone `typecheck:ai-v7` script that can be run on demand. The regular `typecheck` now only checks against the installed `ai`, which resolves consistently across install layouts.
