### PR TITLE
feat(clickhouse): replicate run plan type to task_runs_v2

### DIFF
--- a/.server-changes/task-run-plan-type-clickhouse.md
+++ b/.server-changes/task-run-plan-type-clickhouse.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+Store the run's plan type on the runs analytics table so reporting can group runs by plan.

--- a/apps/webapp/app/services/runsReplicationService.server.ts
+++ b/apps/webapp/app/services/runsReplicationService.server.ts
@@ -1124,6 +1124,7 @@ export class RunsReplicationService {
       run.bulkActionGroupIds ?? [], // bulk_action_group_ids
       baseWorkerQueue(run.masterQueue ?? ""), // worker_queue (raw - operators slice by this)
       run.region ?? "", // region (geo for customers)
+      run.planType ?? "", // plan_type
       run.maxDurationInSeconds ?? null, // max_duration_in_seconds
       annotations?.triggerSource ?? "", // trigger_source
       annotations?.rootTriggerSource ?? "", // root_trigger_source

--- a/apps/webapp/test/runsReplicationService.part1.test.ts
+++ b/apps/webapp/test/runsReplicationService.part1.test.ts
@@ -84,6 +84,7 @@ describe("RunsReplicationService (part 1/7)", () => {
           queue: "test",
           workerQueue: "us-east-1-next",
           region: "us-east-1",
+          planType: "free",
           runtimeEnvironmentId: runtimeEnvironment.id,
           projectId: project.id,
           organizationId: organization.id,
@@ -126,6 +127,7 @@ describe("RunsReplicationService (part 1/7)", () => {
           // worker_queue stays the raw backing (operators); region is the geo (customers)
           worker_queue: "us-east-1-next",
           region: "us-east-1",
+          plan_type: "free",
         })
       );
 

--- a/internal-packages/clickhouse/schema/033_add_task_runs_v2_plan_type.sql
+++ b/internal-packages/clickhouse/schema/033_add_task_runs_v2_plan_type.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE trigger_dev.task_runs_v2
+ADD COLUMN IF NOT EXISTS plan_type LowCardinality(String) DEFAULT '';
+
+-- +goose Down
+ALTER TABLE trigger_dev.task_runs_v2
+DROP COLUMN IF EXISTS plan_type;

--- a/internal-packages/clickhouse/src/taskRuns.test.ts
+++ b/internal-packages/clickhouse/src/taskRuns.test.ts
@@ -84,6 +84,7 @@ describe("Task Runs V2", () => {
       ["bulk_action_group_id_1234", "bulk_action_group_id_1235"], // bulk_action_group_ids
       "", // worker_queue
       "", // region
+      "", // plan_type
       null, // max_duration_in_seconds
       "", // trigger_source
       "", // root_trigger_source
@@ -217,6 +218,7 @@ describe("Task Runs V2", () => {
       [], // bulk_action_group_ids
       "", // worker_queue
       "", // region
+      "", // plan_type
       null, // max_duration_in_seconds
       "", // trigger_source
       "", // root_trigger_source
@@ -273,6 +275,7 @@ describe("Task Runs V2", () => {
       [], // bulk_action_group_ids
       "", // worker_queue
       "", // region
+      "", // plan_type
       null, // max_duration_in_seconds
       "", // trigger_source
       "", // root_trigger_source
@@ -376,6 +379,7 @@ describe("Task Runs V2", () => {
         [], // bulk_action_group_ids
         "", // worker_queue
         "", // region
+        "", // plan_type
         null, // max_duration_in_seconds
         "", // trigger_source
         "", // root_trigger_source
@@ -487,6 +491,7 @@ describe("Task Runs V2", () => {
         [], // bulk_action_group_ids
         "", // worker_queue
         "", // region
+        "", // plan_type
         null, // max_duration_in_seconds
         "", // trigger_source
         "", // root_trigger_source
@@ -543,6 +548,7 @@ describe("Task Runs V2", () => {
         [],
         "", // worker_queue
         "", // region
+        "", // plan_type
         null,
         "",
         "",
@@ -605,6 +611,7 @@ describe("Task Runs V2", () => {
         [],
         "", // worker_queue
         "", // region
+        "", // plan_type
         null,
         "",
         "",
@@ -661,6 +668,7 @@ describe("Task Runs V2", () => {
         [],
         "", // worker_queue
         "", // region
+        "", // plan_type
         null,
         "",
         "",

--- a/internal-packages/clickhouse/src/taskRuns.ts
+++ b/internal-packages/clickhouse/src/taskRuns.ts
@@ -49,6 +49,7 @@ export const TaskRunV2 = z.object({
   bulk_action_group_ids: z.array(z.string()).default([]),
   worker_queue: z.string().default(""),
   region: z.string().default(""),
+  plan_type: z.string().default(""),
   max_duration_in_seconds: z.number().int().nullish(),
   trigger_source: z.string().default(""),
   root_trigger_source: z.string().default(""),
@@ -110,6 +111,7 @@ export const TASK_RUN_COLUMNS = [
   "bulk_action_group_ids",
   "worker_queue",
   "region",
+  "plan_type",
   "max_duration_in_seconds",
   "trigger_source",
   "root_trigger_source",
@@ -178,6 +180,7 @@ export type TaskRunFieldTypes = {
   bulk_action_group_ids: string[];
   worker_queue: string;
   region: string;
+  plan_type: string;
   max_duration_in_seconds: number | null;
   trigger_source: string;
   root_trigger_source: string;
@@ -317,6 +320,7 @@ export type TaskRunInsertArray = [
   bulk_action_group_ids: string[],
   worker_queue: string,
   region: string,
+  plan_type: string,
   max_duration_in_seconds: number | null,
   trigger_source: string,
   root_trigger_source: string,


### PR DESCRIPTION
Replicates `TaskRun.planType` into the `task_runs_v2` ClickHouse table so run analytics can group by plan type.

Adds a `plan_type` column (goose migration `033`, `LowCardinality(String)`), the replication insert mapping, and the matching schema/column/type entries - same shape as the recent `region` addition. Write-once at trigger, so it just rides along on existing replicated rows. Internal analytics only; not exposed in the Query API.
