### PR TITLE
chore(webapp): add currency unit to agent LLM spend chart label

### DIFF
--- a/.server-changes/llm-spend-currency-label.md
+++ b/.server-changes/llm-spend-currency-label.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+Add a currency unit to the agent dashboard "LLM spend" chart label, so it now reads "LLM spend ($)".

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentParam/route.tsx
@@ -293,7 +293,7 @@ export default function Page() {
                         )}
                       </ChartCard>
 
-                      <ChartCard title="LLM spend">
+                      <ChartCard title="LLM spend ($)">
                         <Suspense fallback={<ActivityChartSkeleton />}>
                           <TypedAwait
                             resolve={llmCostActivity}


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Ran the webapp locally with the change applied; it compiles and serves. The edit only swaps the chart card title string from "LLM spend" to "LLM spend ($)" on the agent landing page.

---

## Changelog

The agent dashboard "LLM spend" chart label now includes the currency unit, reading "LLM spend ($)".

---

## Screenshots

_[Screenshots]_

💯
