### PR TITLE
fix(webapp): fetch run-scoped trace subtrees for large traces

### DIFF
--- a/.server-changes/trace-view-large-runs-subtree.md
+++ b/.server-changes/trace-view-large-runs-subtree.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Fix empty trace views for child and nested runs in very large traces. The dashboard and retrieve-trace API now return the requested run's span subtree, including ancestor spans outside the anchor run's time window (so a parent's cancellation/error state propagates down correctly).

--- a/apps/webapp/app/presenters/v3/RunPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/RunPresenter.server.ts
@@ -1,6 +1,7 @@
 import { millisecondsToNanoseconds, RunAnnotations } from "@trigger.dev/core/v3";
 import { createTreeFromFlatItems, flattenTree } from "~/components/primitives/TreeView/TreeView";
 import { prisma, type PrismaClient } from "~/db.server";
+import { logger } from "~/services/logger.server";
 import { createTimelineSpanEventsFromSpanEvents } from "~/utils/timelineSpanEvents";
 import { getUsername } from "~/utils/username";
 import { SpanSummary } from "~/v3/eventRepository/eventRepository.types";
@@ -179,15 +180,48 @@ export class RunPresenter {
       run.runtimeEnvironment.organizationId
     );
 
-    // get the events
+    const traceTimeBounds = {
+      startCreatedAt: run.rootTaskRun?.createdAt ?? run.createdAt,
+      endCreatedAt: run.completedAt ?? undefined,
+    };
+
+    // Fast path: full trace summary. Slow path: subtree fetch when the anchor
+    // span fell past the row cap (large traces ordered by start_time ASC).
     let traceSummary = await repository.getTraceSummary(
       getTaskEventStoreTableForRun(run),
       run.runtimeEnvironment.id,
       run.traceId,
-      run.rootTaskRun?.createdAt ?? run.createdAt,
-      run.completedAt ?? undefined,
+      traceTimeBounds.startCreatedAt,
+      traceTimeBounds.endCreatedAt,
       { includeDebugLogs: showDebug }
     );
+
+    let isTruncated = traceSummary?.isTruncated ?? false;
+    const hasAnchorSpan = traceSummary?.spans.some((span) => span.id === run.spanId) ?? false;
+
+    if (traceSummary && !hasAnchorSpan) {
+      logger.warn("Trace summary missing anchor span, falling back to subtree fetch", {
+        runId: run.friendlyId,
+        spanId: run.spanId,
+        traceId: run.traceId,
+        spanCount: traceSummary.spans.length,
+      });
+
+      const subtreeSummary = await repository.getTraceSubtreeSummary(
+        getTaskEventStoreTableForRun(run),
+        run.runtimeEnvironment.id,
+        run.traceId,
+        run.spanId,
+        traceTimeBounds.startCreatedAt,
+        traceTimeBounds.endCreatedAt,
+        { includeDebugLogs: showDebug }
+      );
+
+      if (subtreeSummary) {
+        traceSummary = subtreeSummary;
+        isTruncated = subtreeSummary.isTruncated ?? false;
+      }
+    }
 
     if (!traceSummary) {
       const spanSummary: SpanSummary = {
@@ -241,6 +275,18 @@ export class RunPresenter {
 
     //this tree starts at the passed in span (hides parent elements if there are any)
     const tree = createTreeFromFlatItems(traceSummary.spans, run.spanId);
+    const missingAnchor = !traceSummary.spans.some((span) => span.id === run.spanId) || !tree;
+
+    if (missingAnchor) {
+      logger.warn("Trace view anchor span not found in trace summary", {
+        runId: run.friendlyId,
+        spanId: run.spanId,
+        traceId: run.traceId,
+        spanCount: traceSummary.spans.length,
+      });
+
+      isTruncated = true;
+    }
 
     //we need the start offset for each item, and the total duration of the entire tree
     const treeRootStartTimeMs = tree ? tree?.data.startTime.getTime() : 0;
@@ -312,6 +358,8 @@ export class RunPresenter {
           : undefined,
         overridesBySpanId: traceSummary.overridesBySpanId,
         linkedRunIdBySpanId,
+        isTruncated,
+        missingAnchor,
       },
       maximumLiveReloadingSetting: repository.maximumLiveReloadingSetting,
     };

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
@@ -36,6 +36,7 @@ import { AdminDebugTooltip } from "~/components/admin/debugTooltip";
 import { PageBody } from "~/components/layout/AppLayout";
 import { Badge } from "~/components/primitives/Badge";
 import { Button, LinkButton } from "~/components/primitives/Buttons";
+import { Callout } from "~/components/primitives/Callout";
 import { CopyableText } from "~/components/primitives/CopyableText";
 import { DateTimeShort } from "~/components/primitives/DateTime";
 import { Dialog, DialogTrigger } from "~/components/primitives/Dialog";
@@ -599,8 +600,16 @@ function TraceView({
     return <></>;
   }
 
-  const { events, duration, rootSpanStatus, rootStartedAt, queuedDuration, overridesBySpanId } =
-    trace;
+  const {
+    events,
+    duration,
+    rootSpanStatus,
+    rootStartedAt,
+    queuedDuration,
+    overridesBySpanId,
+    isTruncated = false,
+    missingAnchor = false,
+  } = trace;
 
   const changeToSpan = useDebounce((selectedSpan: string) => {
     replaceSearchParam("span", selectedSpan, { replace: true });
@@ -647,31 +656,44 @@ function TraceView({
           id={resizableSettings.parent.main.id}
           min={resizableSettings.parent.main.min}
         >
-          <TasksTreeView
-            selectedId={selectedSpanId}
-            key={events[0]?.id ?? "-"}
-            events={events}
-            onSelectedIdChanged={(selectedSpan) => {
-              //instantly close the panel if no span is selected
-              if (!selectedSpan) {
-                replaceSearchParam("span");
-                return;
-              }
+          <div className="flex h-full flex-col overflow-hidden">
+            {isTruncated && (
+              <div className="shrink-0 border-b border-charcoal-700 px-3 py-2">
+                <Callout variant="warning" className="text-sm">
+                  {missingAnchor
+                    ? "Trace too large to display completely."
+                    : "This run's trace is partially displayed because it exceeds the view limit."}
+                </Callout>
+              </div>
+            )}
+            <div className="min-h-0 flex-1">
+              <TasksTreeView
+                selectedId={selectedSpanId}
+                key={events[0]?.id ?? "-"}
+                events={events}
+                onSelectedIdChanged={(selectedSpan) => {
+                  //instantly close the panel if no span is selected
+                  if (!selectedSpan) {
+                    replaceSearchParam("span");
+                    return;
+                  }
 
-              changeToSpan(selectedSpan);
-            }}
-            totalDuration={duration}
-            rootSpanStatus={rootSpanStatus}
-            rootStartedAt={rootStartedAt ? new Date(rootStartedAt) : undefined}
-            queuedDuration={queuedDuration}
-            environmentType={run.environment.type}
-            shouldLiveReload={isLiveReloading}
-            maximumLiveReloadingSetting={maximumLiveReloadingSetting}
-            rootRun={run.rootTaskRun}
-            parentRun={run.parentTaskRun}
-            isCompleted={run.completedAt !== null}
-            treeSnapshot={resizable.tree as ResizableSnapshot}
-          />
+                  changeToSpan(selectedSpan);
+                }}
+                totalDuration={duration}
+                rootSpanStatus={rootSpanStatus}
+                rootStartedAt={rootStartedAt ? new Date(rootStartedAt) : undefined}
+                queuedDuration={queuedDuration}
+                environmentType={run.environment.type}
+                shouldLiveReload={isLiveReloading}
+                maximumLiveReloadingSetting={maximumLiveReloadingSetting}
+                rootRun={run.rootTaskRun}
+                parentRun={run.parentTaskRun}
+                isCompleted={run.completedAt !== null}
+                treeSnapshot={resizable.tree as ResizableSnapshot}
+              />
+            </div>
+          </div>
         </ResizablePanel>
         <ResizableHandle
           id={resizableSettings.parent.handleId}

--- a/apps/webapp/app/routes/api.v1.runs.$runId.trace.ts
+++ b/apps/webapp/app/routes/api.v1.runs.$runId.trace.ts
@@ -93,10 +93,11 @@ export const loader = createLoaderApiRoute(
       authentication.environment.organization.id
     );
 
-    const traceSummary = await eventRepository.getTraceDetailedSummary(
+    const traceSummary = await eventRepository.getTraceDetailedSubtreeSummary(
       getTaskEventStoreTableForRun(run),
       authentication.environment.id,
       run.traceId,
+      run.spanId,
       run.createdAt,
       run.completedAt ?? undefined
     );

--- a/apps/webapp/app/v3/eventRepository/clickhouseEventRepository.server.ts
+++ b/apps/webapp/app/v3/eventRepository/clickhouseEventRepository.server.ts
@@ -1298,44 +1298,355 @@ export class ClickhouseEventRepository implements IEventRepository {
     endCreatedAt?: Date,
     options?: { includeDebugLogs?: boolean }
   ): Promise<TraceSummary | undefined> {
-    const startCreatedAtWithBuffer = new Date(startCreatedAt.getTime() - 60_000);
-    const endCreatedAtWithBuffer = endCreatedAt
-      ? new Date(endCreatedAt.getTime() + 60_000)
-      : undefined;
+    const limit = this._config.maximumTraceSummaryViewCount;
+    const records = await this.#fetchTraceSummaryRecords({
+      environmentId,
+      traceId,
+      startCreatedAt,
+      endCreatedAt,
+      options,
+      limit,
+    });
 
-    const queryBuilder =
-      this._version === "v2"
-        ? this._clickhouse.taskEventsV2.traceSummaryQueryBuilder()
-        : this._clickhouse.taskEvents.traceSummaryQueryBuilder();
+    if (!records) {
+      return;
+    }
+
+    const summary = this.#buildTraceSummaryFromRecords(records);
+    if (!summary) {
+      return;
+    }
+
+    return {
+      ...summary,
+      isTruncated: limit !== undefined && records.length >= limit,
+    };
+  }
+
+  async getTraceSubtreeSummary(
+    storeTable: TaskEventStoreTable,
+    environmentId: string,
+    traceId: string,
+    anchorSpanId: string,
+    startCreatedAt: Date,
+    endCreatedAt?: Date,
+    options?: { includeDebugLogs?: boolean }
+  ): Promise<TraceSummary | undefined> {
+    const { records, isTruncated, missingAnchor } = await this.#fetchTraceSubtreeRecords({
+      environmentId,
+      traceId,
+      anchorSpanId,
+      startCreatedAt,
+      endCreatedAt,
+      options,
+      limit: this._config.maximumTraceSummaryViewCount,
+    });
+
+    if (missingAnchor) {
+      return;
+    }
+
+    const summary = this.#buildTraceSummaryFromRecords(records, {
+      rootSpanId: anchorSpanId,
+    });
+
+    if (!summary) {
+      return;
+    }
+
+    return {
+      ...summary,
+      isTruncated,
+    };
+  }
+
+  async #fetchTraceSubtreeRecords({
+    environmentId,
+    traceId,
+    anchorSpanId,
+    startCreatedAt,
+    endCreatedAt,
+    options,
+    limit: maxRows,
+  }: {
+    environmentId: string;
+    traceId: string;
+    anchorSpanId: string;
+    startCreatedAt: Date;
+    endCreatedAt?: Date;
+    options?: { includeDebugLogs?: boolean };
+    limit?: number;
+  }): Promise<{
+    records: TaskEventSummaryV1Result[];
+    isTruncated: boolean;
+    missingAnchor: boolean;
+  }> {
+    return this.#collectTraceSubtreeRecords({
+      anchorSpanId,
+      maxRows,
+      // Ancestors are fetched by explicit spanIds and start before the anchor
+      // run's time window, so applying startCreatedAt would wrongly exclude them
+      // (and with it the cancellation/error overrides they propagate downward).
+      fetchAncestor: (batch) =>
+        this.#fetchTraceSummaryRecords({
+          environmentId,
+          traceId,
+          skipTimeWindow: true,
+          options,
+          ...batch,
+        }),
+      fetchDescendant: (batch) =>
+        this.#fetchTraceSummaryRecords({
+          environmentId,
+          traceId,
+          startCreatedAt,
+          endCreatedAt,
+          options,
+          ...batch,
+        }),
+    });
+  }
+
+  async #fetchTraceDetailedSubtreeRecords({
+    environmentId,
+    traceId,
+    anchorSpanId,
+    startCreatedAt,
+    endCreatedAt,
+    options,
+    limit: maxRows,
+  }: {
+    environmentId: string;
+    traceId: string;
+    anchorSpanId: string;
+    startCreatedAt: Date;
+    endCreatedAt?: Date;
+    options?: { includeDebugLogs?: boolean };
+    limit?: number;
+  }): Promise<{
+    records: TaskEventDetailedSummaryV1Result[];
+    isTruncated: boolean;
+    missingAnchor: boolean;
+  }> {
+    return this.#collectTraceSubtreeRecords({
+      anchorSpanId,
+      maxRows,
+      // Ancestors are fetched by explicit spanIds and start before the anchor
+      // run's time window, so applying startCreatedAt would wrongly exclude them
+      // (and with it the cancellation/error overrides they propagate downward).
+      fetchAncestor: (batch) =>
+        this.#fetchTraceDetailedSummaryRecords({
+          environmentId,
+          traceId,
+          skipTimeWindow: true,
+          options,
+          ...batch,
+        }),
+      fetchDescendant: (batch) =>
+        this.#fetchTraceDetailedSummaryRecords({
+          environmentId,
+          traceId,
+          startCreatedAt,
+          endCreatedAt,
+          options,
+          ...batch,
+        }),
+    });
+  }
+
+  async #collectTraceSubtreeRecords<T extends { span_id: string; parent_span_id: string }>({
+    anchorSpanId,
+    maxRows,
+    fetchAncestor,
+    fetchDescendant,
+  }: {
+    anchorSpanId: string;
+    maxRows?: number;
+    fetchAncestor: (batch: { spanIds: string[]; limit?: number }) => Promise<T[] | undefined>;
+    fetchDescendant: (batch: {
+      spanIds?: string[];
+      parentSpanIds?: string[];
+      limit?: number;
+    }) => Promise<T[] | undefined>;
+  }): Promise<{
+    records: T[];
+    isTruncated: boolean;
+    missingAnchor: boolean;
+  }> {
+    const allRecords: T[] = [];
+    const collectedSpanIds = new Set<string>();
+    let isTruncated = false;
+
+    const anchorRecords = await fetchDescendant({
+      spanIds: [anchorSpanId],
+      limit: maxRows,
+    });
+
+    if (!anchorRecords || anchorRecords.length === 0) {
+      return { records: [], isTruncated: false, missingAnchor: true };
+    }
+
+    if (maxRows && anchorRecords.length >= maxRows) {
+      isTruncated = true;
+    }
+
+    allRecords.push(...anchorRecords);
+    collectedSpanIds.add(anchorSpanId);
+
+    let parentSpanId = this.#parentSpanIdFromRecords(anchorRecords, anchorSpanId);
+    while (parentSpanId) {
+      if (collectedSpanIds.has(parentSpanId)) {
+        break;
+      }
+
+      if (maxRows && allRecords.length >= maxRows) {
+        isTruncated = true;
+        break;
+      }
+
+      const parentRecords = await fetchAncestor({
+        spanIds: [parentSpanId],
+        limit: maxRows ? maxRows - allRecords.length : undefined,
+      });
+
+      if (!parentRecords || parentRecords.length === 0) {
+        break;
+      }
+
+      allRecords.push(...parentRecords);
+      collectedSpanIds.add(parentSpanId);
+      parentSpanId = this.#parentSpanIdFromRecords(parentRecords, parentSpanId);
+    }
+
+    // Walk descendants level-by-level rather than fetching everything after the anchor in one
+    // windowed query. parent_span_id isn't in the sort key, so each level rescans roughly the same
+    // granules - but trace depth is small in practice and repeated granule reads stay cached. A
+    // single broad query would pull every span after the anchor (a superset of the subtree) and
+    // make the maxRows cap drop real subtree spans in favour of unrelated ones.
+    let frontier = [anchorSpanId];
+    while (frontier.length > 0) {
+      if (maxRows && allRecords.length >= maxRows) {
+        isTruncated = true;
+        break;
+      }
+
+      const remaining = maxRows ? maxRows - allRecords.length : undefined;
+      const childRecords = await fetchDescendant({
+        parentSpanIds: frontier,
+        limit: remaining,
+      });
+
+      if (!childRecords || childRecords.length === 0) {
+        break;
+      }
+
+      if (remaining !== undefined && childRecords.length >= remaining) {
+        isTruncated = true;
+      }
+
+      allRecords.push(...childRecords);
+
+      const nextFrontier: string[] = [];
+      for (const record of childRecords) {
+        if (!collectedSpanIds.has(record.span_id)) {
+          collectedSpanIds.add(record.span_id);
+          nextFrontier.push(record.span_id);
+        }
+      }
+
+      frontier = nextFrontier;
+    }
+
+    return {
+      records: allRecords,
+      isTruncated,
+      missingAnchor: false,
+    };
+  }
+
+  #parentSpanIdFromRecords(
+    records: Array<{ span_id: string; parent_span_id: string }>,
+    spanId: string
+  ): string | undefined {
+    const parentSpanId = records.find((record) => record.span_id === spanId)?.parent_span_id;
+    return parentSpanId ? parentSpanId : undefined;
+  }
+
+  #createTraceSummaryQueryBuilder() {
+    return this._version === "v2"
+      ? this._clickhouse.taskEventsV2.traceSummaryQueryBuilder()
+      : this._clickhouse.taskEvents.traceSummaryQueryBuilder();
+  }
+
+  async #fetchTraceSummaryRecords({
+    environmentId,
+    traceId,
+    startCreatedAt,
+    endCreatedAt,
+    options,
+    spanIds,
+    parentSpanIds,
+    limit,
+    skipTimeWindow,
+  }: {
+    environmentId: string;
+    traceId: string;
+    startCreatedAt?: Date;
+    endCreatedAt?: Date;
+    options?: { includeDebugLogs?: boolean };
+    spanIds?: string[];
+    parentSpanIds?: string[];
+    limit?: number;
+    skipTimeWindow?: boolean;
+  }): Promise<TaskEventSummaryV1Result[] | undefined> {
+    const queryBuilder = this.#createTraceSummaryQueryBuilder();
 
     queryBuilder.where("environment_id = {environmentId: String}", { environmentId });
     queryBuilder.where("trace_id = {traceId: String}", { traceId });
-    queryBuilder.where("start_time >= {startCreatedAt: String}", {
-      startCreatedAt: convertDateToNanoseconds(startCreatedAtWithBuffer).toString(),
-    });
 
-    if (endCreatedAtWithBuffer) {
-      queryBuilder.where("start_time <= {endCreatedAt: String}", {
-        endCreatedAt: convertDateToNanoseconds(endCreatedAtWithBuffer).toString(),
-      });
-    }
+    if (!skipTimeWindow) {
+      if (!startCreatedAt) {
+        throw new Error("startCreatedAt is required when skipTimeWindow is false");
+      }
 
-    // For v2, add inserted_at filtering for partition pruning
-    if (this._version === "v2") {
-      queryBuilder.where("inserted_at >= {insertedAtStart: DateTime64(3)}", {
-        insertedAtStart: convertDateToClickhouseDateTime(startCreatedAtWithBuffer),
+      const startCreatedAtWithBuffer = new Date(startCreatedAt.getTime() - 60_000);
+      const endCreatedAtWithBuffer = endCreatedAt
+        ? new Date(endCreatedAt.getTime() + 60_000)
+        : undefined;
+
+      queryBuilder.where("start_time >= {startCreatedAt: String}", {
+        startCreatedAt: convertDateToNanoseconds(startCreatedAtWithBuffer).toString(),
       });
-      // No upper bound on inserted_at - we want all events inserted up to now
+
+      if (endCreatedAtWithBuffer) {
+        queryBuilder.where("start_time <= {endCreatedAt: String}", {
+          endCreatedAt: convertDateToNanoseconds(endCreatedAtWithBuffer).toString(),
+        });
+      }
+
+      if (this._version === "v2") {
+        queryBuilder.where("inserted_at >= {insertedAtStart: DateTime64(3)}", {
+          insertedAtStart: convertDateToClickhouseDateTime(startCreatedAtWithBuffer),
+        });
+      }
     }
 
     if (options?.includeDebugLogs === false) {
       queryBuilder.where("kind != {kind: String}", { kind: "DEBUG_EVENT" });
     }
 
+    if (spanIds && spanIds.length > 0) {
+      queryBuilder.where("span_id IN {spanIds: Array(String)}", { spanIds });
+    }
+
+    if (parentSpanIds && parentSpanIds.length > 0) {
+      queryBuilder.where("parent_span_id IN {parentSpanIds: Array(String)}", { parentSpanIds });
+    }
+
     queryBuilder.orderBy("start_time ASC");
 
-    if (this._config.maximumTraceSummaryViewCount) {
-      queryBuilder.limit(this._config.maximumTraceSummaryViewCount);
+    if (limit) {
+      queryBuilder.limit(limit);
     }
 
     const [queryError, records] = await queryBuilder.execute();
@@ -1344,11 +1655,17 @@ export class ClickhouseEventRepository implements IEventRepository {
       throw queryError;
     }
 
-    if (!records) {
+    return records;
+  }
+
+  #buildTraceSummaryFromRecords(
+    records: TaskEventSummaryV1Result[],
+    options?: { rootSpanId?: string }
+  ): TraceSummary | undefined {
+    if (records.length === 0) {
       return;
     }
 
-    // O(n) grouping instead of O(n²) array spreading
     const recordsGroupedBySpanId: Record<string, TaskEventSummaryV1Result[]> = {};
     for (const record of records) {
       if (!recordsGroupedBySpanId[record.span_id]) {
@@ -1358,9 +1675,8 @@ export class ClickhouseEventRepository implements IEventRepository {
     }
 
     const spanSummaries = new Map<string, SpanSummary>();
-    let rootSpanId: string | undefined;
+    let rootSpanId: string | undefined = options?.rootSpanId;
 
-    // Create temporary metadata cache for this query
     const metadataCache = new Map<string, Record<string, unknown>>();
 
     for (const [spanId, spanRecords] of Object.entries(recordsGroupedBySpanId)) {
@@ -1865,48 +2181,78 @@ export class ClickhouseEventRepository implements IEventRepository {
     return result;
   }
 
-  async getTraceDetailedSummary(
-    storeTable: TaskEventStoreTable,
-    environmentId: string,
-    traceId: string,
-    startCreatedAt: Date,
-    endCreatedAt?: Date,
-    options?: { includeDebugLogs?: boolean }
-  ): Promise<TraceDetailedSummary | undefined> {
-    const startCreatedAtWithBuffer = new Date(startCreatedAt.getTime() - 1000);
+  #createTraceDetailedSummaryQueryBuilder() {
+    return this._version === "v2"
+      ? this._clickhouse.taskEventsV2.traceDetailedSummaryQueryBuilder()
+      : this._clickhouse.taskEvents.traceDetailedSummaryQueryBuilder();
+  }
 
-    const queryBuilder =
-      this._version === "v2"
-        ? this._clickhouse.taskEventsV2.traceDetailedSummaryQueryBuilder()
-        : this._clickhouse.taskEvents.traceDetailedSummaryQueryBuilder();
+  async #fetchTraceDetailedSummaryRecords({
+    environmentId,
+    traceId,
+    startCreatedAt,
+    endCreatedAt,
+    options,
+    spanIds,
+    parentSpanIds,
+    limit,
+    skipTimeWindow,
+  }: {
+    environmentId: string;
+    traceId: string;
+    startCreatedAt?: Date;
+    endCreatedAt?: Date;
+    options?: { includeDebugLogs?: boolean };
+    spanIds?: string[];
+    parentSpanIds?: string[];
+    limit?: number;
+    skipTimeWindow?: boolean;
+  }): Promise<TaskEventDetailedSummaryV1Result[] | undefined> {
+    const queryBuilder = this.#createTraceDetailedSummaryQueryBuilder();
 
     queryBuilder.where("environment_id = {environmentId: String}", { environmentId });
     queryBuilder.where("trace_id = {traceId: String}", { traceId });
-    queryBuilder.where("start_time >= {startCreatedAt: String}", {
-      startCreatedAt: convertDateToNanoseconds(startCreatedAtWithBuffer).toString(),
-    });
 
-    if (endCreatedAt) {
-      queryBuilder.where("start_time <= {endCreatedAt: String}", {
-        endCreatedAt: convertDateToNanoseconds(endCreatedAt).toString(),
-      });
-    }
+    if (!skipTimeWindow) {
+      if (!startCreatedAt) {
+        throw new Error("startCreatedAt is required when skipTimeWindow is false");
+      }
 
-    // For v2, add inserted_at filtering for partition pruning
-    if (this._version === "v2") {
-      queryBuilder.where("inserted_at >= {insertedAtStart: DateTime64(3)}", {
-        insertedAtStart: convertDateToClickhouseDateTime(startCreatedAtWithBuffer),
+      const startCreatedAtWithBuffer = new Date(startCreatedAt.getTime() - 1000);
+
+      queryBuilder.where("start_time >= {startCreatedAt: String}", {
+        startCreatedAt: convertDateToNanoseconds(startCreatedAtWithBuffer).toString(),
       });
+
+      if (endCreatedAt) {
+        queryBuilder.where("start_time <= {endCreatedAt: String}", {
+          endCreatedAt: convertDateToNanoseconds(endCreatedAt).toString(),
+        });
+      }
+
+      if (this._version === "v2") {
+        queryBuilder.where("inserted_at >= {insertedAtStart: DateTime64(3)}", {
+          insertedAtStart: convertDateToClickhouseDateTime(startCreatedAtWithBuffer),
+        });
+      }
     }
 
     if (options?.includeDebugLogs === false) {
       queryBuilder.where("kind != {kind: String}", { kind: "DEBUG_EVENT" });
     }
 
+    if (spanIds && spanIds.length > 0) {
+      queryBuilder.where("span_id IN {spanIds: Array(String)}", { spanIds });
+    }
+
+    if (parentSpanIds && parentSpanIds.length > 0) {
+      queryBuilder.where("parent_span_id IN {parentSpanIds: Array(String)}", { parentSpanIds });
+    }
+
     queryBuilder.orderBy("start_time ASC");
 
-    if (this._config.maximumTraceDetailedSummaryViewCount) {
-      queryBuilder.limit(this._config.maximumTraceDetailedSummaryViewCount);
+    if (limit) {
+      queryBuilder.limit(limit);
     }
 
     const [queryError, records] = await queryBuilder.execute();
@@ -1915,11 +2261,18 @@ export class ClickhouseEventRepository implements IEventRepository {
       throw queryError;
     }
 
-    if (!records) {
+    return records;
+  }
+
+  #buildTraceDetailedSummaryFromRecords(
+    traceId: string,
+    records: TaskEventDetailedSummaryV1Result[],
+    rootSpanId?: string
+  ): TraceDetailedSummary | undefined {
+    if (records.length === 0) {
       return;
     }
 
-    // O(n) grouping instead of O(n²) array spreading
     const recordsGroupedBySpanId: Record<string, TaskEventDetailedSummaryV1Result[]> = {};
     for (const record of records) {
       if (!recordsGroupedBySpanId[record.span_id]) {
@@ -1929,9 +2282,8 @@ export class ClickhouseEventRepository implements IEventRepository {
     }
 
     const spanSummaries = new Map<string, SpanDetailedSummary>();
-    let rootSpanId: string | undefined;
+    let resolvedRootSpanId: string | undefined = rootSpanId;
 
-    // Create temporary metadata cache for this query
     const metadataCache = new Map<string, Record<string, unknown>>();
 
     for (const [spanId, spanRecords] of Object.entries(recordsGroupedBySpanId)) {
@@ -1947,12 +2299,12 @@ export class ClickhouseEventRepository implements IEventRepository {
 
       spanSummaries.set(spanId, spanSummary);
 
-      if (!rootSpanId && !spanSummary.parentId) {
-        rootSpanId = spanId;
+      if (!resolvedRootSpanId && !spanSummary.parentId) {
+        resolvedRootSpanId = spanId;
       }
     }
 
-    if (!rootSpanId) {
+    if (!resolvedRootSpanId) {
       return;
     }
 
@@ -1967,7 +2319,6 @@ export class ClickhouseEventRepository implements IEventRepository {
       return finalSpan;
     });
 
-    // Second pass: build parent-child relationships
     for (const finalSpan of finalSpans) {
       if (finalSpan.parentId) {
         const parent = spanDetailedSummaryMap.get(finalSpan.parentId);
@@ -1977,7 +2328,7 @@ export class ClickhouseEventRepository implements IEventRepository {
       }
     }
 
-    const rootSpan = spanDetailedSummaryMap.get(rootSpanId);
+    const rootSpan = spanDetailedSummaryMap.get(resolvedRootSpanId);
 
     if (!rootSpan) {
       return;
@@ -1987,6 +2338,120 @@ export class ClickhouseEventRepository implements IEventRepository {
       traceId,
       rootSpan,
     };
+  }
+
+  async getTraceDetailedSummary(
+    storeTable: TaskEventStoreTable,
+    environmentId: string,
+    traceId: string,
+    startCreatedAt: Date,
+    endCreatedAt?: Date,
+    options?: { includeDebugLogs?: boolean }
+  ): Promise<TraceDetailedSummary | undefined> {
+    const limit = this._config.maximumTraceDetailedSummaryViewCount;
+    const records = await this.#fetchTraceDetailedSummaryRecords({
+      environmentId,
+      traceId,
+      startCreatedAt,
+      endCreatedAt,
+      options,
+      limit,
+    });
+
+    if (!records) {
+      return;
+    }
+
+    const summary = this.#buildTraceDetailedSummaryFromRecords(traceId, records);
+    if (!summary) {
+      return;
+    }
+
+    return {
+      ...summary,
+      isTruncated: limit !== undefined && records.length >= limit,
+    };
+  }
+
+  async getTraceDetailedSubtreeSummary(
+    storeTable: TaskEventStoreTable,
+    environmentId: string,
+    traceId: string,
+    anchorSpanId: string,
+    startCreatedAt: Date,
+    endCreatedAt?: Date,
+    options?: { includeDebugLogs?: boolean }
+  ): Promise<TraceDetailedSummary | undefined> {
+    const limit = this._config.maximumTraceDetailedSummaryViewCount;
+
+    // Try one capped full-trace query first so the common case stays at a single
+    // round-trip; large traces pay an extra fetch before the subtree walk below.
+    const fullRecords = await this.#fetchTraceDetailedSummaryRecords({
+      environmentId,
+      traceId,
+      startCreatedAt,
+      endCreatedAt,
+      options,
+      limit,
+    });
+
+    if (fullRecords && this.#canReRootDetailedRecordsAtAnchor(fullRecords, anchorSpanId)) {
+      const summary = this.#buildTraceDetailedSummaryFromRecords(
+        traceId,
+        fullRecords,
+        anchorSpanId
+      );
+      if (summary) {
+        return {
+          ...summary,
+          isTruncated: limit !== undefined && fullRecords.length >= limit,
+        };
+      }
+    }
+
+    const { records, isTruncated, missingAnchor } = await this.#fetchTraceDetailedSubtreeRecords({
+      environmentId,
+      traceId,
+      anchorSpanId,
+      startCreatedAt,
+      endCreatedAt,
+      options,
+      limit,
+    });
+
+    if (missingAnchor) {
+      return;
+    }
+
+    const summary = this.#buildTraceDetailedSummaryFromRecords(traceId, records, anchorSpanId);
+    if (!summary) {
+      return;
+    }
+
+    return {
+      ...summary,
+      isTruncated,
+    };
+  }
+
+  // Only checks the direct parent — not the full ancestor chain. Safe in practice
+  // because ancestors have earlier start_time and usually land inside the cap
+  // when the anchor does; otherwise we fall back to the subtree walk.
+  #canReRootDetailedRecordsAtAnchor(
+    records: Array<{ span_id: string; parent_span_id: string }>,
+    anchorSpanId: string
+  ): boolean {
+    const anchorRecord = records.find((record) => record.span_id === anchorSpanId);
+    if (!anchorRecord) {
+      return false;
+    }
+
+    const parentSpanId = anchorRecord.parent_span_id;
+    if (!parentSpanId) {
+      return true;
+    }
+
+    return records.some((record) => record.span_id === parentSpanId);
   }
 
   async *streamTraceEvents(

--- a/apps/webapp/app/v3/eventRepository/eventRepository.server.ts
+++ b/apps/webapp/app/v3/eventRepository/eventRepository.server.ts
@@ -438,109 +438,22 @@ export class EventRepository implements IEventRepository {
         { includeDebugLogs: options?.includeDebugLogs }
       );
 
-      let preparedEvents: Array<PreparedEvent> = [];
-      let rootSpanId: string | undefined;
-      const eventsBySpanId = new Map<string, PreparedEvent>();
-
-      for (const event of events) {
-        preparedEvents.push(prepareEvent(event));
-
-        if (!rootSpanId && !event.parentId) {
-          rootSpanId = event.spanId;
-        }
-      }
-
-      for (const event of preparedEvents) {
-        const existingEvent = eventsBySpanId.get(event.spanId);
-
-        if (!existingEvent) {
-          eventsBySpanId.set(event.spanId, event);
-          continue;
-        }
-
-        // This is an invisible event, and we just want to keep the original event but concat together
-        // the event.events with the existingEvent.events
-        if (event.kind === "UNSPECIFIED") {
-          eventsBySpanId.set(event.spanId, {
-            ...existingEvent,
-            events: [...(existingEvent.events ?? []), ...(event.events ?? [])],
-          });
-          continue;
-        }
-
-        if (event.isCancelled || !event.isPartial) {
-          const mergedEvent: PreparedEvent = {
-            ...event,
-            // Preserve style from the original partial event
-            style: existingEvent.style,
-            events: [...(existingEvent.events ?? []), ...(event.events ?? [])],
-          };
-          eventsBySpanId.set(event.spanId, mergedEvent);
-          continue;
-        }
-      }
-
-      preparedEvents = Array.from(eventsBySpanId.values());
-
-      const spansBySpanId = new Map<string, SpanSummary>();
-
-      const spans = preparedEvents.map((event) => {
-        const overrides = getAncestorOverrides({
-          spansById: eventsBySpanId,
-          span: event,
-        });
-
-        const ancestorCancelled = overrides?.isCancelled ?? false;
-        const ancestorIsError = overrides?.isError ?? false;
-        const duration = overrides?.duration ?? event.duration;
-        const events = [...(overrides?.events ?? []), ...(event.events ?? [])];
-        const isPartial = ancestorCancelled || ancestorIsError ? false : event.isPartial;
-        const isCancelled =
-          event.isCancelled === true ? true : event.isPartial && ancestorCancelled;
-        const isError = isCancelled
-          ? false
-          : typeof overrides?.isError === "boolean"
-            ? overrides.isError
-            : event.isError;
-
-        const span = {
-          id: event.spanId,
-          parentId: event.parentId ?? undefined,
-          runId: event.runId,
-          data: {
-            message: event.message,
-            style: event.style,
-            duration,
-            isError,
-            isPartial,
-            isCancelled,
-            isDebug: event.kind === TaskEventKind.LOG,
-            startTime: getDateFromNanoseconds(event.startTime),
-            level: event.level,
-            events,
-          },
-        };
-
-        spansBySpanId.set(event.spanId, span);
-
-        return span;
-      });
-
-      if (!rootSpanId) {
-        return;
-      }
-
-      const rootSpan = spansBySpanId.get(rootSpanId);
-
-      if (!rootSpan) {
-        return;
-      }
-
-      return {
-        rootSpan,
-        spans,
-      };
+      return buildTraceSummaryFromQueriedEvents(events);
     });
+  }
+
+  public async getTraceSubtreeSummary(
+    _storeTable: TaskEventStoreTable,
+    _environmentId: string,
+    _traceId: string,
+    _anchorSpanId: string,
+    _startCreatedAt: Date,
+    _endCreatedAt?: Date,
+    _options?: { includeDebugLogs?: boolean }
+  ): Promise<TraceSummary | undefined> {
+    // Subtree traversal is ClickHouse-only. Dashboard falls back to the full
+    // summary when this returns undefined.
+    return undefined;
   }
 
   public async getTraceDetailedSummary(
@@ -560,128 +473,47 @@ export class EventRepository implements IEventRepository {
         { includeDebugLogs: options?.includeDebugLogs }
       );
 
-      let preparedEvents: Array<PreparedDetailedEvent> = [];
-      let rootSpanId: string | undefined;
-      const eventsBySpanId = new Map<string, PreparedDetailedEvent>();
-
-      for (const event of events) {
-        preparedEvents.push(prepareDetailedEvent(event));
-
-        if (!rootSpanId && !event.parentId) {
-          rootSpanId = event.spanId;
-        }
-      }
-
-      for (const event of preparedEvents) {
-        const existingEvent = eventsBySpanId.get(event.spanId);
-
-        if (!existingEvent) {
-          eventsBySpanId.set(event.spanId, event);
-          continue;
-        }
-
-        // This is an invisible event, and we just want to keep the original event but concat together
-        // the event.events with the existingEvent.events
-        if (event.kind === "UNSPECIFIED") {
-          eventsBySpanId.set(event.spanId, {
-            ...existingEvent,
-            events: [...(existingEvent.events ?? []), ...(event.events ?? [])],
-          });
-          continue;
-        }
-
-        if (event.isCancelled || !event.isPartial) {
-          // If we have a cancelled event and an existing partial event,
-          // merge them: use cancelled event data but preserve style from the partial event
-          if (event.isCancelled && existingEvent.isPartial && !existingEvent.isCancelled) {
-            const mergedEvent: PreparedDetailedEvent = {
-              ...event, // Use cancelled event as base (has correct timing, status, events)
-              // Preserve style from the original partial event
-              style: existingEvent.style,
-              events: [...(existingEvent.events ?? []), ...(event.events ?? [])],
-            };
-            eventsBySpanId.set(event.spanId, mergedEvent);
-            continue;
-          }
-        }
-      }
-
-      preparedEvents = Array.from(eventsBySpanId.values());
-
-      if (!rootSpanId) {
-        return;
-      }
-
-      // Build hierarchical structure
-      const spanDetailedSummaryMap = new Map<string, SpanDetailedSummary>();
-
-      // First pass: create all span detailed summaries
-      for (const event of preparedEvents) {
-        const overrides = getAncestorOverrides({
-          spansById: eventsBySpanId,
-          span: event,
-        });
-
-        const ancestorCancelled = overrides?.isCancelled ?? false;
-        const ancestorIsError = overrides?.isError ?? false;
-        const duration = overrides?.duration ?? event.duration;
-        const events = [...(overrides?.events ?? []), ...(event.events ?? [])];
-        const isPartial = ancestorCancelled || ancestorIsError ? false : event.isPartial;
-        const isCancelled =
-          event.isCancelled === true ? true : event.isPartial && ancestorCancelled;
-        const isError = isCancelled
-          ? false
-          : typeof overrides?.isError === "boolean"
-            ? overrides.isError
-            : event.isError;
-
-        const properties = event.properties
-          ? removePrivateProperties(event.properties as Attributes)
-          : {};
-
-        const spanDetailedSummary: SpanDetailedSummary = {
-          id: event.spanId,
-          parentId: event.parentId ?? undefined,
-          runId: event.runId,
-          data: {
-            message: event.message,
-            taskSlug: event.taskSlug ?? undefined,
-            events: events?.filter((e) => !e.name.startsWith("trigger.dev")),
-            startTime: getDateFromNanoseconds(event.startTime),
-            duration: nanosecondsToMilliseconds(duration),
-            isError,
-            isPartial,
-            isCancelled,
-            level: event.level,
-            properties,
-          },
-          children: [],
-        };
-
-        spanDetailedSummaryMap.set(event.spanId, spanDetailedSummary);
-      }
-
-      // Second pass: build parent-child relationships
-      for (const spanSummary of spanDetailedSummaryMap.values()) {
-        if (spanSummary.parentId) {
-          const parent = spanDetailedSummaryMap.get(spanSummary.parentId);
-          if (parent) {
-            parent.children.push(spanSummary);
-          }
-        }
-      }
-
-      const rootSpan = spanDetailedSummaryMap.get(rootSpanId);
-
-      if (!rootSpan) {
-        return;
-      }
-
-      return {
-        traceId,
-        rootSpan,
-      };
+      return buildTraceDetailedSummaryFromQueriedEvents(traceId, events);
     });
+  }
+
+  public async getTraceDetailedSubtreeSummary(
+    storeTable: TaskEventStoreTable,
+    environmentId: string,
+    traceId: string,
+    anchorSpanId: string,
+    startCreatedAt: Date,
+    endCreatedAt?: Date,
+    options?: { includeDebugLogs?: boolean }
+  ): Promise<TraceDetailedSummary | undefined> {
+    const events = await this.taskEventStore.findDetailedTraceEvents(
+      storeTable,
+      traceId,
+      startCreatedAt,
+      endCreatedAt,
+      { includeDebugLogs: options?.includeDebugLogs }
+    );
+
+    let summary = buildTraceDetailedSummaryFromQueriedEvents(traceId, events);
+
+    if (!summary) {
+      summary = buildTraceDetailedSummaryFromQueriedEvents(traceId, events, anchorSpanId);
+    }
+
+    if (!summary) {
+      return;
+    }
+
+    const anchorSpan = findSpanInDetailedTree(summary.rootSpan, anchorSpanId);
+    if (anchorSpan) {
+      return {
+        traceId: summary.traceId,
+        rootSpan: anchorSpan,
+        isTruncated: summary.isTruncated,
+      };
+    }
+
+    return summary;
   }
 
   public async *streamTraceEvents(
@@ -1587,6 +1419,243 @@ function prepareEvent(event: QueriedEvent): PreparedEvent {
     duration: Number(event.duration),
     events: parseEventsField(event.events),
     style: parseStyleField(event.style),
+  };
+}
+
+function buildTraceSummaryFromQueriedEvents(
+  events: QueriedEvent[],
+  rootSpanId?: string
+): TraceSummary | undefined {
+  let preparedEvents: Array<PreparedEvent> = [];
+  let resolvedRootSpanId: string | undefined = rootSpanId;
+  const eventsBySpanId = new Map<string, PreparedEvent>();
+
+  for (const event of events) {
+    preparedEvents.push(prepareEvent(event));
+
+    if (!resolvedRootSpanId && !event.parentId) {
+      resolvedRootSpanId = event.spanId;
+    }
+  }
+
+  for (const event of preparedEvents) {
+    const existingEvent = eventsBySpanId.get(event.spanId);
+
+    if (!existingEvent) {
+      eventsBySpanId.set(event.spanId, event);
+      continue;
+    }
+
+    if (event.kind === "UNSPECIFIED") {
+      eventsBySpanId.set(event.spanId, {
+        ...existingEvent,
+        events: [...(existingEvent.events ?? []), ...(event.events ?? [])],
+      });
+      continue;
+    }
+
+    if (event.isCancelled || !event.isPartial) {
+      const mergedEvent: PreparedEvent = {
+        ...event,
+        style: existingEvent.style,
+        events: [...(existingEvent.events ?? []), ...(event.events ?? [])],
+      };
+      eventsBySpanId.set(event.spanId, mergedEvent);
+      continue;
+    }
+  }
+
+  preparedEvents = Array.from(eventsBySpanId.values());
+
+  const spansBySpanId = new Map<string, SpanSummary>();
+
+  const spans = preparedEvents.map((event) => {
+    const overrides = getAncestorOverrides({
+      spansById: eventsBySpanId,
+      span: event,
+    });
+
+    const ancestorCancelled = overrides?.isCancelled ?? false;
+    const ancestorIsError = overrides?.isError ?? false;
+    const duration = overrides?.duration ?? event.duration;
+    const spanEvents = [...(overrides?.events ?? []), ...(event.events ?? [])];
+    const isPartial = ancestorCancelled || ancestorIsError ? false : event.isPartial;
+    const isCancelled = event.isCancelled === true ? true : event.isPartial && ancestorCancelled;
+    const isError = isCancelled
+      ? false
+      : typeof overrides?.isError === "boolean"
+        ? overrides.isError
+        : event.isError;
+
+    const span = {
+      id: event.spanId,
+      parentId: event.parentId ?? undefined,
+      runId: event.runId,
+      data: {
+        message: event.message,
+        style: event.style,
+        duration,
+        isError,
+        isPartial,
+        isCancelled,
+        isDebug: event.kind === TaskEventKind.LOG,
+        startTime: getDateFromNanoseconds(event.startTime),
+        level: event.level,
+        events: spanEvents,
+      },
+    };
+
+    spansBySpanId.set(event.spanId, span);
+
+    return span;
+  });
+
+  if (!resolvedRootSpanId) {
+    return;
+  }
+
+  const rootSpan = spansBySpanId.get(resolvedRootSpanId);
+
+  if (!rootSpan) {
+    return;
+  }
+
+  return {
+    rootSpan,
+    spans,
+  };
+}
+
+function findSpanInDetailedTree(
+  span: SpanDetailedSummary,
+  spanId: string
+): SpanDetailedSummary | undefined {
+  if (span.id === spanId) {
+    return span;
+  }
+  for (const child of span.children) {
+    const found = findSpanInDetailedTree(child, spanId);
+    if (found) {
+      return found;
+    }
+  }
+  return undefined;
+}
+
+function buildTraceDetailedSummaryFromQueriedEvents(
+  traceId: string,
+  events: DetailedTraceEvent[],
+  rootSpanId?: string
+): TraceDetailedSummary | undefined {
+  let preparedEvents: Array<PreparedDetailedEvent> = [];
+  let resolvedRootSpanId: string | undefined = rootSpanId;
+  const eventsBySpanId = new Map<string, PreparedDetailedEvent>();
+
+  for (const event of events) {
+    preparedEvents.push(prepareDetailedEvent(event));
+
+    if (!resolvedRootSpanId && !event.parentId) {
+      resolvedRootSpanId = event.spanId;
+    }
+  }
+
+  for (const event of preparedEvents) {
+    const existingEvent = eventsBySpanId.get(event.spanId);
+
+    if (!existingEvent) {
+      eventsBySpanId.set(event.spanId, event);
+      continue;
+    }
+
+    if (event.kind === "UNSPECIFIED") {
+      eventsBySpanId.set(event.spanId, {
+        ...existingEvent,
+        events: [...(existingEvent.events ?? []), ...(event.events ?? [])],
+      });
+      continue;
+    }
+
+    if (event.isCancelled || !event.isPartial) {
+      const mergedEvent: PreparedDetailedEvent = {
+        ...event,
+        style: existingEvent.style,
+        events: [...(existingEvent.events ?? []), ...(event.events ?? [])],
+      };
+      eventsBySpanId.set(event.spanId, mergedEvent);
+      continue;
+    }
+  }
+
+  preparedEvents = Array.from(eventsBySpanId.values());
+
+  if (!resolvedRootSpanId) {
+    return;
+  }
+
+  const spanDetailedSummaryMap = new Map<string, SpanDetailedSummary>();
+
+  for (const event of preparedEvents) {
+    const overrides = getAncestorOverrides({
+      spansById: eventsBySpanId as Map<string, PreparedEvent>,
+      span: event as PreparedEvent,
+    });
+
+    const ancestorCancelled = overrides?.isCancelled ?? false;
+    const ancestorIsError = overrides?.isError ?? false;
+    const duration = overrides?.duration ?? event.duration;
+    const spanEvents = [...(overrides?.events ?? []), ...(event.events ?? [])];
+    const isPartial = ancestorCancelled || ancestorIsError ? false : event.isPartial;
+    const isCancelled = event.isCancelled === true ? true : event.isPartial && ancestorCancelled;
+    const isError = isCancelled
+      ? false
+      : typeof overrides?.isError === "boolean"
+        ? overrides.isError
+        : event.isError;
+
+    const properties = event.properties
+      ? removePrivateProperties(event.properties as Attributes)
+      : {};
+
+    const spanDetailedSummary: SpanDetailedSummary = {
+      id: event.spanId,
+      parentId: event.parentId ?? undefined,
+      runId: event.runId,
+      data: {
+        message: event.message,
+        taskSlug: event.taskSlug ?? undefined,
+        events: spanEvents?.filter((e) => !e.name.startsWith("trigger.dev")),
+        startTime: getDateFromNanoseconds(event.startTime),
+        duration: nanosecondsToMilliseconds(duration),
+        isError,
+        isPartial,
+        isCancelled,
+        level: event.level,
+        properties,
+      },
+      children: [],
+    };
+
+    spanDetailedSummaryMap.set(event.spanId, spanDetailedSummary);
+  }
+
+  for (const spanSummary of spanDetailedSummaryMap.values()) {
+    if (spanSummary.parentId) {
+      const parent = spanDetailedSummaryMap.get(spanSummary.parentId);
+      if (parent) {
+        parent.children.push(spanSummary);
+      }
+    }
+  }
+
+  const rootSpan = spanDetailedSummaryMap.get(resolvedRootSpanId);
+
+  if (!rootSpan) {
+    return;
+  }
+
+  return {
+    traceId,
+    rootSpan,
   };
 }
 

--- a/apps/webapp/app/v3/eventRepository/eventRepository.types.ts
+++ b/apps/webapp/app/v3/eventRepository/eventRepository.types.ts
@@ -308,6 +308,8 @@ export type TraceSummary = {
   rootSpan: SpanSummary;
   spans: Array<SpanSummary>;
   overridesBySpanId?: Record<string, SpanOverride>;
+  /** Set when a subtree fetch hit the row cap before collecting all descendants. */
+  isTruncated?: boolean;
 };
 
 export type SpanDetailedSummary = {
@@ -351,6 +353,8 @@ export type StreamedTraceEvent = {
 export type TraceDetailedSummary = {
   traceId: string;
   rootSpan: SpanDetailedSummary;
+  /** Set when a fetch hit the row cap before collecting all spans. */
+  isTruncated?: boolean;
 };
 
 // ============================================================================
@@ -416,10 +420,32 @@ export interface IEventRepository {
     options?: { includeDebugLogs?: boolean }
   ): Promise<TraceSummary | undefined>;
 
+  /** Fetch the anchor span, its ancestors (for override propagation), and all descendants. */
+  getTraceSubtreeSummary(
+    storeTable: TaskEventStoreTable,
+    environmentId: string,
+    traceId: string,
+    anchorSpanId: string,
+    startCreatedAt: Date,
+    endCreatedAt?: Date,
+    options?: { includeDebugLogs?: boolean }
+  ): Promise<TraceSummary | undefined>;
+
   getTraceDetailedSummary(
     storeTable: TaskEventStoreTable,
     environmentId: string,
     traceId: string,
+    startCreatedAt: Date,
+    endCreatedAt?: Date,
+    options?: { includeDebugLogs?: boolean }
+  ): Promise<TraceDetailedSummary | undefined>;
+
+  /** Fetch the anchor span subtree as a detailed hierarchical trace rooted at anchorSpanId. */
+  getTraceDetailedSubtreeSummary(
+    storeTable: TaskEventStoreTable,
+    environmentId: string,
+    traceId: string,
+    anchorSpanId: string,
     startCreatedAt: Date,
     endCreatedAt?: Date,
     options?: { includeDebugLogs?: boolean }

--- a/apps/webapp/app/v3/mollifier/syntheticTrace.server.ts
+++ b/apps/webapp/app/v3/mollifier/syntheticTrace.server.ts
@@ -84,5 +84,7 @@ export function buildSyntheticTraceForBufferedRun(run: SyntheticRun) {
     queuedDuration: undefined,
     overridesBySpanId: undefined,
     linkedRunIdBySpanId: {} as Record<string, string>,
+    isTruncated: false,
+    missingAnchor: false,
   };
 }

--- a/apps/webapp/test/getTraceDetailedSubtreeSummary.integration.test.ts
+++ b/apps/webapp/test/getTraceDetailedSubtreeSummary.integration.test.ts
@@ -1,0 +1,428 @@
+import { ClickHouse, type TaskEventV2Input } from "@internal/clickhouse";
+import { clickhouseTest } from "@internal/testcontainers";
+import { describe, expect } from "vitest";
+import type { SpanDetailedSummary } from "~/v3/eventRepository/eventRepository.types";
+import {
+  ClickhouseEventRepository,
+  convertDateToClickhouseDateTime,
+} from "~/v3/eventRepository/clickhouseEventRepository.server";
+
+/**
+ * Proves getTraceDetailedSubtreeSummary (used by GET /api/v1/runs/:runId/trace)
+ * returns a tree rooted at the requested run's span — not the trace-wide root.
+ *
+ * Reproduces the large-trace failure mode: a full-trace fetch is capped by
+ * ORDER BY start_time ASC LIMIT N, so late spans are excluded. Subtree fetch
+ * looks up the anchor span directly and still returns the run-scoped tree.
+ */
+const INTEGRATION_TIMEOUT_MS = 60_000;
+const TRACE_ROW_LIMIT = 50;
+const FILLER_COUNT = 60;
+
+function startTimeNs(baseMs: number, offsetMs: number): string {
+  return ((BigInt(baseMs) + BigInt(offsetMs)) * 1_000_000n).toString();
+}
+
+function formatClickhouseStartTime(baseMs: number, offsetMs: number): string {
+  const nanoseconds = startTimeNs(baseMs, offsetMs);
+  if (nanoseconds.length !== 19) {
+    return nanoseconds;
+  }
+
+  return `${nanoseconds.substring(0, 10)}.${nanoseconds.substring(10)}`;
+}
+
+function findSpan(
+  span: SpanDetailedSummary | undefined,
+  spanId: string
+): SpanDetailedSummary | undefined {
+  if (!span) {
+    return undefined;
+  }
+  if (span.id === spanId) {
+    return span;
+  }
+  for (const child of span.children) {
+    const found = findSpan(child, spanId);
+    if (found) {
+      return found;
+    }
+  }
+  return undefined;
+}
+
+describe("getTraceDetailedSubtreeSummary", () => {
+  clickhouseTest(
+    "roots the API trace at the requested run span even when it is outside the full-trace row cap",
+    async ({ clickhouseContainer }) => {
+      const clickhouse = new ClickHouse({
+        url: clickhouseContainer.getConnectionUrl(),
+        logLevel: "warn",
+      });
+
+      const repository = new ClickhouseEventRepository({
+        clickhouse,
+        version: "v2",
+        maximumTraceDetailedSummaryViewCount: TRACE_ROW_LIMIT,
+      });
+
+      const environmentId = "env_trace_subtree_test";
+      const organizationId = "org_trace_subtree_test";
+      const projectId = "proj_trace_subtree_test";
+      const traceId = "a".repeat(32);
+      const spanRoot = "rootspan00000001";
+      const spanChild = "childspan0000001";
+      const spanGrandchild = "grandchildspan01";
+      const runRoot = "run_root_task_run";
+      const runChild = "run_child_task_run";
+      const baseMs = Date.now();
+      const runCreatedAt = new Date(baseMs - 60_000);
+      const expiresAt = convertDateToClickhouseDateTime(
+        new Date(baseMs + 365 * 24 * 60 * 60 * 1000)
+      );
+
+      function makeSpanRow({
+        spanId,
+        parentSpanId,
+        runId,
+        startOffsetMs,
+        message,
+      }: {
+        spanId: string;
+        parentSpanId: string;
+        runId: string;
+        startOffsetMs: number;
+        message: string;
+      }): TaskEventV2Input {
+        return {
+          environment_id: environmentId,
+          organization_id: organizationId,
+          project_id: projectId,
+          task_identifier: "subtree-test-task",
+          run_id: runId,
+          start_time: formatClickhouseStartTime(baseMs, startOffsetMs),
+          duration: "1000000",
+          trace_id: traceId,
+          span_id: spanId,
+          parent_span_id: parentSpanId,
+          message,
+          kind: "SPAN",
+          status: "OK",
+          attributes: {},
+          metadata: "{}",
+          expires_at: expiresAt,
+        };
+      }
+
+      const rows: TaskEventV2Input[] = [
+        makeSpanRow({
+          spanId: spanRoot,
+          parentSpanId: "",
+          runId: runRoot,
+          startOffsetMs: 0,
+          message: "root task",
+        }),
+        ...Array.from({ length: FILLER_COUNT }, (_, index) =>
+          makeSpanRow({
+            spanId: `filler${String(index).padStart(10, "0")}`,
+            parentSpanId: spanRoot,
+            runId: runRoot,
+            startOffsetMs: index + 1,
+            message: `filler span ${index}`,
+          })
+        ),
+        makeSpanRow({
+          spanId: spanChild,
+          parentSpanId: spanRoot,
+          runId: runChild,
+          startOffsetMs: 100_000,
+          message: "child task",
+        }),
+        makeSpanRow({
+          spanId: spanGrandchild,
+          parentSpanId: spanChild,
+          runId: runChild,
+          startOffsetMs: 100_001,
+          message: "grandchild span",
+        }),
+      ];
+
+      const [insertError] = await clickhouse.taskEventsV2.insert(rows, {
+        clickhouse_settings: { async_insert: 0 },
+      });
+      expect(insertError).toBeNull();
+
+      const fullTrace = await repository.getTraceDetailedSummary(
+        "taskEvent",
+        environmentId,
+        traceId,
+        runCreatedAt
+      );
+
+      expect(fullTrace?.rootSpan.id).toBe(spanRoot);
+      expect(fullTrace?.isTruncated).toBe(true);
+      expect(findSpan(fullTrace?.rootSpan, spanChild)).toBeUndefined();
+
+      const subtree = await repository.getTraceDetailedSubtreeSummary(
+        "taskEvent",
+        environmentId,
+        traceId,
+        spanChild,
+        runCreatedAt
+      );
+
+      expect(subtree).toBeDefined();
+      expect(subtree!.isTruncated).toBe(false);
+      expect(subtree!.traceId).toBe(traceId);
+      expect(subtree!.rootSpan.id).toBe(spanChild);
+      expect(subtree!.rootSpan.runId).toBe(runChild);
+      expect(subtree!.rootSpan.parentId).toBe(spanRoot);
+      expect(subtree!.rootSpan.children).toHaveLength(1);
+      expect(subtree!.rootSpan.children[0]?.id).toBe(spanGrandchild);
+      expect(subtree!.rootSpan.children[0]?.runId).toBe(runChild);
+    },
+    INTEGRATION_TIMEOUT_MS
+  );
+
+  clickhouseTest(
+    "loads ancestors outside the anchor run time window for override propagation",
+    async ({ clickhouseContainer }) => {
+      const clickhouse = new ClickHouse({
+        url: clickhouseContainer.getConnectionUrl(),
+        logLevel: "warn",
+      });
+
+      const repository = new ClickhouseEventRepository({
+        clickhouse,
+        version: "v2",
+        maximumTraceDetailedSummaryViewCount: TRACE_ROW_LIMIT,
+      });
+
+      const environmentId = "env_trace_subtree_ancestor";
+      const organizationId = "org_trace_subtree_ancestor";
+      const projectId = "proj_trace_subtree_ancestor";
+      const traceId = "b".repeat(32);
+      const spanRoot = "rootspan00000002";
+      const spanChild = "childspan0000002";
+      const runRoot = "run_root_cancelled";
+      const runChild = "run_child_partial";
+      const baseMs = Date.now();
+      const childRunCreatedAt = new Date(baseMs + 100_000);
+      const expiresAt = convertDateToClickhouseDateTime(
+        new Date(baseMs + 365 * 24 * 60 * 60 * 1000)
+      );
+
+      function makeSpanRow({
+        spanId,
+        parentSpanId,
+        runId,
+        startOffsetMs,
+        insertedOffsetMs,
+        message,
+        status,
+      }: {
+        spanId: string;
+        parentSpanId: string;
+        runId: string;
+        startOffsetMs: number;
+        insertedOffsetMs: number;
+        message: string;
+        status: string;
+      }): TaskEventV2Input {
+        return {
+          environment_id: environmentId,
+          organization_id: organizationId,
+          project_id: projectId,
+          task_identifier: "subtree-ancestor-test-task",
+          run_id: runId,
+          start_time: formatClickhouseStartTime(baseMs, startOffsetMs),
+          inserted_at: convertDateToClickhouseDateTime(new Date(baseMs + insertedOffsetMs)),
+          duration: "5000000000",
+          trace_id: traceId,
+          span_id: spanId,
+          parent_span_id: parentSpanId,
+          message,
+          kind: "SPAN",
+          status,
+          attributes: {},
+          metadata: "{}",
+          expires_at: expiresAt,
+        };
+      }
+
+      const rows: TaskEventV2Input[] = [
+        makeSpanRow({
+          spanId: spanRoot,
+          parentSpanId: "",
+          runId: runRoot,
+          startOffsetMs: 0,
+          insertedOffsetMs: 0,
+          message: "root task",
+          status: "PARTIAL",
+        }),
+        makeSpanRow({
+          spanId: spanRoot,
+          parentSpanId: "",
+          runId: runRoot,
+          startOffsetMs: 5_000,
+          insertedOffsetMs: 5_000,
+          message: "root task",
+          status: "CANCELLED",
+        }),
+        makeSpanRow({
+          spanId: spanChild,
+          parentSpanId: spanRoot,
+          runId: runChild,
+          startOffsetMs: 100_000,
+          insertedOffsetMs: 100_000,
+          message: "child task",
+          status: "PARTIAL",
+        }),
+      ];
+
+      const [insertError] = await clickhouse.taskEventsV2.insert(rows, {
+        clickhouse_settings: { async_insert: 0 },
+      });
+      expect(insertError).toBeNull();
+
+      const subtree = await repository.getTraceDetailedSubtreeSummary(
+        "taskEvent",
+        environmentId,
+        traceId,
+        spanChild,
+        childRunCreatedAt
+      );
+
+      expect(subtree).toBeDefined();
+      expect(subtree!.rootSpan.id).toBe(spanChild);
+      expect(subtree!.rootSpan.parentId).toBe(spanRoot);
+      expect(subtree!.rootSpan.data.isPartial).toBe(false);
+      expect(subtree!.rootSpan.data.isCancelled).toBe(true);
+    },
+    INTEGRATION_TIMEOUT_MS
+  );
+
+  clickhouseTest(
+    "re-roots from a single full-trace query when the anchor and parent are inside the row cap",
+    async ({ clickhouseContainer }) => {
+      const clickhouse = new ClickHouse({
+        url: clickhouseContainer.getConnectionUrl(),
+        logLevel: "warn",
+      });
+
+      const repository = new ClickhouseEventRepository({
+        clickhouse,
+        version: "v2",
+        maximumTraceDetailedSummaryViewCount: TRACE_ROW_LIMIT,
+      });
+
+      const environmentId = "env_trace_subtree_fast_path";
+      const organizationId = "org_trace_subtree_fast_path";
+      const projectId = "proj_trace_subtree_fast_path";
+      const traceId = "c".repeat(32);
+      const spanRoot = "rootspan00000003";
+      const spanChild = "childspan0000003";
+      const spanGrandchild = "grandchildspan03";
+      const runRoot = "run_root_fast_path";
+      const runChild = "run_child_fast_path";
+      const baseMs = Date.now();
+      const runCreatedAt = new Date(baseMs - 60_000);
+      const expiresAt = convertDateToClickhouseDateTime(
+        new Date(baseMs + 365 * 24 * 60 * 60 * 1000)
+      );
+
+      function makeSpanRow({
+        spanId,
+        parentSpanId,
+        runId,
+        startOffsetMs,
+        message,
+        status = "OK",
+      }: {
+        spanId: string;
+        parentSpanId: string;
+        runId: string;
+        startOffsetMs: number;
+        message: string;
+        status?: string;
+      }): TaskEventV2Input {
+        return {
+          environment_id: environmentId,
+          organization_id: organizationId,
+          project_id: projectId,
+          task_identifier: "subtree-fast-path-task",
+          run_id: runId,
+          start_time: formatClickhouseStartTime(baseMs, startOffsetMs),
+          inserted_at: convertDateToClickhouseDateTime(new Date(baseMs + startOffsetMs)),
+          duration: "1000000",
+          trace_id: traceId,
+          span_id: spanId,
+          parent_span_id: parentSpanId,
+          message,
+          kind: "SPAN",
+          status,
+          attributes: {},
+          metadata: "{}",
+          expires_at: expiresAt,
+        };
+      }
+
+      const rows: TaskEventV2Input[] = [
+        makeSpanRow({
+          spanId: spanRoot,
+          parentSpanId: "",
+          runId: runRoot,
+          startOffsetMs: 0,
+          message: "root task",
+          status: "PARTIAL",
+        }),
+        makeSpanRow({
+          spanId: spanRoot,
+          parentSpanId: "",
+          runId: runRoot,
+          startOffsetMs: 5_000,
+          message: "root task",
+          status: "CANCELLED",
+        }),
+        makeSpanRow({
+          spanId: spanChild,
+          parentSpanId: spanRoot,
+          runId: runChild,
+          startOffsetMs: 10_000,
+          message: "child task",
+          status: "PARTIAL",
+        }),
+        makeSpanRow({
+          spanId: spanGrandchild,
+          parentSpanId: spanChild,
+          runId: runChild,
+          startOffsetMs: 10_001,
+          message: "grandchild span",
+        }),
+      ];
+
+      const [insertError] = await clickhouse.taskEventsV2.insert(rows, {
+        clickhouse_settings: { async_insert: 0 },
+      });
+      expect(insertError).toBeNull();
+
+      const subtree = await repository.getTraceDetailedSubtreeSummary(
+        "taskEvent",
+        environmentId,
+        traceId,
+        spanChild,
+        runCreatedAt
+      );
+
+      expect(subtree).toBeDefined();
+      expect(subtree!.isTruncated).toBe(false);
+      expect(subtree!.rootSpan.id).toBe(spanChild);
+      expect(subtree!.rootSpan.parentId).toBe(spanRoot);
+      expect(subtree!.rootSpan.data.isPartial).toBe(false);
+      expect(subtree!.rootSpan.data.isCancelled).toBe(true);
+      expect(subtree!.rootSpan.children).toHaveLength(1);
+      expect(subtree!.rootSpan.children[0]?.id).toBe(spanGrandchild);
+    },
+    INTEGRATION_TIMEOUT_MS
+  );
+});

--- a/docs/management/runs/retrieve-trace.mdx
+++ b/docs/management/runs/retrieve-trace.mdx
@@ -2,3 +2,7 @@
 title: "Retrieve run trace"
 openapi: "v3-openapi GET /api/v1/runs/{runId}/trace"
 ---
+
+Returns the OpenTelemetry trace subtree for the run you request. The response `trace.rootSpan` is that run's span — not necessarily the trace-wide root — with its descendant spans nested under `children`.
+
+For a child or nested run inside a large trace, this endpoint scopes the tree to that run so you still get a useful subtree even when the full trace has more spans than the platform can return in one response.

--- a/docs/v3-openapi.yaml
+++ b/docs/v3-openapi.yaml
@@ -448,7 +448,7 @@ paths:
     get:
       operationId: get_run_trace_v1
       summary: Retrieve run trace
-      description: Returns the full OTel trace tree for a run, including all spans and their children.
+      description: Returns the OTel trace subtree for the requested run — the run's span as `rootSpan`, its ancestor chain, and its descendant spans. For child or nested runs in a large trace, this is scoped to that run rather than the trace-wide root.
       responses:
         "200":
           description: Successful request
@@ -464,7 +464,9 @@ paths:
                         type: string
                         description: The OTel trace ID.
                       rootSpan:
-                        $ref: "#/components/schemas/SpanDetailedSummary"
+                        allOf:
+                          - $ref: "#/components/schemas/SpanDetailedSummary"
+                        description: The requested run's span, with nested descendant spans as `children`. Not necessarily the trace-wide root span.
         "401":
           description: Unauthorized request
           content:


### PR DESCRIPTION
## Summary

Large traces are loaded using a capped, time-ordered query. For child or nested runs, the run's span could fall outside that initial slice, causing the trace view to render empty.

This PR adds run-scoped subtree loading when the requested run span is not present in the initial trace results and applies the same behavior to the trace API.

## Changes

### Dashboard

Falls back to run-scoped subtree loading when the requested run span is missing from the initial trace results
Shows a warning when the trace is truncated or cannot be fully resolved

### Trace API (GET /api/v1/runs/:runId/trace)

Returns a trace rooted at the requested run's span
Fixes incomplete or empty traces for child and nested runs in large traces

### Event repositories

Run-scoped subtree retrieval is ClickHouse-only; Postgres re-roots the existing full-trace summary in memory (no new queries).

### Docs

Updated API and trace documentation to reflect run-scoped trace behavior

Testing

- [x]  cd apps/webapp && pnpm run test ./test/getTraceDetailedSubtreeSummary.integration.test.ts 

## Changelog

Fixed trace rendering for child and nested runs in large traces. Dashboard and trace API responses now load the requested run's trace subtree instead of depending on the run span appearing in the initial trace slice.