### PR TITLE
docs: note v3 is retired and 4.5.0 is the last version supporting v3

### DIFF
--- a/.server-changes/remove-v3-engine.md
+++ b/.server-changes/remove-v3-engine.md
@@ -3,4 +3,4 @@ area: webapp
 type: breaking
 ---
 
-Removed support for the end-of-life v3 engine. 4.5.0 is the last version we officially support for running v3, so instances or projects still on v3 must stay on 4.5.0 or upgrade to v4; v3 triggers, batch triggers, reschedules, and deploys now return a clear upgrade message instead of running.
+Trigger.dev v3 is no longer supported. For self-hosted deployments, 4.5.0 is the last version we officially support for running v3; stay on 4.5.0 or upgrade to v4. v3 triggers, batch triggers, reschedules, and deploys now return a clear upgrade message instead of running.

--- a/.server-changes/remove-v3-engine.md
+++ b/.server-changes/remove-v3-engine.md
@@ -3,4 +3,4 @@ area: webapp
 type: breaking
 ---
 
-Removed support for the end-of-life v3 engine. Instances or projects still on v3 must stay on the 4.5.x release line or upgrade to v4; v3 triggers, batch triggers, reschedules, and deploys now return a clear upgrade message instead of running.
+Removed support for the end-of-life v3 engine. 4.5.0 is the last version we officially support for running v3, so instances or projects still on v3 must stay on 4.5.0 or upgrade to v4; v3 triggers, batch triggers, reschedules, and deploys now return a clear upgrade message instead of running.

--- a/docs/cli-introduction.mdx
+++ b/docs/cli-introduction.mdx
@@ -18,7 +18,7 @@ import VersionOption from '/snippets/cli-options-version.mdx';
 | [login](/cli-login-commands)                 | Login with Trigger.dev so you can perform authenticated actions.   |
 | [init](/cli-init-commands)                   | Initialize your existing project for development with Trigger.dev. |
 | [dev](/cli-dev-commands)                     | Run your Trigger.dev tasks locally.                                |
-| [deploy](/cli-deploy-commands)               | Deploy your Trigger.dev v3 project to the cloud.                   |
+| [deploy](/cli-deploy-commands)               | Deploy your Trigger.dev project to the cloud.                      |
 | [whoami](/cli-whoami-commands)               | Display the current logged in user and project details.            |
 | [logout](/cli-logout-commands)               | Logout of Trigger.dev.                                             |
 | [list-profiles](/cli-list-profiles-commands) | List all of your CLI profiles.                                     |

--- a/docs/migrating-from-v3.mdx
+++ b/docs/migrating-from-v3.mdx
@@ -7,16 +7,14 @@ import NodeVersions from "/snippets/node-versions.mdx";
 import MigrateV4UsingAi from "/snippets/migrate-v4-using-ai.mdx";
 
 <Warning>
-  **Action required: Trigger.dev v3 deprecation**
+  **Trigger.dev v3 has been retired**
 
-We're retiring Trigger.dev v3. **New v3 deploys will stop working from 1 April 2026.** Trigger.dev v4 is stable, fully supported, and recommended for all users.
+Trigger.dev v3 is end of life. v4 is stable, fully supported, and recommended for all users.
 
-**Key dates:**
+- On Trigger.dev Cloud, v3 has been shut down: v3 triggers and deploys no longer run.
+- If you self-host, 4.5.0 is the last version we officially support for running v3. Stay on 4.5.0 or upgrade to v4; 4.5.1 and later reject v3 triggers, batch triggers, and deploys with an upgrade message.
 
-- **1 April 2026** — New v3 deploys will no longer work. Existing v3 runs will continue to execute.
-- **1 July 2026** — v3 will be fully shut down. All v3 runs will stop executing.
-
-**What you need to do:** Migrate to v4 before April to avoid disruption to your task executions. The migration takes about 2 minutes — follow the steps on this page below. If you have questions or need help, [contact us](https://trigger.dev/contact) or reach out in our [Discord](https://trigger.dev/discord).
+**What you need to do:** Migrate to v4. The migration takes about 2 minutes, follow the steps on this page below. If you have questions or need help, [contact us](https://trigger.dev/contact) or reach out in our [Discord](https://trigger.dev/discord).
 
 </Warning>
 

--- a/docs/migrating-from-v3.mdx
+++ b/docs/migrating-from-v3.mdx
@@ -14,7 +14,7 @@ Trigger.dev v3 is end of life. v4 is stable, fully supported, and recommended fo
 - On Trigger.dev Cloud, v3 has been shut down: v3 triggers and deploys no longer run.
 - If you self-host, 4.5.0 is the last version we officially support for running v3. Stay on 4.5.0 or upgrade to v4; 4.5.1 and later reject v3 triggers, batch triggers, and deploys with an upgrade message.
 
-**What you need to do:** Migrate to v4. The migration takes about 2 minutes, follow the steps on this page below. If you have questions or need help, [contact us](https://trigger.dev/contact) or reach out in our [Discord](https://trigger.dev/discord).
+**What you need to do:** Migrate to v4. The migration takes about 2 minutes; follow the steps below. If you have questions or need help, [contact us](https://trigger.dev/contact) or reach out in our [Discord](https://trigger.dev/discord).
 
 </Warning>
 

--- a/docs/self-hosting/docker.mdx
+++ b/docs/self-hosting/docker.mdx
@@ -344,6 +344,12 @@ TRIGGER_IMAGE_TAG=v4.5.0
 
 We patch the latest released version line only, so keep an eye on new releases to receive security fixes. See [Security & vulnerability reporting](/self-hosting/security).
 
+<Note>
+  Trigger.dev 4.5.0 is the last version we officially support for running v3 (SDK v3) tasks. If
+  you still have v3 tasks, pin `TRIGGER_IMAGE_TAG` to exactly `v4.5.0` or [migrate to
+  v4](/migrating-from-v3). 4.5.1 and later reject v3 triggers and deploys with an upgrade message.
+</Note>
+
 ## Task events
 
 By default, task events (timeline, logs, spans) are stored in PostgreSQL. For production deployments we recommend storing them in ClickHouse instead, it scales to much higher volumes and avoids unbounded growth of the `TaskEvent` table.

--- a/docs/self-hosting/kubernetes.mdx
+++ b/docs/self-hosting/kubernetes.mdx
@@ -528,6 +528,12 @@ webapp:
 
 ## Version locking
 
+<Note>
+  Trigger.dev 4.5.0 is the last version we officially support for running v3 (SDK v3) tasks. If
+  you still have v3 tasks, pin to exactly 4.5.0 or [migrate to v4](/migrating-from-v3). 4.5.1 and
+  later reject v3 triggers and deploys with an upgrade message.
+</Note>
+
 You can lock versions in two ways:
 
 **Helm chart version (recommended):**

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -10,6 +10,13 @@ You are responsible for provisioning resources, handling updates, and managing a
 
 We provide version-tagged releases for self-hosted deployments. It's highly advised to use these tags exclusively and keep them locked with your CLI version.
 
+<Warning>
+  **v3 is end of life.** Trigger.dev 4.5.0 is the last version we officially support for running
+  v3 (SDK v3) tasks. If you still have v3 tasks, stay on 4.5.0 or [migrate to
+  v4](/migrating-from-v3). 4.5.1 and later reject v3 triggers, batch triggers, and deploys with an
+  upgrade message; v4 workloads are unaffected.
+</Warning>
+
 ## Should you self-host?
 
 Trigger.dev Cloud is fully managed, scalable, and comes with dedicated support. For most users, it offers the best experience. However, if you have specific requirements around data residency, compliance, or infrastructure control, self-hosting may be the right choice for you.


### PR DESCRIPTION
## Summary

Refreshes the docs for the v3 sunset: v3 (SDK v3) is end of life, and 4.5.0 is the last version we officially support for running v3.

- The self-hosting overview, plus the docker and kubernetes version-locking sections, now tell self-hosters on v3 to stay on 4.5.0 or migrate to v4. 4.5.1 and later reject v3 triggers and deploys with an upgrade message.
- The migration guide's deprecation notice was still written in the future tense (with dates that have since passed); it now describes v3 as retired and adds the self-hosted 4.5.0 cutoff. This is the page the server's upgrade message links to.
- Fixes a stale "v3 project" reference in the CLI overview.

The Mintlify preview will render the callouts for a visual check.
