### PR TITLE
feat: disable runner debug logs by default

### DIFF
--- a/.changeset/runner-send-debug-logs-gate.md
+++ b/.changeset/runner-send-debug-logs-gate.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Runner debug logs are now disabled by default. Set `SEND_RUN_DEBUG_LOGS=true` on the supervisor to re-enable them.

--- a/apps/supervisor/src/index.ts
+++ b/apps/supervisor/src/index.ts
@@ -157,6 +157,7 @@ class ManagedSupervisor {
           instanceName: env.TRIGGER_WORKER_INSTANCE_NAME,
           otelEndpoint: env.OTEL_EXPORTER_OTLP_ENDPOINT,
           prettyLogs: env.RUNNER_PRETTY_LOGS,
+          sendRunDebugLogs: env.SEND_RUN_DEBUG_LOGS,
         },
         createRetry: {
           maxAttempts: env.COMPUTE_INSTANCE_CREATE_MAX_ATTEMPTS,

--- a/apps/supervisor/src/workloadManager/compute.ts
+++ b/apps/supervisor/src/workloadManager/compute.ts
@@ -75,6 +75,7 @@ type ComputeWorkloadManagerOptions = WorkloadManagerOptions & {
     instanceName: string;
     otelEndpoint: string;
     prettyLogs: boolean;
+    sendRunDebugLogs: boolean;
   };
   createRetry?: {
     maxAttempts: number;
@@ -162,6 +163,7 @@ export class ComputeWorkloadManager implements WorkloadManager {
       TRIGGER_MACHINE_CPU: String(opts.machine.cpu),
       TRIGGER_MACHINE_MEMORY: String(opts.machine.memory),
       PRETTY_LOGS: String(this.opts.runner.prettyLogs),
+      TRIGGER_SEND_RUN_DEBUG_LOGS: String(this.opts.runner.sendRunDebugLogs),
     };
 
     if (this.opts.warmStartUrl) {

--- a/apps/supervisor/src/workloadManager/docker.ts
+++ b/apps/supervisor/src/workloadManager/docker.ts
@@ -84,6 +84,7 @@ export class DockerWorkloadManager implements WorkloadManager {
       `TRIGGER_MACHINE_CPU=${opts.machine.cpu}`,
       `TRIGGER_MACHINE_MEMORY=${opts.machine.memory}`,
       `PRETTY_LOGS=${env.RUNNER_PRETTY_LOGS}`,
+      `TRIGGER_SEND_RUN_DEBUG_LOGS=${env.SEND_RUN_DEBUG_LOGS}`,
     ];
 
     if (this.opts.warmStartUrl) {

--- a/apps/supervisor/src/workloadManager/kubernetes.ts
+++ b/apps/supervisor/src/workloadManager/kubernetes.ts
@@ -209,6 +209,10 @@ export class KubernetesWorkloadManager implements WorkloadManager {
                     value: `${opts.machine.memory}`,
                   },
                   {
+                    name: "TRIGGER_SEND_RUN_DEBUG_LOGS",
+                    value: `${env.SEND_RUN_DEBUG_LOGS}`,
+                  },
+                  {
                     name: "LIMITS_CPU",
                     valueFrom: {
                       resourceFieldRef: {

--- a/packages/cli-v3/src/entryPoints/managed/env.ts
+++ b/packages/cli-v3/src/entryPoints/managed/env.ts
@@ -8,6 +8,13 @@ const DateEnv = z
   .transform((val) => new Date(parseInt(val, 10)))
   .pipe(z.date());
 
+const BoolEnv = z.preprocess((val) => {
+  if (typeof val !== "string") {
+    return val;
+  }
+  return ["true", "1"].includes(val.toLowerCase().trim());
+}, z.boolean());
+
 // All IDs are friendly IDs
 const Env = z.object({
   // Set at build time
@@ -47,6 +54,9 @@ const Env = z.object({
   TRIGGER_SNAPSHOT_POLL_INTERVAL_SECONDS: z.coerce.number().default(5),
   TRIGGER_SUCCESS_EXIT_CODE: z.coerce.number().default(0),
   TRIGGER_FAILURE_EXIT_CODE: z.coerce.number().default(1),
+
+  // Gates the per-log-line debug-log POST to the supervisor; off by default
+  TRIGGER_SEND_RUN_DEBUG_LOGS: BoolEnv.default(false),
 });
 
 type Env = z.infer<typeof Env>;
@@ -135,6 +145,9 @@ export class RunnerEnv {
   }
   get TRIGGER_FAILURE_EXIT_CODE() {
     return this.env.TRIGGER_FAILURE_EXIT_CODE;
+  }
+  get TRIGGER_SEND_RUN_DEBUG_LOGS() {
+    return this.env.TRIGGER_SEND_RUN_DEBUG_LOGS;
   }
   get TRIGGER_HEARTBEAT_INTERVAL_SECONDS() {
     return this.env.TRIGGER_HEARTBEAT_INTERVAL_SECONDS;

--- a/packages/cli-v3/src/entryPoints/managed/logger.ts
+++ b/packages/cli-v3/src/entryPoints/managed/logger.ts
@@ -55,6 +55,11 @@ export class ManagedRunLogger implements RunLogger {
       this.logger.log(message, mergedProperties);
     }
 
+    // Skip the per-log-line POST to the supervisor unless explicitly enabled
+    if (!this.env.TRIGGER_SEND_RUN_DEBUG_LOGS) {
+      return;
+    }
+
     const flattenedProperties = flattenAttributes(
       mergedProperties
     ) satisfies WorkloadDebugLogRequestBody["properties"];


### PR DESCRIPTION
Runners were POSTing a debug log to the supervisor for every log line - one request per line, unbatched and unconditional. The supervisor already has a `SEND_RUN_DEBUG_LOGS` toggle (off by default) that discards them on receipt, but the runner fired the request regardless, so the traffic hit the supervisor either way.

This gates the send at the source. The runner now reads `TRIGGER_SEND_RUN_DEBUG_LOGS` (off by default, injected by the supervisor from its existing `SEND_RUN_DEBUG_LOGS` setting) and skips the POST entirely when disabled. Local log output is unchanged. Dev runs use a separate path and are unaffected.