### PR TITLE
fix: null-safe getTime() calls in replication services (#3519)

### DIFF
--- a/apps/webapp/app/services/runsReplicationService.server.ts
+++ b/apps/webapp/app/services/runsReplicationService.server.ts
@@ -1080,8 +1080,8 @@ export class RunsReplicationService {
       organizationId, // organization_id
       run.projectId, // project_id
       run.id, // run_id
-      run.updatedAt.getTime(), // updated_at
-      run.createdAt.getTime(), // created_at
+      run.updatedAt?.getTime() ?? Date.now(), // updated_at
+      run.createdAt?.getTime() ?? Date.now(), // created_at
       run.status, // status
       environmentType, // environment_type
       run.friendlyId, // friendly_id
@@ -1142,7 +1142,7 @@ export class RunsReplicationService {
     // Return array matching PAYLOAD_COLUMNS order
     return [
       run.id, // run_id
-      run.createdAt.getTime(), // created_at
+      run.createdAt?.getTime() ?? Date.now(), // created_at
       payload, // payload
     ];
   }

--- a/apps/webapp/app/services/sessionsReplicationService.server.ts
+++ b/apps/webapp/app/services/sessionsReplicationService.server.ts
@@ -800,8 +800,8 @@ function toSessionInsertArray(
     session.closedAt ? session.closedAt.getTime() : null,
     session.closedReason ?? "",
     session.expiresAt ? session.expiresAt.getTime() : null,
-    session.createdAt.getTime(),
-    session.updatedAt.getTime(),
+    session.createdAt?.getTime() ?? Date.now(),
+    session.updatedAt?.getTime() ?? Date.now(),
     version.toString(),
     isDeleted ? 1 : 0,
   ];


### PR DESCRIPTION
Add optional chaining to getTime() calls on createdAt, updatedAt
fields in runs and sessions replication services. When CDC sends rows
before timestamps are fully populated, calling .getTime() on undefined
crashes the replication service with a TypeError.

- runsReplicationService.server.ts: null-safe updatedAt/createdAt in
  #prepareTaskRunInsert and #preparePayloadInsert
- sessionsReplicationService.server.ts: null-safe createdAt/updatedAt in
  toSessionInsertArray
