### PR TITLE
docs: document the trigger skills installer (replaces agent rules)

### DIFF
--- a/docs/building-with-ai.mdx
+++ b/docs/building-with-ai.mdx
@@ -22,7 +22,7 @@ We provide multiple tools to help AI coding assistants write correct Trigger.dev
 </Step>
 
 <Step title="Install Skills">
-  Portable instruction sets that teach any AI coding assistant Trigger.dev best practices: writing tasks, realtime frontends, and `chat.agent` AI agents. They ship with the CLI, version-matched to your SDK, and install into Claude Code, Cursor, VS Code (Copilot), and Codex / AGENTS.md.
+  Portable instruction sets that teach any AI coding assistant Trigger.dev best practices: writing tasks, realtime frontends, and `chat.agent` AI agents. They ship with the CLI, versioned with it, and install into Claude Code, Cursor, VS Code (Copilot), and AGENTS-compatible tools such as Codex via `.agents/skills/`.
 
   ```bash
   npx trigger.dev@latest skills

--- a/docs/building-with-ai.mdx
+++ b/docs/building-with-ai.mdx
@@ -33,9 +33,9 @@ We provide multiple tools to help AI coding assistants write correct Trigger.dev
 
 </Steps>
 
-## Skills vs MCP
+## Skills and the MCP server
 
-Not sure which tool to use? Here's how they compare:
+Skills and the MCP server do different jobs and work best together. Here's how they compare:
 
 | | **Skills** | **MCP Server** |
 |:--|:-----------|:---------------|

--- a/docs/building-with-ai.mdx
+++ b/docs/building-with-ai.mdx
@@ -22,40 +22,30 @@ We provide multiple tools to help AI coding assistants write correct Trigger.dev
 </Step>
 
 <Step title="Install Skills">
-  Portable instruction sets that teach any AI coding assistant Trigger.dev best practices. Works with Claude Code, Cursor, Windsurf, VS Code (Copilot), and any tool that supports the [Agent Skills standard](https://agentskills.io).
+  Portable instruction sets that teach any AI coding assistant Trigger.dev best practices: writing tasks, realtime frontends, and `chat.agent` AI agents. They ship with the CLI, version-matched to your SDK, and install into Claude Code, Cursor, VS Code (Copilot), and Codex / AGENTS.md.
 
   ```bash
-  npx skills add triggerdotdev/skills
+  npx trigger.dev@latest skills
   ```
 
   [Learn more →](/skills)
 </Step>
 
-<Step title="Install Agent Rules">
-  Comprehensive rule sets installed directly into your AI client's config files. Works with Cursor, Claude Code, VS Code (Copilot), Windsurf, Gemini CLI, Cline, and more. Claude Code also gets a dedicated subagent for hands-on help.
-
-  ```bash
-  npx trigger.dev@latest install-rules
-  ```
-
-  [Learn more →](/mcp-agent-rules)
-</Step>
-
 </Steps>
 
-## Skills vs Agent Rules vs MCP
+## Skills vs MCP
 
 Not sure which tool to use? Here's how they compare:
 
-| | **Skills** | **Agent Rules** | **MCP Server** |
-|:--|:-----------|:----------------|:---------------|
-| **What it does** | Drops skill files into your project | Installs rule sets into client config | Runs a live server your AI connects to |
-| **Installs to** | `.claude/skills/`, `.cursor/skills/`, etc. | `.cursor/rules/`, `CLAUDE.md`, `AGENTS.md`, etc. | `mcp.json`, `~/.claude.json`, etc. |
-| **Updates** | Re-run `npx skills add` | Re-run `npx trigger.dev@latest install-rules` or auto-prompted on `trigger dev` | Always latest (uses `@latest`) |
-| **Best for** | Teaching patterns and best practices | Comprehensive code generation guidance | Live project interaction (deploy, trigger, monitor) |
-| **Works offline** | Yes | Yes | No (calls Trigger.dev API) |
+| | **Skills** | **MCP Server** |
+|:--|:-----------|:---------------|
+| **What it does** | Drops skill files into your project that teach Trigger.dev patterns | Runs a live server your AI connects to |
+| **Installs to** | `.claude/skills/`, `.cursor/skills/`, `.github/skills/`, `.agents/skills/` | `mcp.json`, `~/.claude.json`, etc. |
+| **Updates** | Re-run `npx trigger.dev@latest skills`, or auto-prompted on `trigger dev` | Always latest (uses `@latest`) |
+| **Best for** | Teaching patterns and best practices | Live project interaction (deploy, trigger, monitor) |
+| **Works offline** | Yes | No (calls Trigger.dev API) |
 
-**Our recommendation:** Install all three. Skills and Agent Rules teach your AI *how* to write code. The MCP Server lets it *do things* in your project.
+**Our recommendation:** Install both. Skills teach your AI *how* to write Trigger.dev code; the MCP Server lets it *do things* in your project.
 
 ## Project-level context snippet
 
@@ -238,7 +228,7 @@ These follow the [llms.txt standard](https://llmstxt.org) and can be fed directl
 <AccordionGroup>
 
 <Accordion title="AI keeps generating old v2/v3 code">
-  Install [Agent Rules](/mcp-agent-rules) or [Skills](/skills) — they override the outdated patterns in the AI's training data. The [context snippet](#project-level-context-snippet) above is a quick alternative.
+  Install [Skills](/skills); they override the outdated patterns in the AI's training data. The [context snippet](#project-level-context-snippet) above is a quick alternative.
 </Accordion>
 
 <Accordion title="MCP server won't connect">
@@ -249,9 +239,8 @@ These follow the [llms.txt standard](https://llmstxt.org) and can be fed directl
 </Accordion>
 
 <Accordion title="Which tool should I install?">
-  All three if possible. If you can only pick one:
-  - **Agent Rules** if you want the broadest code generation improvement
-  - **Skills** if you use multiple AI tools and want a single install
+  Both if possible:
+  - **Skills** to teach your AI how to write Trigger.dev code (tasks, realtime, chat.agent)
   - **MCP Server** if you need to trigger tasks, deploy, and search docs from your AI
 </Accordion>
 
@@ -264,10 +253,7 @@ These follow the [llms.txt standard](https://llmstxt.org) and can be fed directl
     Install and configure the MCP Server for live project interaction.
   </Card>
   <Card title="Skills" icon="wand-magic-sparkles" href="/skills">
-    Portable instruction sets for any AI coding assistant.
-  </Card>
-  <Card title="Agent Rules" icon="scroll" href="/mcp-agent-rules">
-    Comprehensive rule sets installed into your AI client.
+    Install Trigger.dev agent skills into any AI coding assistant.
   </Card>
   <Card title="Writing tasks" icon="code" href="/tasks/overview">
     Learn the task patterns your AI assistant will follow.

--- a/docs/mcp-agent-rules.mdx
+++ b/docs/mcp-agent-rules.mdx
@@ -11,7 +11,7 @@ sidebarTitle: "Agent rules"
 
 ## What changed
 
-Trigger.dev used to install per-tool *rule files* (`.cursor/rules/trigger.*.mdc`, regions in `CLAUDE.md`, and so on) fetched from GitHub. That has been replaced by [agent skills](/skills): `SKILL.md` directories in the open [Agent Skills standard](https://agentskills.io) that ship inside the CLI, version-matched to the Trigger.dev version you build against, and load on demand instead of always sitting in your context.
+Trigger.dev used to install per-tool *rule files* (`.cursor/rules/trigger.*.mdc`, regions in `CLAUDE.md`, and so on) fetched from GitHub. That has been replaced by [agent skills](/skills): `SKILL.md` directories in the open [Agent Skills standard](https://agentskills.io) that ship inside the CLI, versioned with it, and load on demand instead of always sitting in your context.
 
 The install command is the same, and now installs skills:
 

--- a/docs/mcp-agent-rules.mdx
+++ b/docs/mcp-agent-rules.mdx
@@ -1,132 +1,41 @@
 ---
 title: "Agent rules"
+description: "Trigger.dev agent rules are now agent skills, installed with the trigger.dev CLI."
 sidebarTitle: "Agent rules"
-description: "Install Trigger.dev agent rules to guide AI assistants toward correct, up-to-date code patterns."
 ---
 
-## What are Trigger.dev agent rules?
-
-Trigger.dev agent rules are comprehensive instruction sets that guide AI assistants to write optimal Trigger.dev code. These rules ensure your AI assistant understands best practices, current APIs, and recommended patterns when working with Trigger.dev projects.
-
 <Note>
-  Agent Rules are one of three AI tools we provide. You can also install [Skills](/skills) for portable cross-editor instruction sets or the [MCP Server](/mcp-introduction) for live project interaction. See the [comparison table](/building-with-ai#skills-vs-agent-rules-vs-mcp) for details.
+  Agent rules are now **agent skills**. The standalone rule files have been replaced by skills that
+  work across every major AI assistant from a single install. See [Skills](/skills).
 </Note>
 
-## Installation
+## What changed
 
-Install the agent rules with the following command:
+Trigger.dev used to install per-tool *rule files* (`.cursor/rules/trigger.*.mdc`, regions in `CLAUDE.md`, and so on) fetched from GitHub. That has been replaced by [agent skills](/skills): `SKILL.md` directories in the open [Agent Skills standard](https://agentskills.io) that ship inside the CLI, version-matched to the Trigger.dev version you build against, and load on demand instead of always sitting in your context.
 
-```bash
-npx trigger.dev@latest install-rules
-```
-
-## Available rule sets
-
-We provide five specialized rule sets, each optimized for different aspects of Trigger.dev development:
-
-| Rule set | Tokens | Description | GitHub |
-|:---------|:-------|:------------|:------------|
-| **Basic tasks** | 1,200 | Essential rules for writing basic Trigger.dev tasks and fundamental patterns | [View](https://github.com/triggerdotdev/trigger.dev/blob/main/rules/4.0.0/basic-tasks.md) |
-| **Advanced tasks** | 3,000 | Comprehensive rules for complex workflows, error handling, and advanced task patterns | [View](https://github.com/triggerdotdev/trigger.dev/blob/main/rules/4.0.0/advanced-tasks.md) |
-| **Scheduled tasks** | 780 | Specialized guidance for cron jobs, scheduled workflows, and time-based triggers | [View](https://github.com/triggerdotdev/trigger.dev/blob/main/rules/4.0.0/scheduled-tasks.md) |
-| **Configuration** | 1,900 | Complete guide for trigger.config.ts setup, environment configuration, and project structure | [View](https://github.com/triggerdotdev/trigger.dev/blob/main/rules/4.0.0/config.md) |
-| **Realtime** | 1,700 | Using Trigger.dev Realtime features and frontend integration patterns | [View](https://github.com/triggerdotdev/trigger.dev/blob/main/rules/4.0.0/realtime.md) |
-
-## Claude Code subagent
-
-For Claude Code users, we provide a subagent called `trigger-dev-expert` that's an expert at writing well-structured Trigger.dev code.
-
-### Installation
-
-The subagent is available as an option when running the rules installation command. Select "Claude Code" as your client and choose to include the subagent when prompted.
-
-![Claude Code subagent installation](/images/claude-code-subagent.png)
-
-### Usage
-
-Activate the subagent in your prompts by requesting it explicitly:
-
-```markdown
-use the trigger-dev-expert subagent to create a trigger.dev job that accepts a video url, processes it with ffmpeg to extract the audio, runs the audio through a text-to-speech API like openai, and then uploads both the transcription and the audio to s3
-```
-
-The subagent works best when combined with the appropriate rule sets installed alongside it, providing both high-level architectural guidance and detailed implementation knowledge.
-
-## Supported AI clients
-
-The Trigger.dev rules work across a wide range of AI coding assistants and editors:
-
-| Client | Rule activation | Docs |
-|:--------|:----------------|:--------------|
-| **Cursor** | Automatic when working in trigger directories | [Link](https://docs.cursor.com/en/context/rules#rules/) |
-| **Claude Code** | Context-aware activation + custom subagent | [Link](https://docs.anthropic.com/en/docs/claude-code) |
-| **VSCode Copilot** | Integration with GitHub Copilot chat | [Link](https://code.visualstudio.com/docs/copilot/overview) |
-| **Windsurf** | Automatic activation in Trigger.dev projects | [Link](https://docs.windsurf.com/windsurf/cascade/memories#rules) |
-| **Gemini CLI** | Command-line integration | [Link](https://ai.google.dev/gemini-api/docs) |
-| **Cline** | Automatic context detection | [Link](https://github.com/cline/cline) |
-| **Sourcegraph AMP** | Code intelligence integration | [Link](https://sourcegraph.com/docs) |
-| **Kilo** | Custom rule integration | [Link](https://kilocode.ai/docs/advanced-usage/custom-rules) |
-| **Ruler** | Rule management | [Link](https://github.com/intellectronica/ruler) |
-| **AGENTS.md** | Universal format for OpenAI Codex, Jules, OpenCode, etc. |  |
-
-### Rule activation behavior
-
-Different AI tools handle rules differently:
-
-- **Automatic Activation**: Cursor, Windsurf, VSCode Copilot, and Cline automatically apply relevant rules when working in Trigger.dev projects or when `trigger.config.ts` is detected
-- **Context-Aware**: Claude Code intelligently applies rules based on the current context and file types
-- **Manual Integration**: AGENTS.md clients and others append rules to configuration files for manual activation
-
-## Keeping rules updated
-
-Trigger.dev rules are regularly updated to reflect new features, API changes, and best practices. The CLI includes automatic update detection.
-
-### Automatic update notifications
-
-When running `npx trigger.dev@latest dev`, you'll receive notifications when newer rule versions are available with a simple update command.
-
-### Manual updates
-
-Update rules anytime with:
+The install command is the same, and now installs skills:
 
 ```bash
-npx trigger.dev@latest install-rules
+npx trigger.dev@latest skills
 ```
 
-The update process replaces existing rules without creating duplicates, keeping your configuration files clean and organized.
+`npx trigger.dev@latest install-rules` still works as an alias, and `trigger dev` offers to install the skills on first run.
 
-### Why updates matter
-
-- **Current API patterns**: Access the latest Trigger.dev APIs and features
-- **Performance optimizations**: Benefit from improved patterns and practices
-- **Deprecated pattern avoidance**: Prevent AI assistants from generating outdated code
-- **New feature support**: Immediate access to newly released capabilities
-
-## Getting started
-
-1. Install the rules:
-
-```bash
-npx trigger.dev@latest install-rules
-```
-
-2. Follow the prompts to install the rules for your AI client.
-
-3. Consider installing the `trigger-dev-expert` subagent if using Claude Code.
+The old task and realtime guidance now lives in the `authoring-tasks` and `realtime-and-frontend` skills, alongside two new skills for building `chat.agent` AI agents. See [Skills](/skills) for the full list and supported assistants.
 
 ## Next steps
 
 <CardGroup cols={2}>
   <Card title="Skills" icon="wand-magic-sparkles" href="/skills">
-    Portable instruction sets that work across all AI coding assistants.
+    Install Trigger.dev agent skills into your AI coding assistant.
   </Card>
   <Card title="MCP Server" icon="sparkles" href="/mcp-introduction">
     Give your AI assistant direct access to Trigger.dev tools and APIs.
   </Card>
-  <Card title="Complete AI setup" icon="layer-group" href="/building-with-ai">
-    See all AI tools and how they compare.
+  <Card title="Building with AI" icon="layer-group" href="/building-with-ai">
+    See how skills and the MCP server compare.
   </Card>
   <Card title="Writing tasks" icon="code" href="/tasks/overview">
-    Learn the task patterns that agent rules teach your AI assistant.
+    Learn the task patterns that skills teach your AI assistant.
   </Card>
 </CardGroup>

--- a/docs/mcp-introduction.mdx
+++ b/docs/mcp-introduction.mdx
@@ -382,7 +382,4 @@ Once installed, you can start using the MCP server by asking your AI assistant q
   <Card title="Skills" icon="wand-magic-sparkles" href="/skills">
     Portable instruction sets that teach AI assistants Trigger.dev patterns.
   </Card>
-  <Card title="Agent Rules" icon="scroll" href="/mcp-agent-rules">
-    Install comprehensive rule sets directly into your AI client.
-  </Card>
 </CardGroup>

--- a/docs/skills.mdx
+++ b/docs/skills.mdx
@@ -18,7 +18,7 @@ Each skill is a directory containing a `SKILL.md` file: YAML frontmatter (name, 
 
 ## Installation
 
-The skills ship inside the `trigger.dev` CLI, version-matched to the SDK you have installed. Run:
+The skills ship inside the `trigger.dev` CLI and are versioned with it. Run:
 
 ```bash
 npx trigger.dev@latest skills
@@ -29,9 +29,10 @@ The CLI detects your installed AI tools, lets you pick which skills to install, 
 When you run `trigger dev` for the first time, the CLI offers to install the skills for you.
 
 <Note>
-  Because the skills are bundled with the CLI, the guidance your assistant gets is pinned to the
-  Trigger.dev version you are actually building against, instead of always being the latest from the
-  internet.
+  Because the skills are bundled with the CLI, the guidance your assistant gets is pinned to the CLI
+  version that installs them. To keep it matched to the Trigger.dev version you are building
+  against, run the CLI pinned in your project (`pnpm exec trigger skills`) instead of
+  `npx trigger.dev@latest`.
 </Note>
 
 ### Non-interactive install

--- a/docs/skills.mdx
+++ b/docs/skills.mdx
@@ -1,89 +1,88 @@
 ---
 title: "Skills"
-description: "Install Trigger.dev skills to teach any AI coding assistant best practices for writing tasks, agents, and workflows."
+description: "Install Trigger.dev agent skills to teach any AI coding assistant how to write tasks, realtime frontends, and chat.agent AI agents."
 sidebarTitle: "Skills"
 ---
 
 ## What are agent skills?
 
-Skills are portable instruction sets that teach AI coding assistants how to use Trigger.dev effectively. Unlike vendor-specific config files (`.cursor/rules`, `CLAUDE.md`), skills use an open standard that works across all major AI assistants. For example, Cursor users and Claude Code users can get the same knowledge from a single install.
+Skills are portable instruction sets that teach AI coding assistants how to use Trigger.dev effectively. Unlike vendor-specific config files (`.cursor/rules`, `CLAUDE.md`), skills use an open standard that works across all major AI assistants, so Cursor users and Claude Code users get the same knowledge from a single install.
+
+Each skill is a directory containing a `SKILL.md` file: YAML frontmatter (name, description) plus markdown instructions with patterns, examples, and common mistakes that AI assistants discover on demand and follow.
 
 <Note>
-  Skills are one of three AI tools we provide. You can also install [Agent Rules](/mcp-agent-rules)
-  for client-specific rule sets or the [MCP Server](/mcp-introduction) for live project interaction.
-  See the [comparison table](/building-with-ai#skills-vs-agent-rules-vs-mcp) for details.
+  Skills are one of two AI tools we provide. You can also install the [MCP Server](/mcp-introduction)
+  to give your assistant live access to your project (deploy, trigger, monitor). See the
+  [comparison](/building-with-ai#skills-vs-mcp) for details.
 </Note>
-
-Skills are installed as directories containing a `SKILL.md` file. Each `SKILL.md` includes YAML frontmatter (name, description) and markdown instructions with patterns, examples, and best practices that AI assistants automatically discover and follow.
 
 ## Installation
 
-When you run `npx skills add triggerdotdev/skills`, the CLI detects your installed AI tools and copies the appropriate files to each tool's expected location. For example, `.claude/skills/`, `.cursor/skills/`, `.github/skills/`, etc.
+The skills ship inside the `trigger.dev` CLI, version-matched to the SDK you have installed. Run:
 
 ```bash
-npx skills add triggerdotdev/skills
+npx trigger.dev@latest skills
 ```
 
-<Note>`skills` is an open-source CLI by Vercel. Learn more at [skills.sh](https://skills.sh).</Note>
+The CLI detects your installed AI tools, lets you pick which skills to install, and copies each one into that tool's native skills directory (`.claude/skills/`, `.cursor/skills/`, `.github/skills/`, `.agents/skills/`). It also writes a one-line pointer into your primary instructions file (`CLAUDE.md`, `.cursor/rules`, etc.) so your assistant always knows the skills are there and loads the right one on demand.
 
-The result: your AI assistant understands Trigger.dev's specific patterns for exports, schema validation, error handling, retries, and more.
+When you run `trigger dev` for the first time, the CLI offers to install the skills for you.
+
+<Note>
+  Because the skills are bundled with the CLI, the guidance your assistant gets is pinned to the
+  Trigger.dev version you are actually building against, instead of always being the latest from the
+  internet.
+</Note>
+
+### Non-interactive install
+
+Pass `--target` to choose tools and `-y` to install every skill without prompting (useful in scripts and CI):
+
+```bash
+npx trigger.dev@latest skills --target claude-code --target cursor -y
+```
 
 ## Available skills
 
-Install all skills at once, or pick the ones relevant to your current work:
+| Skill                  | Use for                                                        | Covers                                                                       |
+| ---------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `authoring-tasks`      | Writing background and scheduled tasks                         | `task`/`schemaTask`, retries, queues, waits, idempotency, metadata, triggering, cron, `trigger.config.ts` |
+| `realtime-and-frontend`| Live run updates and triggering from the browser               | `runs.subscribeToRun`, `@trigger.dev/react-hooks`, public access tokens, streams |
+| `authoring-chat-agent` | Building durable AI chat agents                                | `chat.agent` run loop, `toStreamTextOptions`, server actions, `useChat` transport, tools, lifecycle hooks |
+| `chat-agent-advanced`  | Advanced chat.agent patterns                                   | sessions, human-in-the-loop, sub-agents, compaction, fast starts, resilience, version upgrades |
 
-```bash
-# Install all Trigger.dev skills
-npx skills add triggerdotdev/skills
-
-# Or install individual skills
-npx skills add triggerdotdev/skills --skill trigger-tasks
-npx skills add triggerdotdev/skills --skill trigger-agents
-npx skills add triggerdotdev/skills --skill trigger-config
-npx skills add triggerdotdev/skills --skill trigger-realtime
-npx skills add triggerdotdev/skills --skill trigger-setup
-npx skills add triggerdotdev/skills --skill trigger-cost-savings
-
-```
-
-| Skill                  | Use for                                                     | Covers                                                           |
-| ---------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------- |
-| `trigger-setup`        | First time setup, new projects                              | SDK install, `npx trigger init`, project structure               |
-| `trigger-tasks`        | Writing background tasks, async workflows, scheduled tasks  | Triggering, waits, queues, retries, cron, metadata               |
-| `trigger-agents`       | LLM workflows, orchestration, multi-step AI agents          | Prompt chaining, routing, parallelization, human-in-the-loop     |
-| `trigger-realtime`     | Live updates, progress indicators, streaming                | React hooks, progress bars, streaming AI responses               |
-| `trigger-config`       | Project setup, build configuration                          | `trigger.config.ts`, extensions (Prisma, FFmpeg, Playwright)     |
-| `trigger-cost-savings` | Cost savings, performance optimization, resource management | Cost optimization, performance optimization, resource management |
-
-Not sure which skill to install? Install `trigger-tasks`; it covers the most common patterns for writing Trigger.dev tasks.
+Not sure which to install? Pick `authoring-tasks`; it covers the most common patterns for writing Trigger.dev tasks.
 
 ## Supported AI assistants
 
-Skills work with any AI coding assistant that supports the [Agent Skills standard](https://agentskills.io), including:
+Skills use the open [Agent Skills standard](https://agentskills.io). The CLI installs natively into the tools that support a skills directory today:
 
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
-- [Cursor](https://cursor.com)
-- [Windsurf](https://codeium.com/windsurf)
-- [GitHub Copilot](https://github.com/features/copilot)
-- [Cline](https://github.com/cline/cline)
-- [Codex CLI](https://github.com/openai/codex)
-- [Gemini CLI](https://github.com/google-gemini/gemini-cli)
-- [OpenCode](https://opencode.ai)
-- [View all →](https://skills.sh)
+| Assistant | Installs to |
+| --- | --- |
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `.claude/skills/` |
+| [Cursor](https://cursor.com) | `.cursor/skills/` |
+| [GitHub Copilot (VS Code)](https://github.com/features/copilot) | `.github/skills/` |
+| [Codex CLI](https://github.com/openai/codex), Jules, OpenCode | `.agents/skills/` |
+
+Using a tool that does not support skills yet? Select "Unsupported target" in the installer for manual setup instructions.
+
+## Keeping skills updated
+
+Skills are pinned to your installed CLI version. To refresh them after upgrading Trigger.dev, run `npx trigger.dev@latest skills` again, or accept the prompt that `trigger dev` shows when a newer version is available. Re-running overwrites the installed skill files in place without creating duplicates.
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Agent Rules" icon="scroll" href="/mcp-agent-rules">
-    Install comprehensive rule sets directly into your AI client.
-  </Card>
   <Card title="MCP Server" icon="sparkles" href="/mcp-introduction">
     Give your AI assistant direct access to Trigger.dev tools and APIs.
+  </Card>
+  <Card title="Building with AI" icon="layer-group" href="/building-with-ai">
+    See how skills and the MCP server compare, plus a copy-paste context snippet.
   </Card>
   <Card title="Writing tasks" icon="code" href="/tasks/overview">
     Learn the task patterns that skills teach your AI assistant.
   </Card>
-  <Card title="skills.sh" icon="box" href="https://skills.sh">
-    Browse the full Agent Skills ecosystem.
+  <Card title="AI agents" icon="robot" href="/ai-chat/overview">
+    Build durable chat agents with chat.agent, the focus of two of the skills.
   </Card>
 </CardGroup>

--- a/docs/skills.mdx
+++ b/docs/skills.mdx
@@ -11,9 +11,9 @@ Skills are portable instruction sets that teach AI coding assistants how to use 
 Each skill is a directory containing a `SKILL.md` file: YAML frontmatter (name, description) plus markdown instructions with patterns, examples, and common mistakes that AI assistants discover on demand and follow.
 
 <Note>
-  Skills are one of two AI tools we provide. You can also install the [MCP Server](/mcp-introduction)
-  to give your assistant live access to your project (deploy, trigger, monitor). See the
-  [comparison](/building-with-ai#skills-vs-mcp) for details.
+  Skills pair with the [MCP Server](/mcp-introduction), which gives your assistant live access to
+  your project (deploy, trigger, monitor). Skills teach it how to write the code; the MCP server
+  lets it act on your project. See [how they fit together](/building-with-ai#skills-and-the-mcp-server).
 </Note>
 
 ## Installation


### PR DESCRIPTION
## Summary

Updates the AI-tooling docs for the new `trigger skills` installer that shipped in #3868. The Skills page now documents `trigger skills` (skills bundled with the CLI, version-matched to your SDK) and the four bundled skills: `authoring-tasks`, `realtime-and-frontend`, `authoring-chat-agent`, `chat-agent-advanced`. The old Agent Rules page becomes a short "rules are now skills" redirect (kept because existing redirects and the CLI link point at it), and the Building with AI overview collapses the three-way Skills/Rules/MCP comparison into Skills vs MCP.

Hold until the v4.5 CLI release ships, since `trigger skills` is not on npm until then.
