### PR TITLE
fix(webapp): escape realtime tags filter to prevent SQL injection (#3…

### DIFF
--- a/.server-changes/fix-realtime-tags-sql-injection.md
+++ b/.server-changes/fix-realtime-tags-sql-injection.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Escape single quotes in user-supplied realtime `tags` filter to prevent SQL injection into the Electric `where` clause

--- a/apps/webapp/app/services/realtimeClient.server.ts
+++ b/apps/webapp/app/services/realtimeClient.server.ts
@@ -52,6 +52,11 @@ const DEFAULT_ELECTRIC_COLUMNS = [
 const RESERVED_COLUMNS = ["id", "taskIdentifier", "friendlyId", "status", "createdAt"];
 const RESERVED_SEARCH_PARAMS = ["createdAt", "tags", "skipColumns"];
 
+// Doubles single quotes so a value is safe inside a single-quoted SQL string literal.
+export function escapeSqlStringLiteral(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
 export type RealtimeClientOptions = {
   electricOrigin: string | string[];
   redis: RedisWithClusterOptions;
@@ -171,7 +176,10 @@ export class RealtimeClient {
     const whereClauses: string[] = [`"runtimeEnvironmentId"='${environment.id}'`];
 
     if (params.tags) {
-      whereClauses.push(`"runTags" @> ARRAY[${params.tags.map((t) => `'${t}'`).join(",")}]`);
+      // Escape user-supplied tags so they can't break out of the SQL string literal.
+      whereClauses.push(
+        `"runTags" @> ARRAY[${params.tags.map((t) => `'${escapeSqlStringLiteral(t)}'`).join(",")}]`
+      );
     }
 
     const createdAtFilter = await this.#calculateCreatedAtFilter(url, params.createdAt);

--- a/apps/webapp/test/realtimeClientEscapeSqlStringLiteral.test.ts
+++ b/apps/webapp/test/realtimeClientEscapeSqlStringLiteral.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { escapeSqlStringLiteral } from "../app/services/realtimeClient.server";
+
+describe("escapeSqlStringLiteral", () => {
+  it("leaves ordinary tag values unchanged", () => {
+    expect(escapeSqlStringLiteral("important")).toBe("important");
+    expect(escapeSqlStringLiteral("user_42")).toBe("user_42");
+    expect(escapeSqlStringLiteral("")).toBe("");
+  });
+
+  it("doubles a single quote", () => {
+    expect(escapeSqlStringLiteral("O'Brien")).toBe("O''Brien");
+  });
+
+  it("neutralizes the tags injection payload from #3739", () => {
+    const literal = `'${escapeSqlStringLiteral("test' OR '1'='1")}'`;
+    expect(literal).toBe("'test'' OR ''1''=''1'");
+    expect(literal.replace(/''/g, "")).toBe("'test OR 1=1'");
+  });
+
+  it("escapes every quote, not just the first", () => {
+    expect(escapeSqlStringLiteral("a'b'c'")).toBe("a''b''c''");
+  });
+});


### PR DESCRIPTION
Closes #3739

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

The realtime runs stream builds a SQL `WHERE` clause that is passed to Electric as the `where` search param. In `streamRuns()`, user-supplied `tags` were interpolated straight into a single-quoted SQL string literal with no escaping, so a tag containing a `'` could break out of the literal and inject SQL (e.g. `?tags=test' OR '1'='1`).

This PR escapes each tag by doubling embedded single quotes before it is wrapped in the literal, which is sufficient because Postgres runs with `standard_conforming_strings` on (the single quote is the only character that can terminate the literal). The other interpolated values in the same file (`environment.id`, `runId`, `batchId`, `createdAt`) are system-generated IDs/dates that cannot contain a quote, so they are not an injection vector.

**Added a unit test** (`apps/webapp/test/realtimeClientEscapeSqlStringLiteral.test.ts`) covering:
- ordinary tag values pass through unchanged
- a single quote is doubled (`O'Brien` → `O''Brien`)
- the exact injection payload from #3739 is neutralized into a single harmless literal
- every quote in a value is escaped, not just the first

Run it with:

```bash
pnpm run test --filter webapp ./test/realtimeClientEscapeSqlStringLiteral.test.ts --run
```

**Manual verification of the fix:** with the escaped clause, `?tags=test' OR '1'='1` produces the literal `'test'' OR ''1''=''1'`, which Postgres reads as a single (nonexistent) tag name rather than executable SQL — the filter no longer breaks out.

---

## Changelog

Escape single quotes in the user-supplied realtime `tags` filter so they cannot break out of the SQL string literal, closing a SQL injection vector in the `/realtime/v1/runs` stream.

---

## Screenshots

N/A — server-side change, no UI.

💯
