### PR TITLE
fix(dashboard-agent-db): isolate the migration journal table

### DIFF
--- a/internal-packages/dashboard-agent-db/drizzle.config.ts
+++ b/internal-packages/dashboard-agent-db/drizzle.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
   dialect: "postgresql",
   // Only manage our schema — never introspect or diff Prisma's `public` schema.
   schemaFilter: ["trigger_dashboard_agent"],
+  // Own journal table so dev (`drizzle-kit migrate`) and deploy (migrate.mjs)
+  // share one history and we don't cross-poison the default
+  // drizzle.__drizzle_migrations when the DB is shared. See migrate.mjs.
+  migrations: { table: "__dashboard_agent_migrations", schema: "drizzle" },
   dbCredentials: { url },
 });

--- a/internal-packages/dashboard-agent-db/drizzle/0000_magenta_lilandra.sql
+++ b/internal-packages/dashboard-agent-db/drizzle/0000_magenta_lilandra.sql
@@ -1,6 +1,6 @@
-CREATE SCHEMA "trigger_dashboard_agent";
+CREATE SCHEMA IF NOT EXISTS "trigger_dashboard_agent";
 --> statement-breakpoint
-CREATE TABLE "trigger_dashboard_agent"."chat_sessions" (
+CREATE TABLE IF NOT EXISTS "trigger_dashboard_agent"."chat_sessions" (
 	"chat_id" text PRIMARY KEY NOT NULL,
 	"public_access_token" text NOT NULL,
 	"last_event_id" text,
@@ -8,7 +8,7 @@ CREATE TABLE "trigger_dashboard_agent"."chat_sessions" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-CREATE TABLE "trigger_dashboard_agent"."chats" (
+CREATE TABLE IF NOT EXISTS "trigger_dashboard_agent"."chats" (
 	"id" text PRIMARY KEY NOT NULL,
 	"organization_id" text NOT NULL,
 	"user_id" text NOT NULL,
@@ -22,4 +22,4 @@ CREATE TABLE "trigger_dashboard_agent"."chats" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-CREATE INDEX "chats_org_user_last_msg_idx" ON "trigger_dashboard_agent"."chats" USING btree ("organization_id","user_id","last_message_at" DESC NULLS LAST) WHERE "trigger_dashboard_agent"."chats"."deleted_at" is null;
+CREATE INDEX IF NOT EXISTS "chats_org_user_last_msg_idx" ON "trigger_dashboard_agent"."chats" USING btree ("organization_id","user_id","last_message_at" DESC NULLS LAST) WHERE "trigger_dashboard_agent"."chats"."deleted_at" is null;

--- a/internal-packages/dashboard-agent-db/drizzle/0001_slimy_living_tribunal.sql
+++ b/internal-packages/dashboard-agent-db/drizzle/0001_slimy_living_tribunal.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "trigger_dashboard_agent"."chat_turn_evals" (
+CREATE TABLE IF NOT EXISTS "trigger_dashboard_agent"."chat_turn_evals" (
 	"chat_id" text NOT NULL,
 	"turn" integer NOT NULL,
 	"organization_id" text NOT NULL,
@@ -34,5 +34,5 @@ CREATE TABLE "trigger_dashboard_agent"."chat_turn_evals" (
 	CONSTRAINT "chat_turn_evals_chat_id_turn_pk" PRIMARY KEY("chat_id","turn")
 );
 --> statement-breakpoint
-CREATE INDEX "chat_turn_evals_org_created_idx" ON "trigger_dashboard_agent"."chat_turn_evals" USING btree ("organization_id","created_at" DESC NULLS LAST);--> statement-breakpoint
-CREATE INDEX "chat_turn_evals_org_opps_idx" ON "trigger_dashboard_agent"."chat_turn_evals" USING btree ("organization_id","created_at" DESC NULLS LAST) WHERE "trigger_dashboard_agent"."chat_turn_evals"."capability_gap" or "trigger_dashboard_agent"."chat_turn_evals"."docs_gap" or "trigger_dashboard_agent"."chat_turn_evals"."support_opportunity" or "trigger_dashboard_agent"."chat_turn_evals"."feature_request";
+CREATE INDEX IF NOT EXISTS "chat_turn_evals_org_created_idx" ON "trigger_dashboard_agent"."chat_turn_evals" USING btree ("organization_id","created_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "chat_turn_evals_org_opps_idx" ON "trigger_dashboard_agent"."chat_turn_evals" USING btree ("organization_id","created_at" DESC NULLS LAST) WHERE "trigger_dashboard_agent"."chat_turn_evals"."capability_gap" or "trigger_dashboard_agent"."chat_turn_evals"."docs_gap" or "trigger_dashboard_agent"."chat_turn_evals"."support_opportunity" or "trigger_dashboard_agent"."chat_turn_evals"."feature_request";

--- a/internal-packages/dashboard-agent-db/migrate.mjs
+++ b/internal-packages/dashboard-agent-db/migrate.mjs
@@ -44,13 +44,23 @@ const sql = postgres(normalizeConnectionString(connectionString), {
 });
 
 try {
-  // Journal lives in Drizzle's default `drizzle` schema (matching `drizzle-kit
-  // migrate`, so dev and deploy track migrations the same way). It must not be
-  // our data schema: the first migration runs `CREATE SCHEMA
-  // "trigger_dashboard_agent"`, which would collide with the journal schema the
-  // migrator pre-creates. The dashboard agent is the only Drizzle user of its
-  // database, so the `drizzle` schema stays exclusively ours.
-  await migrate(drizzle(sql), { migrationsFolder });
+  // Track our history in a DEDICATED journal table. Drizzle's migrator reads the
+  // latest row from <schema>.<table> by created_at and skips any journal entry
+  // dated at or before it. The default `drizzle.__drizzle_migrations` is shared
+  // by every Drizzle app, so when this DB is shared (OSS single-database fallback
+  // and the enterprise-image E2E gate) billing's journal rows poison ours: a
+  // billing row dated between our 0000 and 0001 makes the migrator skip 0000 (the
+  // CREATE SCHEMA) and run 0001 against a schema that never got created. An own
+  // table keeps our history independent (enterprise/db does the same with
+  // __enterprise_migrations; billing keeps the default).
+  //
+  // The table stays in the `drizzle` schema, not our data schema, so 0000's
+  // `CREATE SCHEMA "trigger_dashboard_agent"` doesn't collide with the schema the
+  // migrator pre-creates for its journal.
+  await migrate(drizzle(sql), {
+    migrationsFolder,
+    migrationsTable: "__dashboard_agent_migrations",
+  });
   console.log("[dashboard-agent-db] migrations complete");
 } finally {
   await sql.end();


### PR DESCRIPTION
## Summary

The dashboard agent's database migrations could be silently skipped when its database is shared with another Drizzle application, leaving the `trigger_dashboard_agent` schema uncreated and a later migration failing with `schema "trigger_dashboard_agent" does not exist`.

## Root cause

Drizzle's migrator decides what to run by reading the most recent row from its journal table by `created_at`, and skipping any migration dated at or before it. The dashboard-agent runner used Drizzle's default journal table, `drizzle.__drizzle_migrations`, which every Drizzle app shares by default. When the database is shared, another app's journal row dated between two of our migrations makes the migrator treat the earlier one (the `CREATE SCHEMA`) as already applied and run a later one against a schema that was never created.

## Fix

- Track the dashboard-agent migrations in a dedicated journal table (`drizzle.__dashboard_agent_migrations`), in both the deploy runner (`migrate.mjs`) and the drizzle-kit config, so its history is independent of any other Drizzle app sharing the database. The table stays in the `drizzle` schema so the first migration's `CREATE SCHEMA "trigger_dashboard_agent"` does not collide with it.
- Make the first two migrations idempotent (`CREATE SCHEMA/TABLE/INDEX IF NOT EXISTS`) so databases that already tracked them under the old journal table re-run cleanly after the rename instead of erroring on the bare `CREATE SCHEMA`.

Verified against a Postgres seeded to reproduce the skip: the old default-table path fails as above, the dedicated-table path creates the schema and all tables, and re-running on an already-migrated database is a clean no-op.
