### PR TITLE
chore: use latest self-host compose images

### DIFF
--- a/docs/self-hosting/docker.mdx
+++ b/docs/self-hosting/docker.mdx
@@ -339,7 +339,7 @@ There are several reasons to lock the version of your Docker images:
 By default, the images will point at the latest versioned release via the `latest` tag. You can override this by specifying a different tag in your `.env` file. For example:
 
 ```bash
-TRIGGER_IMAGE_TAG=v4.0.0
+TRIGGER_IMAGE_TAG=v4.5.0
 ```
 
 ## Task events

--- a/hosting/docker/.env.example
+++ b/hosting/docker/.env.example
@@ -34,8 +34,8 @@ DIRECT_URL=postgresql://postgres:unsafe-postgres-pw@postgres:5432/main?schema=pu
 
 # Trigger image tag
 # - This is the version of the webapp and worker images to use, they should be locked to a specific version in production
-# - For example: TRIGGER_IMAGE_TAG=v4.0.0-v4-beta.21
-TRIGGER_IMAGE_TAG=v4-beta
+# - For example: TRIGGER_IMAGE_TAG=v4.5.0
+TRIGGER_IMAGE_TAG=latest
 
 # Webapp
 # - These should generally be set to the same value

--- a/hosting/docker/webapp/docker-compose.yml
+++ b/hosting/docker/webapp/docker-compose.yml
@@ -9,7 +9,7 @@ x-logging: &logging-config
 
 services:
   webapp:
-    image: ghcr.io/triggerdotdev/trigger.dev:${TRIGGER_IMAGE_TAG:-v4-beta}
+    image: ghcr.io/triggerdotdev/trigger.dev:${TRIGGER_IMAGE_TAG:-latest}
     restart: ${RESTART_POLICY:-unless-stopped}
     logging: *logging-config
     ports:

--- a/hosting/docker/worker/docker-compose.yml
+++ b/hosting/docker/worker/docker-compose.yml
@@ -9,7 +9,7 @@ x-logging: &logging-config
 
 services:
   supervisor:
-    image: ghcr.io/triggerdotdev/supervisor:${TRIGGER_IMAGE_TAG:-v4-beta}
+    image: ghcr.io/triggerdotdev/supervisor:${TRIGGER_IMAGE_TAG:-latest}
     restart: ${RESTART_POLICY:-unless-stopped}
     logging: *logging-config
     depends_on:


### PR DESCRIPTION
## Summary

Depends on #4136.

Docker Compose self-hosting now uses the maintained `latest` image tag by default instead of the frozen prerelease tag. The version-locking docs keep pointing production users at explicit versioned tags when they want pinned upgrades.
