### PR TITLE
fix(cli-v3): forward TRIGGER_WORKER_INSTANCE_NAME into the managed run process env

### DIFF
--- a/.changeset/forward-worker-instance-name.md
+++ b/.changeset/forward-worker-instance-name.md
@@ -1,0 +1,14 @@
+---
+"trigger.dev": patch
+---
+
+Forward `TRIGGER_WORKER_INSTANCE_NAME` into the managed run process env
+
+The Kubernetes workload manager already injects `TRIGGER_WORKER_INSTANCE_NAME`
+(= `spec.nodeName`) into the run-controller container via the downward API, but
+the managed run worker is forked with an explicit env allowlist
+(`RunnerEnv.gatherProcessEnv()`) that dropped it. As a result the run process
+could not attach the node as an OpenTelemetry `host.name` resource attribute, so
+spans/logs exported to an off-node OTLP collector had no host (Datadog tags these
+`issue_type:empty_hostname`). This forwards the value so `trigger.config.ts`
+telemetry (or the worker itself) can surface the node/host.

--- a/packages/cli-v3/src/entryPoints/managed/env.ts
+++ b/packages/cli-v3/src/entryPoints/managed/env.ts
@@ -236,6 +236,11 @@ export class RunnerEnv {
       OTEL_EXPORTER_OTLP_ENDPOINT: this.OTEL_EXPORTER_OTLP_ENDPOINT,
       TRIGGER_OTEL_EXPORTER_OTLP_ENDPOINT: this.OTEL_EXPORTER_OTLP_ENDPOINT,
       UV_USE_IO_URING: this.UV_USE_IO_URING,
+      // Forward the worker instance name (spec.nodeName on k8s) into the run
+      // process so it can be attached as an OTEL host/node resource attribute.
+      // Without this, run spans/logs exported to an off-node OTLP collector
+      // have no host and Datadog tags them issue_type:empty_hostname.
+      TRIGGER_WORKER_INSTANCE_NAME: this.TRIGGER_WORKER_INSTANCE_NAME,
     };
 
     // Filter out undefined values


### PR DESCRIPTION

## Problem
On self-hosted Kubernetes, task-run spans and logs exported over OTLP to an
**off-node** collector (e.g. a central Datadog Agent) have an empty host. Datadog
tags every such span with `issue_type:empty_hostname`. There is no supported way
for a user's `trigger.config.ts` telemetry resource to recover the node, because
the node identity never reaches the run process.

## Root cause
The Kubernetes workload manager already injects the node name into the
**run-controller container** via the downward API
(`apps/supervisor/src/workloadManager/kubernetes.ts`):

```ts
{ name: "TRIGGER_WORKER_INSTANCE_NAME",
  valueFrom: { fieldRef: { fieldPath: "spec.nodeName" } } }
```

But the actual task-run worker is `fork()`ed with an **explicit, replaced env**
built from `RunnerEnv.gatherProcessEnv()` (an allowlist) plus the run's env
(`packages/cli-v3/src/entryPoints/managed/taskRunProcessProvider.ts` →
`packages/cli-v3/src/executions/taskRunProcess.ts`). `gatherProcessEnv()` returns
only `NODE_ENV, NODE_EXTRA_CA_CERTS, OTEL_EXPORTER_OTLP_ENDPOINT,
TRIGGER_OTEL_EXPORTER_OTLP_ENDPOINT, UV_USE_IO_URING`, so
`TRIGGER_WORKER_INSTANCE_NAME` (and container-level vars generally) never reach
`process.env` in the run process. The node identity is present in the pod but
dropped before it can be used.

## Fix
Add `TRIGGER_WORKER_INSTANCE_NAME` to the env returned by
`RunnerEnv.gatherProcessEnv()` (it is already in the `Env` schema and has a
getter). One line + comment; see `change.diff`.

With this, a user can map it in their `trigger.config.ts`:
```ts
const nodeName = process.env.TRIGGER_WORKER_INSTANCE_NAME; // spec.nodeName on k8s
telemetry: {
  resource: resourceFromAttributes(
    nodeName ? { "host.name": nodeName, "k8s.node.name": nodeName } : {}
  ),
  // ...
}
```
which clears `empty_hostname` and attributes the run to its actual node.

## Scope / risk
- Additive: forwards one already-present, non-secret identity var.
- No behavior change when unset (the existing `undefined` filter drops it).
- Docker workload manager already passes `TRIGGER_WORKER_INSTANCE_NAME` to the
  runner (`workloadManager/docker.ts`), so this aligns k8s runs with that.

## Changeset
`trigger.dev`: patch — see `changeset.md`.
