### PR TITLE
chore(docker): tidy dev postgres + clickhouse images

### DIFF
--- a/docker/Dockerfile.postgres
+++ b/docker/Dockerfile.postgres
@@ -1,5 +1,5 @@
 FROM postgres:14
 
 RUN apt-get update \
-    && apt-get install -y postgresql-14-partman \
+    && apt-get install -y --no-install-recommends postgresql-14-partman \
     && rm -rf /var/lib/apt/lists/*

--- a/internal-packages/clickhouse/Dockerfile
+++ b/internal-packages/clickhouse/Dockerfile
@@ -9,4 +9,7 @@ COPY ./schema ./schema
 ENV GOOSE_DRIVER=clickhouse
 ENV GOOSE_DBSTRING="tcp://default:password@clickhouse:9000"
 ENV GOOSE_MIGRATION_DIR=./schema
+
+# Run migrations as non-root (dev-only migration helper; goose needs no root).
+USER nobody
 CMD ["goose", "up"]

--- a/internal-packages/clickhouse/Dockerfile
+++ b/internal-packages/clickhouse/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang
+FROM golang:1.26@sha256:68cb6d68bed024785b69195b89af7ac7a444f27791435f98647edff595aa0479
 
 
-RUN go install github.com/pressly/goose/v3/cmd/goose@latest
+RUN go install github.com/pressly/goose/v3/cmd/goose@v3.27.1
 
 
 COPY ./schema ./schema


### PR DESCRIPTION
Two small hygiene tweaks to **dev-only** images:

- `docker/Dockerfile.postgres`: add `--no-install-recommends` to the partman install (leaner image, skips unneeded recommended packages).
- `internal-packages/clickhouse/Dockerfile`: run the migration helper as a non-root user.

Both are local-dev images (the `pnpm run docker` stack) - no impact on the published webapp image, prod, or self-hosting.