### PR TITLE
fix(cli): friendly error when package.json is missing

### DIFF
--- a/.changeset/dev-missing-package-json-message.md
+++ b/.changeset/dev-missing-package-json-message.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+`trigger dev` now shows an actionable message instead of crashing when no `package.json` is found.

--- a/packages/cli-v3/src/commands/update.ts
+++ b/packages/cli-v3/src/commands/update.ts
@@ -66,11 +66,18 @@ export async function updateTriggerPackages(
 
   const projectPath = resolve(process.cwd(), dir);
 
-  const { packageJson, readonlyPackageJson, packageJsonPath } = await getPackageJson(projectPath);
+  let packageJson: PackageJson;
+  let readonlyPackageJson: PackageJson;
+  let packageJsonPath: string;
 
-  if (!packageJson) {
-    log.error("Failed to load package.json. Try to re-run with `-l debug` to see what's going on.");
-    return false;
+  try {
+    ({ packageJson, readonlyPackageJson, packageJsonPath } = await getPackageJson(projectPath));
+  } catch {
+    // `getPackageJson` throws when no package.json is found — show an
+    // actionable message instead of crashing with a raw stack trace.
+    throw new OutroCommandError(
+      `Couldn't find a package.json in ${projectPath} (or any parent directory). Run this command from your project's root directory. If you haven't set up a project yet, create one first (e.g. \`npm init -y\`), then run \`npx trigger.dev@latest init\`.`
+    );
   }
 
   const newCliVersion = await updateCheck();


### PR DESCRIPTION
Running `trigger dev` (or any command that runs the package update check) in a directory without a `package.json` crashed with a raw `Cannot find matching package.json` stack trace. This is because `getPackageJson` throws before the existing `if (!packageJson)` guard can run, so the guard was dead code.

Now it exits cleanly with an actionable message instead — telling the user to run from their project root, or to `npm init -y` and `trigger.dev init` if they haven't set up a project yet. The fix catches the throw at the call site in `updateTriggerPackages`; `getPackageJson` itself is unchanged (changing its return type rippled type errors into other callers).

Tested e2e via `trigger update` (same code path): no `package.json` → clean message + exit 1, `package.json` present → update check runs as before, version mismatch → still aborts as before.
