### PR TITLE
chore(webapp): prevent db:seed script hang

### DIFF
--- a/.server-changes/prevent-db-seed-script-hang.md
+++ b/.server-changes/prevent-db-seed-script-hang.md
@@ -1,6 +1,6 @@
 ---
 area: webapp
-type: chore
+type: fix
 ---
 
 Exit db:seed script on success to prevent hanging.

--- a/.server-changes/prevent-db-seed-script-hang.md
+++ b/.server-changes/prevent-db-seed-script-hang.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: chore
+---
+
+Exit db:seed script on success to prevent hanging.

--- a/apps/webapp/seed.mts
+++ b/apps/webapp/seed.mts
@@ -168,6 +168,7 @@ seed()
   })
   .finally(async () => {
     await prisma.$disconnect();
+    process.exit(0);
   });
 
 async function findOrCreateOrganization(


### PR DESCRIPTION
Currently the `db:seed` script just hangs on success.

This PR adds `process.exit(0)` to the finally block after db disconnect so the script exits properly.
