### PR TITLE
docs: fix typos across build, config, and upgrade guides

### DIFF
--- a/docs/config/extensions/audioWaveform.mdx
+++ b/docs/config/extensions/audioWaveform.mdx
@@ -14,7 +14,7 @@ export default defineConfig({
   project: "<project ref>",
   // Your other config settings...
   build: {
-    extensions: [audioWaveform()], // uses verson 1.1.0 of audiowaveform by default
+    extensions: [audioWaveform()], // uses version 1.1.0 of audiowaveform by default
   },
 });
 ```

--- a/docs/config/extensions/custom.mdx
+++ b/docs/config/extensions/custom.mdx
@@ -327,7 +327,7 @@ These commands are run after packages have been installed and the code copied in
 <ParamField path="deploy" type="object">
   <Expandable title="properties">
     <ResponseField name="env" type="Record<string, string>">
-      Environment variables that should sync to the Trigger.dev project, which will then be avalable
+      Environment variables that should sync to the Trigger.dev project, which will then be available
       in your tasks at runtime. Importantly, these are NOT added to the image build container, but
       are instead added to the Trigger.dev project and stored securely.
     </ResponseField>

--- a/docs/deploy-environment-variables.mdx
+++ b/docs/deploy-environment-variables.mdx
@@ -26,7 +26,7 @@ We deploy your tasks and scale them up and down when they are triggered. So any 
 </Steps>
 
 <Note>
-  Specifying Dev values is optional. They will be overriden by values in your .env file when running
+  Specifying Dev values is optional. They will be overridden by values in your .env file when running
   locally.
 </Note>
 

--- a/docs/guides/new-build-system-preview.mdx
+++ b/docs/guides/new-build-system-preview.mdx
@@ -5,7 +5,7 @@ description: "How to use the new build system preview release"
 
 Based on feedback and a steady flow of issues from our previous build system, we're happy to share with you a preview release of our new build system that (hopefully) fixes most of the issues you may have faced.
 
-The main features of the new build sytem are:
+The main features of the new build system are:
 
 - **Bundling by default**: All dependencies are bundled by default, so you no longer need to specify which dependencies to bundle. This solves a whole bunch of issues related to monorepos.
 - **Build extensions**: A new way to extend the build process with custom logic. This is a more flexible and powerful way to extend the build process compared to the old system. (including custom esbuild plugin support)
@@ -164,7 +164,7 @@ One other difference is now `params.env` only contains the environment variables
 
 ### emitDecoratorMetadata
 
-If you make use of decorators in your code, and have enabled the `emitDecoratorMetadata` tsconfig compiler option, you'll need to enable this in the new build sytem using the `emitDecoratorMetadata` build extension:
+If you make use of decorators in your code, and have enabled the `emitDecoratorMetadata` tsconfig compiler option, you'll need to enable this in the new build system using the `emitDecoratorMetadata` build extension:
 
 ```ts
 import { defineConfig } from "@trigger.dev/sdk";
@@ -285,7 +285,7 @@ import { audioWaveform } from "@trigger.dev/build/extensions/audioWaveform";
 export default defineConfig({
   project: "<project ref>",
   build: {
-    extensions: [audioWaveform()], // uses verson 1.1.0 of audiowaveform by default
+    extensions: [audioWaveform()], // uses version 1.1.0 of audiowaveform by default
   },
 });
 ```

--- a/docs/guides/use-cases/upgrading-from-v2.mdx
+++ b/docs/guides/use-cases/upgrading-from-v2.mdx
@@ -270,7 +270,7 @@ const openai = new OpenAI({
 export const openaiTask = task({
   id: "openai-task",
   //3. Retries happen if a task throws an error that isn't caught
-  //   The default settings are in your trigger.config.ts (used if not overriden here)
+  //   The default settings are in your trigger.config.ts (used if not overridden here)
   retry: {
     maxAttempts: 3,
   },

--- a/docs/how-it-works.mdx
+++ b/docs/how-it-works.mdx
@@ -406,7 +406,7 @@ When you run `npx trigger.dev@latest deploy` or `npx trigger.dev@latest dev`, we
 
 - **Bundled by default**: Code + dependencies are bundled and tree-shaked by default.
 - **Build extensions**: Use and write custom build extensions to transform your code or the resulting docker image.
-- **ESM ouput**: We output to ESM, which allows tree-shaking and better performance.
+- **ESM output**: We output to ESM, which allows tree-shaking and better performance.
 
 You can review the build output by running deploy with the `--dry-run` flag, which will output the Containerfile and the build output.
 

--- a/docs/snippets/bundle-packages.mdx
+++ b/docs/snippets/bundle-packages.mdx
@@ -1,7 +1,7 @@
 <Tabs>
   <Tab title="Bundle everything">
   
-    Bundle all ESM packages so that you don't have to specifiy them manually like this:
+    Bundle all ESM packages so that you don't have to specify them manually like this:
 
     ```ts trigger.config.ts
     import type { TriggerConfig } from "@trigger.dev/sdk";

--- a/docs/upgrading-beta.mdx
+++ b/docs/upgrading-beta.mdx
@@ -10,7 +10,7 @@ The Trigger.dev packages are now at version `3.0.x` in the `latest` tag. This is
 
 The major changes in this release are a new build system, which is more flexible and powerful than the previous build system. We've also made some changes to the `trigger.dev` CLI to improve the developer experience.
 
-The main features of the new build sytem are:
+The main features of the new build system are:
 
 - **Bundling by default**: All dependencies are bundled by default, so you no longer need to specify which dependencies to bundle. This solves a whole bunch of issues related to monorepos.
 - **Build extensions**: A new way to extend the build process with custom logic. This is a more flexible and powerful way to extend the build process compared to the old system. (including custom esbuild plugin support)
@@ -171,7 +171,7 @@ See the [syncEnvVars](/deploy-environment-variables#sync-env-vars-from-another-s
 
 ### emitDecoratorMetadata
 
-If you make use of decorators in your code, and have enabled the `emitDecoratorMetadata` tsconfig compiler option, you'll need to enable this in the new build sytem using the `emitDecoratorMetadata` build extension:
+If you make use of decorators in your code, and have enabled the `emitDecoratorMetadata` tsconfig compiler option, you'll need to enable this in the new build system using the `emitDecoratorMetadata` build extension:
 
 ```ts
 import { defineConfig } from "@trigger.dev/sdk";
@@ -292,7 +292,7 @@ import { audioWaveform } from "@trigger.dev/build/extensions/audioWaveform";
 export default defineConfig({
   project: "<project ref>",
   build: {
-    extensions: [audioWaveform()], // uses verson 1.1.0 of audiowaveform by default
+    extensions: [audioWaveform()], // uses version 1.1.0 of audiowaveform by default
   },
 });
 ```


### PR DESCRIPTION
## Summary

Fixes 12 spelling typos across the documentation (build system, config extensions, and upgrade guides). Documentation-only change, no content or behavior changes.

## Details

- config/extensions/audioWaveform.mdx, config/extensions/custom.mdx, upgrading-beta.mdx: `verson` to `version`
- deploy-environment-variables.mdx: `avalable` to `available`
- guides/use-cases/upgrading-from-v2.mdx, upgrading-beta.mdx: `overriden` to `overridden`
- guides/new-build-system-preview.mdx, upgrading-beta.mdx: `sytem` to `system`
- how-it-works.mdx: `ouput` to `output`
- snippets/bundle-packages.mdx: `specifiy` to `specify`
