### PR TITLE
fix(core): enforce maxElapsed against wall-clock in ExponentialBackoff.execute

### DIFF
--- a/.changeset/backoff-maxelapsed-wallclock.md
+++ b/.changeset/backoff-maxelapsed-wallclock.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Honor `maxElapsed` against real wall-clock time in `ExponentialBackoff.execute()`, including time spent inside the callback—not only sleep delays.

--- a/packages/core/src/v3/apps/backoff.ts
+++ b/packages/core/src/v3/apps/backoff.ts
@@ -290,13 +290,25 @@ export class ExponentialBackoff {
   > {
     let elapsedMs = 0;
     let finalError: unknown = undefined;
+    // maxElapsed is in seconds (see class docs). Enforce wall-clock time for
+    // the whole execute() loop (sleeps + callbacks), not only sleep delays.
+    const maxElapsedMs = this.#maxElapsed * 1000;
+    const wallStart = Date.now();
 
     for await (const { delay, retry } of this) {
+      if (Date.now() - wallStart > maxElapsedMs) {
+        break;
+      }
+
       const start = Date.now();
 
       if (retry > 0) {
         console.log(`Retrying in ${delay.milliseconds}ms`);
         await timeout(delay.milliseconds);
+      }
+
+      if (Date.now() - wallStart > maxElapsedMs) {
+        break;
       }
 
       let attemptTimeout: NodeJS.Timeout | undefined = undefined;


### PR DESCRIPTION
Closes #3726

## Checklist

- [x] Followed CONTRIBUTING.md
- [x] Single issue PR
- [x] Changeset / server-changes when required

## Summary
`execute()` tracked callback elapsed time but never enforced `maxElapsed` against wall-clock (only sleep delays counted in `retryAsync`).

## Fix
Abort the loop when wall-clock since start exceeds `maxElapsed` seconds.

**Vouch request:** #4290