### PR TITLE
fix(supervisor): copy retry-prisma-generate.mjs into the image build

### DIFF
--- a/.server-changes/supervisor-generate-retry-script.md
+++ b/.server-changes/supervisor-generate-retry-script.md
@@ -1,0 +1,6 @@
+---
+area: supervisor
+type: fix
+---
+
+Copy `scripts/retry-prisma-generate.mjs` into the supervisor image build before `pnpm run generate`. The database packages' `generate` scripts shell out to that file, so the supervisor `Containerfile` fails to build without it. Companion to the same fix in the webapp Dockerfile (#4156).

--- a/.server-changes/supervisor-generate-retry-script.md
+++ b/.server-changes/supervisor-generate-retry-script.md
@@ -1,6 +1,0 @@
----
-area: supervisor
-type: fix
----
-
-Copy `scripts/retry-prisma-generate.mjs` into the supervisor image build before `pnpm run generate`. The database packages' `generate` scripts shell out to that file, so the supervisor `Containerfile` fails to build without it. Companion to the same fix in the webapp Dockerfile (#4156).

--- a/apps/supervisor/Containerfile
+++ b/apps/supervisor/Containerfile
@@ -34,6 +34,7 @@ COPY --from=dev-deps --chown=node:node /app/ .
 COPY --chown=node:node turbo.json turbo.json
 COPY --chown=node:node .configs/tsconfig.base.json .configs/tsconfig.base.json
 COPY --chown=node:node scripts/updateVersion.ts scripts/updateVersion.ts
+COPY --chown=node:node scripts/retry-prisma-generate.mjs scripts/retry-prisma-generate.mjs
 
 RUN pnpm run generate && \
   pnpm run --filter supervisor... build&& \


### PR DESCRIPTION
## What

Adds the missing `COPY scripts/retry-prisma-generate.mjs` to the supervisor `Containerfile` builder stage, before `RUN pnpm run generate`.

## Why

The `generate` scripts in `internal-packages/database` and `internal-packages/run-ops-database` shell out to `scripts/retry-prisma-generate.mjs`. The supervisor build never copied that file into the image, so `pnpm run generate` failed:

```
@internal/run-ops-database:generate: Error: Cannot find module '/app/scripts/retry-prisma-generate.mjs'
```

This is the same failure class as #4156 (webapp Dockerfile). The supervisor `Containerfile` is the **only other** build file that runs `pnpm run generate` — the coordinator / docker-provider / kubernetes-provider Containerfiles don't, so this completes the fix.

## Verification

Local `docker build` of the supervisor `Containerfile` builder target — result appended below once the build completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)