### PR TITLE
fix(sdk): resolve ReferenceError in envvars.update outside task context

### DIFF
--- a/.changeset/envvars-update-name-scope.md
+++ b/.changeset/envvars-update-name-scope.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+Fix `envvars.update()` throwing `ReferenceError: name is not defined` when called outside a task run (for example from a deploy script).

--- a/packages/trigger-sdk/src/v3/envvars.ts
+++ b/packages/trigger-sdk/src/v3/envvars.ts
@@ -332,13 +332,17 @@ export function update(
       throw new Error("projectRef is required");
     }
 
+    if (typeof nameOrRequestOptions !== "string") {
+      throw new Error("name is required");
+    }
+
     if (!params) {
       throw new Error("params is required");
     }
 
     $projectRef = projectRefOrName;
     $slug = slugOrParams;
-    $name = name!;
+    $name = nameOrRequestOptions;
     $params = params;
   }
 

--- a/packages/trigger-sdk/src/v3/triggerClient.types.test.ts
+++ b/packages/trigger-sdk/src/v3/triggerClient.types.test.ts
@@ -40,6 +40,15 @@ describe("TriggerClient surface — type-level guarantees", () => {
     // Zero-arg form (uses task context — still typeable at the call site)
     expectTypeOf(client.envvars.list).toBeCallableWith();
   });
+
+  it("preserves envvars.update overloads (out of task context form AND in-task form)", () => {
+    // Four-arg form (out-of-task: projectRef, slug, name, params)
+    expectTypeOf(client.envvars.update).toBeCallableWith("proj_1234", "dev", "MY_VAR", {
+      value: "secret",
+    });
+    // Two-arg form (in-task: name, params)
+    expectTypeOf(client.envvars.update).toBeCallableWith("MY_VAR", { value: "secret" });
+  });
 });
 
 describe("TriggerClient surface — curated subsets", () => {


### PR DESCRIPTION
Closes #4264

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Summary

`envvars.update(projectRef, slug, name, params)` crashed outside a task run with:

```
ReferenceError: name is not defined
```

In the non-task branch the third parameter is named `nameOrRequestOptions`, but the code assigned `$name = name!`. That identifier is not a parameter (and is only a browser global), so Node throws.

`create` / `del` / `retrieve` / `list` were already fine on the same path.

## Fix

- Validate `typeof nameOrRequestOptions === string` (clear error if missing)
- Assign `$name = nameOrRequestOptions`
- Type-level overload coverage for in-task and out-of-task forms
- Patch changeset for `@trigger.dev/sdk`

## Testing

```bash
pnpm run build --filter @trigger.dev/sdk
pnpm --filter @trigger.dev/sdk exec vitest run src/v3/triggerClient.types.test.ts --run
```

- Build succeeded
- 11/11 type tests passed (including the new `envvars.update` overload cases)
- Compiled `dist/commonjs/v3/envvars.js` uses `nameOrRequestOptions` for `$name`

## Changelog

Fix `envvars.update()` throwing `ReferenceError: name is not defined` when called outside a task run (for example from a deploy script).

## Note for maintainers

Vouch request: #4290