### PR TITLE
fix(webapp): return 415 for invalid SSO form content types

### DIFF
--- a/.server-changes/sso-form-content-type.md
+++ b/.server-changes/sso-form-content-type.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Return a clear client error when SSO form submissions use an unsupported content type

--- a/apps/webapp/app/routes/auth.sso.ts
+++ b/apps/webapp/app/routes/auth.sso.ts
@@ -23,6 +23,14 @@ export async function action({ request }: ActionFunctionArgs) {
     return new Response(null, { status: 405 });
   }
 
+  const contentType = request.headers.get("content-type")?.toLowerCase() ?? "";
+  if (
+    !contentType.includes("application/x-www-form-urlencoded") &&
+    !contentType.includes("multipart/form-data")
+  ) {
+    return new Response(null, { status: 415 });
+  }
+
   const form = await request.formData();
   const rawEmail = form.get("email");
   if (typeof rawEmail !== "string" || rawEmail.trim().length === 0) {


### PR DESCRIPTION
## Summary

SSO form submissions with an unsupported content type now receive a 415 response instead of failing while parsing the request body.