### PR TITLE
ci: raise CLAUDE.md audit turn limit and pin Opus 4.8

### DIFF
--- a/.github/workflows/claude-md-audit.yml
+++ b/.github/workflows/claude-md-audit.yml
@@ -43,7 +43,8 @@ jobs:
           allowed_bots: "devin-ai-integration[bot]"
 
           claude_args: |
-            --max-turns 15
+            --max-turns 25
+            --model claude-opus-4-8
             --allowedTools "Read,Glob,Grep,Bash(git diff:*)"
 
           prompt: |


### PR DESCRIPTION
## Summary

The CLAUDE.md audit job (`.github/workflows/claude-md-audit.yml`) frequently hits its 15-turn cap before it finishes reviewing a PR, so the job fails without posting a verdict. For example, the audit job failed on [this run](https://github.com/triggerdotdev/trigger.dev/actions/runs/27837408945/job/82390460772?pr=3990).

This raises `--max-turns` from 15 to 25 to give the review room to complete, and pins `--model claude-opus-4-8` (the job previously inherited the action default model).