### PR TITLE
fix(docker): copy retry-prisma-generate.mjs into the image build (unbreaks publish)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,6 +71,7 @@ RUN chmod +x ./scripts/entrypoint.sh
 COPY --chown=node:node .configs/tsconfig.base.json .configs/tsconfig.base.json
 COPY --chown=node:node scripts/updateVersion.ts scripts/updateVersion.ts
 COPY --chown=node:node scripts/bundleSdkDocs.ts scripts/bundleSdkDocs.ts
+COPY --chown=node:node scripts/retry-prisma-generate.mjs scripts/retry-prisma-generate.mjs
 RUN pnpm run generate
 RUN --mount=type=secret,id=sentry_auth_token \
     SENTRY_AUTH_TOKEN=$(cat /run/secrets/sentry_auth_token) \


### PR DESCRIPTION
## Build-blocker hotfix

`publish.yml` on `main` is failing to build the image after #4154 merged:

```
@trigger.dev/database:generate: Error: Cannot find module '/triggerdotdev/scripts/retry-prisma-generate.mjs'
… ERROR: process "/bin/sh -c pnpm run generate" did not complete successfully: exit code: 1
```

## Cause
#4154 (Windows-CI hardening) changed the `generate` scripts of `@trigger.dev/database` and `@internal/run-ops-database` to call `node ../../scripts/retry-prisma-generate.mjs`. But `docker/Dockerfile`'s `builder` stage does `COPY docker/scripts ./scripts` (replacing the scripts dir) and then copies back only the specific root scripts it needs (`updateVersion.ts`, `bundleSdkDocs.ts`) before `RUN pnpm run generate` — the new `retry-prisma-generate.mjs` wasn't copied, so `pnpm run generate` can't find it and the image build fails.

`publish.yml` only runs on push to `main` (not on PRs), so #4154's PR CI never built the image and this slipped through.

## Fix
One line — copy the retry script alongside the other root scripts before the generate step:

```dockerfile
COPY --chown=node:node scripts/retry-prisma-generate.mjs scripts/retry-prisma-generate.mjs
```

## Verification
Built locally with `docker build --target builder` (the stage that runs `pnpm run generate`) to confirm the generate step now passes — result appended once it finishes.

No changeset / `.server-changes` — Dockerfile/build-only change, no package or server-runtime change.
