### PR TITLE
fix(build): parse Playwright 1.58+ dry-run output in playwright extension

### DIFF
--- a/.changeset/playwright-dry-run-format.md
+++ b/.changeset/playwright-dry-run-format.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/build": patch
+---
+
+Support Playwright 1.58+ dry-run output when installing browsers in the Playwright build extension.

--- a/packages/build/src/extensions/playwright.ts
+++ b/packages/build/src/extensions/playwright.ts
@@ -317,7 +317,9 @@ class PlaywrightExtension implements BuildExtension {
 
     Array.from(browsersToInstall).forEach((browser) => {
       instructions.push(
-        `RUN grep -A5 -m1 "browser: ${browser}" /tmp/browser-info.txt > /tmp/${browser}-info.txt`,
+        // Playwright ≤1.57: "browser: chromium version ..."
+        // Playwright ≥1.58: "Chrome for Testing ... (playwright chromium v...)"
+        `RUN grep -A5 -m1 -E "browser: ${browser}|playwright ${browser}" /tmp/browser-info.txt > /tmp/${browser}-info.txt`,
 
         `RUN INSTALL_DIR=$(grep "Install location:" /tmp/${browser}-info.txt | cut -d':' -f2- | xargs) && \
           DIR_NAME=$(basename "$INSTALL_DIR") && \


### PR DESCRIPTION
Closes #3089

## Checklist

- [x] Followed CONTRIBUTING.md
- [x] Single issue PR
- [x] Changeset / server-changes when required

## Summary
Playwright 1.58 changed `--dry-run` lines from `browser: chromium` to `(playwright chromium v…)`.

## Fix
Match either format in the Docker install grep.

**Vouch request:** #4290