### PR TITLE
fix(cli): optimize truncateMessage to O(n) and bypass if not TTY

### DIFF
--- a/packages/cli-v3/src/utilities/windows.ts
+++ b/packages/cli-v3/src/utilities/windows.ts
@@ -19,6 +19,11 @@ function getVisibleLength(str: string): number {
 }
 
 function truncateMessage(msg: string, maxLength?: number): string {
+  // If not a TTY and no explicit length provided, don't truncate
+  if (!process.stdout.isTTY && maxLength === undefined) {
+    return msg;
+  }
+
   const terminalWidth = maxLength ?? process.stdout.columns ?? 80;
   const availableWidth = terminalWidth - 5; // Reserve some space for the spinner and padding
   const visibleLength = getVisibleLength(msg);
@@ -28,13 +33,45 @@ function truncateMessage(msg: string, maxLength?: number): string {
   }
 
   // We need to truncate based on visible characters, but preserve ANSI sequences
-  // Simple approach: truncate character by character until we fit
-  let truncated = msg;
-  while (getVisibleLength(truncated) > availableWidth - 3) {
-    truncated = truncated.slice(0, -1);
+  const targetLength = availableWidth - 3;
+  let visibleCount = 0;
+  let result = "";
+
+  const ansiRegex = /\x1b\]8;;[^\x07]*\x07|\x1b\[[0-9;]*[a-zA-Z]/g;
+  let lastIndex = 0;
+  let match;
+
+  while ((match = ansiRegex.exec(msg)) !== null) {
+    const textPart = msg.slice(lastIndex, match.index);
+    const textPartVisibleLength = textPart.length;
+
+    if (visibleCount + textPartVisibleLength > targetLength) {
+      if (visibleCount <= targetLength) {
+        result += textPart.slice(0, targetLength - visibleCount) + "...";
+        visibleCount = targetLength + 1; // Mark as done
+      }
+      result += match[0];
+    } else {
+      if (visibleCount <= targetLength) {
+        result += textPart + match[0];
+        visibleCount += textPartVisibleLength;
+      } else {
+        result += match[0];
+      }
+    }
+    lastIndex = ansiRegex.lastIndex;
   }
 
-  return truncated + "...";
+  if (visibleCount <= targetLength) {
+    const remainingText = msg.slice(lastIndex);
+    if (visibleCount + remainingText.length > targetLength) {
+      result += remainingText.slice(0, targetLength - visibleCount) + "...";
+    } else {
+      result += remainingText;
+    }
+  }
+
+  return result;
 }
 
 const wrappedClackSpinner = () => {


### PR DESCRIPTION
Closes #3826

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

1. Created a script to measure the execution time of `truncateMessage` using heavily repeated ANSI strings.
2. Verified that the original logic (O(n²)) took >2.4s for a long string, whereas the new regex-based logic takes <1ms.
3. Verified the resulting truncated string accurately preserves ANSI codes.
4. Ensured that if the CI runner does not allocate a TTY (`!process.stdout.isTTY`), it bypasses the `truncateMessage` function logic entirely to prevent hang in environments where `process.stdout.columns` may be undefined.
5. Successfully ran `pnpm run build --filter trigger.dev` locally to verify there are no typescript or compilation errors.

---

## Changelog

Optimized the `truncateMessage` algorithm in the CLI from O(n²) to O(n) using an ANSI regex. Additionally, bypassed message truncation for non-TTY processes. This resolves an issue where `trigger deploy` could hang indefinitely with 100% CPU usage in CI environments while trying to process large spinner messages.

---

## Screenshots

_N/A_


