### PR TITLE
fix(cli): terminate GITHUB_ENV/GITHUB_OUTPUT entries with trailing newline

### DIFF
--- a/.changeset/github-actions-trailing-newline.md
+++ b/.changeset/github-actions-trailing-newline.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Terminate each GITHUB_ENV and GITHUB_OUTPUT entry with a trailing newline so later appends cannot merge onto the last value.

--- a/packages/cli-v3/src/utilities/githubActions.ts
+++ b/packages/cli-v3/src/utilities/githubActions.ts
@@ -7,11 +7,12 @@ export function setGithubActionsOutputAndEnvVars({
   envVars: Record<string, string>;
   outputs: Record<string, string>;
 }) {
-  // Set environment variables
+  // Set environment variables. Terminate each entry with a newline so a
+  // subsequent append cannot concatenate onto the last KEY=value line.
   if (process.env.GITHUB_ENV) {
     const contents = Object.entries(envVars)
-      .map(([key, value]) => `${key}=${value}`)
-      .join("\n");
+      .map(([key, value]) => `${key}=${value}\n`)
+      .join("");
 
     appendFileSync(process.env.GITHUB_ENV, contents);
   }
@@ -19,8 +20,8 @@ export function setGithubActionsOutputAndEnvVars({
   // Set outputs
   if (process.env.GITHUB_OUTPUT) {
     const contents = Object.entries(outputs)
-      .map(([key, value]) => `${key}=${value}`)
-      .join("\n");
+      .map(([key, value]) => `${key}=${value}\n`)
+      .join("");
 
     appendFileSync(process.env.GITHUB_OUTPUT, contents);
   }


### PR DESCRIPTION
Closes #4003

## Checklist

- [x] Followed CONTRIBUTING.md
- [x] Single issue PR
- [x] Changeset / server-changes when required

## Summary
`setGithubActionsOutputAndEnvVars` joined entries with `\n` but did not terminate the last line. A later append can merge onto the last KEY=value (e.g. `needsPromotion`).

## Fix
Write each entry as `KEY=value\n` (matching `@actions/core`).

**Vouch request:** #4290