### PR TITLE
chore: exit changeset prerelease mode for the 4.5.0 release

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "rc",
   "initialVersions": {
     "coordinator": "0.0.1",


### PR DESCRIPTION
Takes changesets out of rc prerelease mode so the next version bump produces the stable 4.5.0 GA release rather than another release candidate.