### PR TITLE
fix(webapp): correct docs link on the blank prompts page

### DIFF
--- a/.server-changes/prompts-blank-state-docs-link.md
+++ b/.server-changes/prompts-blank-state-docs-link.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Fix the docs link on the empty Prompts page, which pointed to a page that no longer exists.

--- a/apps/webapp/app/components/BlankStatePanels.tsx
+++ b/apps/webapp/app/components/BlankStatePanels.tsx
@@ -748,11 +748,7 @@ export function PromptsNone() {
       iconClassName="text-aiPrompts"
       panelClassName="max-w-lg"
       accessory={
-        <LinkButton
-          to={docsPath("prompt-management")}
-          variant="docs/small"
-          LeadingIcon={BookOpenIcon}
-        >
+        <LinkButton to={docsPath("ai/prompts")} variant="docs/small" LeadingIcon={BookOpenIcon}>
           Prompts docs
         </LinkButton>
       }


### PR DESCRIPTION
## Summary

The empty-state panel on the Prompts page linked to a docs path that no longer exists, so the "Prompts docs" button returned a 404. It now points to the current prompts documentation at /docs/ai/prompts, matching the link already used in the page header.