### PR TITLE
test(webapp): use relative fixture dates in runs cursor pagination tests

### DIFF
--- a/apps/webapp/test/runsRepositoryCursor.test.ts
+++ b/apps/webapp/test/runsRepositoryCursor.test.ts
@@ -70,7 +70,7 @@ describe("RunsRepository cursor pagination", () => {
         "dddddddddddddddddddddddd",
         "eeeeeeeeeeeeeeeeeeeeeeee",
       ];
-      const base = new Date("2026-06-04T16:55:07.000Z").getTime();
+      const base = Date.now() - 60 * 60 * 1000; // relative, so fixtures never age out of the default 7d window
       for (let i = 0; i < ids.length; i++) {
         await prisma.taskRun.create({
           data: {
@@ -160,7 +160,7 @@ describe("RunsRepository cursor pagination", () => {
         "bbbbbbbbbbbbbbbbbbbbbbbb",
         "cccccccccccccccccccccccc",
       ];
-      const base = new Date("2026-06-04T16:55:07.000Z").getTime();
+      const base = Date.now() - 60 * 60 * 1000; // relative, so fixtures never age out of the default 7d window
       for (let i = 0; i < ids.length; i++) {
         await prisma.taskRun.create({
           data: {
@@ -255,7 +255,7 @@ describe("RunsRepository cursor pagination", () => {
         "bbbbbbbbbbbbbbbbbbbbbbbb",
         "cccccccccccccccccccccccc",
       ];
-      const base = new Date("2026-06-04T16:55:07.000Z").getTime();
+      const base = Date.now() - 60 * 60 * 1000; // relative, so fixtures never age out of the default 7d window
       for (let i = 0; i < ids.length; i++) {
         await prisma.taskRun.create({
           data: {
@@ -339,7 +339,7 @@ describe("RunsRepository cursor pagination", () => {
         "dddddddddddddddddddddddd",
         "eeeeeeeeeeeeeeeeeeeeeeee",
       ];
-      const base = new Date("2026-06-04T16:55:07.000Z").getTime();
+      const base = Date.now() - 60 * 60 * 1000; // relative, so fixtures never age out of the default 7d window
       for (let i = 0; i < ids.length; i++) {
         await prisma.taskRun.create({
           data: {
@@ -458,7 +458,7 @@ describe("RunsRepository cursor pagination", () => {
         "bbbbbbbbbbbbbbbbbbbbbbbb",
         "cccccccccccccccccccccccc",
       ];
-      const base = new Date("2026-06-04T16:55:07.000Z").getTime();
+      const base = Date.now() - 60 * 60 * 1000; // relative, so fixtures never age out of the default 7d window
       for (let i = 0; i < ids.length; i++) {
         await prisma.taskRun.create({
           data: {


### PR DESCRIPTION
## Summary

`test/runsRepositoryCursor.test.ts` pinned its fixture runs to `createdAt = 2026-06-04T16:55:07Z`. `listRuns` applies the default 7 day window when no time filter is given, so the fixtures aged out of the window at 16:55 UTC on 2026-06-11 and all five tests started failing for every branch, regardless of what the branch changed. The tests were green on their own CI two days earlier because the fixtures were only five days old at the time.

This switches the fixture base to a relative timestamp (one hour ago), so the fixtures stay inside the default window permanently. Verified the suite goes 5/5 green with this change on the same environment where the pinned dates fail 5/5.
