### PR TITLE
chore: switch build jobs to blacksmith

### DIFF
--- a/.github/workflows/publish-webapp.yml
+++ b/.github/workflows/publish-webapp.yml
@@ -38,7 +38,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     env:
       PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING: 1
     outputs:

--- a/.github/workflows/publish-worker-v4.yml
+++ b/.github/workflows/publish-worker-v4.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         package: [supervisor]
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     env:
       DOCKER_BUILDKIT: "1"
     steps:

--- a/.github/workflows/publish-worker.yml
+++ b/.github/workflows/publish-worker.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         package: [coordinator, docker-provider, kubernetes-provider]
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     env:
       DOCKER_BUILDKIT: "1"
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/trivy-image-webapp.yml
+++ b/.github/workflows/trivy-image-webapp.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   scan:
     name: Scan
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
       packages: read # pull the image from GHCR


### PR DESCRIPTION
Switches the build jobs over to blacksmith runner (publish-webapp, publish-worker, trivy).