### PR TITLE
feat(sdk): export RunStatus type from @trigger.dev/sdk

### DIFF
--- a/.changeset/export-run-status-type.md
+++ b/.changeset/export-run-status-type.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+Export the `RunStatus` type from `@trigger.dev/sdk` for typing run list filters and status-based tooling.

--- a/packages/trigger-sdk/src/v3/index.ts
+++ b/packages/trigger-sdk/src/v3/index.ts
@@ -23,9 +23,9 @@ export type { Context };
 
 import type { Context } from "./shared.js";
 
-import type { ApiClientConfiguration, TaskRunContext } from "@trigger.dev/core/v3";
+import type { ApiClientConfiguration, RunStatus, TaskRunContext } from "@trigger.dev/core/v3";
 
-export type { ApiClientConfiguration, TaskRunContext };
+export type { ApiClientConfiguration, TaskRunContext, RunStatus };
 
 export {
   ApiError,


### PR DESCRIPTION
Closes #4051

## Checklist

- [x] Followed CONTRIBUTING.md
- [x] Single issue PR
- [x] Changeset / server-changes when required

## Summary
Consumers had to derive run status types from method return types.

## Fix
Re-export `RunStatus` from `@trigger.dev/sdk`.

**Vouch request:** #4290