### PR TITLE
chore: add format and lint to .md guides

### DIFF
--- a/.claude/REVIEW.md
+++ b/.claude/REVIEW.md
@@ -65,7 +65,7 @@ Every PR gets a performance pass — not just the ones that look perf-sensitive.
 
 ## Skip (do NOT flag)
 
-- Anything Prettier / ESLint catches. CI runs both.
+- Anything oxfmt / oxlint catches. CI enforces both via the `code-quality` check.
 - TypeScript style preferences (`type` vs `interface`) — already covered by repo standards.
 - Test coverage exhortations as a generic suggestion. Only flag missing tests when a specific code path is genuinely untested and the path has prior incidents.
 - `agentcrumbs` markers (`// @crumbs`, `// #region @crumbs`) and `agentcrumbs` imports — these are temporary debug instrumentation stripped before merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ For full setup instructions see `CONTRIBUTING.md`.
 Refer to `ai/references/tests.md` for details on writing tests. Tests should avoid mocks or stubs and use the helpers from `@internal/testcontainers` when Redis or Postgres are needed.
 
 ## Coding style
-- Formatting is enforced using Prettier. Run `pnpm run format` before committing.
+- Formatting is enforced using oxfmt. Run `pnpm run format` before committing.
 - Follow the existing project conventions. Test files live beside the files under test and use descriptive `describe` and `it` blocks.
 - Do not commit directly to the `main` branch. All changes should be made in a separate branch and go through a pull request.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,16 @@ containerTest("should use both", async ({ prisma, redisOptions }) => {
 
 ## Code Style
 
+### Formatting and linting
+
+Format and lint are enforced by CI (`code-quality` check). Run before committing:
+
+```bash
+pnpm run format      # oxfmt — auto-fixes formatting
+pnpm run lint:fix    # oxlint — auto-fixes lint violations
+pnpm run lint        # oxlint — check only (no fixes)
+```
+
 ### Imports
 
 **Prefer static imports over dynamic imports.** Only use dynamic `import()` when:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,9 +223,15 @@ pnpm exec trigger dev --log-level debug
 ### PR workflow
 
 1. **Always open your PR in draft status first.** Do not mark it as "Ready for Review" until the steps below are complete.
-2. **Address all CodeRabbit code review comments.** Our CI runs an automated code review via CodeRabbit. Go through each comment and either fix the issue or resolve it with a comment explaining why no change is needed.
-3. **Wait for all CI checks to pass.** Do not mark the PR as "Ready for Review" until every check is green.
-4. **Then mark the PR as "Ready for Review"** so a maintainer can take a look.
+2. **Run format and lint locally before pushing:**
+   ```bash
+   pnpm run format      # auto-fixes formatting (oxfmt)
+   pnpm run lint:fix    # auto-fixes lint violations (oxlint)
+   ```
+   Both are enforced by CI — the `code-quality` check will fail if either produces a diff or errors.
+3. **Address all CodeRabbit code review comments.** Our CI runs an automated code review via CodeRabbit. Go through each comment and either fix the issue or resolve it with a comment explaining why no change is needed.
+4. **Wait for all CI checks to pass.** Do not mark the PR as "Ready for Review" until every check is green.
+5. **Then mark the PR as "Ready for Review"** so a maintainer can take a look.
 
 ### Cost/benefit analysis for risky changes
 


### PR DESCRIPTION
follow on from #3977 #4056
