### PR TITLE
fix(webapp): clamp oversized toast messages and quiet expected pause errors

### DIFF
--- a/.server-changes/toast-message-length-clamp.md
+++ b/.server-changes/toast-message-length-clamp.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Dashboard error toasts with very long messages no longer exceed the session cookie limit and break the request; over-long messages are truncated.

--- a/apps/webapp/app/models/message.server.ts
+++ b/apps/webapp/app/models/message.server.ts
@@ -34,6 +34,16 @@ export type ToastMessageOptions = {
 
 const ONE_YEAR = 1000 * 60 * 60 * 24 * 365;
 
+// Clamp so a flashed toast can never overflow the ~4KB `__message` cookie and 500 in commitSession.
+const MAX_TOAST_MESSAGE_LENGTH = 1000;
+
+function clampToastMessage(message: string) {
+  if (message.length <= MAX_TOAST_MESSAGE_LENGTH) {
+    return message;
+  }
+  return `${message.slice(0, MAX_TOAST_MESSAGE_LENGTH)}...`;
+}
+
 export const { commitSession, getSession } = createCookieSessionStorage({
   cookie: {
     name: "__message",
@@ -51,7 +61,7 @@ export function setSuccessMessage(
   options?: ToastMessageOptions
 ) {
   session.flash("toastMessage", {
-    message,
+    message: clampToastMessage(message),
     type: "success",
     options: {
       ...options,
@@ -62,7 +72,7 @@ export function setSuccessMessage(
 
 export function setErrorMessage(session: Session, message: string, options?: ToastMessageOptions) {
   session.flash("toastMessage", {
-    message,
+    message: clampToastMessage(message),
     type: "error",
     options: {
       ...options,

--- a/apps/webapp/app/models/message.server.ts
+++ b/apps/webapp/app/models/message.server.ts
@@ -34,14 +34,27 @@ export type ToastMessageOptions = {
 
 const ONE_YEAR = 1000 * 60 * 60 * 24 * 365;
 
-// Clamp so a flashed toast can never overflow the ~4KB `__message` cookie and 500 in commitSession.
-const MAX_TOAST_MESSAGE_LENGTH = 1000;
+// Clamp in UTF-8 bytes (not code units) so a flashed toast can never overflow the ~4KB
+// `__message` cookie and 500 in commitSession, even for multibyte messages.
+const MAX_TOAST_MESSAGE_BYTES = 1024;
+const toastMessageEncoder = new TextEncoder();
 
 function clampToastMessage(message: string) {
-  if (message.length <= MAX_TOAST_MESSAGE_LENGTH) {
+  if (toastMessageEncoder.encode(message).length <= MAX_TOAST_MESSAGE_BYTES) {
     return message;
   }
-  return `${message.slice(0, MAX_TOAST_MESSAGE_LENGTH)}...`;
+  const budget = MAX_TOAST_MESSAGE_BYTES - 3; // leave room for the "..." suffix
+  let bytes = 0;
+  let truncated = "";
+  for (const char of message) {
+    const charBytes = toastMessageEncoder.encode(char).length;
+    if (bytes + charBytes > budget) {
+      break;
+    }
+    bytes += charBytes;
+    truncated += char;
+  }
+  return `${truncated}...`;
 }
 
 export const { commitSession, getSession } = createCookieSessionStorage({

--- a/apps/webapp/app/v3/services/pauseEnvironment.server.ts
+++ b/apps/webapp/app/v3/services/pauseEnvironment.server.ts
@@ -60,7 +60,12 @@ export class PauseEnvironmentService extends WithRunEngine {
             state: manualPauseGuard.state,
           };
         }
-        throw new Error(manualPauseGuard.error);
+        // Expected, user-actionable guard result, not an error: return it as a failure
+        // result so it doesn't reach Sentry via the catch below.
+        return {
+          success: false,
+          error: manualPauseGuard.error,
+        };
       }
 
       if (!org.runsEnabled && action === "resumed") {
@@ -82,9 +87,13 @@ export class PauseEnvironmentService extends WithRunEngine {
         });
 
         if (resumed.count === 0) {
-          throw new Error(
-            "This environment is paused because your organization reached its billing limit. Resolve the limit on the billing limits settings page to resume."
-          );
+          // Raced into the paused state after the guard read above: expected,
+          // return as a failure result rather than throwing to Sentry.
+          return {
+            success: false,
+            error:
+              "This environment is paused because your organization reached its billing limit. Resolve the limit on the billing limits settings page to resume.",
+          };
         }
       } else {
         await this._prisma.runtimeEnvironment.update({


### PR DESCRIPTION
## Summary

Two robustness fixes in the dashboard's error handling, found while testing the billing-limit pause/resume flow.

## Toast cookie overflow

Toast messages are flashed into the `__message` session cookie, which the session store rejects once the serialized cookie passes the browser's ~4KB limit. Any call site that flashes a raw caught error (a verbose database or validation message, for example) could turn a toast into a failed request. `setErrorMessage` / `setSuccessMessage` now clamp the message length, so a toast can never overflow the cookie. This protects every toast helper at once.

## Pause/resume reporting

Resuming an environment that is paused by a billing limit is an expected, user-actionable state, but `PauseEnvironmentService` threw it, and the service's catch reports every throw at error level. It now returns that case as a failure result, so callers still surface the message to the user while genuine errors keep reporting.
