### PR TITLE
fix(dashboard-agent-db): load .env for local migrations

### DIFF
--- a/internal-packages/dashboard-agent-db/migrate-status.mjs
+++ b/internal-packages/dashboard-agent-db/migrate-status.mjs
@@ -8,12 +8,13 @@ import postgres from "postgres";
 const MIGRATIONS_SCHEMA = "drizzle";
 const MIGRATIONS_TABLE = "__dashboard_agent_migrations";
 
-// Match migrate.mjs: a direct (non-pooler) connection, same precedence.
-const connectionString =
+// Match migrate.mjs: same precedence, and expand `${VAR}` refs (see migrate.mjs).
+const connectionString = (
   process.env.DASHBOARD_AGENT_DIRECT_URL ??
   process.env.DASHBOARD_AGENT_DATABASE_URL ??
   process.env.DIRECT_URL ??
-  process.env.DATABASE_URL;
+  process.env.DATABASE_URL
+)?.replace(/\$\{(\w+)\}/g, (_, k) => process.env[k] ?? "");
 
 if (!connectionString) {
   console.error(

--- a/internal-packages/dashboard-agent-db/migrate.mjs
+++ b/internal-packages/dashboard-agent-db/migrate.mjs
@@ -14,11 +14,14 @@ import postgres from "postgres";
 // can't run the migrator. Prefer the agent's direct url, then its pooled url,
 // then the main DIRECT_URL/DATABASE_URL (OSS single-database fallback; tables
 // still land in the `trigger_dashboard_agent` schema).
-const connectionString =
+// `.replace` expands `${VAR}` refs (e.g. the repo .env's DIRECT_URL=${DATABASE_URL});
+// node's --env-file loads them literally, unlike Prisma's dotenv-expand.
+const connectionString = (
   process.env.DASHBOARD_AGENT_DIRECT_URL ??
   process.env.DASHBOARD_AGENT_DATABASE_URL ??
   process.env.DIRECT_URL ??
-  process.env.DATABASE_URL;
+  process.env.DATABASE_URL
+)?.replace(/\$\{(\w+)\}/g, (_, k) => process.env[k] ?? "");
 
 if (!connectionString) {
   console.error(

--- a/internal-packages/dashboard-agent-db/package.json
+++ b/internal-packages/dashboard-agent-db/package.json
@@ -16,8 +16,8 @@
     "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
-    "db:migrate:deploy": "node migrate.mjs",
-    "db:migrate:status": "node migrate-status.mjs",
+    "db:migrate:deploy": "node --env-file-if-exists=../../.env migrate.mjs",
+    "db:migrate:status": "node --env-file-if-exists=../../.env migrate-status.mjs",
     "db:studio": "drizzle-kit studio"
   }
 }


### PR DESCRIPTION
 c06005b35 added new package wiwth Drizzle but didn't load .env

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/triggerdotdev/codesmith/trigger.dev/pr/4069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785325374&installation_id=143281562&pr_number=4069&repository=triggerdotdev%2Ftrigger.dev&return_to=https%3A%2F%2Fgithub.com%2Ftriggerdotdev%2Ftrigger.dev%2Fpull%2F4069&signature=301a2a02345ca60d32c945cbc9bc3cbb1eb363ca9ef38ac20ba458f7df0412a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->