### PR TITLE
fix(cli): ensure store dir exists in createFileWithStore

### DIFF
--- a/.changeset/dev-session-store-dir.md
+++ b/.changeset/dev-session-store-dir.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Ensure the shared content-addressable store directory exists before writing so a second `trigger dev` session cannot crash after the previous session cleans it up.

--- a/packages/cli-v3/src/utilities/fileSystem.ts
+++ b/packages/cli-v3/src/utilities/fileSystem.ts
@@ -55,6 +55,10 @@ export async function createFileWithStore(
     await fsModule.unlink(filePath);
   }
 
+  // Ensure store directory exists. Concurrent `trigger dev` sessions share this
+  // path; the previous session's exit cleanup can delete it mid-build.
+  await fsModule.mkdir(storeDir, { recursive: true });
+
   // Check if content already exists in store by hash
   if (fsSync.existsSync(storePath)) {
     // Create hardlink from build path to store path


### PR DESCRIPTION
Closes #4286

## Checklist

- [x] Followed CONTRIBUTING.md
- [x] Single issue PR
- [x] Changeset / server-changes when required

## Summary
Second `trigger dev` session can hit ENOENT or silent rebuild hangs when the previous session deletes shared `.trigger/tmp/store`.

## Fix
`mkdir(storeDir, { recursive: true })` before store reads/writes.

**Vouch request:** #4290