### PR TITLE
fix(webapp): escape single quotes in realtime tags filter

### DIFF
--- a/.server-changes/fix-realtime-tags-sql-escape.md
+++ b/.server-changes/fix-realtime-tags-sql-escape.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Hardened realtime run filtering so special characters in tags cannot interfere with the query.

--- a/apps/webapp/app/services/realtimeClient.server.ts
+++ b/apps/webapp/app/services/realtimeClient.server.ts
@@ -171,7 +171,10 @@ export class RealtimeClient {
     const whereClauses: string[] = [`"runtimeEnvironmentId"='${environment.id}'`];
 
     if (params.tags) {
-      whereClauses.push(`"runTags" @> ARRAY[${params.tags.map((t) => `'${t}'`).join(",")}]`);
+      // Escape single quotes so user-provided tags cannot break out of the
+      // ARRAY literal (Electric WHERE clause is string-interpolated).
+      const escapedTags = params.tags.map((t) => `'${t.replace(/'/g, "''")}'`).join(",");
+      whereClauses.push(`"runTags" @> ARRAY[${escapedTags}]`);
     }
 
     const createdAtFilter = await this.#calculateCreatedAtFilter(url, params.createdAt);


### PR DESCRIPTION
Closes #3739

## Checklist

- [x] Followed CONTRIBUTING.md
- [x] Single issue PR
- [x] Changeset / server-changes when required

## Summary
Realtime tags were interpolated into an Electric WHERE ARRAY literal without escaping.

## Fix
Escape `'` as `''` in each tag before building the clause.

**Vouch request:** #4290