### PR TITLE
Fix Testbox scripts pnpm bootstrap

### DIFF
--- a/scripts/test-pr-check-windows.ps1
+++ b/scripts/test-pr-check-windows.ps1
@@ -2,6 +2,76 @@ $ErrorActionPreference = "Stop"
 
 Set-Location (git rev-parse --show-toplevel)
 
+function Find-NodeBin {
+  param([Parameter(Mandatory = $true)][string]$VersionPrefix)
+
+  $roots = @()
+  if ($env:RUNNER_TOOL_CACHE) {
+    $roots += $env:RUNNER_TOOL_CACHE
+  }
+  $roots += @(
+    "C:\hostedtoolcache\windows",
+    "C:\hostedtoolcache",
+    "C:\actions-runner\_work\_tool"
+  )
+
+  foreach ($root in $roots) {
+    $nodeRoot = Join-Path $root "node"
+    if (-not (Test-Path $nodeRoot)) {
+      continue
+    }
+
+    $match = Get-ChildItem -Path $nodeRoot -Directory -ErrorAction SilentlyContinue |
+      Where-Object { $_.Name.StartsWith($VersionPrefix) } |
+      Sort-Object Name |
+      Select-Object -Last 1
+
+    if ($match) {
+      $bin = Join-Path $match.FullName "x64"
+      if (Test-Path (Join-Path $bin "node.exe")) {
+        return $bin
+      }
+    }
+  }
+
+  return $null
+}
+
+function Ensure-Pnpm {
+  $pnpmVersion = if ($env:PNPM_VERSION) { $env:PNPM_VERSION } else { "10.33.2" }
+  $npmPrefix = Join-Path $env:USERPROFILE ".npm-global"
+  $env:PATH = "$npmPrefix;$env:PATH"
+
+  if (Get-Command pnpm -ErrorAction SilentlyContinue) {
+    return
+  }
+
+  if (Get-Command corepack -ErrorAction SilentlyContinue) {
+    try {
+      Invoke-Native corepack prepare "pnpm@$pnpmVersion" --activate
+    } catch {
+      Write-Warning "corepack could not activate pnpm: $_"
+    }
+  }
+
+  if (Get-Command pnpm -ErrorAction SilentlyContinue) {
+    return
+  }
+
+  if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+    throw "Unable to find pnpm or npm on PATH."
+  }
+
+  New-Item -ItemType Directory -Force -Path $npmPrefix | Out-Null
+  Invoke-Native npm config set prefix $npmPrefix
+  Invoke-Native npm install -g "pnpm@$pnpmVersion"
+  $env:PATH = "$npmPrefix;$env:PATH"
+
+  if (-not (Get-Command pnpm -ErrorAction SilentlyContinue)) {
+    throw "Unable to install pnpm."
+  }
+}
+
 function Start-Section {
   param([Parameter(Mandatory = $true)][string]$Title)
 
@@ -38,6 +108,14 @@ function Invoke-Section {
     Stop-Section
   }
 }
+
+$node20Bin = Find-NodeBin "20.20"
+if ($node20Bin) {
+  $env:PATH = "$node20Bin;$env:PATH"
+}
+
+Ensure-Pnpm
+Invoke-Native pnpm --version
 
 Invoke-Section "Install CLI dependencies" {
   Invoke-Native pnpm install --frozen-lockfile --filter trigger.dev...

--- a/scripts/test-pr-check.sh
+++ b/scripts/test-pr-check.sh
@@ -39,6 +39,36 @@ find_node_bin() {
   find /opt/hostedtoolcache/node -maxdepth 3 -type d -path "*/${version_prefix}*/x64/bin" 2>/dev/null | sort -V | tail -n 1
 }
 
+ensure_pnpm() {
+  local pnpm_version="${PNPM_VERSION:-10.33.2}"
+  local npm_prefix="${HOME}/.npm-global"
+  export PATH="${npm_prefix}/bin:${PATH}"
+
+  if command -v pnpm >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if command -v corepack >/dev/null 2>&1; then
+    corepack prepare "pnpm@${pnpm_version}" --activate || true
+  fi
+
+  if command -v pnpm >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if ! command -v npm >/dev/null 2>&1; then
+    echo "Unable to find pnpm or npm on PATH." >&2
+    return 1
+  fi
+
+  mkdir -p "${npm_prefix}"
+  npm config set prefix "${npm_prefix}"
+  npm install -g "pnpm@${pnpm_version}"
+  export PATH="${npm_prefix}/bin:${PATH}"
+
+  command -v pnpm >/dev/null 2>&1
+}
+
 with_node() {
   local node_bin="$1"
   shift
@@ -125,6 +155,7 @@ run_sdk_runtime_compat_tests() {
 }
 
 export -f find_node_bin
+export -f ensure_pnpm
 export -f with_node
 export -f run_webapp_unit_tests
 export -f run_package_unit_tests
@@ -145,6 +176,13 @@ export NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=8192}"
 
 NODE20_BIN="${NODE20_BIN:-$(find_node_bin 20.20)}"
 NODE22_BIN="${NODE22_BIN:-$(find_node_bin 22.12)}"
+
+if [[ -n "${NODE20_BIN}" ]]; then
+  export PATH="${NODE20_BIN}:${PATH}"
+fi
+
+ensure_pnpm
+pnpm --version
 
 run_section "Install dependencies" pnpm install --frozen-lockfile
 run_section "Generate Prisma client" pnpm run generate


### PR DESCRIPTION
## Summary

- add Node/pnpm bootstrapping to the Linux Testbox PR check script because Testbox run shells do not inherit the GitHub Actions PATH from warmup
- add the same bootstrap to the Windows Testbox PR check script

## Testing

- `bash -n scripts/test-pr-check.sh`
- PowerShell syntax check skipped locally because `pwsh` is not installed
