### PR TITLE
fix: only count preview branches toward the preview branch limit

### DIFF
--- a/.server-changes/fix-preview-branch-limit-count.md
+++ b/.server-changes/fix-preview-branch-limit-count.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+The "Preview branches" usage on the Limits page now counts only preview branches, so it no longer includes development branches or show over-limit values.

--- a/.server-changes/fix-preview-branch-limit-count.md
+++ b/.server-changes/fix-preview-branch-limit-count.md
@@ -3,4 +3,4 @@ area: webapp
 type: fix
 ---
 
-The "Preview branches" usage on the Limits page now counts only preview branches, so it no longer includes development branches or show over-limit values.
+The "Preview branches" usage on the Limits page now counts only preview branches.

--- a/apps/webapp/app/presenters/v3/LimitsPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/LimitsPresenter.server.ts
@@ -151,11 +151,14 @@ export class LimitsPresenter extends BasePresenter {
       },
     });
 
-    // Get active branches count for this org (uses @@index([organizationId]))
+    // Get active preview branches count for this org (uses @@index([organizationId]))
+    // Mirror checkBranchLimit: only PREVIEW branches (exclude the branchable parent).
+    // DEVELOPMENT branches have a separate limit and must not be counted here.
     const activeBranchCount = await this._replica.runtimeEnvironment.count({
       where: {
         projectId,
-        branchName: {
+        type: "PREVIEW",
+        parentEnvironmentId: {
           not: null,
         },
         archivedAt: null,

--- a/apps/webapp/app/presenters/v3/LimitsPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/LimitsPresenter.server.ts
@@ -151,9 +151,7 @@ export class LimitsPresenter extends BasePresenter {
       },
     });
 
-    // Get active preview branches count for this org (uses @@index([organizationId]))
-    // Mirror checkBranchLimit: only PREVIEW branches (exclude the branchable parent).
-    // DEVELOPMENT branches have a separate limit and must not be counted here.
+    // Get active branches count for this org (uses @@index([organizationId]))
     const activeBranchCount = await this._replica.runtimeEnvironment.count({
       where: {
         projectId,


### PR DESCRIPTION
## Problem

On the org Manage/Limits page, the "Preview branches" usage count included **development** branches, not just preview branches. Because the count is rendered against the preview-branch limit, it could show nonsensical over-limit values (e.g. "12 / 5" when most were dev branches).

This is display-only — actual quota enforcement is correct. `checkBranchLimit` enforces two separate limits (PREVIEW -> `branches`, DEVELOPMENT -> `branchesDev`); dev branches never consumed the preview quota, only the displayed number was wrong.

## Root cause

The count in `LimitsPresenter.server.ts` filtered only on `branchName \!= null` / `archivedAt: null` with no `type` filter, so it counted DEVELOPMENT branches too.

## Fix

Add `type: "PREVIEW"` and `parentEnvironmentId: { not: null }` to the count's where clause, mirroring `checkBranchLimit` (also excludes the branchable parent env).

Closes #4281.

TRI-12199