### PR TITLE
fix: avoid precision loss converting milliseconds to nanoseconds

### DIFF
--- a/apps/webapp/app/v3/eventRepository/common.server.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.ts
@@ -25,7 +25,7 @@ export function extractContextFromCarrier(carrier: Record<string, unknown>) {
 }
 
 export function getNowInNanoseconds(): bigint {
-  return BigInt(new Date().getTime() * 1_000_000);
+  return BigInt(new Date().getTime()) * BigInt(1_000_000);
 }
 
 export function getDateFromNanoseconds(nanoseconds: bigint): Date {
@@ -39,7 +39,7 @@ export function calculateDurationFromStart(
 ) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  const duration = Number(BigInt($endtime.getTime() * 1_000_000) - startTime);
+  const duration = Number(BigInt($endtime.getTime()) * BigInt(1_000_000) - startTime);
 
   if (minimumDuration && duration < minimumDuration) {
     return minimumDuration;

--- a/apps/webapp/app/v3/runEngineHandlers.server.ts
+++ b/apps/webapp/app/v3/runEngineHandlers.server.ts
@@ -547,7 +547,7 @@ export function registerRunEngineEventBusHandlers() {
         );
 
         await eventRepository.recordEvent(retryMessage, {
-          startTime: BigInt(time.getTime() * 1000000),
+          startTime: BigInt(time.getTime()) * BigInt(1_000_000),
           taskSlug: run.taskIdentifier,
           environment,
           attributes: {


### PR DESCRIPTION
Fixes #3292

## Problem

Several places convert a millisecond timestamp to nanoseconds like this:

```ts
BigInt(new Date().getTime() * 1_000_000)
```

The `* 1_000_000` runs in **floating-point** before `BigInt()` is called. `getTime()` is ~`1.7e12`, so the product is ~`1.7e18` — far above `Number.MAX_SAFE_INTEGER` (~`9.007e15`). The low-order digits are lost, so the nanosecond timestamp is silently rounded (the last few digits become zeros), which corrupts event ordering/durations that rely on nanosecond precision.

The same file already has the correct implementation:

```ts
export function convertDateToNanoseconds(date: Date): bigint {
  return BigInt(date.getTime()) * BigInt(1_000_000);
}
```

## Fix

Do the multiplication in BigInt space at the three affected sites, matching `convertDateToNanoseconds`:

- `eventRepository/common.server.ts` — `getNowInNanoseconds()` and `calculateDurationFromStart()`
- `runEngineHandlers.server.ts` — the `startTime` for the retry event

`BigInt(x.getTime()) * BigInt(1_000_000)` keeps full integer precision. Type is unchanged (`bigint`). `calculateDurationFromStartJsDate` (which returns a `number` delta, not an absolute BigInt timestamp) is intentionally left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)