### PR TITLE
fix: .env.example file state DIRECT_URL without ref

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ LOGIN_ORIGIN=http://localhost:3030
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres?schema=public
 # This sets the URL used for direct connections to the database and should only be needed in limited circumstances
 # See: https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#fields:~:text=the%20shadow%20database.-,directUrl,-No
-DIRECT_URL=${DATABASE_URL}
+DIRECT_URL=postgresql://postgres:postgres@localhost:5432/postgres?schema=public
 # Dedicated run-ops database (@internal/run-ops-database). Only needed to run prisma commands
 # against it or to enable the run-ops split; start it with `docker compose --profile runops up`.
 RUN_OPS_DATABASE_URL=postgresql://postgres:postgres@localhost:5434/postgres?schema=public


### PR DESCRIPTION
The `DIRECT_URL=${DATABASE_URL}` wasn't working in at least one user of the var.
