### PR TITLE
chore: vouch saasjesus as a contributor

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -23,3 +23,4 @@ bhekanik
 jrossi
 ThullyoCunha
 ConProgramming
+saasjesus


### PR DESCRIPTION
Vouches `saasjesus` as a contributor (vouch request #3915) so their PRs clear the vouch check instead of being auto-closed.