### PR TITLE
fix(cli): skip catalog: versions in update check

### DIFF
--- a/.changeset/cli-catalog-protocol.md
+++ b/.changeset/cli-catalog-protocol.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Skip `catalog:` dependency versions in the CLI update check so monorepos using bun/pnpm catalogs no longer crash with Invalid comparator.

--- a/packages/cli-v3/src/commands/update.ts
+++ b/packages/cli-v3/src/commands/update.ts
@@ -332,7 +332,7 @@ async function getTriggerDependencies(
         continue;
       }
 
-      if (version.startsWith("workspace")) {
+      if (version.startsWith("workspace") || version.startsWith("catalog:")) {
         continue;
       }
 


### PR DESCRIPTION
Closes #3905

## Checklist

- [x] Followed CONTRIBUTING.md
- [x] Single issue PR
- [x] Changeset / server-changes when required

## Summary
`catalog:` protocol versions reached `semver.minVersion` and crashed the CLI update check.

## Fix
Skip `catalog:` the same way `workspace:` is skipped.

**Vouch request:** #4290