### PR TITLE
fix(webapp): correct button disabling state broken by Remix v2 useNav…

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.alerts.new/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.alerts.new/route.tsx
@@ -243,7 +243,7 @@ export default function Page() {
 
   const isLoading =
     navigation.state !== "idle" &&
-    navigation.formMethod === "post" &&
+    navigation.formMethod === "POST" &&
     navigation.formData?.get("action") === "create";
 
   const [

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.alerts/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.alerts/route.tsx
@@ -383,7 +383,7 @@ function DeleteAlertChannelButton(props: { id: string }) {
 
   const isLoading =
     navigation.state !== "idle" &&
-    navigation.formMethod === "post" &&
+    navigation.formMethod === "POST" &&
     navigation.formData?.get("action") === "delete";
 
   const [form] = useForm({
@@ -422,7 +422,7 @@ function DisableAlertChannelButton(props: { id: string }) {
 
   const isLoading =
     navigation.state !== "idle" &&
-    navigation.formMethod === "post" &&
+    navigation.formMethod === "POST" &&
     navigation.formData?.get("action") === "delete";
 
   const [form] = useForm({
@@ -462,7 +462,7 @@ function EnableAlertChannelButton(props: { id: string }) {
 
   const isLoading =
     navigation.state !== "idle" &&
-    navigation.formMethod === "post" &&
+    navigation.formMethod === "POST" &&
     navigation.formData?.get("action") === "delete";
 
   const [form] = useForm({

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.dashboards.custom.$dashboardId/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.dashboards.custom.$dashboardId/route.tsx
@@ -652,7 +652,7 @@ function RenameDashboardDialog({ title }: { title: string }) {
 
   const isRenaming =
     navigation.state !== "idle" &&
-    navigation.formMethod === "post" &&
+    navigation.formMethod === "POST" &&
     navigation.formData?.get("action") === "rename";
 
   // Close dialog when navigation completes
@@ -724,7 +724,7 @@ function DeleteDashboardDialog({ title }: { title: string }) {
 
   const isDeleting =
     navigation.state !== "idle" &&
-    navigation.formMethod === "post" &&
+    navigation.formMethod === "POST" &&
     navigation.formData?.get("action") === "delete";
 
   // Close dialog when navigation completes

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.environment-variables.new/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.environment-variables.new/route.tsx
@@ -230,7 +230,7 @@ export default function Page() {
   const selectedEnvironments = environments.filter((env) => selectedEnvironmentIds.has(env.id));
   const previewIsSelected = selectedEnvironments.some((env) => env.type === "PREVIEW");
 
-  const isLoading = navigation.state !== "idle" && navigation.formMethod === "post";
+  const isLoading = navigation.state !== "idle" && navigation.formMethod === "POST";
 
   const [form, fields] = useForm<z.infer<typeof schema>>({
     id: "create-environment-variables",

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.environment-variables/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.environment-variables/route.tsx
@@ -868,7 +868,7 @@ function DeleteEnvironmentVariableButton({
 
   const isLoading =
     navigation.state !== "idle" &&
-    navigation.formMethod === "post" &&
+    navigation.formMethod === "POST" &&
     navigation.formData?.get("action") === "delete";
 
   const [form] = useForm({


### PR DESCRIPTION
## Summary

This PR fixes an issue where loading states were no longer activated for several form submissions after the Remix v2 upgrade.

`navigation.formMethod` now returns uppercase HTTP methods (e.g. `"POST"`), while the existing code was still comparing against lowercase (`"post"`). As a result, the loading state was never triggered, leaving action buttons enabled during submissions.

On the Alerts page, this allowed users to click **Save** multiple times before the first request completed, resulting in duplicate alert channels being created.

**Fixes #3455**

---

## Problem

Several routes determine whether a form is submitting using logic similar to:

```ts
const isLoading =
  navigation.state !== "idle" &&
  navigation.formMethod === "post" &&
  navigation.formData?.get("action") === "create";
```

With Remix v2, `navigation.formMethod` is now uppercase (`"POST"`). Since the comparison never matched, `isLoading` always remained `false`.

This caused:
- Submit buttons to remain enabled during requests.
- Loading indicators to never appear.
- Multiple rapid submissions to be possible on slower networks or high-latency connections.

---

## Solution

Updated the affected routes to compare against the correct uppercase HTTP method:

```ts
navigation.formMethod === "POST"
```

This restores the expected loading state behavior across the affected forms, ensuring that action buttons are disabled while a submission is in progress.

The change applies to:

- Creating alert channels
- Deleting alert channels
- Enabling/disabling alert channels
- Creating environment variables
- Deleting environment variables
- Renaming dashboards
- Deleting dashboards

---

## Testing

- Verified that the loading state is correctly activated during form submission.
- Verified that action buttons are disabled while the request is in progress.
- Reproduced the original issue by rapidly clicking **Save** on the Alerts page.
- Confirmed that only a single alert channel is created after this change.