### PR TITLE
chore: fix flakey build worker test

### DIFF
--- a/packages/cli-v3/e2e/e2e.test.ts
+++ b/packages/cli-v3/e2e/e2e.test.ts
@@ -52,7 +52,7 @@ if (testCases.length === 0) {
   }
 }
 
-describe.concurrent("buildWorker", async () => {
+describe("buildWorker", async () => {
   beforeEach<E2EFixtureTest>(async ({ fixtureDir, skip, packageManager, workspaceDir }) => {
     await rimraf(path.join(workspaceDir, "**/node_modules"), {
       glob: true,


### PR DESCRIPTION
## Summary

Fixes flaky CLI v3 E2E tests by removing fixture-level parallelism.

The suite was using `describe.concurrent`, but each fixture test mutates its fixture workspace during setup: removing `node_modules`, renaming/restoring lockfiles, and running package installs. On Windows/npm this can race or hit file-lock/cache contention, causing intermittent failures.

## Fix

Run the CLI v3 E2E fixtures serially instead of concurrently.

## Expected impact

This should make the Windows/npm E2E job more stable. The E2E step may slow down from ~30s to roughly ~60–90s in typical runs, with a conservative upper bound around ~2 minutes.
