### PR TITLE
fix(webapp): allow resuming manually paused environments

### DIFF
--- a/.server-changes/fix-resume-user-paused-environment.md
+++ b/.server-changes/fix-resume-user-paused-environment.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Fixed manually paused environments not being resumable. Resuming incorrectly failed with a billing-limit error even when no billing limit was in effect.

--- a/apps/webapp/app/v3/services/pauseEnvironment.server.ts
+++ b/apps/webapp/app/v3/services/pauseEnvironment.server.ts
@@ -78,7 +78,12 @@ export class PauseEnvironmentService extends WithRunEngine {
         const resumed = await this._prisma.runtimeEnvironment.updateMany({
           where: {
             id: environment.id,
-            NOT: { pauseSource: EnvironmentPauseSource.BILLING_LIMIT },
+            // NOT on a nullable field excludes NULL rows in Prisma, which made
+            // user-paused envs (pauseSource null) unresumable.
+            OR: [
+              { pauseSource: null },
+              { NOT: { pauseSource: EnvironmentPauseSource.BILLING_LIMIT } },
+            ],
           },
           data: {
             paused: false,


### PR DESCRIPTION
## Bug

Manually pausing an environment works, but resuming it always fails with:

> This environment is paused because your organization reached its billing limit. Resolve the limit on the billing limits settings page to resume.

even when no billing limit is in effect. Once paused by a user, an environment cannot be resumed at all.

## Root cause

A manual pause leaves `RuntimeEnvironment.pauseSource` as `NULL` (only billing-limit enforcement sets `BILLING_LIMIT`). The resume path in `PauseEnvironmentService` guards its `updateMany` with:

```ts
NOT: { pauseSource: EnvironmentPauseSource.BILLING_LIMIT }
```

Prisma's `NOT` on a nullable field translates to SQL `!=`, which excludes `NULL` rows. So the update matches zero rows for every user-paused environment, and the zero-count branch (meant to catch a race with billing-limit pausing) returns the misleading billing-limit error.

Introduced in #3996 (the guard is correct for `BILLING_LIMIT` rows; it just also swallows `NULL`).

## Fix

Explicitly include `pauseSource: null` rows:

```ts
OR: [
  { pauseSource: null },
  { NOT: { pauseSource: EnvironmentPauseSource.BILLING_LIMIT } },
]
```

Billing-limit-paused environments are still blocked from manual resume, both by the `getManualPauseEnvironmentResult` guard and by this clause.

## Verification

Reproduced locally: paused an environment via `PauseEnvironmentService` (DB shows `paused = true`, `pauseSource = NULL`), resume returned the billing-limit error with `updateMany` matching 0 rows. With the fix, resume succeeds and the environment unpauses. Billing-paused rows remain excluded by the same clause.
