### PR TITLE
fix(webapp): clear overlapping timeouts and reset useCopy hook state on value change

### DIFF
--- a/apps/webapp/app/hooks/useCopy.ts
+++ b/apps/webapp/app/hooks/useCopy.ts
@@ -1,7 +1,8 @@
-import { useCallback, useState } from "react";
+import { useCallback, useState, useRef, useEffect } from "react";
 
 export function useCopy(value: string, duration = 1500) {
   const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const copy = useCallback(
     (e?: React.MouseEvent) => {
@@ -10,13 +11,23 @@ export function useCopy(value: string, duration = 1500) {
         e.stopPropagation();
       }
       navigator.clipboard.writeText(value);
+      
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      
       setCopied(true);
-      setTimeout(() => {
+      timeoutRef.current = setTimeout(() => {
         setCopied(false);
       }, duration);
     },
     [value, duration]
   );
+
+  useEffect(() => {
+    setCopied(false);
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [value]);
 
   return { copy, copied };
 }


### PR DESCRIPTION
Closes  #4036
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.MD)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

- Verified by executing local event sequences on the `CopyButton` primitive. Confirmed that making rapid, successive clicks cleanly evicts previous macro-task timer registrations from the event loop using the `useRef` pointer.
- Verified state alignment by mutating the incoming `value` prop during an active `copied === true` state window, confirming that the button cleanly reverts back to the copy icon via the new `useEffect` hook dependency array tracking layout switches.

---

## Changelog

Refactored the core state mechanics of the custom `useCopy` hook to handle edge cases and quick-navigation updates seamlessly:
- Introduced a mutable `useRef` pointer container (`timeoutRef`) to tracking scheduled `setTimeout` identifiers across rendering cycles.
- Enforced an upfront `clearTimeout` pass before initializing a new timer instance, resolving visual race conditions from stacked execution intervals.
- Appended a `useEffect` synchronization block that automatically unsets the `copied` visual state whenever the target text prop changes or when the context unmounts.

---

## Screenshots

_N/A — Structural hook logic adjustment._