### PR TITLE
fix: deploy the dashboard agent one environment at a time

### DIFF
--- a/.github/workflows/dashboard-agent-deploy.yml
+++ b/.github/workflows/dashboard-agent-deploy.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20.20.2
+          node-version: 22.23.1
           cache: "pnpm"
 
       - name: Install + build the CLI and the agent's deps

--- a/.github/workflows/dashboard-agent-deploy.yml
+++ b/.github/workflows/dashboard-agent-deploy.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # One environment at a time: parallel deploys of the same project race.
+      max-parallel: 1
       matrix:
         environment: [staging, prod]
     # Per-environment reviewer gate + source of the scoped deploy PAT.


### PR DESCRIPTION
The dashboard agent deploy runs a matrix leg per environment (staging, prod). Running them in parallel deployed the same Trigger.dev project twice at once, and one leg failed to create the background worker while the other succeeded. `max-parallel: 1` runs the legs sequentially so a deploy never races itself.

Also aligns the workflow's Node version to the repo standard (`22.23.1`, per `.nvmrc`).

Verified: re-running the staging leg on its own (no parallel prod) deployed cleanly.
