### PR TITLE
fix: run npm release jobs on ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   show-release-summary:
     name: 📋 Release Summary
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: ubuntu-latest
     permissions: {}
     if: |
       github.repository == 'triggerdotdev/trigger.dev' &&
@@ -48,7 +48,7 @@ jobs:
 
   release:
     name: 🚀 Release npm packages
-    runs-on: warp-ubuntu-latest-x64-8x
+    runs-on: ubuntu-latest
     environment: npm-publish
     permissions:
       contents: write
@@ -211,7 +211,7 @@ jobs:
     name: 🔗 Update release Docker link
     needs: [release, publish-docker]
     if: needs.release.outputs.published == 'true'
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: read
@@ -253,7 +253,7 @@ jobs:
     name: 📝 Dispatch changelog PR
     needs: [release, update-release]
     if: needs.release.outputs.published == 'true' && needs.release.outputs.is_prerelease != 'true'
-    runs-on: warp-ubuntu-latest-x64-2x
+    runs-on: ubuntu-latest
     permissions: {}
     steps:
       - uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
@@ -266,7 +266,7 @@ jobs:
   # The prerelease job needs to be on the same workflow file due to a limitation related to how npm verifies OIDC claims.
   prerelease:
     name: 🧪 Prerelease
-    runs-on: warp-ubuntu-latest-x64-8x
+    runs-on: ubuntu-latest
     environment: npm-publish
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,7 @@ jobs:
     name: 🔗 Update release Docker link
     needs: [release, publish-docker]
     if: needs.release.outputs.published == 'true'
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
     permissions:
       contents: write
       packages: read
@@ -253,7 +253,7 @@ jobs:
     name: 📝 Dispatch changelog PR
     needs: [release, update-release]
     if: needs.release.outputs.published == 'true' && needs.release.outputs.is_prerelease != 'true'
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
     permissions: {}
     steps:
       - uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1


### PR DESCRIPTION
Failed trying to run trust npm publish on warp runner:
https://github.com/triggerdotdev/trigger.dev/actions/runs/29016820615/job/86113758922
