### PR TITLE
chore: correct changeset guidance in contributing.md and elsewhere

### DIFF
--- a/.claude/REVIEW.md
+++ b/.claude/REVIEW.md
@@ -25,7 +25,7 @@ Reserve 🔴 for things that would page someone or block a rollback. In this cod
 
 - **Tests use testcontainers, not mocks.** Vitest with `redisTest` / `postgresTest` / `containerTest` from `@internal/testcontainers`. Any new `vi.mock(...)` on Redis, Postgres, BullMQ, or other infra is wrong here — 🔴 if added in production-path tests, 🟡 if isolated unit test.
 - **Public-package changes have a changeset.** `pnpm run changeset:add` produces `.changeset/*.md`. Required for any edit under `packages/*`. Missing → 🟡; missing on a breaking change → 🔴.
-- **Server-only changes have `.server-changes/*.md`.** Required for `apps/webapp/`, `apps/supervisor/` edits with no public-package change. Body should be 1-2 sentences (it has to fit as one bullet in a future changelog). Missing → 🟡.
+- **Server changes have `.server-changes/*.md`.** Required for `apps/webapp/`, `apps/supervisor/` edits. Body should be 1-2 sentences (it has to fit as one bullet in a future changelog). Missing → 🟡.
 - **Lua script naming.** Coexisting scripts use behavior-descriptive suffixes (`Tracked`), never `V2`. Old name must keep working until the next deploy clears it.
 - **RunQueue payload shape.** V2 run-queue payload's `projectId` is consumed by `workerQueueResolver` for override matching. If a PR drops it from the payload, 🔴.
 - **`safeSend` scope.** Defensive IPC wrappers belong on loop / interval / handler contexts, not one-shot terminal sends. If the PR adds `safeSend` to a single terminal call for consistency, 🟡 with a "remove this" suggestion.

--- a/.claude/rules/server-apps.md
+++ b/.claude/rules/server-apps.md
@@ -5,7 +5,7 @@ paths:
 
 # Server App Changes
 
-When modifying server apps (webapp, supervisor, coordinator, etc.) with **no package changes**, add a `.server-changes/` file instead of a changeset:
+When modifying server apps (webapp, supervisor, coordinator, etc.), add a `.server-changes/`:
 
 ```bash
 cat > .server-changes/descriptive-name.md << 'EOF'
@@ -20,4 +20,3 @@ EOF
 
 - **area**: `webapp` | `supervisor` | `coordinator` | `kubernetes-provider` | `docker-provider`
 - **type**: `feature` | `fix` | `improvement` | `breaking`
-- If the PR also touches `packages/`, just the changeset is sufficient (no `.server-changes/` needed).

--- a/.server-changes/README.md
+++ b/.server-changes/README.md
@@ -6,9 +6,9 @@ This directory tracks changes to server-only components (webapp, supervisor, coo
 
 **Server-only PRs**: If your PR only changes `apps/webapp/`, `apps/supervisor/`, `apps/coordinator/`, or other server components (and does NOT change anything in `packages/`), add a `.server-changes/` file.
 
-**Mixed PRs** (both packages and server): Just add a changeset as usual. No `.server-changes/` file needed — the changeset covers it.
-
 **Package-only PRs**: Just add a changeset as usual.
+
+**Mixed PRs** (both packages and server): Do changeset and server-changes
 
 ## File format
 

--- a/CHANGESETS.md
+++ b/CHANGESETS.md
@@ -34,7 +34,7 @@ See `.server-changes/README.md` for full documentation.
 |---|---|
 | Only packages (`packages/`) | Changeset (`pnpm run changeset:add`) |
 | Only server (`apps/`) | `.server-changes/` file |
-| Both packages and server | Just the changeset |
+| Both packages and server | Both |
 
 ## Release instructions (CI)
 

--- a/CHANGESETS.md
+++ b/CHANGESETS.md
@@ -24,7 +24,7 @@ EOF
 - `area`: `webapp` | `supervisor` | `coordinator` | `kubernetes-provider` | `docker-provider`
 - `type`: `feature` | `fix` | `improvement` | `breaking`
 
-For **mixed PRs** (both packages and server): just add a changeset. No `.server-changes/` file needed.
+For **mixed PRs** (both packages and server): add both a changeset and a .server-changes file.
 
 See `.server-changes/README.md` for full documentation.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ pnpm run changeset:add
 - Confirm with maintainers before selecting **minor** (new features)
 - **Never** select major without explicit approval
 
-When modifying only server components (`apps/webapp/`, `apps/supervisor/`, etc.) with no package changes, add a `.server-changes/` file instead. See `.server-changes/README.md` for format and documentation.
+When modifying server components (`apps/webapp/`, `apps/supervisor/`, etc.), add a `.server-changes/` file as well. See `.server-changes/README.md` for format and documentation.
 
 ## Dependency Pinning
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,7 +259,7 @@ Most of the time the changes you'll make are likely to be categorized as patch r
 
 ## Adding server changes
 
-Changesets only track published npm packages. If your PR only changes server components (`apps/webapp/`, `apps/supervisor/`, `apps/coordinator/`, etc.) with no package changes, add a `.server-changes/` file so the change appears in release notes.
+Changesets only track published npm packages. If your PR changes server components (`apps/webapp/`, `apps/supervisor/`, `apps/coordinator/`, etc.), add a `.server-changes/` file so the change appears in release notes.
 
 Create a markdown file with a descriptive name:
 
@@ -286,7 +286,7 @@ The body text (below the frontmatter) is a one-line description of the change. K
 |---|---|
 | Only packages (`packages/`) | Changeset |
 | Only server (`apps/`) | `.server-changes/` file |
-| Both packages and server | Just the changeset |
+| Both packages and server | Both |
 
 See `.server-changes/README.md` for more details.
 


### PR DESCRIPTION
Existing advice says if you have a PR that touches packages AND apps, ONLY do a changeset.

This fixes that to say if your app touches both, you do a changeset AND a .server-changes.