### PR TITLE
fix(core): escape periods in attribute keys during flatten/unflatten (#1510)

### DIFF
--- a/packages/core/src/v3/utils/flattenAttributes.ts
+++ b/packages/core/src/v3/utils/flattenAttributes.ts
@@ -2,6 +2,7 @@ import { Attributes } from "@opentelemetry/api";
 
 export const NULL_SENTINEL = "$@null((";
 export const CIRCULAR_REFERENCE_SENTINEL = "$@circular((";
+const DOT_ESCAPE = "$@dot";
 
 const DEFAULT_MAX_DEPTH = 128;
 
@@ -200,7 +201,8 @@ class AttributeFlattener {
         break;
       }
 
-      const newPrefix = `${prefix ? `${prefix}.` : ""}${Array.isArray(obj) ? `[${key}]` : key}`;
+      const escapedKey = Array.isArray(obj) ? `[${key}]` : key.replace(/\./g, DOT_ESCAPE);
+      const newPrefix = `${prefix ? `${prefix}.` : ""}${escapedKey}`;
 
       if (Array.isArray(value)) {
         for (let i = 0; i < value.length; i++) {
@@ -280,17 +282,18 @@ export function unflattenAttributes(
 
     const parts = key.split(".").reduce(
       (acc, part) => {
-        if (part.startsWith("[") && part.endsWith("]")) {
+        const unescaped = part.split(DOT_ESCAPE).join(".");
+        if (unescaped.startsWith("[") && unescaped.endsWith("]")) {
           // Handle array indices more precisely
-          const match = part.match(/^\[(\d+)\]$/);
+          const match = unescaped.match(/^\[(\d+)\]$/);
           if (match && match[1]) {
             acc.push(parseInt(match[1]));
           } else {
             // Remove brackets for non-numeric array keys
-            acc.push(part.slice(1, -1));
+            acc.push(unescaped.slice(1, -1));
           }
         } else {
-          acc.push(part);
+          acc.push(unescaped);
         }
         return acc;
       },

--- a/packages/core/test/flattenAttributes.test.ts
+++ b/packages/core/test/flattenAttributes.test.ts
@@ -1,6 +1,30 @@
 import { flattenAttributes, unflattenAttributes } from "../src/v3/utils/flattenAttributes.js";
 
 describe("flattenAttributes", () => {
+  it("escapes periods in object keys", () => {
+    const obj = { "Key 0.002mm": 31.4 };
+    const flattened = flattenAttributes(obj);
+    expect(flattened).toEqual({ "Key 0$@dot002mm": 31.4 });
+    expect(unflattenAttributes(flattened)).toEqual(obj);
+  });
+
+  it("handles multiple periods in a single key", () => {
+    const obj = { "a.b.c": "value" };
+    const flattened = flattenAttributes(obj);
+    expect(flattened).toEqual({ "a$@dotb$@dotc": "value" });
+    expect(unflattenAttributes(flattened)).toEqual(obj);
+  });
+
+  it("handles period keys nested inside regular objects", () => {
+    const obj = { meta: { "Key 0.002mm": 31.4, "version": 2 } };
+    const flattened = flattenAttributes(obj);
+    expect(flattened).toEqual({
+      "meta.Key 0$@dot002mm": 31.4,
+      "meta.version": 2,
+    });
+    expect(unflattenAttributes(flattened)).toEqual(obj);
+  });
+
   it("handles number keys correctly", () => {
     expect(flattenAttributes({ bar: { "25": "foo" } })).toEqual({ "bar.25": "foo" });
     expect(unflattenAttributes({ "bar.25": "foo" })).toEqual({ bar: { "25": "foo" } });


### PR DESCRIPTION
Fixes #1510

Object keys containing periods (e.g. `{ "Key 0.002mm": 31.4 }`) were incorrectly split on the `.` delimiter during flattening, causing dashboard display corruption.

**Fix:** Escape `.` in object keys with `$@dot` sentinel during flatten and unescape during unflatten. This is consistent with the existing `$@null((` and `$@circular((` sentinel pattern.

**Changes:**
- `flattenAttributes.ts`: escape dots in non-array keys during flatten
- `unflattenAttributes()`: unescape sentinel back to `.` after splitting  
- Added 3 test cases for period-containing keys
