### PR TITLE
chore: vouch brentshulman-silkline

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -24,3 +24,4 @@ jrossi
 ThullyoCunha
 ConProgramming
 saasjesus
+brentshulman-silkline


### PR DESCRIPTION
Adds `brentshulman-silkline` to the list of vouched outside contributors so their PRs aren't auto-closed by the vouch check.