### PR TITLE
fix(webapp): stop logging expected auth/restore conditions as errors

### DIFF
--- a/.server-changes/quiet-expected-error-logs.md
+++ b/.server-changes/quiet-expected-error-logs.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+Log expected auth-code and checkpoint-restore conditions at `warn` instead of `error`.

--- a/apps/webapp/app/routes/api.v1.token.ts
+++ b/apps/webapp/app/routes/api.v1.token.ts
@@ -37,10 +37,13 @@ export async function action({ request }: ActionFunctionArgs) {
     return json(responseJson);
   } catch (error) {
     if (error instanceof Error) {
-      logger.error("Error getting PersonalAccessToken from AuthorizationCode", {
-        url: request.url,
-        error: error.message,
-      });
+      const expected = error.message === "Invalid authorization code, or code expired";
+      const fields = { url: request.url, error: error.message };
+      if (expected) {
+        logger.warn("Error getting PersonalAccessToken from AuthorizationCode", fields);
+      } else {
+        logger.error("Error getting PersonalAccessToken from AuthorizationCode", fields);
+      }
 
       return json({ error: error.message }, { status: 400 });
     }

--- a/apps/webapp/app/v3/services/restoreCheckpoint.server.ts
+++ b/apps/webapp/app/v3/services/restoreCheckpoint.server.ts
@@ -82,7 +82,7 @@ export class RestoreCheckpointService extends BaseService {
     });
 
     if (restoreEvent) {
-      logger.error("Restore event already exists", {
+      logger.warn("Restore event already exists", {
         runId: checkpoint.runId,
         attemptId: checkpoint.attemptId,
         checkpointId: checkpoint.id,


### PR DESCRIPTION
Two expected, non-failure conditions were being logged at `error` level, which surfaces them as exceptions in error tracking and adds noise without signal. This downgrades both to `warn`. The first is the checkpoint-restore path when a `RESTORE` event already exists for a checkpoint — a benign idempotency skip on a duplicate or retried event. The second is the `/api/v1/token` endpoint when the authorization code is invalid or expired, which is the expected steady state while the CLI polls the endpoint during login; genuinely unexpected failures there still log at `error`. No behavior or response changes — the token endpoint still returns 400 in the same cases.