### PR TITLE
feat(webapp): add SENTRY_ENVIRONMENT to override the Sentry environment

### DIFF
--- a/.server-changes/sentry-environment-override.md
+++ b/.server-changes/sentry-environment-override.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+Add an optional `SENTRY_ENVIRONMENT` env var to set the Sentry environment independently; it falls back to `APP_ENV` when unset, so existing deployments are unchanged.

--- a/.server-changes/sentry-environment-override.md
+++ b/.server-changes/sentry-environment-override.md
@@ -1,6 +1,0 @@
----
-area: webapp
-type: improvement
----
-
-Add an optional `SENTRY_ENVIRONMENT` env var to set the Sentry environment independently; it falls back to `APP_ENV` when unset, so existing deployments are unchanged.

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -151,6 +151,7 @@ const EnvironmentSchema = z
     APP_ENV: z.string().default(process.env.NODE_ENV),
     SERVICE_NAME: z.string().default("trigger.dev webapp"),
     SENTRY_DSN: z.string().optional(),
+    SENTRY_ENVIRONMENT: z.string().optional(),
     POSTHOG_PROJECT_KEY: z.string().default("phc_LFH7kJiGhdIlnO22hTAKgHpaKhpM8gkzWAFvHmf5vfS"),
     TRIGGER_TELEMETRY_DISABLED: z.string().optional(),
     AUTH_GITHUB_CLIENT_ID: z.string().optional(),

--- a/apps/webapp/sentry.server.ts
+++ b/apps/webapp/sentry.server.ts
@@ -39,7 +39,8 @@ if (process.env.SENTRY_DSN) {
     shutdownTimeout: 10,
 
     serverName: process.env.SERVICE_NAME,
-    environment: process.env.APP_ENV,
+    // Falls back to APP_ENV; set SENTRY_ENVIRONMENT to override (e.g. preview deployments) without touching APP_ENV.
+    environment: process.env.SENTRY_ENVIRONMENT ?? process.env.APP_ENV,
 
     // ServiceValidationError is thrown deliberately for user-facing
     // validation failures (quota, parent run state, invalid input). Anchored


### PR DESCRIPTION
## Summary

The webapp's Sentry `environment` was hardcoded to `APP_ENV`. Because `APP_ENV` also drives other behavior, it can't be repurposed to give deployments that share another environment's config (for example preview deployments) their own Sentry environment, so their errors are indistinguishable from the environment whose config they inherit.

This adds an optional `SENTRY_ENVIRONMENT` that takes precedence over `APP_ENV`:

```ts
environment: process.env.SENTRY_ENVIRONMENT ?? process.env.APP_ENV,
```

Unset by default, so existing deployments keep their `APP_ENV`-derived Sentry environment with no change.
