### PR TITLE
feat(sdk): export RunStatus type from @trigger.dev/sdk

### DIFF
--- a/packages/cli-v3/src/utilities/githubActions.ts
+++ b/packages/cli-v3/src/utilities/githubActions.ts
@@ -10,8 +10,8 @@ export function setGithubActionsOutputAndEnvVars({
   // Set environment variables
   if (process.env.GITHUB_ENV) {
     const contents = Object.entries(envVars)
-      .map(([key, value]) => `${key}=${value}`)
-      .join("\n");
+      .map(([key, value]) => `${key}=${value}\n`)
+      .join("");
 
     appendFileSync(process.env.GITHUB_ENV, contents);
   }
@@ -19,8 +19,8 @@ export function setGithubActionsOutputAndEnvVars({
   // Set outputs
   if (process.env.GITHUB_OUTPUT) {
     const contents = Object.entries(outputs)
-      .map(([key, value]) => `${key}=${value}`)
-      .join("\n");
+      .map(([key, value]) => `${key}=${value}\n`)
+      .join("");
 
     appendFileSync(process.env.GITHUB_OUTPUT, contents);
   }

--- a/packages/trigger-sdk/src/v3/index.ts
+++ b/packages/trigger-sdk/src/v3/index.ts
@@ -27,6 +27,8 @@ import type { ApiClientConfiguration, TaskRunContext } from "@trigger.dev/core/v
 
 export type { ApiClientConfiguration, TaskRunContext };
 
+export type { RunStatus } from "@trigger.dev/core/v3";
+
 export {
   ApiError,
   AuthenticationError,


### PR DESCRIPTION
## Problem

`RunStatus` is defined in `@trigger.dev/core/v3` but not re-exported from `@trigger.dev/sdk`. Consumers who need to type run status values (dashboards, monitoring tools, replay scripts) are forced to derive it indirectly:

```ts
// current workaround — couples code to internal SDK method signatures
type Run = Awaited<ReturnType<typeof runs.retrieve>>;
type RunStatus = Run["status"];
```

## Fix

Add a direct type re-export from the SDK's v3 index:

```ts
export type { RunStatus } from "@trigger.dev/core/v3";
```

`RunStatus` is already exported from `@trigger.dev/core/v3` (via `schemas/api.ts` → `schemas/index.ts` → `apiClient/types.ts`). This change surfaces it as a first-class public type:

```ts
import type { RunStatus } from "@trigger.dev/sdk";
```

Closes #4051