### PR TITLE
fix(ci): retry prisma generate to survive Windows EPERM engine-DLL race

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,6 +42,8 @@ jobs:
       - name: 📥 Download deps
         run: pnpm install --frozen-lockfile --filter trigger.dev...
 
+      # Prisma clients generate concurrently and share one engine binary in the
+      # pnpm store; the generate script retries the transient Windows EPERM race.
       - name: 📀 Generate Prisma Client
         run: pnpm run generate
 

--- a/internal-packages/database/package.json
+++ b/internal-packages/database/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "generate": "prisma generate",
+    "generate": "node ../../scripts/retry-prisma-generate.mjs",
     "db:migrate:dev:create": "prisma migrate dev --create-only",
     "db:migrate:deploy": "prisma migrate deploy",
     "db:push": "prisma db push",

--- a/internal-packages/run-ops-database/package.json
+++ b/internal-packages/run-ops-database/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "generate": "prisma generate",
+    "generate": "node ../../scripts/retry-prisma-generate.mjs",
     "db:migrate:dev:create": "prisma migrate dev --create-only",
     "db:migrate:deploy": "node scripts/migrate.mjs deploy",
     "db:migrate:status": "node scripts/migrate.mjs status",

--- a/scripts/retry-prisma-generate.mjs
+++ b/scripts/retry-prisma-generate.mjs
@@ -1,0 +1,53 @@
+// Retry wrapper around `prisma generate`. Our two prisma clients pin the same
+// prisma version and so share one package instance in the pnpm store; when
+// `turbo run generate` runs them concurrently both race to write the shared
+// query-engine binary, and on Windows the loser fails with `EPERM ... rename`.
+// Retrying lets it succeed once the engine file is present and unlocked. On
+// non-Windows the first attempt succeeds, so this is a zero-cost no-op.
+import { spawnSync } from "node:child_process";
+
+const MAX_ATTEMPTS = 5;
+const BASE_DELAY_MS = 500;
+
+// Transient, retryable filesystem contention on the shared engine binary.
+const TRANSIENT =
+  /\b(EPERM|EBUSY|EACCES)\b|operation not permitted|resource busy or locked|being used by another process/i;
+
+const passthroughArgs = process.argv.slice(2);
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+let lastStatus = 1;
+
+for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+  const result = spawnSync("prisma", ["generate", ...passthroughArgs], {
+    shell: true,
+    encoding: "utf8",
+  });
+
+  process.stdout.write(result.stdout ?? "");
+  process.stderr.write(result.stderr ?? "");
+
+  if (result.status === 0) {
+    process.exit(0);
+  }
+
+  lastStatus = result.status ?? 1;
+
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+  const isRetryable = TRANSIENT.test(output);
+
+  if (!isRetryable || attempt === MAX_ATTEMPTS) {
+    break;
+  }
+
+  const delay = BASE_DELAY_MS * attempt;
+  console.error(
+    `prisma generate hit a transient filesystem error (attempt ${attempt}/${MAX_ATTEMPTS}); retrying in ${delay}ms...`
+  );
+  sleepSync(delay);
+}
+
+process.exit(lastStatus);


### PR DESCRIPTION
## Problem

The `e2e / CLI v3 tests (windows - npm)` job intermittently dies during dependency setup at the `@trigger.dev/database` prisma generate step, before any test runs:

```
@trigger.dev/database:generate: Error: EPERM: operation not permitted, rename
  '...\node_modules\.pnpm\prisma@6.14.0_...\node_modules\prisma\query_engine-windows.dll.node.tmp5744'
  -> '...\node_modules\.pnpm\prisma@6.14.0_...\node_modules\prisma\query_engine-windows.dll.node'
Failed: @trigger.dev/database#generate
```

## Root cause

Confirmed a structural concurrency race, not a random transient. `@trigger.dev/database` and `@internal/run-ops-database` pin the same prisma version, so pnpm gives them a single shared package instance in the store. `turbo run generate` runs their `generate` scripts concurrently, and both `prisma generate` processes race to write the shared `query_engine-windows.dll.node`. On Windows the loser fails with `EPERM` on the `.tmp -> .dll.node` rename because the file was just written/held by the winner.

The CI logs show both `:generate` tasks executing at the same timestamp against the identical shared store path — one finishes, the other EPERMs. In the run that surfaced this, the Windows-pnpm job passed while Windows-npm failed on the same commit, which is the signature of a timing-dependent race.

## Fix

Wrap `prisma generate` in a small cross-platform node script that retries on transient filesystem contention (EPERM/EBUSY/EACCES) with a short backoff. On the retry the engine binary is already present and unlocked, so it succeeds. Non-transient errors (e.g. schema errors) fail fast without retrying.

- Fixing it in the two package `generate` scripts covers every invocation path (all `pnpm run generate` CI jobs plus local dev) without editing many workflow files.
- On non-Windows the first attempt always succeeds, so it is a zero-cost no-op — no serialization, no slowdown to Linux CI.

## Validation

- Verified locally on macOS: the wrapper runs `prisma generate` successfully (exit 0) and does not retry on hard errors.
- The added comment on the e2e generate step brings this PR into the CLI-v3 path filter so the Windows job actually runs here and exercises the fix on the real runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)