### PR TITLE
fix(clickhouse): raise binary type complexity limit so nested JSON columns stay readable

### DIFF
--- a/.server-changes/clickhouse-binary-type-complexity.md
+++ b/.server-changes/clickhouse-binary-type-complexity.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Fix runs with deeply nested output or error payloads disappearing from the runs list by raising the ClickHouse binary type complexity limit

--- a/internal-packages/clickhouse/src/client/client.ts
+++ b/internal-packages/clickhouse/src/client/client.ts
@@ -72,6 +72,10 @@ export class ClickhouseClient implements ClickhouseReader, ClickhouseWriter {
         output_format_json_quote_64bit_integers: 0,
         output_format_json_quote_64bit_floats: 0,
         cancel_http_readonly_queries_on_client_close: 1,
+        // Deeply nested JSON-typed columns (e.g. run output/error) can exceed
+        // the default binary type complexity of 1000 when read back, which
+        // fails the whole query. Raise the ceiling so those rows stay readable.
+        input_format_binary_max_type_complexity: 100000,
       },
       log: {
         level: convertLogLevelToClickhouseLogLevel(config.logLevel),


### PR DESCRIPTION
## Summary

Runs whose `output` or `error` payload produces a deeply nested type could disappear from the runs list: the status filter still counted them, but the list itself came back empty. This makes those runs visible again.

## Root cause

`output` and `error` are stored as ClickHouse `JSON` columns. For a sufficiently nested payload, the materialized type's binary encoding exceeds the default `input_format_binary_max_type_complexity` of 1000. When the runs-list query reads the column back it throws `Code 117 ... complexity limit exceeded`, which fails the entire query, so no rows render. Status aggregates never touch these columns, so the count kept working, hence the mismatch.

## Fix

Raise `input_format_binary_max_type_complexity` on the ClickHouse client defaults so every query can read these columns. The setting only widens a guard against pathological binary type payloads; for our own data it is safe to raise.