### PR TITLE
feat(webapp): show runtime versions in deployment lists

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments/route.tsx
@@ -303,6 +303,7 @@ export default function Page() {
                               <RuntimeIcon
                                 runtime={deployment.runtime}
                                 runtimeVersion={deployment.runtimeVersion}
+                                withLabel
                               />
                             </TableCell>
                             <TableCell to={path} isSelected={isSelected}>


### PR DESCRIPTION
## Summary

The Deployments table now displays the runtime name and resolved version beside its icon. This makes it easier to identify which Node.js runtime each deployment uses without opening its details.
