### PR TITLE
fix(cli): hide mutating tools in read-only MCP mode

### DIFF
--- a/.changeset/readonly-mcp-mutations.md
+++ b/.changeset/readonly-mcp-mutations.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Hide profile switching and local dev-server process controls when the MCP server runs in read-only mode.

--- a/packages/cli-v3/src/mcp/tools.ts
+++ b/packages/cli-v3/src/mcp/tools.ts
@@ -48,6 +48,9 @@ const WRITE_TOOLS = new Set([
   startAgentChatTool.name,
   sendAgentMessageTool.name,
   closeAgentChatTool.name,
+  switchProfileTool.name,
+  startDevServerTool.name,
+  stopDevServerTool.name,
 ]);
 
 export function registerTools(context: McpContext) {


### PR DESCRIPTION
Hide profile switching and local dev-server process controls when the MCP server runs in read-only mode.