### PR TITLE
ci: gate optional publish/notify jobs behind repository variables

### DIFF
--- a/.github/workflows/dependabot-critical-alerts.yml
+++ b/.github/workflows/dependabot-critical-alerts.yml
@@ -25,6 +25,10 @@ permissions:
 jobs:
   alert:
     name: Post critical alerts
+    # Set the ENABLE_DEPENDABOT_ALERTS repository variable to 'false' to turn off
+    # the Dependabot alert/summary notifiers — e.g. forks/mirrors that lack the
+    # DEPENDABOT_ALERTS_TOKEN / SLACK_BOT_TOKEN secrets. Defaults to enabled.
+    if: ${{ vars.ENABLE_DEPENDABOT_ALERTS != 'false' }}
     runs-on: ubuntu-latest
     environment: dependabot-summary
     env:

--- a/.github/workflows/dependabot-weekly-summary.yml
+++ b/.github/workflows/dependabot-weekly-summary.yml
@@ -19,6 +19,10 @@ permissions:
 jobs:
   summary:
     name: Post weekly Dependabot summary
+    # Set the ENABLE_DEPENDABOT_ALERTS repository variable to 'false' to turn off
+    # the Dependabot alert/summary notifiers — e.g. forks/mirrors that lack the
+    # DEPENDABOT_ALERTS_TOKEN / SLACK_BOT_TOKEN secrets. Defaults to enabled.
+    if: ${{ vars.ENABLE_DEPENDABOT_ALERTS != 'false' }}
     runs-on: ubuntu-latest
     environment: dependabot-summary
     env:

--- a/.github/workflows/helm-prerelease.yml
+++ b/.github/workflows/helm-prerelease.yml
@@ -68,10 +68,15 @@ jobs:
 
   prerelease:
     needs: lint-and-test
+    # Set the ENABLE_HELM_PRERELEASE repository variable to 'false' to turn off
+    # publishing the chart to GHCR — e.g. forks/mirrors that lack write_package
+    # on the owner's charts namespace. Defaults to enabled; the lint-and-test
+    # job above always runs regardless.
     if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      vars.ENABLE_HELM_PRERELEASE != 'false' &&
+      ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
       github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -63,6 +63,11 @@ jobs:
 
   release:
     needs: lint-and-test
+    # Set the ENABLE_HELM_PRERELEASE repository variable to 'false' to turn off
+    # publishing the chart to GHCR — e.g. forks/mirrors that lack write_package
+    # on the owner's charts namespace. Defaults to enabled; the lint-and-test
+    # job above always runs regardless.
+    if: ${{ vars.ENABLE_HELM_PRERELEASE != 'false' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write # for gh-release


### PR DESCRIPTION
## Summary

Several optional workflow jobs fail on forks and private mirrors that lack org-specific secrets or registry permissions. This adds per-job repository-variable gates so those deployments can switch them off without editing workflows — matching the pattern from #3901 (`ENABLE_CLAUDE_CODE` / `ENABLE_WORKFLOW_SECURITY_SCAN`).

Two variables, both **default-enabled** (a job runs unless its variable is explicitly `'false'`), so canonical-repo behaviour is unchanged where the variables are unset:

**`ENABLE_HELM_PRERELEASE`** — gates the chart-publish jobs that push to `oci://ghcr.io/<owner>/charts` (needs `write_package` on the owner's charts namespace):
- `helm-prerelease.yml` → `prerelease` job
- `release-helm.yml` → `release` job

  Without the permission these fail with `403: denied: permission_denied: write_package` on every PR / `helm-v*` tag. The `lint-and-test` jobs (lint + template + kubeconform, no push) always run, so chart validity is still enforced everywhere.

**`ENABLE_DEPENDABOT_ALERTS`** — gates the Dependabot notifier crons that need `DEPENDABOT_ALERTS_TOKEN` / `SLACK_BOT_TOKEN` and post to a specific Slack:
- `dependabot-critical-alerts.yml` → `alert` job (daily cron)
- `dependabot-weekly-summary.yml` → `summary` job (weekly cron)

  On a fork/mirror these otherwise fire on schedule and fail (or post nowhere) indefinitely.

## Test plan

- Variables unset (default): all jobs run as today.
- `ENABLE_HELM_PRERELEASE=false`: helm `lint-and-test` runs, publish jobs skip — no 403 on repos lacking `write_package`.
- `ENABLE_DEPENDABOT_ALERTS=false`: the two cron jobs skip cleanly (neutral, not failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
