### PR TITLE
chore: update self-host image release references

### DIFF
--- a/.github/workflows/publish-webapp.yml
+++ b/.github/workflows/publish-webapp.yml
@@ -76,6 +76,10 @@ jobs:
           # therefore publishes to its own package automatically.
           image_tags=$REF_WITHOUT_TAG:${STEPS_GET_TAG_OUTPUTS_TAG}
 
+          if [[ "${STEPS_GET_TAG_OUTPUTS_TAG}" =~ ^v4\.[0-9]+\.[0-9]+$ ]]; then
+            image_tags=$image_tags,$REF_WITHOUT_TAG:v4,$REF_WITHOUT_TAG:latest
+          fi
+
           # when pushing the mutable main tag, also push an immutable-by-convention
           # full-commit-sha tag so a commit can be resolved to a specific digest
           if [[ "${STEPS_GET_TAG_OUTPUTS_TAG}" == "main" ]]; then

--- a/.github/workflows/publish-worker-v4.yml
+++ b/.github/workflows/publish-worker-v4.yml
@@ -76,6 +76,10 @@ jobs:
           ref_without_tag=${IMAGE_REGISTRY}/${STEPS_GET_REPOSITORY_OUTPUTS_REPO}
           image_tags=$ref_without_tag:${STEPS_GET_TAG_OUTPUTS_TAG}
 
+          if [[ "${STEPS_GET_TAG_OUTPUTS_TAG}" =~ ^v4\.[0-9]+\.[0-9]+$ ]]; then
+            image_tags=$image_tags,$ref_without_tag:v4,$ref_without_tag:latest
+          fi
+
           echo "image_tags=${image_tags}" >> "$GITHUB_OUTPUT"
         env:
           IMAGE_REGISTRY: ${{ inputs.image_registry || vars.IMAGE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}

--- a/docs/self-hosting/kubernetes.mdx
+++ b/docs/self-hosting/kubernetes.mdx
@@ -61,7 +61,7 @@ webapp:
 ```bash
 helm upgrade -n trigger --install trigger \
   oci://ghcr.io/triggerdotdev/charts/trigger \
-  --version "~4.0.0" \
+  --version "^4.5.0" \
   --create-namespace
 ```
 
@@ -107,11 +107,11 @@ The following commands will display the default values:
 ```bash
 # Specific version
 helm show values oci://ghcr.io/triggerdotdev/charts/trigger \
-  --version "4.0.5"
+  --version "4.5.0"
 
 # Latest v4
 helm show values oci://ghcr.io/triggerdotdev/charts/trigger \
-  --version "~4.0.0"
+  --version "^4.5.0"
 ```
 
 ### Custom values
@@ -171,7 +171,7 @@ Deploy with your custom values:
 ```bash
 helm upgrade -n trigger --install trigger \
   oci://ghcr.io/triggerdotdev/charts/trigger \
-  --version "~4.0.0" \
+  --version "^4.5.0" \
   --create-namespace \
   -f values-custom.yaml
 ```
@@ -510,14 +510,14 @@ You can lock versions in two ways:
 # Pin to a specific version for production
 helm upgrade -n trigger --install trigger \
   oci://ghcr.io/triggerdotdev/charts/trigger \
-  --version "4.0.5"
+  --version "4.5.0"
 
 # The app version will be different from the chart version
 # This is the version of the Trigger.dev webapp and supervisor
 # ..and should always match your Trigger.dev CLI version
 helm show chart \
   oci://ghcr.io/triggerdotdev/charts/trigger \
-  --version "4.0.5" | grep appVersion
+  --version "4.5.0" | grep appVersion
 ```
 
 **Specific image tags:**
@@ -525,11 +525,11 @@ helm show chart \
 ```yaml
 webapp:
   image:
-    tag: "v4.0.0"
+    tag: "v4.5.0"
 
 supervisor:
   image:
-    tag: "v4.0.0"
+    tag: "v4.5.0"
 ```
 
 The chart version's `appVersion` field determines the default image tags. Newer image tags may be incompatible with older chart versions and vice versa.


### PR DESCRIPTION
## Summary

Stable v4 Docker image builds now also publish `v4` and `latest` tags, giving Docker-based self-hosters a maintained floating tag to use after a stable release. The Kubernetes guide now uses the current Helm chart line and current pinned examples, so new installs and upgrades resolve to the 4.5 chart line instead of the 4.0 line.

## Design

The publish workflows add the floating tags only for stable `v4.x.x` image tags. Prerelease and `main` builds keep their existing tags.
