### PR TITLE
fix(webapp): gate SSO UI on plugin presence, not managed-cloud

### DIFF
--- a/apps/webapp/app/components/navigation/OrganizationSettingsSideMenu.tsx
+++ b/apps/webapp/app/components/navigation/OrganizationSettingsSideMenu.tsx
@@ -147,7 +147,7 @@ export function OrganizationSettingsSideMenu({
               data-action="roles"
             />
           )}
-          {isManagedCloud && isSsoUsingPlugin && (
+          {isSsoUsingPlugin && (
             <SideMenuItem
               name="SSO"
               icon={PadlockIcon}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.settings.sso/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.settings.sso/route.tsx
@@ -31,7 +31,6 @@ import { Paragraph } from "~/components/primitives/Paragraph";
 import { Select, SelectItem } from "~/components/primitives/Select";
 import { Switch } from "~/components/primitives/Switch";
 import { $replica } from "~/db.server";
-import { featuresForRequest } from "~/features.server";
 import { useOrganization } from "~/hooks/useOrganizations";
 import { rbac } from "~/services/rbac.server";
 import { ssoController } from "~/services/sso.server";
@@ -79,12 +78,8 @@ export const loader = dashboardLoader(
     authorization: { action: "manage", resource: { type: "sso" } },
   },
   async ({ context, request }) => {
-    const { isManagedCloud } = featuresForRequest(request);
-    // Gate on managed cloud AND the SSO plugin actually being loaded
-    // (SSO_ENABLED off → OSS fallback → isUsingPlugin false). Without
-    // this the page renders for every managed-cloud org even when SSO
-    // is disabled for the deployment.
-    if (!isManagedCloud || !(await ssoController.isUsingPlugin())) {
+    // True only when SSO_ENABLED is on and a real SSO plugin is loaded.
+    if (!(await ssoController.isUsingPlugin())) {
       throw new Response("Not Found", { status: 404 });
     }
 
@@ -175,8 +170,8 @@ export const action = dashboardAction(
       throw new Response("Not Found", { status: 404 });
     }
 
-    const { isManagedCloud } = featuresForRequest(request);
-    if (!isManagedCloud) {
+    // Mirror the loader gate.
+    if (!(await ssoController.isUsingPlugin())) {
       throw new Response("Not Found", { status: 404 });
     }
     await requireSsoEntitlement(orgId);

--- a/apps/webapp/app/routes/login._index/route.tsx
+++ b/apps/webapp/app/routes/login._index/route.tsx
@@ -13,7 +13,6 @@ import { FormError } from "~/components/primitives/FormError";
 import { Header1 } from "~/components/primitives/Headers";
 import { Paragraph } from "~/components/primitives/Paragraph";
 import { TextLink } from "~/components/primitives/TextLink";
-import { featuresForRequest } from "~/features.server";
 import { isGithubAuthSupported, isGoogleAuthSupported } from "~/services/auth.server";
 import { getLastAuthMethod } from "~/services/lastAuthMethod.server";
 import { commitSession, setRedirectTo } from "~/services/redirectTo.server";
@@ -86,16 +85,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
       ? "Your SSO session expired. Please sign in again."
       : null;
 
-  const { isManagedCloud } = featuresForRequest(request);
-  // /login is unauthenticated and high-traffic; don't pay the plugin
-  // resolution + flag fetch on self-hosted where the result is unused.
+  // SSO login requires both an active plugin (SSO_ENABLED on + a real plugin loaded)
+  // and the hasSso global flag — a DB-backed runtime kill switch that disables the
+  // SSO login button without a redeploy. isUsingPlugin() is cheap and short-circuits
+  // before the flag fetch, so self-hosted/no-plugin deployments pay nothing.
   let showSsoAuth = false;
-  if (isManagedCloud) {
-    const [pluginActive, globalFlags] = await Promise.all([
-      ssoController.isUsingPlugin(),
-      getGlobalFlags(),
-    ]);
-    showSsoAuth = pluginActive && (globalFlags as Record<string, unknown>).hasSso === true;
+  if (await ssoController.isUsingPlugin()) {
+    const globalFlags = await getGlobalFlags();
+    showSsoAuth = (globalFlags as Record<string, unknown>).hasSso === true;
   }
 
   if (redirectTo) {


### PR DESCRIPTION
`isManagedCloud` was a wrong way to gate the SSO feature, system now checks if SSO_ENABLED is set, and if the plugin is available