### PR TITLE
ci: make the main-image dispatch repo and ref configurable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,13 +116,18 @@ jobs:
       image-ref: ${{ needs.publish-webapp.outputs.image_repo }}:${{ needs.publish-webapp.outputs.version }}
 
   # Announce the freshly published mutable `main` webapp image to subscriber
-  # repos in the org via repository_dispatch, handing them a digest-pinned ref to
-  # build or deploy from. Fires only for the `main` tag — never semver releases or
-  # other tag builds — and only from the canonical repo (forks have no PAT).
+  # repos via repository_dispatch, handing them a digest-pinned ref to build or
+  # deploy from. The repo, ref prefix, and dispatch target all default to the
+  # canonical values and can be overridden by repository variables.
+  #
+  # `push` only: release builds reach publish.yml via workflow_call (from
+  # release.yml) with an explicit image_tag while github.ref_name is still
+  # `main`, so gate on the event to avoid dispatching — and failing on the
+  # absent CROSS_REPO_PAT — during a release.
   dispatch-main-image:
     name: 📣 Dispatch main image
     needs: [publish-webapp]
-    if: github.repository == (vars.MAIN_IMAGE_DISPATCH_REPO || 'triggerdotdev/trigger.dev') && startsWith(github.ref_name, vars.MAIN_IMAGE_DISPATCH_REF_PREFIX || 'main')
+    if: github.repository == (vars.MAIN_IMAGE_DISPATCH_REPO || 'triggerdotdev/trigger.dev') && github.event_name == 'push' && startsWith(github.ref_name, vars.MAIN_IMAGE_DISPATCH_REF_PREFIX || 'main')
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -153,6 +158,6 @@ jobs:
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.CROSS_REPO_PAT }}
-          repository: triggerdotdev/cloud
+          repository: ${{ vars.MAIN_IMAGE_DISPATCH_TARGET || 'triggerdotdev/cloud' }}
           event-type: main-image-published
           client-payload: ${{ steps.payload.outputs.client_payload }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,7 +122,7 @@ jobs:
   dispatch-main-image:
     name: 📣 Dispatch main image
     needs: [publish-webapp]
-    if: github.repository == 'triggerdotdev/trigger.dev' && needs.publish-webapp.outputs.version == 'main'
+    if: github.repository == (vars.MAIN_IMAGE_DISPATCH_REPO || 'triggerdotdev/trigger.dev') && startsWith(github.ref_name, vars.MAIN_IMAGE_DISPATCH_REF_PREFIX || 'main')
     runs-on: ubuntu-latest
     permissions: {}
     steps:


### PR DESCRIPTION
The `dispatch-main-image` job was hard-gated to `triggerdotdev/trigger.dev` on the `main` ref. This makes it configurable via repository variables, all defaulting to the current values:

- `MAIN_IMAGE_DISPATCH_REPO` — the repo allowed to dispatch (default `triggerdotdev/trigger.dev`).
- `MAIN_IMAGE_DISPATCH_REF_PREFIX` — the ref-name prefix that dispatches, matched with `startsWith(github.ref_name, …)` (default `main`).
- `MAIN_IMAGE_DISPATCH_TARGET` — the `repository_dispatch` target (default `triggerdotdev/cloud`).

The job is additionally gated on `github.event_name == 'push'`. This is necessary, not just defensive: the gate now keys off `github.ref_name` rather than the computed image tag, and `ref_name` is still `main` when `release.yml` invokes this workflow via `workflow_call` during a release — so without the event guard the job would fire during every release and fail on the absent `CROSS_REPO_PAT`. A version-equality check can't replace it because `build-*` tags strip the prefix to the version output.

Behaviour note: the intended dispatch paths — push to `main`, and push of a `<prefix>*` tag in a downstream repo — are `push` events and are unchanged. The one case that no longer dispatches is a manual `workflow_dispatch` run of `publish.yml` on `main` (it previously did, via the old `version == 'main'` check). That path is indistinguishable from a manual release by event name, so `push`-only is the clean discriminator.

Dispatching still requires `CROSS_REPO_PAT`, so setting the variables alone doesn't enable anything.