### PR TITLE
fix(webapp): make SDK bundle-docs build step work in pruned Docker image

### DIFF
--- a/.server-changes/fix-webapp-docker-sdk-bundle-docs.md
+++ b/.server-changes/fix-webapp-docker-sdk-bundle-docs.md
@@ -1,6 +1,0 @@
----
-area: webapp
-type: fix
----
-
-Fix webapp Docker build failing because the SDK's bundle-docs build step was not runnable in the pruned image

--- a/.server-changes/fix-webapp-docker-sdk-bundle-docs.md
+++ b/.server-changes/fix-webapp-docker-sdk-bundle-docs.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Fix webapp Docker build failing because the SDK's bundle-docs build step was not runnable in the pruned image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,6 +68,7 @@ RUN chmod +x ./scripts/wait-for-it.sh
 RUN chmod +x ./scripts/entrypoint.sh
 COPY --chown=node:node .configs/tsconfig.base.json .configs/tsconfig.base.json
 COPY --chown=node:node scripts/updateVersion.ts scripts/updateVersion.ts
+COPY --chown=node:node scripts/bundleSdkDocs.ts scripts/bundleSdkDocs.ts
 RUN pnpm run generate
 RUN --mount=type=secret,id=sentry_auth_token \
     SENTRY_AUTH_TOKEN=$(cat /run/secrets/sentry_auth_token) \

--- a/scripts/bundleSdkDocs.ts
+++ b/scripts/bundleSdkDocs.ts
@@ -65,6 +65,19 @@ async function collectManifest(): Promise<string[]> {
 }
 
 async function bundleSdkDocs() {
+  // When the SDK is built as a dependency inside a pruned workspace (e.g. the webapp Docker
+  // image), the repo-level docs/ tree is a separate workspace package that isn't part of that
+  // build's dependency graph, so it isn't present. The SDK isn't being published there, so
+  // there's nothing to bundle: skip rather than fail. Publishing always runs from the full
+  // monorepo where docs/ exists, so the missing-docs guard below still protects releases.
+  const docsRoot = path.join(repoRoot, "docs");
+  try {
+    await fs.access(docsRoot);
+  } catch {
+    console.log(`[bundleSdkDocs] docs/ not present at ${docsRoot}; skipping (pruned build)`);
+    return;
+  }
+
   const manifest = await collectManifest();
 
   if (manifest.length === 0) {


### PR DESCRIPTION
## Summary

The webapp Docker image build runs `pnpm run build --filter=webapp...`, which builds `@trigger.dev/sdk` as a dependency. The SDK's `build` script recently gained a `bundle-docs` step (`tsx ../../scripts/bundleSdkDocs.ts`), but the build couldn't run it in the pruned image, breaking the image build.

Two things were missing:

- `docker/Dockerfile` copied `scripts/updateVersion.ts` into the builder stage but not `scripts/bundleSdkDocs.ts`, so the step failed with `ERR_MODULE_NOT_FOUND`.
- Even with the script present, the repo-level `docs/` tree it reads is a separate workspace package that isn't in webapp's dependency graph, so `turbo prune --scope=webapp` excludes it — the script's missing-docs guard would then fail the build.

## Design

The Dockerfile now copies `bundleSdkDocs.ts` alongside `updateVersion.ts`. `bundleSdkDocs.ts` skips gracefully when the repo `docs/` tree is absent, which is exactly the pruned-dependency-build case (the SDK is compiled there but never published). Publishing always runs from the full monorepo where `docs/` exists, so the missing-docs guard still protects releases — it only fires when `docs/` is present but a cited doc is genuinely missing, rather than when the whole tree was pruned away. This avoids dragging 27M of docs into a throwaway builder stage.

## Test plan

- [x] `bundle-docs` from the full monorepo still bundles all cited docs (exit 0)
- [x] Simulated pruned tree without `docs/` skips cleanly instead of failing
- [ ] Webapp Docker image build succeeds in CI