### PR TITLE
chore: ignore plugins package in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -14,7 +14,8 @@
   "updateInternalDependencies": "patch",
   "ignore": [
     "webapp",
-    "supervisor"
+    "supervisor",
+    "@trigger.dev/plugins"
   ],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true


### PR DESCRIPTION
## Summary

Excludes the non-published plugins workspace from Changesets release planning so it cannot drive public package version bumps.

## Verification

Ran `pnpm run changeset:version` with temporary changesets for `@trigger.dev/plugins` and `@trigger.dev/core`; the ignored workspace produced no release-driver updates, and the public package changeset versioned normally.