### PR TITLE
feat(webapp): hide self-serve billing UI for managed-billing orgs

### DIFF
--- a/.server-changes/hide-self-serve-billing-ui.md
+++ b/.server-changes/hide-self-serve-billing-ui.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+Hide self-serve billing and upgrade options for directly-billed organizations; show Contact us instead.

--- a/apps/webapp/app/components/BlankStatePanels.tsx
+++ b/apps/webapp/app/components/BlankStatePanels.tsx
@@ -434,7 +434,7 @@ export function NoWaitpointTokens() {
   );
 }
 
-export function BranchesNoBranchableEnvironment() {
+export function BranchesNoBranchableEnvironment({ showSelfServe }: { showSelfServe: boolean }) {
   const { isManagedCloud } = useFeatures();
   const organization = useOrganization();
 
@@ -462,9 +462,16 @@ export function BranchesNoBranchableEnvironment() {
       iconClassName="text-preview"
       panelClassName="max-w-full"
       accessory={
-        <LinkButton variant="primary/small" to={v3BillingPath(organization)}>
-          Upgrade
-        </LinkButton>
+        showSelfServe ? (
+          <LinkButton variant="primary/small" to={v3BillingPath(organization)}>
+            Upgrade
+          </LinkButton>
+        ) : (
+          <Feedback
+            button={<Button variant="secondary/small">Request more</Button>}
+            defaultValue="enterprise"
+          />
+        )
       }
     >
       <Paragraph spacing variant="small">
@@ -483,10 +490,12 @@ export function BranchesNoBranches({
   parentEnvironment,
   limits,
   canUpgrade,
+  showSelfServe,
 }: {
   parentEnvironment: { id: string };
   limits: { used: number; limit: number };
   canUpgrade: boolean;
+  showSelfServe: boolean;
 }) {
   const organization = useOrganization();
 
@@ -498,14 +507,18 @@ export function BranchesNoBranches({
         iconClassName="text-preview"
         panelClassName="max-w-full"
         accessory={
-          canUpgrade ? (
+          showSelfServe && canUpgrade ? (
             <LinkButton variant="primary/small" to={v3BillingPath(organization)}>
               Upgrade
             </LinkButton>
           ) : (
             <Feedback
-              button={<Button variant="primary/small">Request more</Button>}
-              defaultValue="help"
+              button={
+                <Button variant={showSelfServe ? "primary/small" : "secondary/small"}>
+                  Request more
+                </Button>
+              }
+              defaultValue={showSelfServe ? "help" : "enterprise"}
             />
           )
         }

--- a/apps/webapp/app/components/navigation/OrganizationSettingsSideMenu.tsx
+++ b/apps/webapp/app/components/navigation/OrganizationSettingsSideMenu.tsx
@@ -29,6 +29,7 @@ import { LinkButton } from "../primitives/Buttons";
 import { HelpAndFeedback } from "./HelpAndFeedbackPopover";
 import { SideMenuHeader } from "./SideMenuHeader";
 import { SideMenuItem } from "./SideMenuItem";
+import { useShowSelfServe } from "~/hooks/useShowSelfServe";
 import { useCurrentPlan } from "~/routes/_app.orgs.$organizationSlug/route";
 import { Paragraph } from "../primitives/Paragraph";
 import { Badge } from "../primitives/Badge";
@@ -55,6 +56,7 @@ export function OrganizationSettingsSideMenu({
   const { isManagedCloud } = useFeatures();
   const featureFlags = useFeatureFlags();
   const currentPlan = useCurrentPlan();
+  const showSelfServe = useShowSelfServe();
   const isAdmin = useHasAdminAccess();
   const showBuildInfo = isAdmin || !isManagedCloud;
 
@@ -103,14 +105,16 @@ export function OrganizationSettingsSideMenu({
                   ) : undefined
                 }
               />
-              <SideMenuItem
-                name="Billing alerts"
-                icon={BellIcon}
-                activeIconColor="text-text-bright"
-                inactiveIconColor="text-text-dimmed"
-                to={v3BillingAlertsPath(organization)}
-                data-action="billing-alerts"
-              />
+              {showSelfServe ? (
+                <SideMenuItem
+                  name="Billing alerts"
+                  icon={BellIcon}
+                  activeIconColor="text-text-bright"
+                  inactiveIconColor="text-text-dimmed"
+                  to={v3BillingAlertsPath(organization)}
+                  data-action="billing-alerts"
+                />
+              ) : null}
             </>
           )}
           <SideMenuItem

--- a/apps/webapp/app/components/schedules/PurchaseSchedulesModal.tsx
+++ b/apps/webapp/app/components/schedules/PurchaseSchedulesModal.tsx
@@ -4,6 +4,7 @@ import { EnvelopeIcon } from "@heroicons/react/20/solid";
 import { DialogClose } from "@radix-ui/react-dialog";
 import { useFetcher } from "@remix-run/react";
 import { type ReactNode, useEffect, useState } from "react";
+import { Feedback } from "~/components/Feedback";
 import { Button } from "~/components/primitives/Buttons";
 import {
   Dialog,
@@ -20,6 +21,7 @@ import { InputNumberStepper } from "~/components/primitives/InputNumberStepper";
 import { Label } from "~/components/primitives/Label";
 import { Paragraph } from "~/components/primitives/Paragraph";
 import { SpinnerWhite } from "~/components/primitives/Spinner";
+import { useShowSelfServe } from "~/hooks/useShowSelfServe";
 import { PurchaseSchema } from "~/routes/resources.orgs.$organizationSlug.schedules-addon";
 import { cn } from "~/utils/cn";
 import { formatCurrency, formatNumber } from "~/utils/numberFormatter";
@@ -49,6 +51,7 @@ export function PurchaseSchedulesModal({
   planScheduleLimit,
   triggerButton,
 }: Props) {
+  const showSelfServe = useShowSelfServe();
   const fetcher = useFetcher();
   const lastSubmission =
     fetcher.data && typeof fetcher.data === "object" && "intent" in fetcher.data
@@ -104,6 +107,15 @@ export function PurchaseSchedulesModal({
   const pricePerStep = schedulePricing.centsPerStep / 100;
   const stepUnit = formatNumber(stepSize);
   const title = extraSchedules === 0 ? "Purchase extra schedules…" : "Add/remove extra schedules…";
+
+  if (!showSelfServe) {
+    return (
+      <Feedback
+        defaultValue="enterprise"
+        button={<Button variant="secondary/small">Request more</Button>}
+      />
+    );
+  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/apps/webapp/app/components/schedules/ScheduleLimitActions.tsx
+++ b/apps/webapp/app/components/schedules/ScheduleLimitActions.tsx
@@ -1,0 +1,83 @@
+import { ArrowUpCircleIcon } from "@heroicons/react/20/solid";
+import { Feedback } from "~/components/Feedback";
+import { Button, LinkButton } from "~/components/primitives/Buttons";
+import { useShowSelfServe } from "~/hooks/useShowSelfServe";
+import { type MatchedOrganization } from "~/hooks/useOrganizations";
+import { v3BillingPath } from "~/utils/pathBuilder";
+import { PurchaseSchedulesModal, type SchedulePricing } from "./PurchaseSchedulesModal";
+
+type Props = {
+  actionPath: string;
+  canPurchaseSchedules: boolean;
+  schedulePricing: SchedulePricing | null;
+  extraSchedules: number;
+  limits: { used: number; limit: number };
+  maxScheduleQuota: number;
+  planScheduleLimit: number;
+  canUpgrade: boolean;
+  organization: MatchedOrganization;
+  variant?: "dialog" | "banner";
+};
+
+export function ScheduleLimitActions({
+  actionPath,
+  canPurchaseSchedules,
+  schedulePricing,
+  extraSchedules,
+  limits,
+  maxScheduleQuota,
+  planScheduleLimit,
+  canUpgrade,
+  organization,
+  variant = "banner",
+}: Props) {
+  const showSelfServe = useShowSelfServe();
+
+  if (!showSelfServe) {
+    return (
+      <Feedback
+        button={<Button variant="secondary/small">Request more</Button>}
+        defaultValue="enterprise"
+      />
+    );
+  }
+
+  if (canPurchaseSchedules && schedulePricing) {
+    return (
+      <PurchaseSchedulesModal
+        actionPath={actionPath}
+        schedulePricing={schedulePricing}
+        extraSchedules={extraSchedules}
+        usedSchedules={limits.used}
+        maxQuota={maxScheduleQuota}
+        planScheduleLimit={planScheduleLimit}
+        triggerButton={
+          variant === "dialog" ? (
+            <Button variant="primary/small">Purchase more…</Button>
+          ) : undefined
+        }
+      />
+    );
+  }
+
+  if (canUpgrade) {
+    return variant === "dialog" ? (
+      <LinkButton variant="primary/small" to={v3BillingPath(organization)}>
+        Upgrade
+      </LinkButton>
+    ) : (
+      <LinkButton
+        to={v3BillingPath(organization)}
+        variant="secondary/small"
+        LeadingIcon={ArrowUpCircleIcon}
+        leadingIconClassName="text-indigo-500"
+      >
+        Upgrade
+      </LinkButton>
+    );
+  }
+
+  return (
+    <Feedback button={<Button variant="primary/small">Request more</Button>} defaultValue="help" />
+  );
+}

--- a/apps/webapp/app/components/schedules/SchedulesUsageBar.tsx
+++ b/apps/webapp/app/components/schedules/SchedulesUsageBar.tsx
@@ -1,14 +1,9 @@
-import { ArrowUpCircleIcon } from "@heroicons/react/20/solid";
-import { Feedback } from "~/components/Feedback";
-import { Button, LinkButton } from "~/components/primitives/Buttons";
 import { Header3 } from "~/components/primitives/Headers";
 import { InfoIconTooltip, SimpleTooltip } from "~/components/primitives/Tooltip";
 import { useOrganization } from "~/hooks/useOrganizations";
-import { v3BillingPath, v3SchedulesAddOnPath } from "~/utils/pathBuilder";
-import {
-  PurchaseSchedulesModal,
-  type SchedulePricing,
-} from "./PurchaseSchedulesModal";
+import { v3SchedulesAddOnPath } from "~/utils/pathBuilder";
+import { ScheduleLimitActions } from "./ScheduleLimitActions";
+import { type SchedulePricing } from "./PurchaseSchedulesModal";
 
 type Props = {
   limits: { used: number; limit: number };
@@ -81,30 +76,17 @@ export function SchedulesUsageBar({
             </div>
           )}
 
-          {canPurchaseSchedules && schedulePricing ? (
-            <PurchaseSchedulesModal
-              actionPath={actionPath}
-              schedulePricing={schedulePricing}
-              extraSchedules={extraSchedules}
-              usedSchedules={limits.used}
-              maxQuota={maxScheduleQuota}
-              planScheduleLimit={planScheduleLimit}
-            />
-          ) : canUpgrade ? (
-            <LinkButton
-              to={v3BillingPath(organization)}
-              variant="secondary/small"
-              LeadingIcon={ArrowUpCircleIcon}
-              leadingIconClassName="text-indigo-500"
-            >
-              Upgrade
-            </LinkButton>
-          ) : (
-            <Feedback
-              button={<Button variant="secondary/small">Request more</Button>}
-              defaultValue="help"
-            />
-          )}
+          <ScheduleLimitActions
+            actionPath={actionPath}
+            canPurchaseSchedules={canPurchaseSchedules}
+            schedulePricing={schedulePricing}
+            extraSchedules={extraSchedules}
+            limits={limits}
+            maxScheduleQuota={maxScheduleQuota}
+            planScheduleLimit={planScheduleLimit}
+            canUpgrade={canUpgrade}
+            organization={organization}
+          />
         </div>
       </div>
     </div>

--- a/apps/webapp/app/hooks/useShowSelfServe.ts
+++ b/apps/webapp/app/hooks/useShowSelfServe.ts
@@ -1,0 +1,7 @@
+import { useCurrentPlan } from "~/routes/_app.orgs.$organizationSlug/route";
+
+/** Whether the org should see self-serve billing UI (plan picker, Stripe checkout, upgrades). */
+export function useShowSelfServe(): boolean {
+  const plan = useCurrentPlan();
+  return plan?.v3Subscription?.showSelfServe ?? true;
+}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.alerts/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.alerts/route.tsx
@@ -18,6 +18,7 @@ import assertNever from "assert-never";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { z } from "zod";
 import { AlertsNoneDev, AlertsNoneDeployed } from "~/components/BlankStatePanels";
+import { Feedback } from "~/components/Feedback";
 import { EnvironmentCombo } from "~/components/environments/EnvironmentLabel";
 import { MainCenteredContainer, PageBody, PageContainer } from "~/components/layout/AppLayout";
 import { Button, LinkButton } from "~/components/primitives/Buttons";
@@ -45,6 +46,7 @@ import {
 import { EnabledStatus } from "~/components/runs/v3/EnabledStatus";
 import { prisma } from "~/db.server";
 import { useEnvironment } from "~/hooks/useEnvironment";
+import { useShowSelfServe } from "~/hooks/useShowSelfServe";
 import { useOrganization } from "~/hooks/useOrganizations";
 import { useProject } from "~/hooks/useProject";
 import { redirectWithSuccessMessage } from "~/models/message.server";
@@ -182,6 +184,7 @@ export default function Page() {
   const organization = useOrganization();
   const project = useProject();
   const environment = useEnvironment();
+  const showSelfServe = useShowSelfServe();
 
   const requiresUpgrade = limits.used >= limits.limit;
 
@@ -343,9 +346,16 @@ export default function Page() {
                       </Header3>
                     )}
 
-                    <LinkButton to={v3BillingPath(organization)} variant="secondary/small">
-                      Upgrade
-                    </LinkButton>
+                    {showSelfServe ? (
+                      <LinkButton to={v3BillingPath(organization)} variant="secondary/small">
+                        Upgrade
+                      </LinkButton>
+                    ) : (
+                      <Feedback
+                        defaultValue="enterprise"
+                        button={<Button variant="secondary/small">Request more</Button>}
+                      />
+                    )}
                   </div>
                 </div>
               </div>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.branches/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.branches/route.tsx
@@ -12,6 +12,7 @@ import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { z } from "zod";
 import { BranchEnvironmentIconSmall } from "~/assets/icons/EnvironmentIcons";
 import { BranchesNoBranchableEnvironment, BranchesNoBranches } from "~/components/BlankStatePanels";
+import { Feedback } from "~/components/Feedback";
 import { GitMetadata } from "~/components/GitMetadata";
 import { V4Title } from "~/components/V4Badge";
 import { AdminDebugTooltip } from "~/components/admin/debugTooltip";
@@ -56,6 +57,7 @@ import {
 } from "~/components/primitives/Table";
 import { InfoIconTooltip, SimpleTooltip } from "~/components/primitives/Tooltip";
 import { useEnvironment } from "~/hooks/useEnvironment";
+import { useShowSelfServe } from "~/hooks/useShowSelfServe";
 import { useOrganization } from "~/hooks/useOrganizations";
 import { useProject } from "~/hooks/useProject";
 
@@ -63,6 +65,7 @@ import { findProjectBySlug } from "~/models/project.server";
 import { redirectWithErrorMessage, redirectWithSuccessMessage } from "~/models/message.server";
 import { BranchesPresenter } from "~/presenters/v3/BranchesPresenter.server";
 import { logger } from "~/services/logger.server";
+import { getCurrentPlan, getSelfServePurchaseBlockReason } from "~/services/platform.v3.server";
 import { requireUserId } from "~/services/session.server";
 import { UpsertBranchService } from "~/services/upsertBranch.server";
 import { cn } from "~/utils/cn";
@@ -155,6 +158,21 @@ export async function action({ request, params }: ActionFunctionArgs) {
       throw redirectWithErrorMessage(redirectPath, request, "Project not found");
     }
 
+    const currentPlan = await getCurrentPlan(project.organizationId);
+    const purchaseBlockReason = getSelfServePurchaseBlockReason(currentPlan);
+    if (purchaseBlockReason === "plan_unavailable") {
+      return json(
+        { ok: false, error: "Unable to verify billing status. Please try again." } as const,
+        { status: 503 }
+      );
+    }
+    if (purchaseBlockReason === "managed_billing") {
+      return json(
+        { ok: false, error: "Contact us to request more branches." } as const,
+        { status: 403 }
+      );
+    }
+
     const submission = parse(formData, { schema: PurchaseSchema });
 
     if (!submission.value || submission.intent !== "submit") {
@@ -237,6 +255,7 @@ export default function Page() {
   const environment = useEnvironment();
 
   const plan = useCurrentPlan();
+  const showSelfServe = useShowSelfServe();
   const requiresUpgrade =
     plan?.v3Subscription?.plan &&
     limits.used >= plan.v3Subscription.plan.limits.branches.number &&
@@ -254,7 +273,7 @@ export default function Page() {
         </NavBar>
         <PageBody>
           <MainCenteredContainer className="max-w-md">
-            <BranchesNoBranchableEnvironment />
+            <BranchesNoBranchableEnvironment showSelfServe={showSelfServe} />
           </MainCenteredContainer>
         </PageBody>
       </PageContainer>
@@ -322,6 +341,7 @@ export default function Page() {
                 parentEnvironment={branchableEnvironment}
                 limits={limits}
                 canUpgrade={canUpgrade ?? false}
+                showSelfServe={showSelfServe}
               />
             </MainCenteredContainer>
           ) : (
@@ -484,19 +504,26 @@ export default function Page() {
                         planBranchLimit={planBranchLimit}
                       />
                     ) : canUpgrade ? (
-                      <div className="flex items-center gap-3">
-                        <Paragraph variant="small" className="whitespace-nowrap text-text-dimmed">
-                          Upgrade plan for more Preview Branches
-                        </Paragraph>
-                        <LinkButton
-                          to={v3BillingPath(organization)}
-                          variant="secondary/small"
-                          LeadingIcon={ArrowUpCircleIcon}
-                          leadingIconClassName="text-indigo-500"
-                        >
-                          Upgrade
-                        </LinkButton>
-                      </div>
+                      showSelfServe ? (
+                        <div className="flex items-center gap-3">
+                          <Paragraph variant="small" className="whitespace-nowrap text-text-dimmed">
+                            Upgrade plan for more Preview Branches
+                          </Paragraph>
+                          <LinkButton
+                            to={v3BillingPath(organization)}
+                            variant="secondary/small"
+                            LeadingIcon={ArrowUpCircleIcon}
+                            leadingIconClassName="text-indigo-500"
+                          >
+                            Upgrade
+                          </LinkButton>
+                        </div>
+                      ) : (
+                        <Feedback
+                          defaultValue="enterprise"
+                          button={<Button variant="secondary/small">Request more</Button>}
+                        />
+                      )
                     ) : null}
                   </div>
                 </div>
@@ -559,6 +586,7 @@ function UpgradePanel({
   planBranchLimit: number;
 }) {
   const organization = useOrganization();
+  const showSelfServe = useShowSelfServe();
 
   if (canPurchaseBranches && branchPricing) {
     return (
@@ -604,9 +632,16 @@ function UpgradePanel({
         </div>
         <DialogFooter>
           {canUpgrade ? (
-            <LinkButton variant="primary/small" to={v3BillingPath(organization)}>
-              Upgrade
-            </LinkButton>
+            showSelfServe ? (
+              <LinkButton variant="primary/small" to={v3BillingPath(organization)}>
+                Upgrade
+              </LinkButton>
+            ) : (
+              <Feedback
+                defaultValue="enterprise"
+                button={<Button variant="secondary/small">Request more</Button>}
+              />
+            )
           ) : null}
         </DialogFooter>
       </DialogContent>
@@ -632,6 +667,7 @@ function PurchaseBranchesModal({
   planBranchLimit: number;
   triggerButton?: React.ReactNode;
 }) {
+  const showSelfServe = useShowSelfServe();
   const fetcher = useFetcher();
   const lastSubmission =
     fetcher.data && typeof fetcher.data === "object" && "intent" in fetcher.data
@@ -678,6 +714,15 @@ function PurchaseBranchesModal({
 
   const pricePerBranch = branchPricing.centsPerStep / branchPricing.stepSize / 100;
   const title = extraBranches === 0 ? "Purchase extra branches…" : "Add/remove extra branches…";
+
+  if (!showSelfServe) {
+    return (
+      <Feedback
+        defaultValue="enterprise"
+        button={<Button variant="secondary/small">Request more</Button>}
+      />
+    );
+  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.concurrency/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.concurrency/route.tsx
@@ -23,6 +23,7 @@ import simplur from "simplur";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { z } from "zod";
 import { AdminDebugTooltip } from "~/components/admin/debugTooltip";
+import { Feedback } from "~/components/Feedback";
 import { EnvironmentCombo } from "~/components/environments/EnvironmentLabel";
 import {
   MainHorizontallyCenteredContainer,
@@ -52,6 +53,7 @@ import {
 } from "~/components/primitives/Table";
 import { InfoIconTooltip } from "~/components/primitives/Tooltip";
 import { useFeatures } from "~/hooks/useFeatures";
+import { useShowSelfServe } from "~/hooks/useShowSelfServe";
 import { useOrganization } from "~/hooks/useOrganizations";
 import { redirectWithErrorMessage, redirectWithSuccessMessage } from "~/models/message.server";
 import { findProjectBySlug } from "~/models/project.server";
@@ -60,7 +62,11 @@ import {
   type ConcurrencyResult,
   type EnvironmentWithConcurrency,
 } from "~/presenters/v3/ManageConcurrencyPresenter.server";
-import { getPlans } from "~/services/platform.v3.server";
+import {
+  getCurrentPlan,
+  getPlans,
+  getSelfServePurchaseBlockReason,
+} from "~/services/platform.v3.server";
 import { requireUserId } from "~/services/session.server";
 import { formatCurrency, formatNumber } from "~/utils/numberFormatter";
 import { concurrencyPath, EnvironmentParamSchema, v3BillingPath } from "~/utils/pathBuilder";
@@ -184,6 +190,17 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
       request,
       "Concurrency allocated successfully"
     );
+  }
+
+  const currentPlan = await getCurrentPlan(project.organizationId);
+  const purchaseBlockReason = getSelfServePurchaseBlockReason(currentPlan);
+  if (purchaseBlockReason === "plan_unavailable") {
+    submission.error.amount = ["Unable to verify billing status. Please try again."];
+    return json(submission, { status: 503 });
+  }
+  if (purchaseBlockReason === "managed_billing") {
+    submission.error.amount = ["Contact us to request more concurrency."];
+    return json(submission, { status: 403 });
   }
 
   const service = new SetConcurrencyAddOnService();
@@ -530,6 +547,7 @@ function NotUpgradable({ environments }: { environments: EnvironmentWithConcurre
   const { isManagedCloud } = useFeatures();
   const plan = useCurrentPlan();
   const organization = useOrganization();
+  const showSelfServe = useShowSelfServe();
 
   return (
     <div className="flex flex-col gap-3">
@@ -543,9 +561,16 @@ function NotUpgradable({ environments }: { environments: EnvironmentWithConcurre
             upgrade your plan to get more concurrency. You are currently on the{" "}
             {plan?.v3Subscription?.plan?.title ?? "Free"} plan.
           </Paragraph>
-          <LinkButton variant="primary/small" to={v3BillingPath(organization)}>
-            Upgrade for more concurrency
-          </LinkButton>
+          {showSelfServe ? (
+            <LinkButton variant="primary/small" to={v3BillingPath(organization)}>
+              Upgrade for more concurrency
+            </LinkButton>
+          ) : (
+            <Feedback
+              defaultValue="enterprise"
+              button={<Button variant="secondary/small">Contact us</Button>}
+            />
+          )}
         </>
       ) : null}
       <div className="mt-3 flex flex-col gap-3">
@@ -588,6 +613,7 @@ function PurchaseConcurrencyModal({
   maxQuota: number;
   disabled: boolean;
 }) {
+  const showSelfServe = useShowSelfServe();
   const lastSubmission = useActionData();
   const [form, { amount }] = useForm({
     id: "purchase-concurrency",
@@ -628,6 +654,15 @@ function PurchaseConcurrencyModal({
     state === "decrease" ? "text-error" : state === "increase" ? "text-success" : undefined;
 
   const title = extraConcurrency === 0 ? "Purchase extra concurrency" : "Add/remove concurrency";
+
+  if (!showSelfServe) {
+    return (
+      <Feedback
+        defaultValue="enterprise"
+        button={<Button variant="secondary/small">Request more</Button>}
+      />
+    );
+  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.limits/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.limits/route.tsx
@@ -27,6 +27,7 @@ import {
 import { InfoIconTooltip } from "~/components/primitives/Tooltip";
 import { useAutoRevalidate } from "~/hooks/useAutoRevalidate";
 import { useEnvironment } from "~/hooks/useEnvironment";
+import { useShowSelfServe } from "~/hooks/useShowSelfServe";
 import { useOrganization } from "~/hooks/useOrganizations";
 import { useProject } from "~/hooks/useProject";
 import { findProjectBySlug } from "~/models/project.server";
@@ -189,6 +190,8 @@ function CurrentPlanSection({
   isOnTopPlan: boolean;
   billingPath: string;
 }) {
+  const showSelfServe = useShowSelfServe();
+
   return (
     <div className="flex flex-col gap-3">
       <Header2 className="flex items-center gap-1">
@@ -205,10 +208,15 @@ function CurrentPlanSection({
                   button={<Button variant="secondary/small">Request Enterprise</Button>}
                   defaultValue="help"
                 />
-              ) : (
+              ) : showSelfServe ? (
                 <LinkButton to={billingPath} variant="secondary/small">
                   View plans
                 </LinkButton>
+              ) : (
+                <Feedback
+                  defaultValue="enterprise"
+                  button={<Button variant="secondary/small">Contact us</Button>}
+                />
               )}
             </TableCell>
           </TableRow>
@@ -260,6 +268,8 @@ function RateLimitsSection({
   project: ReturnType<typeof useProject>;
   environment: ReturnType<typeof useEnvironment>;
 }) {
+  const showSelfServe = useShowSelfServe();
+
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between">
@@ -325,15 +335,23 @@ function RateLimitsSection({
                 />
               </span>
             </TableHeaderCell>
-            <TableHeaderCell alignment="right">Upgrade</TableHeaderCell>
+            {showSelfServe ? (
+              <TableHeaderCell alignment="right">Upgrade</TableHeaderCell>
+            ) : null}
           </TableRow>
         </TableHeader>
         <TableBody>
-          <RateLimitRow info={rateLimits.api} isOnTopPlan={isOnTopPlan} billingPath={billingPath} />
+          <RateLimitRow
+            info={rateLimits.api}
+            isOnTopPlan={isOnTopPlan}
+            billingPath={billingPath}
+            showSelfServe={showSelfServe}
+          />
           <RateLimitRow
             info={rateLimits.batch}
             isOnTopPlan={isOnTopPlan}
             billingPath={billingPath}
+            showSelfServe={showSelfServe}
           />
         </TableBody>
       </Table>
@@ -345,10 +363,12 @@ function RateLimitRow({
   info,
   isOnTopPlan,
   billingPath,
+  showSelfServe,
 }: {
   info: RateLimitInfo;
   isOnTopPlan: boolean;
   billingPath: string;
+  showSelfServe: boolean;
 }) {
   const maxTokens = info.config.type === "tokenBucket" ? info.config.maxTokens : info.config.tokens;
   const percentage =
@@ -389,27 +409,29 @@ function RateLimitRow({
           <span className="text-text-dimmed">–</span>
         )}
       </TableCell>
-      <TableCell alignment="right">
-        <div className="flex justify-end">
-          {info.name === "Batch rate limit" ? (
-            isOnTopPlan ? (
+      {showSelfServe ? (
+        <TableCell alignment="right">
+          <div className="flex justify-end">
+            {info.name === "Batch rate limit" ? (
+              isOnTopPlan ? (
+                <Feedback
+                  button={<Button variant="secondary/small">Contact us</Button>}
+                  defaultValue="help"
+                />
+              ) : (
+                <LinkButton to={billingPath} variant="secondary/small">
+                  View plans
+                </LinkButton>
+              )
+            ) : (
               <Feedback
                 button={<Button variant="secondary/small">Contact us</Button>}
                 defaultValue="help"
               />
-            ) : (
-              <LinkButton to={billingPath} variant="secondary/small">
-                View plans
-              </LinkButton>
-            )
-          ) : (
-            <Feedback
-              button={<Button variant="secondary/small">Contact us</Button>}
-              defaultValue="help"
-            />
-          )}
-        </div>
-      </TableCell>
+            )}
+          </div>
+        </TableCell>
+      ) : null}
     </TableRow>
   );
 }
@@ -516,6 +538,8 @@ function QuotasSection({
   if (quotas.metricWidgetsPerDashboard) quotaRows.push(quotas.metricWidgetsPerDashboard);
   if (quotas.queryPeriodDays) quotaRows.push(quotas.queryPeriodDays);
 
+  const showSelfServe = useShowSelfServe();
+
   return (
     <div className="flex flex-col gap-3">
       <Header2 className="flex items-center gap-1">
@@ -533,7 +557,9 @@ function QuotasSection({
             <TableHeaderCell alignment="right">Limit</TableHeaderCell>
             <TableHeaderCell alignment="right">Current</TableHeaderCell>
             <TableHeaderCell alignment="right">Source</TableHeaderCell>
-            <TableHeaderCell alignment="right">Upgrade</TableHeaderCell>
+            {showSelfServe ? (
+              <TableHeaderCell alignment="right">Upgrade</TableHeaderCell>
+            ) : null}
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -543,6 +569,7 @@ function QuotasSection({
               quota={quota}
               isOnTopPlan={isOnTopPlan}
               billingPath={billingPath}
+              showSelfServe={showSelfServe}
             />
           ))}
         </TableBody>
@@ -555,10 +582,12 @@ function QuotaRow({
   quota,
   isOnTopPlan,
   billingPath,
+  showSelfServe,
 }: {
   quota: QuotaInfo;
   isOnTopPlan: boolean;
   billingPath: string;
+  showSelfServe: boolean;
 }) {
   // For log retention and query period, we don't show current usage as it's a duration, not a count
   // For widgets per dashboard, the usage varies per dashboard so we don't show a single number
@@ -567,7 +596,7 @@ function QuotaRow({
   const isRetentionQuota = isDurationQuota || isPerItemQuota;
   const isQueueSizeQuota = quota.name === "Max queued runs";
   const hideCurrentUsage = isRetentionQuota || isQueueSizeQuota;
-  
+
   const percentage =
     !hideCurrentUsage && quota.limit && quota.limit > 0 ? quota.currentUsage / quota.limit : null;
 
@@ -582,8 +611,8 @@ function QuotaRow({
         </TableCell>
         <TableCell alignment="right" className="font-medium tabular-nums">
           {quota.limit !== null
-              ? `${formatNumber(quota.limit)} ${quota.limit === 1 ? "day" : "days"}`
-              : "Unlimited"}
+            ? `${formatNumber(quota.limit)} ${quota.limit === 1 ? "day" : "days"}`
+            : "Unlimited"}
         </TableCell>
         <TableCell alignment="right" className="tabular-nums text-text-dimmed">
           –
@@ -591,20 +620,22 @@ function QuotaRow({
         <TableCell alignment="right">
           <SourceBadge source={quota.source} />
         </TableCell>
-        <TableCell alignment="right">
-          <div className="flex justify-end">
-            {canUpgrade ? (
-              <LinkButton to={billingPath} variant="secondary/small">
-                View plans
-              </LinkButton>
-            ) : (
-              <Feedback
-                button={<Button variant="secondary/small">Contact us</Button>}
-                defaultValue="help"
-              />
-            )}
-          </div>
-        </TableCell>
+        {showSelfServe ? (
+          <TableCell alignment="right">
+            <div className="flex justify-end">
+              {canUpgrade ? (
+                <LinkButton to={billingPath} variant="secondary/small">
+                  View plans
+                </LinkButton>
+              ) : (
+                <Feedback
+                  button={<Button variant="secondary/small">Contact us</Button>}
+                  defaultValue="help"
+                />
+              )}
+            </div>
+          </TableCell>
+        ) : null}
       </TableRow>
     );
   }
@@ -678,7 +709,7 @@ function QuotaRow({
       <TableCell alignment="right">
         <SourceBadge source={quota.source} />
       </TableCell>
-      <TableCell alignment="right">{renderUpgrade()}</TableCell>
+      {showSelfServe ? <TableCell alignment="right">{renderUpgrade()}</TableCell> : null}
     </TableRow>
   );
 }
@@ -694,6 +725,7 @@ function FeaturesSection({
 }) {
   // For staging environment: show View plans if not enabled (i.e., on Free plan)
   const stagingUpgradeType = features.hasStagingEnvironment.enabled ? "none" : "view-plans";
+  const showSelfServe = useShowSelfServe();
 
   return (
     <div className="flex flex-col gap-3">
@@ -706,7 +738,9 @@ function FeaturesSection({
           <TableRow>
             <TableHeaderCell>Feature</TableHeaderCell>
             <TableHeaderCell alignment="right">Status</TableHeaderCell>
-            <TableHeaderCell alignment="right">Upgrade</TableHeaderCell>
+            {showSelfServe ? (
+              <TableHeaderCell alignment="right">Upgrade</TableHeaderCell>
+            ) : null}
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -714,16 +748,19 @@ function FeaturesSection({
             feature={features.hasStagingEnvironment}
             upgradeType={stagingUpgradeType}
             billingPath={billingPath}
+            showSelfServe={showSelfServe}
           />
           <FeatureRow
             feature={features.support}
             upgradeType={isOnTopPlan ? "contact-us" : "view-plans"}
             billingPath={billingPath}
+            showSelfServe={showSelfServe}
           />
           <FeatureRow
             feature={features.includedUsage}
             upgradeType={isOnTopPlan ? "contact-us" : "view-plans"}
             billingPath={billingPath}
+            showSelfServe={showSelfServe}
           />
         </TableBody>
       </Table>
@@ -735,10 +772,12 @@ function FeatureRow({
   feature,
   upgradeType,
   billingPath,
+  showSelfServe,
 }: {
   feature: FeatureInfo;
   upgradeType: "view-plans" | "contact-us" | "none";
   billingPath: string;
+  showSelfServe: boolean;
 }) {
   const displayValue = () => {
     if (feature.name === "Included compute" && typeof feature.value === "number") {
@@ -795,7 +834,7 @@ function FeatureRow({
         <InfoIconTooltip content={feature.description} disableHoverableContent />
       </TableCell>
       <TableCell alignment="right">{displayValue()}</TableCell>
-      <TableCell alignment="right">{renderUpgrade()}</TableCell>
+      {showSelfServe ? <TableCell alignment="right">{renderUpgrade()}</TableCell> : null}
     </TableRow>
   );
 }

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.tasks.scheduled.$taskParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.tasks.scheduled.$taskParam/route.tsx
@@ -21,7 +21,7 @@ import {
   DialogHeader,
   DialogTrigger,
 } from "~/components/primitives/Dialog";
-import { PurchaseSchedulesModal } from "~/components/schedules/PurchaseSchedulesModal";
+import { ScheduleLimitActions } from "~/components/schedules/ScheduleLimitActions";
 import { SchedulesUsageBar } from "~/components/schedules/SchedulesUsageBar";
 import { useCurrentPlan } from "../_app.orgs.$organizationSlug/route";
 import { CopyableText } from "~/components/primitives/CopyableText";
@@ -439,21 +439,18 @@ function CreateScheduleButton({
             You've used {limits.used}/{limits.limit} of your schedules.
           </DialogDescription>
           <DialogFooter>
-            {canPurchaseSchedules && schedulePricing ? (
-              <PurchaseSchedulesModal
-                actionPath={addOnPath}
-                schedulePricing={schedulePricing}
-                extraSchedules={extraSchedules}
-                usedSchedules={limits.used}
-                maxQuota={maxScheduleQuota}
-                planScheduleLimit={planScheduleLimit}
-                triggerButton={<Button variant="primary/small">Purchase more…</Button>}
-              />
-            ) : canUpgrade ? (
-              <LinkButton variant="primary/small" to={v3BillingPath(organization)}>
-                Upgrade
-              </LinkButton>
-            ) : null}
+            <ScheduleLimitActions
+              actionPath={addOnPath}
+              canPurchaseSchedules={canPurchaseSchedules}
+              schedulePricing={schedulePricing}
+              extraSchedules={extraSchedules}
+              limits={limits}
+              maxScheduleQuota={maxScheduleQuota}
+              planScheduleLimit={planScheduleLimit}
+              canUpgrade={canUpgrade}
+              organization={organization}
+              variant="dialog"
+            />
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.settings.billing-alerts/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.settings.billing-alerts/route.tsx
@@ -28,7 +28,7 @@ import { InfoIconTooltip } from "~/components/primitives/Tooltip";
 import { prisma } from "~/db.server";
 import { featuresForRequest } from "~/features.server";
 import { redirectWithErrorMessage, redirectWithSuccessMessage } from "~/models/message.server";
-import { getBillingAlerts, setBillingAlert } from "~/services/platform.v3.server";
+import { getBillingAlerts, getCurrentPlan, setBillingAlert } from "~/services/platform.v3.server";
 import { requireUserId } from "~/services/session.server";
 import { formatCurrency, formatNumber } from "~/utils/numberFormatter";
 import {
@@ -36,6 +36,7 @@ import {
   OrganizationParamsSchema,
   organizationPath,
   v3BillingAlertsPath,
+  v3BillingPath,
 } from "~/utils/pathBuilder";
 import { useCurrentPlan } from "../_app.orgs.$organizationSlug/route";
 
@@ -62,6 +63,11 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 
   if (!organization) {
     throw new Response(null, { status: 404, statusText: "Organization not found" });
+  }
+
+  const currentPlan = await getCurrentPlan(organization.id);
+  if (currentPlan?.v3Subscription?.showSelfServe === false) {
+    return redirect(v3BillingPath({ slug: organizationSlug }));
   }
 
   const [error, alerts] = await tryCatch(getBillingAlerts(organization.id));
@@ -108,6 +114,23 @@ export const action: ActionFunction = async ({ request, params }) => {
   const userId = await requireUserId(request);
   const { organizationSlug } = OrganizationParamsSchema.parse(params);
 
+  const organization = await prisma.organization.findFirst({
+    where: { slug: organizationSlug, members: { some: { userId } } },
+  });
+
+  if (!organization) {
+    return redirectWithErrorMessage(
+      v3BillingPath({ slug: organizationSlug }),
+      request,
+      "You are not authorized to update billing alerts"
+    );
+  }
+
+  const currentPlan = await getCurrentPlan(organization.id);
+  if (currentPlan?.v3Subscription?.showSelfServe === false) {
+    return redirect(v3BillingPath({ slug: organizationSlug }));
+  }
+
   const formData = await request.formData();
   const submission = parse(formData, { schema });
 
@@ -116,18 +139,6 @@ export const action: ActionFunction = async ({ request, params }) => {
   }
 
   try {
-    const organization = await prisma.organization.findFirst({
-      where: { slug: organizationSlug, members: { some: { userId } } },
-    });
-
-    if (!organization) {
-      return redirectWithErrorMessage(
-        v3BillingAlertsPath({ slug: organizationSlug }),
-        request,
-        "You are not authorized to update billing alerts"
-      );
-    }
-
     const [error, updatedAlert] = await tryCatch(
       setBillingAlert(organization.id, {
         ...submission.value,

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.settings.billing/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.settings.billing/route.tsx
@@ -1,11 +1,14 @@
-import { CalendarDaysIcon, StarIcon } from "@heroicons/react/20/solid";
+import { CalendarDaysIcon, CreditCardIcon, StarIcon } from "@heroicons/react/20/solid";
 import { type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { type PlanDefinition } from "@trigger.dev/platform";
 import { redirect, typedjson, useTypedLoaderData } from "remix-typedjson";
-import { PageBody, PageContainer } from "~/components/layout/AppLayout";
-import { LinkButton } from "~/components/primitives/Buttons";
+import { Feedback } from "~/components/Feedback";
+import { MainCenteredContainer, PageBody, PageContainer } from "~/components/layout/AppLayout";
+import { Button, LinkButton } from "~/components/primitives/Buttons";
 import { DateTime } from "~/components/primitives/DateTime";
+import { InfoPanel } from "~/components/primitives/InfoPanel";
 import { NavBar, PageAccessories, PageTitle } from "~/components/primitives/PageHeader";
+import { Paragraph } from "~/components/primitives/Paragraph";
 import { prisma } from "~/db.server";
 import { featuresForRequest } from "~/features.server";
 import { getCurrentPlan, getPlans } from "~/services/platform.v3.server";
@@ -14,6 +17,7 @@ import {
   OrganizationParamsSchema,
   organizationPath,
   v3StripePortalPath,
+  v3UsagePath,
 } from "~/utils/pathBuilder";
 import { PricingPlans } from "../resources.orgs.$organizationSlug.select-plan";
 import { type MetaFunction } from "@remix-run/react";
@@ -36,11 +40,6 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     return redirect(organizationPath({ slug: organizationSlug }));
   }
 
-  const plans = await getPlans();
-  if (!plans) {
-    throw new Response(null, { status: 404, statusText: "Plans not found" });
-  }
-
   const organization = await prisma.organization.findFirst({
     where: { slug: organizationSlug, members: { some: { userId } } },
   });
@@ -50,6 +49,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   }
 
   const currentPlan = await getCurrentPlan(organization.id);
+  const showSelfServe = currentPlan?.v3Subscription?.showSelfServe !== false;
 
   //periods
   const periodStart = new Date();
@@ -69,7 +69,25 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const url = new URL(request.url);
   const message = url.searchParams.get("message");
 
+  if (!showSelfServe) {
+    return typedjson({
+      showSelfServe: false as const,
+      ...currentPlan,
+      organizationSlug,
+      periodStart,
+      periodEnd,
+      daysRemaining,
+      message,
+    });
+  }
+
+  const plans = await getPlans();
+  if (!plans) {
+    throw new Response(null, { status: 404, statusText: "Plans not found" });
+  }
+
   return typedjson({
+    showSelfServe: true as const,
     ...plans,
     ...currentPlan,
     organizationSlug,
@@ -81,22 +99,23 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 }
 
 export default function ChoosePlanPage() {
+  const loaderData = useTypedLoaderData<typeof loader>();
   const {
-    plans,
-    addOnPricing,
+    showSelfServe,
     v3Subscription,
     organizationSlug,
     periodStart,
     periodEnd,
     daysRemaining,
     message,
-  } = useTypedLoaderData<typeof loader>();
+  } = loaderData;
+
   return (
     <PageContainer>
       <NavBar>
         <PageTitle title="Billing" />
         <PageAccessories>
-          {v3Subscription?.isPaying && (
+          {v3Subscription?.isPaying && showSelfServe && (
             <>
               <LinkButton
                 to={v3StripePortalPath({ slug: organizationSlug })}
@@ -114,42 +133,70 @@ export default function ChoosePlanPage() {
           )}
         </PageAccessories>
       </NavBar>
-      <PageBody scrollable={true}>
-        <div className="flex flex-col gap-3">
-          {message && (
-            <Callout variant="idea" className="mb-2">
-              {message}
-            </Callout>
-          )}
-          <div className="flex flex-col gap-y-3 divide-grid-bright rounded-sm border border-grid-bright bg-background-bright py-2 pr-1 text-text-bright lg:w-fit lg:flex-row lg:items-center lg:divide-x">
-            <div className="flex gap-2 px-3 lg:items-center">
-              <StarIcon className="size-5 min-w-5 lg:-mt-0.5" />
-              {planLabel(v3Subscription?.plan, v3Subscription?.canceledAt !== undefined, periodEnd)}
-            </div>
-            {v3Subscription?.isPaying ? (
+      <PageBody scrollable={showSelfServe}>
+        {showSelfServe ? (
+          <div className="flex flex-col gap-3">
+            {message && (
+              <Callout variant="idea" className="mb-2">
+                {message}
+              </Callout>
+            )}
+            <div className="flex flex-col gap-y-3 divide-grid-bright rounded-sm border border-grid-bright bg-background-bright py-2 pr-1 text-text-bright lg:w-fit lg:flex-row lg:items-center lg:divide-x">
               <div className="flex gap-2 px-3 lg:items-center">
-                <CalendarDaysIcon className="size-5 min-w-5 lg:-mt-0.5" />
-                Billing period: <DateTime
-                  date={periodStart}
-                  includeTime={false}
-                  timeZone="UTC"
-                />{" "}
-                to <DateTime date={periodEnd} includeTime={false} timeZone="UTC" /> ({daysRemaining}{" "}
-                days remaining)
+                <StarIcon className="size-5 min-w-5 lg:-mt-0.5" />
+                {planLabel(
+                  v3Subscription?.plan,
+                  v3Subscription?.canceledAt !== undefined,
+                  periodEnd
+                )}
               </div>
-            ) : null}
+              {v3Subscription?.isPaying ? (
+                <div className="flex gap-2 px-3 lg:items-center">
+                  <CalendarDaysIcon className="size-5 min-w-5 lg:-mt-0.5" />
+                  Billing period: <DateTime
+                    date={periodStart}
+                    includeTime={false}
+                    timeZone="UTC"
+                  />{" "}
+                  to <DateTime date={periodEnd} includeTime={false} timeZone="UTC" /> (
+                  {daysRemaining} days remaining)
+                </div>
+              ) : null}
+            </div>
+            <div>
+              <PricingPlans
+                plans={loaderData.plans}
+                concurrencyAddOnPricing={loaderData.addOnPricing.concurrency}
+                subscription={v3Subscription}
+                organizationSlug={organizationSlug}
+                hasPromotedPlan={false}
+                periodEnd={periodEnd}
+              />
+            </div>
           </div>
-          <div>
-            <PricingPlans
-              plans={plans}
-              concurrencyAddOnPricing={addOnPricing.concurrency}
-              subscription={v3Subscription}
-              organizationSlug={organizationSlug}
-              hasPromotedPlan={false}
-              periodEnd={periodEnd}
-            />
-          </div>
-        </div>
+        ) : (
+          <MainCenteredContainer className="max-w-md">
+            <InfoPanel
+              title="Billing"
+              icon={CreditCardIcon}
+              iconClassName="text-emerald-500"
+              panelClassName="max-w-full"
+              accessory={
+                <Feedback
+                  defaultValue="enterprise"
+                  button={<Button variant="secondary/small">Contact us</Button>}
+                />
+              }
+            >
+              <Paragraph spacing variant="small">
+                Your billing is managed by our team.
+              </Paragraph>
+              <Paragraph spacing variant="small">
+                Get in touch for invoices, plan changes, or other billing questions.
+              </Paragraph>
+            </InfoPanel>
+          </MainCenteredContainer>
+        )}
       </PageBody>
     </PageContainer>
   );
@@ -161,7 +208,7 @@ function planLabel(plan: PlanDefinition | undefined, canceled: boolean, periodEn
   }
 
   if (plan.type === "enterprise") {
-    return `You're on the Enterprise plan`;
+    return "You're on the Enterprise plan";
   }
 
   const text = `You're on the $${plan.tierPrice}/mo ${plan.title} plan`;

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.settings.roles/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.settings.roles/route.tsx
@@ -3,6 +3,7 @@ import { type MetaFunction } from "@remix-run/react";
 import { useState } from "react";
 import { type UseDataFunctionReturn, typedjson, useTypedLoaderData } from "remix-typedjson";
 import { z } from "zod";
+import { Feedback } from "~/components/Feedback";
 import { PageBody, PageContainer } from "~/components/layout/AppLayout";
 import { Badge } from "~/components/primitives/Badge";
 import { Button } from "~/components/primitives/Buttons";
@@ -24,7 +25,7 @@ import { $replica } from "~/db.server";
 import { useOrganization } from "~/hooks/useOrganizations";
 import { rbac } from "~/services/rbac.server";
 import { dashboardLoader } from "~/services/routeBuilders/dashboardBuilder";
-import { useCurrentPlan } from "../_app.orgs.$organizationSlug/route";
+import { useShowSelfServe } from "~/hooks/useShowSelfServe";
 import { TextLink } from "~/components/primitives/TextLink";
 
 export const meta: MetaFunction = () => {
@@ -68,10 +69,7 @@ export const loader = dashboardLoader(
         rbac.getAssignableRoleIds(orgId),
         rbac.allPermissions(orgId),
         rbac.systemRoles(orgId),
-        // OSS self-host: no enterprise plugin → no role infrastructure to
-        // show. Render a "roles aren't available" layout in that case
-        // rather than the plan-upsell empty state (which assumes a cloud
-        // plan and would be misleading).
+        // OSS self-host has no RBAC plugin.
         rbac.isUsingPlugin(),
       ]);
 
@@ -90,33 +88,19 @@ type LoaderRole = LoaderData["roles"][number];
 type LoaderPermission = LoaderData["allPermissions"][number];
 type RolePermission = LoaderRole["permissions"][number];
 
-// Permissions are bucketed by `permission.group` from the plugin.
-// Section order = first-seen order in `allPermissions()`. Permissions
-// without a group fall into "Other" at the bottom.
+// Ungrouped permissions fall into "Other".
 const FALLBACK_GROUP = "Other";
 
 export default function Page() {
   const { roles, assignableRoleIds, allPermissions, systemRoles, isUsingPlugin } =
     useTypedLoaderData<typeof loader>();
   const organization = useOrganization();
-  const plan = useCurrentPlan();
-  const planCode = plan?.v3Subscription?.plan?.code;
-  const isEnterprise = planCode === "enterprise";
+  const showSelfServe = useShowSelfServe();
 
-  // Map role-id → role for fast cell lookup. Each role's permissions are
-  // already the expanded `effectivePermissions` output (system roles
-  // populated server-side; custom roles too) so cells just filter that
-  // list by permission name.
   const rolesById = new Map<string, LoaderRole>(roles.map((r) => [r.id, r]));
   const assignable = new Set(assignableRoleIds);
 
-  // Column ordering follows the plugin's canonical systemRoles order
-  // (highest authority first), then any custom roles in the order
-  // rbac.allRoles returned them. systemRoles is null when no plugin is
-  // installed; fall through to whatever order rbac.allRoles returns.
-  // Each entry's `available` flag reflects plan-tier eligibility — we
-  // render unavailable system roles too, but PlanBadge tags them so
-  // customers see the comparison and know what an upgrade unlocks.
+  // System roles first (plugin order), then custom roles.
   const systemRoleOrder = systemRoles ?? [];
   const systemRoleIdSet = new Set(systemRoleOrder.map((r) => r.id));
   const systemColumns = systemRoleOrder.flatMap((meta) => {
@@ -134,12 +118,8 @@ export default function Page() {
     <PageContainer>
       <NavBar>
         <PageTitle title="Roles" />
-        {/* Suppress the Enterprise-upsell button on OSS — there's no
-            plan to upgrade to in a self-hosted deployment, and the
-            dialog copy ("Available on the Enterprise plan") doesn't
-            apply. The not-supported empty state below makes the
-            absence of role infrastructure clear instead. */}
-        {isUsingPlugin && !isEnterprise ? <CreateRoleUpsell /> : null}
+        {/* Hide on OSS self-host and managed customers (!showSelfServe). */}
+        {isUsingPlugin && showSelfServe ? <RequestCustomRoles /> : null}
       </NavBar>
       <PageBody scrollable={false}>
         <div className="grid max-h-full min-h-full grid-rows-[auto_1fr]">
@@ -152,7 +132,7 @@ export default function Page() {
           </div>
           <div className="overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600">
             {columns.length === 0 ? (
-              <EmptyState isUsingPlugin={isUsingPlugin} />
+              <EmptyState isUsingPlugin={isUsingPlugin} showSelfServe={showSelfServe} />
             ) : (
               <Table containerClassName="border-t-0">
                 <TableHeader>
@@ -223,17 +203,14 @@ export default function Page() {
   );
 }
 
-function EmptyState({ isUsingPlugin }: { isUsingPlugin: boolean }) {
-  // Two distinct empty states:
-  //
-  // 1. Plugin loaded, but rbac.allRoles returned nothing the org can
-  //    use under its plan tier. The plan-upsell copy is correct —
-  //    upgrade unlocks the role infrastructure.
-  // 2. No plugin loaded (OSS self-host). There's no "plan" to upgrade
-  //    to. RBAC simply isn't part of this deployment; we use a
-  //    permissive ability for every authenticated user and rely on
-  //    org-membership for access control. Surface that honestly
-  //    instead of dangling a fake upgrade carrot.
+function EmptyState({
+  isUsingPlugin,
+  showSelfServe,
+}: {
+  isUsingPlugin: boolean;
+  showSelfServe: boolean;
+}) {
+  // OSS self-host vs plan-gated empty state.
   if (!isUsingPlugin) {
     return (
       <div className="flex flex-col items-center gap-2 p-8 text-center">
@@ -249,8 +226,16 @@ function EmptyState({ isUsingPlugin }: { isUsingPlugin: boolean }) {
     <div className="flex flex-col items-center gap-2 p-8 text-center">
       <Header3>No roles available on this plan.</Header3>
       <Paragraph variant="small" className="text-text-dimmed">
-        Upgrade to Pro to unlock RBAC.
+        {showSelfServe
+          ? "Upgrade to Pro to unlock RBAC."
+          : "Contact us to discuss RBAC for your organization."}
       </Paragraph>
+      {!showSelfServe ? (
+        <Feedback
+          defaultValue="enterprise"
+          button={<Button variant="secondary/small">Contact us</Button>}
+        />
+      ) : null}
     </div>
   );
 }
@@ -264,23 +249,14 @@ function PlanBadge({
   assignable: ReadonlySet<string>;
   systemRoleIdSet: ReadonlySet<string>;
 }) {
-  // Roles the org's plan doesn't permit get a small upgrade-tier hint
-  // in the column header. The cell rendering is identical regardless
-  // — the comparison value is still useful even on Free/Hobby.
   if (assignable.has(roleId)) return null;
-  // System roles render as "Pro" (the gating tier where they unlock —
-  // Free/Hobby see Owner+Admin only, Pro adds the rest). Custom roles
-  // render as "Enterprise" — only Enterprise plans can create or assign
-  // them.
+  // Unassignable system roles → Pro; custom roles → Enterprise.
   if (systemRoleIdSet.has(roleId)) {
     return <Badge variant="extra-small">Pro</Badge>;
   }
   return <Badge variant="extra-small">Enterprise</Badge>;
 }
 
-// Render a single (role × permission) cell. Filters the role's
-// effectivePermissions list to entries matching this permission name
-// and emits an icon + optional condition badge based on the rules.
 function RoleCell({
   permissionName,
   rolePermissions,
@@ -291,7 +267,6 @@ function RoleCell({
   const matching = rolePermissions.filter((p) => p.name === permissionName);
 
   if (matching.length === 0) {
-    // No rule matches — the role denies this permission by omission.
     return (
       <span className="text-text-dimmed" aria-label="Not granted">
         <XMarkIcon className="size-4" />
@@ -302,8 +277,6 @@ function RoleCell({
   const allowed = matching.filter((p) => !p.inverted);
   const denied = matching.filter((p) => p.inverted);
 
-  // Only inverted rules apply — the role explicitly denies this
-  // permission. Render as ✗ in error colour.
   if (allowed.length === 0) {
     return (
       <span className="text-error" aria-label="Denied">
@@ -312,10 +285,6 @@ function RoleCell({
     );
   }
 
-  // At least one allow rule applies. If there's a conditional cannot
-  // rule, replace the ✓ with just the condition label so the user sees
-  // the restriction without a misleading tick. Plain unconditional
-  // allow keeps the ✓.
   const conditionalDeny = denied.find((p) => p.conditions);
   if (conditionalDeny?.conditions) {
     return (
@@ -329,10 +298,7 @@ function RoleCell({
   );
 }
 
-// Render a CASL conditions object into a tier badge label. Only
-// `envType` is recognised today (the catalogue's only allowed condition);
-// extending this requires adding a new branch when ALLOWED_CONDITIONS
-// grows.
+// Only `envType` is supported today.
 function conditionLabel(conditions: Record<string, unknown>): string {
   if (typeof conditions.envType === "string") {
     if (conditions.envType === "PRODUCTION") return "Non-prod only";
@@ -344,9 +310,6 @@ function conditionLabel(conditions: Record<string, unknown>): string {
 function groupPermissions(
   permissions: LoaderPermission[]
 ): { group: string; permissions: LoaderPermission[] }[] {
-  // Insertion-ordered map: groups appear in the order their first
-  // permission was seen. Plugins that want a specific section order
-  // just emit permissions in that order from `allPermissions()`.
   const buckets = new Map<string, LoaderPermission[]>();
   for (const permission of permissions) {
     const group = permission.group ?? FALLBACK_GROUP;
@@ -357,7 +320,7 @@ function groupPermissions(
   return Array.from(buckets, ([group, permissions]) => ({ group, permissions }));
 }
 
-function CreateRoleUpsell() {
+function RequestCustomRoles() {
   const [open, setOpen] = useState(false);
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.settings.team/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.settings.team/route.tsx
@@ -15,6 +15,7 @@ import { useEffect, useRef, useState } from "react";
 import { type UseDataFunctionReturn, typedjson, useTypedLoaderData } from "remix-typedjson";
 import invariant from "tiny-invariant";
 import { z } from "zod";
+import { Feedback } from "~/components/Feedback";
 import { UserAvatar } from "~/components/UserProfilePhoto";
 import { AdminDebugTooltip } from "~/components/admin/debugTooltip";
 import { PageBody, PageContainer } from "~/components/layout/AppLayout";
@@ -45,11 +46,13 @@ import { Select, SelectItem, SelectLinkItem } from "~/components/primitives/Sele
 import { SpinnerWhite } from "~/components/primitives/Spinner";
 import { SimpleTooltip } from "~/components/primitives/Tooltip";
 import { $replica } from "~/db.server";
+import { useShowSelfServe } from "~/hooks/useShowSelfServe";
 import { useOrganization } from "~/hooks/useOrganizations";
 import { useUser } from "~/hooks/useUser";
 import { removeTeamMember } from "~/models/member.server";
 import { redirectWithSuccessMessage } from "~/models/message.server";
 import { TeamPresenter } from "~/presenters/TeamPresenter.server";
+import { getCurrentPlan, getSelfServePurchaseBlockReason } from "~/services/platform.v3.server";
 import { rbac } from "~/services/rbac.server";
 import { dashboardAction, dashboardLoader } from "~/services/routeBuilders/dashboardBuilder";
 import { cn } from "~/utils/cn";
@@ -210,6 +213,21 @@ export const action = dashboardAction(
         return json({ ok: false, error: "Organization not found" } as const);
       }
 
+      const currentPlan = await getCurrentPlan(orgId);
+      const purchaseBlockReason = getSelfServePurchaseBlockReason(currentPlan);
+      if (purchaseBlockReason === "plan_unavailable") {
+        return json(
+          { ok: false, error: "Unable to verify billing status. Please try again." } as const,
+          { status: 503 }
+        );
+      }
+      if (purchaseBlockReason === "managed_billing") {
+        return json(
+          { ok: false, error: "Contact us to request more seats." } as const,
+          { status: 403 }
+        );
+      }
+
       const submission = parse(formData, { schema: PurchaseSchema });
 
       if (!submission.value || submission.intent !== "submit") {
@@ -310,6 +328,7 @@ export default function Page() {
   const organization = useOrganization();
 
   const plan = useCurrentPlan();
+  const showSelfServe = useShowSelfServe();
   const requiresUpgrade = limits.used >= limits.limit;
   const usageRatio = limits.limit > 0 ? Math.min(limits.used / limits.limit, 1) : 0;
   const canUpgrade =
@@ -515,9 +534,16 @@ export default function Page() {
                   planSeatLimit={planSeatLimit}
                 />
               ) : canUpgrade ? (
-                <LinkButton to={v3BillingPath(organization)} variant="primary/small">
-                  Upgrade
-                </LinkButton>
+                showSelfServe ? (
+                  <LinkButton to={v3BillingPath(organization)} variant="primary/small">
+                    Upgrade
+                  </LinkButton>
+                ) : (
+                  <Feedback
+                    defaultValue="enterprise"
+                    button={<Button variant="secondary/small">Request more</Button>}
+                  />
+                )
               ) : null}
             </div>
           </div>
@@ -841,6 +867,7 @@ export function PurchaseSeatsModal({
   planSeatLimit: number;
   triggerButton?: React.ReactElement;
 }) {
+  const showSelfServe = useShowSelfServe();
   const fetcher = useFetcher();
   const organization = useOrganization();
   const lastSubmission =
@@ -888,6 +915,15 @@ export function PurchaseSeatsModal({
 
   const pricePerSeat = seatPricing.centsPerStep / seatPricing.stepSize / 100;
   const title = extraSeats === 0 ? "Purchase extra seats…" : "Add/remove extra seats…";
+
+  if (!showSelfServe) {
+    return (
+      <Feedback
+        defaultValue="enterprise"
+        button={<Button variant="secondary/small">Request more</Button>}
+      />
+    );
+  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.schedules-addon.ts
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.schedules-addon.ts
@@ -3,6 +3,7 @@ import { type ActionFunctionArgs, json } from "@remix-run/server-runtime";
 import { tryCatch } from "@trigger.dev/core/v3";
 import { z } from "zod";
 import { prisma } from "~/db.server";
+import { getCurrentPlan, getSelfServePurchaseBlockReason } from "~/services/platform.v3.server";
 import { requireUserId } from "~/services/session.server";
 import { SetSchedulesAddOnService } from "~/v3/services/setSchedulesAddOn.server";
 
@@ -32,6 +33,21 @@ export async function action({ request, params }: ActionFunctionArgs) {
   });
   if (!organization) {
     return json({ error: "Organization not found" }, { status: 404 });
+  }
+
+  const currentPlan = await getCurrentPlan(organization.id);
+  const purchaseBlockReason = getSelfServePurchaseBlockReason(currentPlan);
+  if (purchaseBlockReason === "plan_unavailable") {
+    return json(
+      { ok: false, error: "Unable to verify billing status. Please try again." } as const,
+      { status: 503 }
+    );
+  }
+  if (purchaseBlockReason === "managed_billing") {
+    return json(
+      { ok: false, error: "Contact us to request more schedules." } as const,
+      { status: 403 }
+    );
   }
 
   const formData = await request.formData();

--- a/apps/webapp/app/services/platform.v3.server.ts
+++ b/apps/webapp/app/services/platform.v3.server.ts
@@ -255,6 +255,30 @@ export async function getCurrentPlan(orgId: string) {
   }
 }
 
+export type SelfServePurchaseBlockReason = "plan_unavailable" | "managed_billing";
+
+/**
+ * When cloud billing is configured, self-serve purchase endpoints must fail closed
+ * if the current plan can't be loaded or the org is on managed billing.
+ */
+export function getSelfServePurchaseBlockReason(
+  currentPlan: Awaited<ReturnType<typeof getCurrentPlan>>
+): SelfServePurchaseBlockReason | undefined {
+  if (!isBillingConfigured()) {
+    return undefined;
+  }
+
+  if (!currentPlan) {
+    return "plan_unavailable";
+  }
+
+  if (currentPlan.v3Subscription?.showSelfServe === false) {
+    return "managed_billing";
+  }
+
+  return undefined;
+}
+
 export async function getLimits(orgId: string) {
   if (!client) return undefined;
 


### PR DESCRIPTION
### Summary 
Self-serve billing UI is now hidden for managed-billing organizations.

Plan pickers, upgrade actions, billing alerts, and related upgrade prompts are replaced with a "Contact us" option where appropriate.

Uses the new showSelfServe subscription flag, defaulting to true for existing self-serve organizations.

### Testing

- [x] billing pages render correctly for self-serve organizations.
- [x] managed-billing organizations no longer see self-serve upgrade flows.
- [x] "Contact us" actions are shown instead of upgrade actions where applicable.

### Changelog

Hide self-serve billing flows for managed-billing organizations behind the new showSelfServe subscription flag.