### PR TITLE
docs(ai-chat): correct the extractNewToolResults return type

### DIFF
--- a/docs/ai-chat/patterns/tool-result-auditing.mdx
+++ b/docs/ai-chat/patterns/tool-result-auditing.mdx
@@ -112,12 +112,11 @@ await auditLog.upsert({
 ## What `extractNewToolResults` returns
 
 ```ts
-type ExtractedToolResult = {
+type ChatNewToolResult = {
   toolCallId: string;
   toolName: string;
-  input: unknown;       // The arguments the model passed when calling the tool
-  output?: unknown;     // The tool's return value (output-available state)
-  errorText?: string;   // Error message (output-error state)
+  output: unknown;      // The tool's return value (carries the resolved value; in output-error state see errorText)
+  errorText?: string;   // Set iff the part is in output-error state
 };
 ```
 


### PR DESCRIPTION
## Summary

The "What extractNewToolResults returns" reference in the tool-result-auditing guide did not match the SDK. It listed an `input` field that `chat.history.extractNewToolResults()` never returns, and marked `output` as optional when it is always present.

This corrects the block to the real `ChatNewToolResult` shape (`toolCallId`, `toolName`, `output`, optional `errorText`). Every usage example in the same guide already reads only those fields, so the reference now matches both the examples and the code.