### PR TITLE
test(webapp): regression tests for resuming manually paused environments

### DIFF
--- a/apps/webapp/test/pauseEnvironment.server.test.ts
+++ b/apps/webapp/test/pauseEnvironment.server.test.ts
@@ -1,0 +1,112 @@
+import { postgresTest } from "@internal/testcontainers";
+import { EnvironmentPauseSource, type PrismaClient } from "@trigger.dev/database";
+import { describe, expect, vi } from "vitest";
+import type { AuthenticatedEnvironment } from "~/services/apiAuth.server";
+import { authIncludeBase, toAuthenticated } from "~/models/runtimeEnvironment.server";
+import { PauseEnvironmentService } from "~/v3/services/pauseEnvironment.server";
+import {
+  createRuntimeEnvironment,
+  createTestOrgProjectWithMember,
+  uniqueId,
+} from "./fixtures/environmentVariablesFixtures";
+
+vi.setConfig({ testTimeout: 60_000 });
+
+async function authEnv(prisma: PrismaClient, environmentId: string): Promise<AuthenticatedEnvironment> {
+  const row = await prisma.runtimeEnvironment.findFirstOrThrow({
+    where: { id: environmentId },
+    include: authIncludeBase,
+  });
+  return toAuthenticated(row);
+}
+
+async function seedProductionEnv(prisma: PrismaClient) {
+  const { organization, project } = await createTestOrgProjectWithMember(prisma);
+  const environment = await createRuntimeEnvironment(prisma, {
+    projectId: project.id,
+    organizationId: organization.id,
+    type: "PRODUCTION",
+    slug: uniqueId("prod"),
+  });
+  return { organization, project, environment };
+}
+
+describe("PauseEnvironmentService", () => {
+  postgresTest(
+    "resumes a manually paused env (pauseSource stays null through pause and resume)",
+    async ({ prisma }) => {
+      const { environment } = await seedProductionEnv(prisma);
+      const service = new PauseEnvironmentService(prisma);
+      const env = await authEnv(prisma, environment.id);
+
+      const paused = await service.call(env, "paused");
+      expect(paused).toEqual({ success: true, state: "paused" });
+
+      const afterPause = await prisma.runtimeEnvironment.findFirstOrThrow({
+        where: { id: environment.id },
+      });
+      // Manual pause never sets pauseSource; leaving it null is what tripped the
+      // pre-fix resume guard (Prisma NOT on a nullable field excludes NULL rows).
+      expect(afterPause.paused).toBe(true);
+      expect(afterPause.pauseSource).toBeNull();
+
+      const resumed = await service.call(env, "resumed");
+      expect(resumed).toEqual({ success: true, state: "resumed" });
+
+      const afterResume = await prisma.runtimeEnvironment.findFirstOrThrow({
+        where: { id: environment.id },
+      });
+      expect(afterResume.paused).toBe(false);
+      expect(afterResume.pauseSource).toBeNull();
+    }
+  );
+
+  postgresTest("rejects resume of a billing-limit paused env and leaves it paused", async ({
+    prisma,
+  }) => {
+    const { environment } = await seedProductionEnv(prisma);
+    await prisma.runtimeEnvironment.update({
+      where: { id: environment.id },
+      data: { paused: true, pauseSource: EnvironmentPauseSource.BILLING_LIMIT },
+    });
+
+    const service = new PauseEnvironmentService(prisma);
+    const env = await authEnv(prisma, environment.id);
+
+    const result = await service.call(env, "resumed");
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toContain("billing limit");
+
+    const after = await prisma.runtimeEnvironment.findFirstOrThrow({
+      where: { id: environment.id },
+    });
+    expect(after.paused).toBe(true);
+    expect(after.pauseSource).toBe(EnvironmentPauseSource.BILLING_LIMIT);
+  });
+
+  postgresTest(
+    "manual pause while billing-limit paused is a no-op that preserves pauseSource",
+    async ({ prisma }) => {
+      const { environment } = await seedProductionEnv(prisma);
+      await prisma.runtimeEnvironment.update({
+        where: { id: environment.id },
+        data: { paused: true, pauseSource: EnvironmentPauseSource.BILLING_LIMIT },
+      });
+
+      const service = new PauseEnvironmentService(prisma);
+      const env = await authEnv(prisma, environment.id);
+
+      const result = await service.call(env, "paused");
+      // Idempotent success without overwriting pauseSource, so billing-limit
+      // converge can still find and unpause this env on resolve.
+      expect(result).toEqual({ success: true, state: "paused" });
+
+      const after = await prisma.runtimeEnvironment.findFirstOrThrow({
+        where: { id: environment.id },
+      });
+      expect(after.paused).toBe(true);
+      expect(after.pauseSource).toBe(EnvironmentPauseSource.BILLING_LIMIT);
+    }
+  );
+});

--- a/apps/webapp/test/pauseEnvironment.server.test.ts
+++ b/apps/webapp/test/pauseEnvironment.server.test.ts
@@ -1,9 +1,8 @@
-import { postgresTest } from "@internal/testcontainers";
+import { containerTest } from "@internal/testcontainers";
 import { EnvironmentPauseSource, type PrismaClient } from "@trigger.dev/database";
+import type { RedisOptions } from "ioredis";
 import { describe, expect, vi } from "vitest";
 import type { AuthenticatedEnvironment } from "~/services/apiAuth.server";
-import { authIncludeBase, toAuthenticated } from "~/models/runtimeEnvironment.server";
-import { PauseEnvironmentService } from "~/v3/services/pauseEnvironment.server";
 import {
   createRuntimeEnvironment,
   createTestOrgProjectWithMember,
@@ -12,15 +11,34 @@ import {
 
 vi.setConfig({ testTimeout: 60_000 });
 
+// The service's import chain reaches module-level singletons that throw at load
+// time when REDIS_HOST/REDIS_PORT are unset (autoIncrementCounter via
+// triggerTaskV1), so the env must point at the redis container BEFORE the
+// module is imported. Hence dynamic imports; vitest runs each file in its own
+// fork, so the env mutation cannot leak into other suites.
+async function loadService(redisOptions: RedisOptions) {
+  process.env.REDIS_HOST = redisOptions.host;
+  process.env.REDIS_PORT = String(redisOptions.port);
+  process.env.REDIS_TLS_DISABLED = "true";
+  const [{ PauseEnvironmentService }, { authIncludeBase, toAuthenticated }] = await Promise.all([
+    import("~/v3/services/pauseEnvironment.server"),
+    import("~/models/runtimeEnvironment.server"),
+  ]);
+  return { PauseEnvironmentService, authIncludeBase, toAuthenticated };
+}
+
+type Loaded = Awaited<ReturnType<typeof loadService>>;
+
 async function authEnv(
+  loaded: Loaded,
   prisma: PrismaClient,
   environmentId: string
 ): Promise<AuthenticatedEnvironment> {
   const row = await prisma.runtimeEnvironment.findFirstOrThrow({
     where: { id: environmentId },
-    include: authIncludeBase,
+    include: loaded.authIncludeBase,
   });
-  return toAuthenticated(row);
+  return loaded.toAuthenticated(row);
 }
 
 async function seedProductionEnv(prisma: PrismaClient) {
@@ -35,12 +53,13 @@ async function seedProductionEnv(prisma: PrismaClient) {
 }
 
 describe("PauseEnvironmentService", () => {
-  postgresTest(
+  containerTest(
     "resumes a manually paused env (pauseSource stays null through pause and resume)",
-    async ({ prisma }) => {
+    async ({ prisma, redisOptions }) => {
+      const loaded = await loadService(redisOptions);
       const { environment } = await seedProductionEnv(prisma);
-      const service = new PauseEnvironmentService(prisma);
-      const env = await authEnv(prisma, environment.id);
+      const service = new loaded.PauseEnvironmentService(prisma);
+      const env = await authEnv(loaded, prisma, environment.id);
 
       const paused = await service.call(env, "paused");
       expect(paused).toEqual({ success: true, state: "paused" });
@@ -64,17 +83,18 @@ describe("PauseEnvironmentService", () => {
     }
   );
 
-  postgresTest(
+  containerTest(
     "rejects resume of a billing-limit paused env and leaves it paused",
-    async ({ prisma }) => {
+    async ({ prisma, redisOptions }) => {
+      const loaded = await loadService(redisOptions);
       const { environment } = await seedProductionEnv(prisma);
       await prisma.runtimeEnvironment.update({
         where: { id: environment.id },
         data: { paused: true, pauseSource: EnvironmentPauseSource.BILLING_LIMIT },
       });
 
-      const service = new PauseEnvironmentService(prisma);
-      const env = await authEnv(prisma, environment.id);
+      const service = new loaded.PauseEnvironmentService(prisma);
+      const env = await authEnv(loaded, prisma, environment.id);
 
       const result = await service.call(env, "resumed");
       expect(result.success).toBe(false);
@@ -89,17 +109,18 @@ describe("PauseEnvironmentService", () => {
     }
   );
 
-  postgresTest(
+  containerTest(
     "manual pause while billing-limit paused is a no-op that preserves pauseSource",
-    async ({ prisma }) => {
+    async ({ prisma, redisOptions }) => {
+      const loaded = await loadService(redisOptions);
       const { environment } = await seedProductionEnv(prisma);
       await prisma.runtimeEnvironment.update({
         where: { id: environment.id },
         data: { paused: true, pauseSource: EnvironmentPauseSource.BILLING_LIMIT },
       });
 
-      const service = new PauseEnvironmentService(prisma);
-      const env = await authEnv(prisma, environment.id);
+      const service = new loaded.PauseEnvironmentService(prisma);
+      const env = await authEnv(loaded, prisma, environment.id);
 
       const result = await service.call(env, "paused");
       // Idempotent success without overwriting pauseSource, so billing-limit

--- a/apps/webapp/test/pauseEnvironment.server.test.ts
+++ b/apps/webapp/test/pauseEnvironment.server.test.ts
@@ -12,7 +12,10 @@ import {
 
 vi.setConfig({ testTimeout: 60_000 });
 
-async function authEnv(prisma: PrismaClient, environmentId: string): Promise<AuthenticatedEnvironment> {
+async function authEnv(
+  prisma: PrismaClient,
+  environmentId: string
+): Promise<AuthenticatedEnvironment> {
   const row = await prisma.runtimeEnvironment.findFirstOrThrow({
     where: { id: environmentId },
     include: authIncludeBase,
@@ -61,29 +64,30 @@ describe("PauseEnvironmentService", () => {
     }
   );
 
-  postgresTest("rejects resume of a billing-limit paused env and leaves it paused", async ({
-    prisma,
-  }) => {
-    const { environment } = await seedProductionEnv(prisma);
-    await prisma.runtimeEnvironment.update({
-      where: { id: environment.id },
-      data: { paused: true, pauseSource: EnvironmentPauseSource.BILLING_LIMIT },
-    });
+  postgresTest(
+    "rejects resume of a billing-limit paused env and leaves it paused",
+    async ({ prisma }) => {
+      const { environment } = await seedProductionEnv(prisma);
+      await prisma.runtimeEnvironment.update({
+        where: { id: environment.id },
+        data: { paused: true, pauseSource: EnvironmentPauseSource.BILLING_LIMIT },
+      });
 
-    const service = new PauseEnvironmentService(prisma);
-    const env = await authEnv(prisma, environment.id);
+      const service = new PauseEnvironmentService(prisma);
+      const env = await authEnv(prisma, environment.id);
 
-    const result = await service.call(env, "resumed");
-    expect(result.success).toBe(false);
-    if (result.success) return;
-    expect(result.error).toContain("billing limit");
+      const result = await service.call(env, "resumed");
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error).toContain("billing limit");
 
-    const after = await prisma.runtimeEnvironment.findFirstOrThrow({
-      where: { id: environment.id },
-    });
-    expect(after.paused).toBe(true);
-    expect(after.pauseSource).toBe(EnvironmentPauseSource.BILLING_LIMIT);
-  });
+      const after = await prisma.runtimeEnvironment.findFirstOrThrow({
+        where: { id: environment.id },
+      });
+      expect(after.paused).toBe(true);
+      expect(after.pauseSource).toBe(EnvironmentPauseSource.BILLING_LIMIT);
+    }
+  );
 
   postgresTest(
     "manual pause while billing-limit paused is a no-op that preserves pauseSource",


### PR DESCRIPTION
Follow-up to #4120, adding regression coverage for the pause/resume path in `PauseEnvironmentService`.

Three tests against the real service with testcontainers Postgres (no mocks), seeded org/project/environment rows, and the same `AuthenticatedEnvironment` coercion production uses:

1. **resumes a manually paused env** - the actual regression: pause leaves `pauseSource` null, resume must succeed. Verified this fails with the exact pre-#4120 symptom (false billing-limit error) when the fix is reverted locally.
2. **rejects resume of a billing-limit paused env** - the guard still blocks manual resume while `pauseSource = BILLING_LIMIT`, and the env stays paused.
3. **manual pause while billing-limit paused is a no-op** - returns success without overwriting `pauseSource`, so billing-limit converge can still find and unpause the environment.

Tests-only change, no runtime behavior touched.
