### PR TITLE
Fix update check for catalog protocol deps

### DIFF
--- a/packages/cli-v3/src/commands/update.test.ts
+++ b/packages/cli-v3/src/commands/update.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { getTriggerDependencies, getVersionMismatches, type Dependency } from "./update.js";
+
+describe("update command dependency checks", () => {
+  it("skips unresolved package-manager protocol specifiers", async () => {
+    const deps = await getTriggerDependencies(
+      {
+        dependencies: {
+          "@trigger.dev/sdk": "catalog:",
+          "@trigger.dev/core": "workspace:4.5.0",
+          "@trigger.dev/build": "file:../build",
+          react: "^19.0.0",
+        },
+        devDependencies: {
+          "@trigger.dev/eslint-plugin": "link:../eslint-plugin",
+        },
+      },
+      "/tmp/trigger-catalog-repro/package.json"
+    );
+
+    expect(deps).toEqual([]);
+  });
+
+  it("keeps normal trigger dependencies for version mismatch checks", async () => {
+    const deps = await getTriggerDependencies(
+      {
+        dependencies: {
+          "@trigger.dev/sdk": "4.4.6",
+        },
+      },
+      "/tmp/trigger-version-repro/package.json"
+    );
+
+    expect(deps).toEqual([
+      {
+        type: "dependencies",
+        name: "@trigger.dev/sdk",
+        version: "4.4.6",
+      },
+    ]);
+  });
+
+  it("does not throw when an invalid specifier reaches downgrade detection", () => {
+    const deps: Dependency[] = [
+      {
+        type: "dependencies",
+        name: "@trigger.dev/sdk",
+        version: "catalog:",
+      },
+    ];
+
+    expect(() => getVersionMismatches(deps, "4.5.0")).not.toThrow();
+    expect(getVersionMismatches(deps, "4.5.0")).toEqual({
+      mismatches: deps,
+      isDowngrade: false,
+    });
+  });
+
+  it("still detects downgrade prompts for valid semver ranges", () => {
+    const deps: Dependency[] = [
+      {
+        type: "dependencies",
+        name: "@trigger.dev/sdk",
+        version: "^5.0.0",
+      },
+    ];
+
+    expect(getVersionMismatches(deps, "4.5.0")).toEqual({
+      mismatches: deps,
+      isDowngrade: true,
+    });
+  });
+});

--- a/packages/cli-v3/src/commands/update.ts
+++ b/packages/cli-v3/src/commands/update.ts
@@ -42,6 +42,7 @@ export function configureUpdateCommand(program: Command) {
 }
 
 const triggerPackageFilter = /^@trigger\.dev/;
+const packageManagerProtocolFilter = /^(catalog|workspace|file|link|portal|patch):/;
 
 export async function updateCommand(dir: string, options: UpdateCommandOptions) {
   await updateTriggerPackages(dir, options, false);
@@ -110,45 +111,6 @@ export async function updateTriggerPackages(
   const triggerDependencies = await getTriggerDependencies(packageJson, packageJsonPath);
 
   logger.debug("Resolved trigger deps", { triggerDependencies });
-
-  function getVersionMismatches(
-    deps: Dependency[],
-    targetVersion: string
-  ): {
-    mismatches: Dependency[];
-    isDowngrade: boolean;
-  } {
-    logger.debug("Checking for version mismatches", { deps, targetVersion });
-
-    const mismatches: Dependency[] = [];
-
-    for (const dep of deps) {
-      if (
-        dep.version === targetVersion ||
-        dep.version.startsWith("https://pkg.pr.new") ||
-        dep.version.startsWith("0.0.0")
-      ) {
-        continue;
-      }
-
-      mismatches.push(dep);
-    }
-
-    const isDowngrade = mismatches.some((dep) => {
-      const depMinVersion = semver.minVersion(dep.version);
-
-      if (!depMinVersion) {
-        return false;
-      }
-
-      return semver.gt(depMinVersion, targetVersion);
-    });
-
-    return {
-      mismatches,
-      isDowngrade,
-    };
-  }
 
   const { mismatches, isDowngrade } = getVersionMismatches(triggerDependencies, cliVersion);
 
@@ -309,13 +271,59 @@ export async function updateTriggerPackages(
   return hasOutput;
 }
 
-type Dependency = {
+export type Dependency = {
   type: "dependencies" | "devDependencies";
   name: string;
   version: string;
 };
 
-async function getTriggerDependencies(
+export function getVersionMismatches(
+  deps: Dependency[],
+  targetVersion: string
+): {
+  mismatches: Dependency[];
+  isDowngrade: boolean;
+} {
+  logger.debug("Checking for version mismatches", { deps, targetVersion });
+
+  const mismatches: Dependency[] = [];
+
+  for (const dep of deps) {
+    if (
+      dep.version === targetVersion ||
+      dep.version.startsWith("https://pkg.pr.new") ||
+      dep.version.startsWith("0.0.0")
+    ) {
+      continue;
+    }
+
+    mismatches.push(dep);
+  }
+
+  const isDowngrade = mismatches.some((dep) => {
+    if (!semver.validRange(dep.version)) {
+      logger.debug("Skipping downgrade check for non-semver dependency specifier", {
+        dep,
+      });
+      return false;
+    }
+
+    const depMinVersion = semver.minVersion(dep.version);
+
+    if (!depMinVersion) {
+      return false;
+    }
+
+    return semver.gt(depMinVersion, targetVersion);
+  });
+
+  return {
+    mismatches,
+    isDowngrade,
+  };
+}
+
+export async function getTriggerDependencies(
   packageJson: PackageJson,
   packageJsonPath: string
 ): Promise<Dependency[]> {
@@ -324,10 +332,6 @@ async function getTriggerDependencies(
   for (const type of ["dependencies", "devDependencies"] as const) {
     for (const [name, version] of Object.entries(packageJson[type] ?? {})) {
       if (!version) {
-        continue;
-      }
-
-      if (version.startsWith("workspace")) {
         continue;
       }
 
@@ -343,7 +347,21 @@ async function getTriggerDependencies(
 
       const $version = await tryResolveTriggerPackageVersion(name, dirname(packageJsonPath));
 
-      deps.push({ type, name, version: $version ?? version });
+      if ($version) {
+        deps.push({ type, name, version: $version });
+        continue;
+      }
+
+      if (packageManagerProtocolFilter.test(version)) {
+        logger.debug("Skipping unresolved package-manager dependency specifier", {
+          type,
+          name,
+          version,
+        });
+        continue;
+      }
+
+      deps.push({ type, name, version });
     }
   }
 


### PR DESCRIPTION
## Summary
- fixes the embedded update check crash when @trigger.dev packages use unresolved package-manager protocol specs like catalog:
- keeps resolving installed package versions first, so catalog/workspace users still get checks when node_modules can provide the real version
- skips unresolved package-manager protocol specs instead of passing them to semver
- guards downgrade detection so a future non-semver specifier cannot throw Invalid comparator
- adds regression coverage for catalog:, workspace:, file:, link:, normal semver mismatch, and downgrade detection

Fixes #3905

## Checks
- bunx prettier@3.5.3 --check packages/cli-v3/src/commands/update.ts packages/cli-v3/src/commands/update.test.ts
- git diff --check

I tried bunx vitest run packages/cli-v3/src/commands/update.test.ts, but the local runner failed before tests started because the temporary Rolldown native binding was rejected by macOS code signing. I could not use pnpm here because the shell has no pnpm binary and the bundled pnpm entrypoint hung on --version.