### PR TITLE
fix(webapp): convert epoch-ms to BigInt before multiplying to nanoseconds

### DIFF
--- a/.server-changes/fix-otlp-nanosecond-overflow.md
+++ b/.server-changes/fix-otlp-nanosecond-overflow.md
@@ -1,0 +1,12 @@
+---
+area: webapp
+type: fix
+---
+
+Fix OTLP nanosecond-timestamp overflow in the v3 event repository. Four call sites computed `BigInt(date.getTime() * 1_000_000)` — the multiplication runs in float-land before the BigInt conversion, and `epoch_ms * 1e6` is ~1.7e18, well past `Number.MAX_SAFE_INTEGER` (~9e15). The result loses ~256 ns of precision on ~0.2% of calls, which can disorder spans that finish near a millisecond boundary. Convert to BigInt first (`BigInt(ms) * BigInt(1_000_000)`) to match the existing `convertDateToNanoseconds()` pattern in the same file.
+
+Sites fixed:
+- `apps/webapp/app/v3/eventRepository/common.server.ts:getNowInNanoseconds`
+- `apps/webapp/app/v3/eventRepository/common.server.ts:calculateDurationFromStart`
+- `apps/webapp/app/v3/eventRepository/index.server.ts:recordRunDebugLog`
+- `apps/webapp/app/v3/runEngineHandlers.server.ts` retry event recording

--- a/apps/webapp/app/v3/eventRepository/common.server.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.ts
@@ -21,7 +21,10 @@ export function extractContextFromCarrier(carrier: Record<string, unknown>) {
 }
 
 export function getNowInNanoseconds(): bigint {
-  return BigInt(new Date().getTime() * 1_000_000);
+  // Convert to BigInt BEFORE multiplying — epoch-ms times 1e6 is ~1.7e18,
+  // which exceeds Number.MAX_SAFE_INTEGER (~9e15) and loses ~256 ns of
+  // precision on ~0.2 % of calls when done in float-land.
+  return BigInt(new Date().getTime()) * BigInt(1_000_000);
 }
 
 export function getDateFromNanoseconds(nanoseconds: bigint): Date {
@@ -35,7 +38,11 @@ export function calculateDurationFromStart(
 ) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  const duration = Number(BigInt($endtime.getTime() * 1_000_000) - startTime);
+  // Convert to BigInt BEFORE multiplying — same overflow class as
+  // `getNowInNanoseconds()` above; the float-land multiply silently loses
+  // ~256 ns of precision and can disorder spans that complete close to the
+  // start of a millisecond boundary.
+  const duration = Number(BigInt($endtime.getTime()) * BigInt(1_000_000) - startTime);
 
   if (minimumDuration && duration < minimumDuration) {
     return minimumDuration;

--- a/apps/webapp/app/v3/eventRepository/index.server.ts
+++ b/apps/webapp/app/v3/eventRepository/index.server.ts
@@ -262,7 +262,11 @@ async function recordRunEvent(
         runId: foundRun.friendlyId,
         ...attributes,
       },
-      startTime: BigInt((startTime?.getTime() ?? Date.now()) * 1_000_000),
+      // Convert to BigInt BEFORE multiplying — see `getNowInNanoseconds()` /
+      // `convertDateToNanoseconds()` in common.server.ts. The float-land
+      // multiply overflows Number.MAX_SAFE_INTEGER and silently loses
+      // ~256 ns of precision.
+      startTime: BigInt(startTime?.getTime() ?? Date.now()) * BigInt(1_000_000),
       ...optionsRest,
     });
 

--- a/apps/webapp/app/v3/runEngineHandlers.server.ts
+++ b/apps/webapp/app/v3/runEngineHandlers.server.ts
@@ -521,7 +521,9 @@ export function registerRunEngineEventBusHandlers() {
         );
 
         await eventRepository.recordEvent(retryMessage, {
-          startTime: BigInt(time.getTime() * 1000000),
+          // Convert to BigInt BEFORE multiplying — float-land multiply
+          // overflows Number.MAX_SAFE_INTEGER and loses ~256 ns of precision.
+          startTime: BigInt(time.getTime()) * BigInt(1_000_000),
           taskSlug: run.taskIdentifier,
           environment,
           attributes: {


### PR DESCRIPTION
Closes #3292.

## Summary

Four sites in the v3 event repository computed `BigInt(date.getTime() * 1_000_000)`. The multiplication runs in float-land before the BigInt conversion, and `epoch_ms * 1e6` is ~1.7e18 — well past `Number.MAX_SAFE_INTEGER` (~9e15). The result loses ~256 ns of precision on ~0.2 % of calls, which can disorder spans that finish near a millisecond boundary.

The corrected pattern — `BigInt(ms) * BigInt(1_000_000)` — already exists in `convertDateToNanoseconds()` in the same file; the buggy functions just didn't use it.

## Sites fixed

```ts
// Before (each site)
BigInt(date.getTime() * 1_000_000)

// After
BigInt(date.getTime()) * BigInt(1_000_000)
```

- `apps/webapp/app/v3/eventRepository/common.server.ts:getNowInNanoseconds`
- `apps/webapp/app/v3/eventRepository/common.server.ts:calculateDurationFromStart`
- `apps/webapp/app/v3/eventRepository/index.server.ts:recordRunDebugLog`
- `apps/webapp/app/v3/runEngineHandlers.server.ts` retry event recording

`.server-changes/fix-otlp-nanosecond-overflow.md` added per the webapp-only convention.