### PR TITLE
fix(webapp): convert epoch-ms to BigInt before nanosecond multiply

### DIFF
--- a/.server-changes/fix-otlp-nanosecond-overflow.md
+++ b/.server-changes/fix-otlp-nanosecond-overflow.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Improve accuracy of run timeline timestamps by converting times to nanoseconds without floating-point rounding errors.

--- a/apps/webapp/app/v3/eventRepository/common.server.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.ts
@@ -25,7 +25,7 @@ export function extractContextFromCarrier(carrier: Record<string, unknown>) {
 }
 
 export function getNowInNanoseconds(): bigint {
-  return BigInt(new Date().getTime() * 1_000_000);
+  return BigInt(new Date().getTime()) * BigInt(1_000_000);
 }
 
 export function getDateFromNanoseconds(nanoseconds: bigint): Date {
@@ -39,7 +39,7 @@ export function calculateDurationFromStart(
 ) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  const duration = Number(BigInt($endtime.getTime() * 1_000_000) - startTime);
+  const duration = Number(BigInt($endtime.getTime()) * BigInt(1_000_000) - startTime);
 
   if (minimumDuration && duration < minimumDuration) {
     return minimumDuration;

--- a/apps/webapp/app/v3/runEngineHandlers.server.ts
+++ b/apps/webapp/app/v3/runEngineHandlers.server.ts
@@ -555,7 +555,7 @@ export function registerRunEngineEventBusHandlers() {
         );
 
         await eventRepository.recordEvent(retryMessage, {
-          startTime: BigInt(time.getTime() * 1000000),
+          startTime: BigInt(time.getTime()) * BigInt(1_000_000),
           taskSlug: run.taskIdentifier,
           environment,
           attributes: {


### PR DESCRIPTION
Closes #3292

## Checklist

- [x] Followed CONTRIBUTING.md
- [x] Single issue PR
- [x] Changeset / server-changes when required

## Summary
`ms * 1_000_000` exceeds `Number.MAX_SAFE_INTEGER` and loses precision before BigInt conversion.

## Fix
`BigInt(ms) * BigInt(1_000_000)` in event repository helpers and run engine handlers.

**Vouch request:** #4290