### PR TITLE
chore: format prisma schemas

### DIFF
--- a/internal-packages/database/package.json
+++ b/internal-packages/database/package.json
@@ -16,7 +16,8 @@
   "scripts": {
     "clean": "rimraf dist",
     "generate": "node ../../scripts/retry-prisma-generate.mjs",
-    "db:migrate:dev:create": "prisma migrate dev --create-only",
+    "db:migrate:dev:create": "pnpm run format:prisma && prisma migrate dev --create-only",
+    "format:prisma": "prisma format",
     "db:migrate:deploy": "prisma migrate deploy",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -299,7 +299,7 @@ model OrgMemberInvite {
   /// a separate schema (Drizzle, not Prisma) so we can't model the FK
   /// here. Validation happens at write time (action) and read time
   /// (acceptInvite).
-  rbacRoleId String?
+  rbacRoleId     String?
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   organizationId String
 
@@ -340,9 +340,9 @@ model RuntimeEnvironment {
   ///A memorable code for the environment
   shortcode String
 
-  maximumConcurrencyLimit     Int     @default(5)
-  concurrencyLimitBurstFactor Decimal @default("2.00") @db.Decimal(4, 2)
-  paused                      Boolean @default(false)
+  maximumConcurrencyLimit     Int                     @default(5)
+  concurrencyLimitBurstFactor Decimal                 @default("2.00") @db.Decimal(4, 2)
+  paused                      Boolean                 @default(false)
   pauseSource                 EnvironmentPauseSource?
 
   autoEnableInternalSources Boolean @default(true)
@@ -378,21 +378,21 @@ model RuntimeEnvironment {
   taskScheduleInstances      TaskScheduleInstance[]
   alerts                     ProjectAlert[]
 
-  sessions             RuntimeEnvironmentSession[]
-  currentSession       RuntimeEnvironmentSession?  @relation("currentSession", fields: [currentSessionId], references: [id], onDelete: SetNull, onUpdate: Cascade)
-  currentSessionId     String?
-  taskRunNumberCounter TaskRunNumberCounter[]
-  taskRunCheckpoints   TaskRunCheckpoint[]
-  waitpoints           Waitpoint[]
-  workerInstances      WorkerInstance[]
-  waitpointTags        WaitpointTag[]
-  BulkActionGroup      BulkActionGroup[]
-  customerQueries      CustomerQuery[]
-  prompts                  Prompt[]
-  playgroundConversations  PlaygroundConversation[]
-  errorGroupStates     ErrorGroupState[]
-  taskIdentifiers      TaskIdentifier[]
-  revokedApiKeys       RevokedApiKey[]
+  sessions                RuntimeEnvironmentSession[]
+  currentSession          RuntimeEnvironmentSession?  @relation("currentSession", fields: [currentSessionId], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  currentSessionId        String?
+  taskRunNumberCounter    TaskRunNumberCounter[]
+  taskRunCheckpoints      TaskRunCheckpoint[]
+  waitpoints              Waitpoint[]
+  workerInstances         WorkerInstance[]
+  waitpointTags           WaitpointTag[]
+  BulkActionGroup         BulkActionGroup[]
+  customerQueries         CustomerQuery[]
+  prompts                 Prompt[]
+  playgroundConversations PlaygroundConversation[]
+  errorGroupStates        ErrorGroupState[]
+  taskIdentifiers         TaskIdentifier[]
+  revokedApiKeys          RevokedApiKey[]
 
   @@unique([projectId, slug, orgMemberId])
   @@unique([projectId, shortcode])
@@ -2479,7 +2479,7 @@ model BulkActionGroup {
   environment   RuntimeEnvironment? @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   environmentId String?
 
-  type  BulkActionType
+  type BulkActionType
 
   /// When the group is created it's pending. After we've processed all the items it's completed. This does not mean the associated runs are completed.
   status BulkActionStatus @default(PENDING)

--- a/internal-packages/run-ops-database/package.json
+++ b/internal-packages/run-ops-database/package.json
@@ -26,7 +26,8 @@
   "scripts": {
     "clean": "rimraf dist",
     "generate": "node ../../scripts/retry-prisma-generate.mjs",
-    "db:migrate:dev:create": "prisma migrate dev --create-only",
+    "db:migrate:dev:create": "pnpm run format:prisma && prisma migrate dev --create-only",
+    "format:prisma": "prisma format",
     "db:migrate:deploy": "node scripts/migrate.mjs deploy",
     "db:migrate:status": "node scripts/migrate.mjs status",
     "db:push": "prisma db push",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "i:dev": "infisical run -- turbo run dev",
     "generate": "turbo run generate",
     "format": "oxfmt .",
+    "format:prisma": "pnpm --filter @trigger.dev/database run format:prisma && pnpm --filter @internal/run-ops-database run format:prisma",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "docker": "node scripts/docker.mjs -f docker/docker-compose.yml up -d --build --remove-orphans",


### PR DESCRIPTION
Creating a Prisma migration now formats its schema first, keeping migration-related schema edits consistently formatted without adding work to the repository-wide format command. Run `pnpm run format:prisma` to format either schema on demand.