### PR TITLE
docs: fix wait.for() idempotency example to use a single options object

### DIFF
--- a/docs/wait-for.mdx
+++ b/docs/wait-for.mdx
@@ -38,5 +38,5 @@ You can pass an idempotency key to any wait function, allowing you to skip waits
 
 ```ts
 // Specify the idempotency key and TTL when waiting for a duration:
-await wait.for({ seconds: 10 }, { idempotencyKey: "my-idempotency-key", idempotencyKeyTTL: "1h" });
+await wait.for({ seconds: 10, idempotencyKey: "my-idempotency-key", idempotencyKeyTTL: "1h" });
 ```


### PR DESCRIPTION
 Documentation-only change; no runtime code paths are affected. Verified against the
  SDK source rather than executed:

  - wait.for() is defined as for: async (options: WaitForOptions) —
  packages/trigger-sdk/src/v3/wait.ts:394
  - WaitForOptions = WaitPeriod & CommonWaitOptions (wait.ts:358), and idempotencyKey /
  idempotencyKeyTTL are members of CommonWaitOptions (wait.ts:343)

  So the idempotency keys must live in the single options object alongside the duration.
  The corrected example mirrors the existing wait.until() example in
  docs/wait-until.mdx.

  ---
  Changelog

  Docs: fixed the wait.for() idempotency example to pass
  idempotencyKey/idempotencyKeyTTL inside the single options object (they were
  previously passed as a second argument, which is silently ignored).

  ---
  Screenshots

  N/A — documentation text change only.

  💯

  Two notes:
  - I dropped the `Closes #<issue>` line since there's no associated issue (it's a
  spotted docs typo). If you'd rather file a quick issue first and link it, I can draft
  that too.
  - The CONTRIBUTING checkbox is checked on the assumption you're good with their guide
  for a trivial docs change — it requires no changeset (docs-only, no package version
  bump). If you want, I can read `CONTRIBUTING.md` to confirm there's nothing extra
  before you submit