### PR TITLE
docs: fix wait.for() idempotency example to use a single options object

### DIFF
--- a/docs/wait-for.mdx
+++ b/docs/wait-for.mdx
@@ -38,5 +38,5 @@ You can pass an idempotency key to any wait function, allowing you to skip waits
 
 ```ts
 // Specify the idempotency key and TTL when waiting for a duration:
-await wait.for({ seconds: 10 }, { idempotencyKey: "my-idempotency-key", idempotencyKeyTTL: "1h" });
+await wait.for({ seconds: 10, idempotencyKey: "my-idempotency-key", idempotencyKeyTTL: "1h" });
 ```


### PR DESCRIPTION
The wait.for() idempotency example passed the idempotency options as a second argument, but wait.for() takes a single options object — so the second object was silently ignored and the key never applied. Merged the fields into the single options object, matching the wait.until() example.

Supersedes #4021.