### PR TITLE
fix(cli): terminate each GITHUB_ENV/GITHUB_OUTPUT entry with a trailing newline

### DIFF
--- a/packages/cli-v3/src/utilities/githubActions.ts
+++ b/packages/cli-v3/src/utilities/githubActions.ts
@@ -10,8 +10,8 @@ export function setGithubActionsOutputAndEnvVars({
   // Set environment variables
   if (process.env.GITHUB_ENV) {
     const contents = Object.entries(envVars)
-      .map(([key, value]) => `${key}=${value}`)
-      .join("\n");
+      .map(([key, value]) => `${key}=${value}\n`)
+      .join("");
 
     appendFileSync(process.env.GITHUB_ENV, contents);
   }
@@ -19,8 +19,8 @@ export function setGithubActionsOutputAndEnvVars({
   // Set outputs
   if (process.env.GITHUB_OUTPUT) {
     const contents = Object.entries(outputs)
-      .map(([key, value]) => `${key}=${value}`)
-      .join("\n");
+      .map(([key, value]) => `${key}=${value}\n`)
+      .join("");
 
     appendFileSync(process.env.GITHUB_OUTPUT, contents);
   }


### PR DESCRIPTION
## Problem

`setGithubActionsOutputAndEnvVars` in `packages/cli-v3/src/utilities/githubActions.ts` builds entries with `.map(...).join('\n')` — which *separates* entries but leaves the **last entry without a trailing newline**.

Both `$GITHUB_ENV` and `$GITHUB_OUTPUT` are job-scoped append files. Without a trailing newline, the last written entry (`needsPromotion=...`) is left on an unterminated line. Any subsequent write by the runner or another step can concatenate onto it, producing merged/malformed values like `needsPromotion=trueSOME_OTHER_KEY=value` — breaking promotion branching. The bug is intermittent because GitHub Actions sometimes inserts its own newline.

## Fix

Match the [`@actions/core` convention](https://github.com/actions/toolkit/blob/main/packages/core/src/core.ts) — every entry gets its own trailing `\n`:

```diff
- .map(([key, value]) => `${key}=${value}`)
- .join("\n");
+ .map(([key, value]) => `${key}=${value}\n`)
+ .join("");
```

Applied to both the `GITHUB_ENV` and `GITHUB_OUTPUT` writes.

Fixes #4003