### PR TITLE
fix(plugins): drop unused gitBranch re-export from the package entry

### DIFF
--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -18,8 +18,3 @@ export type {
 } from "./rbac.js";
 
 export { buildJwtAbility } from "./rbac.js";
-
-// Convenience re-exports — give plugin authors one import surface
-// without reaching into @trigger.dev/core directly. Both helpers live in
-// core; this is purely a forwarder.
-export { sanitizeBranchName, isValidGitBranchName } from "@trigger.dev/core/v3/utils/gitBranch";


### PR DESCRIPTION
`@trigger.dev/plugins` re-exported `sanitizeBranchName`/`isValidGitBranchName` from `@trigger.dev/core` as a convenience forwarder. Nothing actually imports them through this package — every consumer (webapp, `@trigger.dev/rbac`, …) imports them directly from `@trigger.dev/core/v3/utils/gitBranch`.

Removing the forwarder keeps the package entry free of **runtime** core imports (only type re-exports + `buildJwtAbility` remain), so consumers that bundle `@trigger.dev/plugins` from source don't pull an unrelated core subpath into their build.

No behavior change; the helpers remain available from `@trigger.dev/core` where they're defined.