### PR TITLE
ci: run oxfmt + oxlint on pre-push (lefthook)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,3 +4,14 @@ pre-commit:
   jobs:
     - name: 🚫 Prevent main branch commits
       run: exit 1
+
+# Mirror the CI code-quality check locally so unformatted / lint-failing pushes
+# are caught before they hit the PR. Note: GitButler uses its own git
+# implementation and only runs hooks when "Run hooks" is enabled in its
+# settings - with that off, this protects plain `git push` only.
+pre-push:
+  jobs:
+    - name: format
+      run: pnpm exec oxfmt --check .
+    - name: lint
+      run: pnpm exec oxlint .


### PR DESCRIPTION
Adds a lefthook `pre-push` job that runs the same checks as CI code-quality (`oxfmt --check .` + `oxlint .`), so formatting/lint failures are caught locally before they reach a PR. Uses the existing lefthook setup - no new tooling.

Caveat noted in the config: GitButler uses its own git implementation and only runs hooks when "Run hooks" is enabled in its per-project settings; with that off, this protects plain `git push`. Enable that setting to have it fire on `but push` too.