### PR TITLE
docs(skills): reflect the SDK-bundled, version-pinned agent reference

### DIFF
--- a/docs/building-with-ai.mdx
+++ b/docs/building-with-ai.mdx
@@ -22,7 +22,7 @@ We provide multiple tools to help AI coding assistants write correct Trigger.dev
 </Step>
 
 <Step title="Install Skills">
-  Portable instruction sets that teach any AI coding assistant Trigger.dev best practices: writing tasks, realtime frontends, and `chat.agent` AI agents. They ship with the CLI, versioned with it, and install into Claude Code, Cursor, VS Code (Copilot), and AGENTS-compatible tools such as Codex via `.agents/skills/`.
+  Portable instruction sets that teach any AI coding assistant Trigger.dev best practices: writing tasks, realtime frontends, and `chat.agent` AI agents. They install with the CLI into Claude Code, Cursor, VS Code (Copilot), and AGENTS-compatible tools such as Codex via `.agents/skills/`, and draw their API guidance from a version-pinned reference shipped in `@trigger.dev/sdk`.
 
   ```bash
   npx trigger.dev@latest skills

--- a/docs/mcp-agent-rules.mdx
+++ b/docs/mcp-agent-rules.mdx
@@ -11,7 +11,7 @@ sidebarTitle: "Agent rules"
 
 ## What changed
 
-Trigger.dev used to install per-tool *rule files* (`.cursor/rules/trigger.*.mdc`, regions in `CLAUDE.md`, and so on) fetched from GitHub. That has been replaced by [agent skills](/skills): `SKILL.md` directories in the open [Agent Skills standard](https://agentskills.io) that ship inside the CLI, versioned with it, and load on demand instead of always sitting in your context.
+Trigger.dev used to install per-tool *rule files* (`.cursor/rules/trigger.*.mdc`, regions in `CLAUDE.md`, and so on) fetched from GitHub. That has been replaced by [agent skills](/skills): `SKILL.md` directories in the open [Agent Skills standard](https://agentskills.io) that install with the CLI, draw their API guidance from a version-pinned reference in `@trigger.dev/sdk`, and load on demand instead of always sitting in your context.
 
 The install command is the same, and now installs skills:
 

--- a/docs/skills.mdx
+++ b/docs/skills.mdx
@@ -18,22 +18,17 @@ Each skill is a directory containing a `SKILL.md` file: YAML frontmatter (name, 
 
 ## Installation
 
-The skills ship inside the `trigger.dev` CLI and are versioned with it. Run:
+Run the installer with the CLI:
 
 ```bash
 npx trigger.dev@latest skills
 ```
 
-The CLI detects your installed AI tools, lets you pick which skills to install, and copies each one into that tool's native skills directory (`.claude/skills/`, `.cursor/skills/`, `.github/skills/`, `.agents/skills/`). It also writes a one-line pointer into your primary instructions file (`CLAUDE.md`, `.cursor/rules`, etc.) so your assistant always knows the skills are there and loads the right one on demand.
+The CLI detects your installed AI tools, lets you pick which skills to install, and writes each one into that tool's native skills directory (`.claude/skills/`, `.cursor/skills/`, `.github/skills/`, `.agents/skills/`). It also adds a one-line pointer to your primary instructions file (`CLAUDE.md`, `.cursor/rules`, etc.) so your assistant always knows the skills are there and loads the right one on demand.
 
 When you run `trigger dev` for the first time, the CLI offers to install the skills for you.
 
-<Note>
-  Because the skills are bundled with the CLI, the guidance your assistant gets is pinned to the CLI
-  version that installs them. To keep it matched to the Trigger.dev version you are building
-  against, run the CLI pinned in your project (`pnpm exec trigger skills`) instead of
-  `npx trigger.dev@latest`.
-</Note>
+The installed skills are lightweight. Most point to the full, version-pinned reference that ships inside `@trigger.dev/sdk`, which your assistant reads straight from `node_modules`. The API guidance it follows always matches the `@trigger.dev/sdk` version installed in your project, with no extra step on your part. The `getting-started` skill is self-contained, since it runs before the SDK is installed.
 
 ### Non-interactive install
 
@@ -69,7 +64,7 @@ Using a tool that does not support skills yet? Select "Unsupported target" in th
 
 ## Keeping skills updated
 
-Skills are pinned to your installed CLI version. To refresh them after upgrading Trigger.dev, run `npx trigger.dev@latest skills` again, or accept the prompt that `trigger dev` shows when a newer version is available. Re-running overwrites the installed skill files in place without creating duplicates.
+The API guidance updates on its own: it lives in `@trigger.dev/sdk` and is read from `node_modules`, so upgrading the SDK in your project upgrades the guidance with it. Re-run `npx trigger.dev@latest skills` (or accept the prompt that `trigger dev` shows when a newer version is available) only to add skills or refresh the installed pointer files. Re-running overwrites them in place without creating duplicates.
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

The agent skills' deep guidance now ships inside `@trigger.dev/sdk` and is read from `node_modules`, so it tracks the `@trigger.dev/sdk` version installed in your project automatically. This updates the Skills page, the Building with AI step, and the rules-redirect page to drop the old "pinned to the CLI version, re-run to refresh" framing and describe the version-pinned reference instead.

Pairs with the SDK/CLI change in #3937. Keep this draft until that ships, since it describes behavior that is not released yet.
