### PR TITLE
fix(supervisor): bump turbo to fix docker build

### DIFF
--- a/apps/supervisor/Containerfile
+++ b/apps/supervisor/Containerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 FROM node-22-alpine AS pruner
 
 COPY --chown=node:node . .
-RUN npx -q turbo@2.5.4 prune --scope=supervisor --docker
+RUN npx -q turbo@2.10.0 prune --scope=supervisor --docker
 
 FROM node-22-alpine AS base
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ FROM ${NODE_IMAGE} AS pruner
 WORKDIR /triggerdotdev
 
 COPY --chown=node:node . .
-RUN npx -q turbo@2.5.4 prune --scope=webapp --docker
+RUN npx -q turbo@2.10.0 prune --scope=webapp --docker
 RUN find . -name "node_modules" -type d -prune -exec rm -rf '{}' +
 
 # Base strategy to have layer caching


### PR DESCRIPTION
The supervisor image build has been failing since `@trigger.dev/core` gained
an `ai` peer dependency. `turbo prune` (2.5.4) generates a pruned lockfile
that references the `ai@6.0.116(zod@3.25.76)` snapshot without including the
entry itself, which causes `pnpm fetch --frozen-lockfile` to abort.

Bumping to 2.10.0 fixes the pnpm v9 peer dep snapshot pruning. Updated both
Containerfiles for consistency.

Example failure here:
https://github.com/triggerdotdev/trigger.dev/actions/runs/28225353375/job/83618124564

Broken since:
c06005b3
