### PR TITLE
docs: technical SEO cleanup for CLI pages, titles, and links

### DIFF
--- a/docs/building-with-ai.mdx
+++ b/docs/building-with-ai.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Overview"
+title: "Building with AI: overview"
 sidebarTitle: "Overview"
 description: "Tools and resources for building Trigger.dev projects with AI coding assistants."
 ---

--- a/docs/cli-deploy.mdx
+++ b/docs/cli-deploy.mdx
@@ -1,8 +1,0 @@
----
-title: "CLI deploy command"
-description: "The `trigger.dev deploy` command can be used to deploy your tasks to our infrastructure."
----
-
-import CliDeployCommands from "/snippets/cli-commands-deploy.mdx";
-
-<CliDeployCommands />

--- a/docs/cli-dev.mdx
+++ b/docs/cli-dev.mdx
@@ -1,8 +1,0 @@
----
-title: "CLI dev command"
-description: "The `trigger.dev dev` command is used to run your tasks locally."
----
-
-import CliDevCommands from "/snippets/cli-commands-develop.mdx";
-
-<CliDevCommands />

--- a/docs/cli-development-commands.mdx
+++ b/docs/cli-development-commands.mdx
@@ -1,9 +1,0 @@
----
-title: "CLI development commands"
-sidebarTitle: "Development commands"
-description: "Use these commands to help develop your tasks locally."
----
-
-import CliDevelopCommands from '/snippets/cli-commands-develop.mdx';
-
-<CliDevelopCommands/>

--- a/docs/deploy-environment-variables.mdx
+++ b/docs/deploy-environment-variables.mdx
@@ -230,7 +230,7 @@ To sync environment variables from your Vercel projects to Trigger.dev, you can 
 
 #### Deploy
 
-When you run the [CLI deploy command](/cli-deploy) directly or using [GitHub Actions](/github-actions) it will sync the environment variables from [Infisical](https://infisical.com) to Trigger.dev. This means they'll appear on the Environment Variables page so you can confirm that it's worked.
+When you run the [CLI deploy command](/cli-deploy-commands) directly or using [GitHub Actions](/github-actions) it will sync the environment variables from [Infisical](https://infisical.com) to Trigger.dev. This means they'll appear on the Environment Variables page so you can confirm that it's worked.
 
 This means that you need to redeploy your Trigger.dev tasks if you change the environment variables in [Infisical](https://infisical.com).
 

--- a/docs/deployment/overview.mdx
+++ b/docs/deployment/overview.mdx
@@ -6,7 +6,7 @@ description: "Learn how to deploy your tasks to Trigger.dev."
 
 import CorepackError from "/snippets/corepack-error.mdx";
 
-Before you can run production workloads on Trigger.dev, you need to deploy your tasks. The only way to do this at the moment is through the [deploy CLI command](/cli-deploy):
+Before you can run production workloads on Trigger.dev, you need to deploy your tasks. The only way to do this at the moment is through the [deploy CLI command](/cli-deploy-commands):
 
 <CodeGroup>
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -193,12 +193,6 @@
             ]
           },
           {
-            "group": "Development",
-            "pages": [
-              "cli-dev-commands"
-            ]
-          },
-          {
             "group": "Deployment",
             "pages": [
               "deployment/overview",
@@ -748,11 +742,13 @@
   "redirects": [
     {
       "source": "/cli-dev",
-      "destination": "/cli-dev-commands"
+      "destination": "/cli-dev-commands",
+      "permanent": true
     },
     {
       "source": "/cli-deploy",
-      "destination": "/cli-deploy-commands"
+      "destination": "/cli-deploy-commands",
+      "permanent": true
     },
     {
       "source": "/cli-development-commands",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -195,7 +195,7 @@
           {
             "group": "Development",
             "pages": [
-              "cli-dev"
+              "cli-dev-commands"
             ]
           },
           {
@@ -746,6 +746,18 @@
     ]
   },
   "redirects": [
+    {
+      "source": "/cli-dev",
+      "destination": "/cli-dev-commands"
+    },
+    {
+      "source": "/cli-deploy",
+      "destination": "/cli-deploy-commands"
+    },
+    {
+      "source": "/cli-development-commands",
+      "destination": "/cli-dev-commands"
+    },
     {
       "source": "/v3/feature-matrix",
       "destination": "https://feedback.trigger.dev/roadmap"

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -752,7 +752,8 @@
     },
     {
       "source": "/cli-development-commands",
-      "destination": "/cli-dev-commands"
+      "destination": "/cli-dev-commands",
+      "permanent": true
     },
     {
       "source": "/v3/feature-matrix",

--- a/docs/guides/example-projects/anchor-browser-web-scraper.mdx
+++ b/docs/guides/example-projects/anchor-browser-web-scraper.mdx
@@ -119,6 +119,6 @@ export default defineConfig({
 
 ## Learn more
 
-- View the [Anchor Browser docs](https://anchorbrowser.io/docs) to learn more about Anchor Browser's AI-powered browser automation tools.
+- View the [Anchor Browser docs](https://docs.anchorbrowser.io/) to learn more about Anchor Browser's AI-powered browser automation tools.
 - Check out the source code for the [Anchor Browser web scraper repo](https://github.com/triggerdotdev/examples/tree/main/anchor-browser-web-scraper) on GitHub.
 - Browser our [example projects](/guides/introduction) to see how you can use Trigger.dev with other services.

--- a/docs/guides/examples/libreoffice-pdf-conversion.mdx
+++ b/docs/guides/examples/libreoffice-pdf-conversion.mdx
@@ -9,7 +9,7 @@ import LocalDevelopment from "/snippets/local-development-extensions.mdx";
 ## Prerequisites
 
 - A project with [Trigger.dev initialized](/quick-start)
-- [LibreOffice](https://www.libreoffice.org/download/libreoffice-fresh/) installed on your machine
+- [LibreOffice](https://www.libreoffice.org/download/download-libreoffice/) installed on your machine
 - A [Cloudflare R2](https://developers.cloudflare.com) account and bucket
 
 ### Using our `aptGet` build extension to add the LibreOffice package

--- a/docs/guides/examples/replicate-image-generation.mdx
+++ b/docs/guides/examples/replicate-image-generation.mdx
@@ -6,7 +6,7 @@ description: "Learn how to generate images from source image URLs using Replicat
 
 ## Overview
 
-This example demonstrates how to use Trigger.dev to generate images from source image URLs using [Replicate](https://replicate.com/), the [nano-banana-image-to-image](https://replicate.com/meta/nano-banana-image-to-image) model.
+This example demonstrates how to use Trigger.dev to generate images from source image URLs using [Replicate](https://replicate.com/), the [nano-banana](https://replicate.com/google/nano-banana) model.
 
 ## Task code
 

--- a/docs/guides/frameworks/supabase-edge-functions-basic.mdx
+++ b/docs/guides/frameworks/supabase-edge-functions-basic.mdx
@@ -185,7 +185,7 @@ Once loaded you should see ‘OK’ on the new screen.
 
 The task will be triggered when your edge function URL is accessed.
 
-Check your [cloud.trigger.dev](http://cloud.trigger.dev) dashboard and you should see a succesful `hello-world` task.
+Check your [cloud.trigger.dev](https://cloud.trigger.dev) dashboard and you should see a succesful `hello-world` task.
 
     **Congratulations, you have run a simple Hello World task from a Supabase edge function!**
 

--- a/docs/guides/frameworks/supabase-edge-functions-basic.mdx
+++ b/docs/guides/frameworks/supabase-edge-functions-basic.mdx
@@ -185,7 +185,7 @@ Once loaded you should see ‘OK’ on the new screen.
 
 The task will be triggered when your edge function URL is accessed.
 
-Check your [cloud.trigger.dev](https://cloud.trigger.dev) dashboard and you should see a succesful `hello-world` task.
+Check your [cloud.trigger.dev](https://cloud.trigger.dev) dashboard and you should see a successful `hello-world` task.
 
     **Congratulations, you have run a simple Hello World task from a Supabase edge function!**
 

--- a/docs/guides/frameworks/supabase-edge-functions-database-webhooks.mdx
+++ b/docs/guides/frameworks/supabase-edge-functions-database-webhooks.mdx
@@ -422,7 +422,7 @@ You can use the following public video URL for testing: `https://content.trigger
 
 ![How to insert a new row 2](/images/supabase-new-table-4.png)
 
-Once the new table row has been inserted, check your [cloud.trigger.dev](http://cloud.trigger.dev) project 'Runs' list <Icon icon="circle-1" iconType="solid" size={20} color="A8FF53" /> and you should see a processing `videoProcessAndUpdate` task <Icon icon="circle-2" iconType="solid" size={20} color="A8FF53" /> which has been triggered when you added a new row with the video url to your `video_transcriptions` table.
+Once the new table row has been inserted, check your [cloud.trigger.dev](https://cloud.trigger.dev) project 'Runs' list <Icon icon="circle-1" iconType="solid" size={20} color="A8FF53" /> and you should see a processing `videoProcessAndUpdate` task <Icon icon="circle-2" iconType="solid" size={20} color="A8FF53" /> which has been triggered when you added a new row with the video url to your `video_transcriptions` table.
 
 ![Supabase successful run](/images/supabase-run-result.png)
 

--- a/docs/help-slack.mdx
+++ b/docs/help-slack.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Slack support"
+description: "Trigger.dev Pro plan customers can request a private Slack Connect channel for support."
 ---
 
 If you're on the Trigger.dev Pro plan, you can request a private Slack Connect channel.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -91,19 +91,19 @@ We provide everything you need to build and manage background tasks: a CLI and S
 
 | Extension             | What it does                                                 | Docs                                                   |
 | :-------------------- | :----------------------------------------------------------- | :----------------------------------------------------- |
-| prismaExtension       | Use Prisma with Trigger.dev                                  | [Learn more](/config/extensions/prismaExtension)       |
-| pythonExtension       | Execute Python scripts in Trigger.dev                        | [Learn more](/config/extensions/pythonExtension)       |
-| playwright            | Use Playwright with Trigger.dev                              | [Learn more](/config/extensions/playwright)            |
-| puppeteer             | Use Puppeteer with Trigger.dev                               | [Learn more](/config/extensions/puppeteer)             |
-| lightpanda            | Use Lightpanda with Trigger.dev                              | [Learn more](/config/extensions/lightpanda)            |
-| ffmpeg                | Use FFmpeg with Trigger.dev                                  | [Learn more](/config/extensions/ffmpeg)                |
-| aptGet                | Install system packages with aptGet                          | [Learn more](/config/extensions/aptGet)                |
-| additionalFiles       | Copy additional files to the build directory                 | [Learn more](/config/extensions/additionalFiles)       |
-| additionalPackages    | Include additional packages in the build                     | [Learn more](/config/extensions/additionalPackages)    |
-| syncEnvVars           | Automatically sync environment variables to Trigger.dev      | [Learn more](/config/extensions/syncEnvVars)           |
-| esbuildPlugin         | Add existing or custom esbuild plugins to your build process | [Learn more](/config/extensions/esbuildPlugin)         |
-| emitDecoratorMetadata | Support for the emitDecoratorMetadata TypeScript compiler    | [Learn more](/config/extensions/emitDecoratorMetadata) |
-| audioWaveform         | Support for Audio Waveform in your project                   | [Learn more](/config/extensions/audioWaveform)         |
+| prismaExtension       | Use Prisma with Trigger.dev                                  | [prismaExtension docs](/config/extensions/prismaExtension)             |
+| pythonExtension       | Execute Python scripts in Trigger.dev                        | [pythonExtension docs](/config/extensions/pythonExtension)             |
+| playwright            | Use Playwright with Trigger.dev                              | [playwright extension docs](/config/extensions/playwright)             |
+| puppeteer             | Use Puppeteer with Trigger.dev                               | [puppeteer extension docs](/config/extensions/puppeteer)               |
+| lightpanda            | Use Lightpanda with Trigger.dev                              | [lightpanda extension docs](/config/extensions/lightpanda)             |
+| ffmpeg                | Use FFmpeg with Trigger.dev                                  | [ffmpeg extension docs](/config/extensions/ffmpeg)                     |
+| aptGet                | Install system packages with aptGet                          | [aptGet extension docs](/config/extensions/aptGet)                     |
+| additionalFiles       | Copy additional files to the build directory                 | [additionalFiles docs](/config/extensions/additionalFiles)             |
+| additionalPackages    | Include additional packages in the build                     | [additionalPackages docs](/config/extensions/additionalPackages)       |
+| syncEnvVars           | Automatically sync environment variables to Trigger.dev      | [syncEnvVars docs](/config/extensions/syncEnvVars)                     |
+| esbuildPlugin         | Add existing or custom esbuild plugins to your build process | [esbuildPlugin docs](/config/extensions/esbuildPlugin)                 |
+| emitDecoratorMetadata | Support for the emitDecoratorMetadata TypeScript compiler    | [emitDecoratorMetadata docs](/config/extensions/emitDecoratorMetadata) |
+| audioWaveform         | Support for Audio Waveform in your project                   | [audioWaveform docs](/config/extensions/audioWaveform)                 |
 
 ## Explore by example
 

--- a/docs/management/overview.mdx
+++ b/docs/management/overview.mdx
@@ -37,7 +37,7 @@ configure({
 });
 
 async function main() {
-  const runs = await runs.list({
+  const completedRuns = await runs.list({
     limit: 10,
     status: ["COMPLETED"],
   });

--- a/docs/management/overview.mdx
+++ b/docs/management/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: "Management API overview"
 sidebarTitle: Overview
 description: Using the Trigger.dev management API
 ---

--- a/docs/open-source-self-hosting.mdx
+++ b/docs/open-source-self-hosting.mdx
@@ -156,7 +156,7 @@ TRIGGER_DOMAIN=1234-42-42-42-42.ngrok-free.app
 
 ### Registry setup
 
-If you want to deploy v3 projects, you will need access to a Docker registry. The [CLI deploy](/cli-deploy) command will push the images, and then the worker machine can pull them when needed. We will use Docker Hub as an example.
+If you want to deploy v3 projects, you will need access to a Docker registry. The [CLI deploy](/cli-deploy-commands) command will push the images, and then the worker machine can pull them when needed. We will use Docker Hub as an example.
 
 1. Sign up for a free account at [Docker Hub](https://hub.docker.com/)
 

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Overview"
+title: "Self-hosting overview"
+sidebarTitle: "Overview"
 description: "You can self-host Trigger.dev on your own infrastructure."
 ---
 

--- a/docs/snippets/deplopying-your-task.mdx
+++ b/docs/snippets/deplopying-your-task.mdx
@@ -1,6 +1,6 @@
 ## Deploying your task to Trigger.dev
 
-For this guide, we'll manually deploy your task by running the [CLI deploy command](/cli-deploy) below. Other ways to deploy are listed in the next section.
+For this guide, we'll manually deploy your task by running the [CLI deploy command](/cli-deploy-commands) below. Other ways to deploy are listed in the next section.
 
 <CodeGroup>
 

--- a/docs/snippets/useful-next-steps.mdx
+++ b/docs/snippets/useful-next-steps.mdx
@@ -7,7 +7,7 @@
    <Card title="Writing tasks" icon="pen-nib" href="/writing-tasks-introduction">
     Learn how to write your own tasks
   </Card>
-  <Card title="Deploy using the CLI" icon="terminal" href="/cli-deploy">
+  <Card title="Deploy using the CLI" icon="terminal" href="/cli-deploy-commands">
     Learn how to deploy your task manually using the CLI
   </Card>
    <Card title="Deploy using GitHub actions" icon="github" href="/github-actions">

--- a/docs/tasks/scheduled.mdx
+++ b/docs/tasks/scheduled.mdx
@@ -95,7 +95,7 @@ There are two ways of doing this:
 
 ### Declarative schedules
 
-These sync when you run the [dev](/cli-dev) or [deploy](/cli-deploy) commands.
+These sync when you run the [dev](/cli-dev-commands) or [deploy](/cli-deploy-commands) commands.
 
 To create them you add the `cron` property to your `schedules.task()`. This property is optional and is only used if you want to add a declarative schedule to your task:
 
@@ -127,7 +127,7 @@ export const secondScheduledTask = schedules.task({
 });
 ```
 
-When you run the [dev](/cli-dev) or [deploy](/cli-deploy) commands, declarative schedules will be synced. If you add, delete or edit the `cron` property it will be updated when you run these commands. You can view your schedules on the Schedules page in the dashboard.
+When you run the [dev](/cli-dev-commands) or [deploy](/cli-deploy-commands) commands, declarative schedules will be synced. If you add, delete or edit the `cron` property it will be updated when you run these commands. You can view your schedules on the Schedules page in the dashboard.
 
 ### Imperative schedules
 

--- a/docs/troubleshooting-debugging-in-vscode.mdx
+++ b/docs/troubleshooting-debugging-in-vscode.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Debugging in VS Code"
 sidebarTitle: "Debugging in VS Code"
+description: "Attach the VS Code debugger to your Trigger.dev tasks to set breakpoints and step through your code."
 ---
 
 import DebuggingInVSCode from '/snippets/debugging_in_vscode.mdx';

--- a/docs/troubleshooting-github-issues.mdx
+++ b/docs/troubleshooting-github-issues.mdx
@@ -3,4 +3,4 @@ title: "GitHub Issues"
 url: "https://github.com/triggerdotdev/trigger.dev/issues"
 ---
 
-Please [join our community on Discord](https://github.com/triggerdotdev/trigger.dev/issues) to ask questions, share your projects, and get help from other developers.
+Please [join our community on Discord](https://trigger.dev/discord) to report bugs, request features, or get help from the team and other developers.

--- a/docs/troubleshooting-uptime-status.mdx
+++ b/docs/troubleshooting-uptime-status.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Uptime Status"
+description: "Subscribe to email notifications for Trigger.dev platform incidents and status updates."
 ---
 
 Get email notifications when Trigger.dev creates, updates or resolves a platform incident.

--- a/docs/video-walkthrough.mdx
+++ b/docs/video-walkthrough.mdx
@@ -20,4 +20,4 @@ description: "Go from zero to a working task in your Next.js app in 10 minutes."
 - [1:44](https://youtu.be/YH_4c0K7fGM?si=J8svVzotZtyTXDap&t=104) – [Run and test](/run-tests) the "Hello, world!" example project
 - [2:09](https://youtu.be/YH_4c0K7fGM?si=FMTP8ep_cDBCU0_x&t=128) – Create and run an AI image generation task that uses [Fal.ai](https://fal.ai) – ([View the code](/guides/examples/fal-ai-image-to-cartoon))
 - [6:25](https://youtu.be/YH_4c0K7fGM?si=pPc8iLI2Y9FGD3yo&t=385) – Create and run a [Realtime](/realtime/overview) example using [React hooks](/realtime/react-hooks) – ([View the code](/guides/examples/fal-ai-realtime))
-- [11:10](https://youtu.be/YH_4c0K7fGM?si=Mjd0EvvNsNlVouvY&t=670) – [Deploy your task](/cli-deploy) to the Trigger.dev Cloud
+- [11:10](https://youtu.be/YH_4c0K7fGM?si=Mjd0EvvNsNlVouvY&t=670) – [Deploy your task](/cli-deploy-commands) to the Trigger.dev Cloud


### PR DESCRIPTION
A batch of technical-SEO fixes across the docs, all reader-facing (titles, links, redirects):

- Canonicalize the duplicate CLI command pages: the bare `/cli-dev` and `/cli-deploy` paths now permanently redirect to their `-commands` equivalents, and a duplicate navigation entry is removed.
- Give the three pages that all rendered as "Overview" distinct titles (Building with AI, self-hosting overview, Management API overview), with sidebar labels unchanged.
- Replace the generic "Learn more" links in the introduction's build-extension list with descriptive anchor text.
- Switch two http links to https in the Supabase guides, point a troubleshooting page's help link to Discord, and add missing meta descriptions to three help and troubleshooting pages.