### PR TITLE
fix(webapp): prevent nanosecond overflow in OTLP timestamps (#3292)

### DIFF
--- a/apps/webapp/app/v3/eventRepository/common.server.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.ts
@@ -21,7 +21,7 @@ export function extractContextFromCarrier(carrier: Record<string, unknown>) {
 }
 
 export function getNowInNanoseconds(): bigint {
-  return BigInt(new Date().getTime() * 1_000_000);
+  return BigInt(new Date().getTime()) * BigInt(1_000_000);
 }
 
 export function getDateFromNanoseconds(nanoseconds: bigint): Date {
@@ -35,7 +35,7 @@ export function calculateDurationFromStart(
 ) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  const duration = Number(BigInt($endtime.getTime() * 1_000_000) - startTime);
+  const duration = Number(BigInt($endtime.getTime()) * BigInt(1_000_000) - startTime);
 
   if (minimumDuration && duration < minimumDuration) {
     return minimumDuration;

--- a/apps/webapp/app/v3/eventRepository/index.server.ts
+++ b/apps/webapp/app/v3/eventRepository/index.server.ts
@@ -262,7 +262,7 @@ async function recordRunEvent(
         runId: foundRun.friendlyId,
         ...attributes,
       },
-      startTime: BigInt((startTime?.getTime() ?? Date.now()) * 1_000_000),
+      startTime: BigInt((startTime?.getTime() ?? Date.now())) * BigInt(1_000_000),
       ...optionsRest,
     });
 

--- a/apps/webapp/app/v3/runEngineHandlers.server.ts
+++ b/apps/webapp/app/v3/runEngineHandlers.server.ts
@@ -464,7 +464,7 @@ export function registerRunEngineEventBusHandlers() {
         );
 
         await eventRepository.recordEvent(retryMessage, {
-          startTime: BigInt(time.getTime() * 1000000),
+          startTime: BigInt(time.getTime()) * BigInt(1_000_000),
           taskSlug: run.taskIdentifier,
           environment,
           attributes: {

--- a/pr-body-3321.txt
+++ b/pr-body-3321.txt
@@ -1,0 +1,25 @@
+## What
+
+This PR updates route components to use the animated Resizable panel pattern:
+- Converts conditionally-rendered panels to always-mounted animated panels with `collapsible`, `collapsed`, and `collapseAnimation` props
+- Adds `useFrozenValue` hook usage to keep last selected item visible during panel collapse animation
+- Minor UI polish on logs, runs, schedules, waitpoints pages
+
+## Changes
+
+- **Resizable.tsx** — skipped (main already has these exports)
+- **Route files** (logs, runs, schedules, batches, etc.) — convert panel pattern, add `useFrozenValue`
+- **LogsTable, TreeView, GitMetadata** — minor improvements
+
+## Manual resolution
+
+Merge had 3 conflicts:
+- `Resizable.tsx`: kept main's version (already has animated panel exports with Firefox workarounds)
+- `logs/route.tsx` line 419: removed pointless `?? undefined` (PR's cleaner version)
+- `runs.$runParam/route.tsx`: kept `panel-run-parent-v3` autosaveId, removed `?? undefined`
+
+## Original PRs
+- Original: #3267
+- This replaces: #3319
+
+Co-authored-by: James Ritchie <james@trigger.dev>

--- a/pr-body-3322.txt
+++ b/pr-body-3322.txt
@@ -1,0 +1,34 @@
+## What
+
+Adds **OpenClaw agent** integration — a new agent provisioning system with Slack webhooks, agent setup/status pages, and database models.
+
+## Changes
+
+### New files
+- `routes/agents.$agentId.status.tsx` — agent status dashboard page
+- `routes/agents.setup.tsx` — agent setup wizard
+- `routes/api.agents.provision.ts` — provisioning API
+- `routes/webhooks.slack.ts` — Slack webhook handler
+- `internal-packages/database/prisma/migrations/20260325122458_add_openclaw_agents/migration.sql`
+- `.changeset/openclaw-agent-integration.md`
+
+### Schema
+- Added `AgentConfig`, `AgentExecution`, `AgentHealthCheck` models
+- Added `agentConfigs` relation to User model
+
+### Manual resolutions (merge conflicts)
+11 files conflicted during merge:
+- **LoginPageLayout, CodeBlock, AppLayout, Table, api.v1.artifacts, HelpAndFeedbackPopover**: kept main's version (branding/styling)
+- **test.tasks route, spans route**: kept main's version
+- **tailwind.css, tailwind.config.js**: kept main's version
+- **schema.prisma**: merged both sides (added AgentConfig + AgentExecution + AgentHealthCheck alongside main's LLM/PlatformNotification models)
+
+### Branding cleanup
+Reverted fork-specific branding (`AirTrigger` → `Trigger.dev`, `airtrigger.dev` → `trigger.dev`) across 53 files.
+
+## Notes
+- This is a rebased version of #3266, replacing the original PR
+- Some PR features (test task inline machine/version controls) were dropped during conflict resolution — consider re-adding as a follow-up
+- The animated resizable panel changes from #3267 are handled in PR #3321
+
+Co-authored-by: James Ritchie <james@trigger.dev>


### PR DESCRIPTION
Fixes #3292

Multiply after BigInt conversion to avoid IEEE 754 precision loss. Affects 4 locations where epoch-ms \* 1e6 exceeds Number.MAX_SAFE_INTEGER.

**Changes:**
- \common.server.ts\: 2 locations — trace start/end timestamps
- \index.server.ts\: 1 location — span timestamp
- \unEngineHandlers.server.ts\: 1 location — epoch timestamp