### PR TITLE
feat(supervisor): make run pod automountServiceAccountToken configurable

### DIFF
--- a/.server-changes/kubernetes-worker-automount-service-account-token.md
+++ b/.server-changes/kubernetes-worker-automount-service-account-token.md
@@ -1,0 +1,6 @@
+---
+area: supervisor
+type: feature
+---
+
+Self-hosted Kubernetes deployments can now let run pods reach the Kubernetes API. A new option makes mounting the pod's service account token configurable (off by default), so workloads that need in-cluster access — like backup tooling — can be granted it.

--- a/apps/supervisor/src/env.ts
+++ b/apps/supervisor/src/env.ts
@@ -165,6 +165,14 @@ export const Env = z
     KUBERNETES_NAMESPACE: z.string().default("default"),
     KUBERNETES_WORKER_NODETYPE_LABEL: z.string().default("v4-worker"),
     KUBERNETES_IMAGE_PULL_SECRETS: z.string().optional(), // csv
+    // Mount an in-cluster ServiceAccount token/CA into run pods so workload code can reach the
+    // Kubernetes API (e.g. via @kubernetes/client-node or CLIs like velero/kubectl). Defaults to
+    // false to preserve the existing hardened behavior. Only enable when runs use a ServiceAccount
+    // with appropriately scoped RBAC.
+    KUBERNETES_WORKER_AUTOMOUNT_SERVICE_ACCOUNT_TOKEN: BoolEnv.default(false),
+    // ServiceAccount to run worker pods under. Only useful alongside
+    // KUBERNETES_WORKER_AUTOMOUNT_SERVICE_ACCOUNT_TOKEN=true; leaves the cluster default when unset.
+    KUBERNETES_WORKER_SERVICE_ACCOUNT_NAME: z.string().optional(),
     KUBERNETES_EPHEMERAL_STORAGE_SIZE_LIMIT: z.string().default("10Gi"),
     KUBERNETES_EPHEMERAL_STORAGE_SIZE_REQUEST: z.string().default("2Gi"),
     KUBERNETES_STRIP_IMAGE_DIGEST: BoolEnv.default(false),

--- a/apps/supervisor/src/workloadManager/kubernetes.ts
+++ b/apps/supervisor/src/workloadManager/kubernetes.ts
@@ -317,8 +317,13 @@ export class KubernetesWorkloadManager implements WorkloadManager {
   get #defaultPodSpec(): Omit<k8s.V1PodSpec, "containers"> {
     return {
       restartPolicy: "Never",
-      automountServiceAccountToken: false,
+      automountServiceAccountToken: env.KUBERNETES_WORKER_AUTOMOUNT_SERVICE_ACCOUNT_TOKEN,
       imagePullSecrets: this.getImagePullSecrets(),
+      ...(env.KUBERNETES_WORKER_SERVICE_ACCOUNT_NAME
+        ? {
+            serviceAccountName: env.KUBERNETES_WORKER_SERVICE_ACCOUNT_NAME,
+          }
+        : {}),
       ...(env.KUBERNETES_SCHEDULER_NAME
         ? {
             schedulerName: env.KUBERNETES_SCHEDULER_NAME,

--- a/docs/self-hosting/env/supervisor.mdx
+++ b/docs/self-hosting/env/supervisor.mdx
@@ -48,6 +48,8 @@ mode: "wide"
 | `KUBERNETES_NAMESPACE`                      | No       | default     | The namespace that runs should be in.                       |
 | `KUBERNETES_WORKER_NODETYPE_LABEL`          | No       | v4-worker   | Nodes for runs need this label, e.g. `nodetype=v4-worker`.  |
 | `KUBERNETES_IMAGE_PULL_SECRETS`             | No       | —           | Image pull secrets (CSV).                                   |
+| `KUBERNETES_WORKER_AUTOMOUNT_SERVICE_ACCOUNT_TOKEN` | No | false | Mount an in-cluster ServiceAccount token/CA into run pods so workloads can reach the Kubernetes API. Enable only with scoped RBAC. |
+| `KUBERNETES_WORKER_SERVICE_ACCOUNT_NAME`    | No       | —           | ServiceAccount to run worker pods under. Pairs with the automount option above.        |
 | `KUBERNETES_EPHEMERAL_STORAGE_SIZE_LIMIT`   | No       | 10Gi        | Ephemeral storage size limit. Applies to all runs.          |
 | `KUBERNETES_EPHEMERAL_STORAGE_SIZE_REQUEST` | No       | 2Gi         | Ephemeral storage size request. Applies to all runs.        |
 | **Metrics**                                 |          |             |                                                             |


### PR DESCRIPTION
## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

- Set env var `KUBERNETES_WORKER_AUTOMOUNT_SERVICE_ACCOUNT_TOKEN` to true
- Start a task, check the value spec.automountServiceAccountToken, the value should be true

---

## Changelog

Run (worker) pods hardcoded automountServiceAccountToken: false, so no in-cluster ServiceAccount token/CA was mounted and workload code talking to the Kubernetes API failed (e.g. @kubernetes/client-node falling back to http://localhost:8080 -> ECONNREFUSED).

Add KUBERNETES_WORKER_AUTOMOUNT_SERVICE_ACCOUNT_TOKEN (bool, default false) to control the pod spec field, plus KUBERNETES_WORKER_SERVICE_ACCOUNT_NAME to optionally run pods under a specific ServiceAccount. Both default to today's behavior, so this is non-breaking.

---

## Screenshots
(No screenshots)

💯
