### PR TITLE
fix(build): replace tsconfck with native typescript config parsing to support ts 6

### DIFF
--- a/.changeset/afraid-bags-pretend.md
+++ b/.changeset/afraid-bags-pretend.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/build": patch
+---
+
+Remove deprecated tsconfck dependency and replace with native typescript compiler api to resolve typescript 6 peer dependency installation issues

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -82,8 +82,7 @@
     "mlly": "^1.7.1",
     "pkg-types": "^1.1.3",
     "resolve": "^1.22.8",
-    "tinyglobby": "^0.2.2",
-    "tsconfck": "3.1.3"
+    "tinyglobby": "^0.2.2"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.4",

--- a/packages/build/src/extensions/typescript.ts
+++ b/packages/build/src/extensions/typescript.ts
@@ -1,8 +1,9 @@
+import { dirname } from "node:path";
 import { BuildExtension } from "@trigger.dev/core/v3/build";
 import { readFile } from "node:fs/promises";
 import typescriptPkg from "typescript";
 
-const { transpileModule, ModuleKind } = typescriptPkg;
+const { transpileModule, ModuleKind, findConfigFile, readConfigFile, parseJsonConfigFileContent, sys } = typescriptPkg;
 
 const decoratorMatcher = new RegExp(/((?<![(\s]\s*['"])@\w[.[\]\w\d]*\s*(?![;])[((?=\s)])/);
 
@@ -13,27 +14,42 @@ export function emitDecoratorMetadata(): BuildExtension {
       context.registerPlugin({
         name: "emitDecoratorMetadata",
         async setup(build) {
-          const { parseNative, TSConfckCache } = await import("tsconfck");
-          const cache = new TSConfckCache<any>();
+          const configCache = new Map<string, any>();
 
           build.onLoad({ filter: /\.ts$/ }, async (args) => {
             context.logger.debug("emitDecoratorMetadata onLoad", { args });
 
-            const { tsconfigFile, tsconfig } = await parseNative(args.path, {
-              ignoreNodeModules: true,
-              cache,
-            });
+            const searchPath = dirname(args.path);
+            const tsconfigFile = findConfigFile(searchPath, sys.fileExists, "tsconfig.json");
 
-            context.logger.debug("emitDecoratorMetadata parsed native tsconfig", {
-              tsconfig,
+            context.logger.debug("emitDecoratorMetadata resolved tsconfig file", {
               tsconfigFile,
               args,
             });
 
-            if (tsconfig.compilerOptions?.emitDecoratorMetadata !== true) {
+            let compilerOptions: any = {};
+
+            if (tsconfigFile) {
+              if (configCache.has(tsconfigFile)) {
+                compilerOptions = configCache.get(tsconfigFile);
+              } else {
+                const configFile = readConfigFile(tsconfigFile, sys.readFile);
+                if (configFile.config) {
+                  const parsedConfig = parseJsonConfigFileContent(
+                    configFile.config,
+                    sys,
+                    dirname(tsconfigFile)
+                  );
+                  compilerOptions = parsedConfig.options || {};
+                }
+                configCache.set(tsconfigFile, compilerOptions);
+              }
+            }
+
+            if (compilerOptions.emitDecoratorMetadata !== true) {
               context.logger.debug("emitDecoratorMetadata skipping", {
                 args,
-                tsconfig,
+                compilerOptions,
               });
 
               return undefined;
@@ -55,7 +71,7 @@ export function emitDecoratorMetadata(): BuildExtension {
             const program = transpileModule(ts, {
               fileName: args.path,
               compilerOptions: {
-                ...tsconfig.compilerOptions,
+                ...compilerOptions,
                 module: ModuleKind.ES2022,
               },
             });
@@ -67,3 +83,4 @@ export function emitDecoratorMetadata(): BuildExtension {
     },
   };
 }
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1502,9 +1502,6 @@ importers:
       tinyglobby:
         specifier: ^0.2.2
         version: 0.2.2
-      tsconfck:
-        specifier: 3.1.3
-        version: 3.1.3(typescript@5.5.4)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.15.4
@@ -16157,16 +16154,6 @@ packages:
   tsconfck@2.1.2:
     resolution: {integrity: sha512-ghqN1b0puy3MhhviwO2kGF8SeMDNhEbnKxjK7h6+fvY9JAxqvXi8y5NAHSQv687OVboS2uZIByzGd45/YxrRHg==}
     engines: {node: ^14.13.1 || ^16 || >=18}
-    hasBin: true
-    peerDependencies:
-      typescript: 5.5.4
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  tsconfck@3.1.3:
-    resolution: {integrity: sha512-ulNZP1SVpRDesxeMLON/LtWM8HIgAJEIVpVVhBM6gsmvQ8+Rh+ZG7FWGvHh7Ah3pRABwVJWklWCr/BTZSv0xnQ==}
-    engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:
       typescript: 5.5.4
@@ -34929,10 +34916,6 @@ snapshots:
   tsafe@1.4.1: {}
 
   tsconfck@2.1.2(typescript@5.5.4):
-    optionalDependencies:
-      typescript: 5.5.4
-
-  tsconfck@3.1.3(typescript@5.5.4):
     optionalDependencies:
       typescript: 5.5.4
 


### PR DESCRIPTION
Closes #3953 

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

1. Force rebuilt the `@trigger.dev/build` package successfully:
   ```bash
   pnpm run build --force --filter @trigger.dev/build

2. Ran package typecheck successfully (0 errors):
    ```bash
     pnpm run typecheck --filter @trigger.dev/build

4. Ran the E2E decorators metadata tests in packages/cli-v3 to verify config resolution and decorator transpilation behaves exactly as before:
    ```bash 
     MOD=emit-decorator-metadata pnpm run test:e2e

Result: Passed successfully.


---

## Changelog

Removed tsconfck dependency from @trigger.dev/build to fix the peer dependency installation conflict when using TypeScript 6 and pnpm.
Implemented native tsconfig.json parsing in typescript.ts using the already runtime-imported typescript package APIs (findConfigFile, readConfigFile, and parseJsonConfigFileContent).
Added Map-based caching for resolved compiler options to avoid duplicate disk reads and parsing.

💯
