### PR TITLE
feat: auto-update dev and preview branch selector

### DIFF
--- a/.server-changes/env-selector-dropdown-auto-revalidate.md
+++ b/.server-changes/env-selector-dropdown-auto-revalidate.md
@@ -3,4 +3,4 @@ area: webapp
 type: improvement
 ---
 
-The environment and branch selector dropdown will automatically revalidate (poll) while it's open so that new branches show up.
+The environment and branch selector dropdown will automatically revalidate when opened so that new branches show up.

--- a/.server-changes/env-selector-dropdown-auto-revalidate.md
+++ b/.server-changes/env-selector-dropdown-auto-revalidate.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+The environment and branch selector dropdown will automatically revalidate (poll) while it's open so that new branches show up.

--- a/apps/webapp/app/components/navigation/EnvironmentSelector.tsx
+++ b/apps/webapp/app/components/navigation/EnvironmentSelector.tsx
@@ -5,6 +5,7 @@ import { DropdownIcon } from "~/assets/icons/DropdownIcon";
 import { useNavigation } from "@remix-run/react";
 import { useEffect, useRef, useState } from "react";
 import { BranchEnvironmentIconSmall } from "~/assets/icons/EnvironmentIcons";
+import { useAutoRevalidate } from "~/hooks/useAutoRevalidate";
 import { useEnvironment } from "~/hooks/useEnvironment";
 import { useEnvironmentSwitcher } from "~/hooks/useEnvironmentSwitcher";
 import { useFeatures } from "~/hooks/useFeatures";
@@ -53,9 +54,20 @@ export function EnvironmentSelector({
   const navigation = useNavigation();
   const { urlForEnvironment } = useEnvironmentSwitcher();
 
+  // Keep branch list fresh, only fires while the menu is open
+  const revalidator = useAutoRevalidate({ interval: 5000, disabled: !isMenuOpen });
+
   useEffect(() => {
     setIsMenuOpen(false);
   }, [navigation.location?.pathname]);
+
+  // Fetch immediately on open so the list is fresh right away
+  useEffect(() => {
+    if (isMenuOpen && revalidator.state !== "loading") {
+      revalidator.revalidate();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMenuOpen]);
 
   const hasStaging = project.environments.some((env) => env.type === "STAGING");
   return (

--- a/apps/webapp/app/components/navigation/EnvironmentSelector.tsx
+++ b/apps/webapp/app/components/navigation/EnvironmentSelector.tsx
@@ -2,10 +2,9 @@ import { ChevronRightIcon, Cog8ToothIcon } from "@heroicons/react/20/solid";
 import { DEFAULT_DEV_BRANCH } from "@trigger.dev/core/v3/utils/gitBranch";
 import { isBranchableEnvironment } from "~/utils/branchableEnvironment";
 import { DropdownIcon } from "~/assets/icons/DropdownIcon";
-import { useNavigation } from "@remix-run/react";
+import { useNavigation, useRevalidator } from "@remix-run/react";
 import { useEffect, useRef, useState } from "react";
 import { BranchEnvironmentIconSmall } from "~/assets/icons/EnvironmentIcons";
-import { useAutoRevalidate } from "~/hooks/useAutoRevalidate";
 import { useEnvironment } from "~/hooks/useEnvironment";
 import { useEnvironmentSwitcher } from "~/hooks/useEnvironmentSwitcher";
 import { useFeatures } from "~/hooks/useFeatures";
@@ -53,9 +52,7 @@ export function EnvironmentSelector({
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const navigation = useNavigation();
   const { urlForEnvironment } = useEnvironmentSwitcher();
-
-  // Keep branch list fresh, only fires while the menu is open
-  const revalidator = useAutoRevalidate({ interval: 5000, disabled: !isMenuOpen });
+  const revalidator = useRevalidator();
 
   useEffect(() => {
     setIsMenuOpen(false);


### PR DESCRIPTION
Currently, the environment/branch selector dropdown doesn't auto-reload, so if you create a new dev branch from the CLI, you need to manually refresh the dashboard for the dropdown to update.

This adds a little auto revalidator that only fires when the menu is open.

Left out of the initial feature to avoid extra server polls but I think it's needed.
