### PR TITLE
ci(publish): unify image scanning across published images

### DIFF
--- a/.github/workflows/publish-worker-v4.yml
+++ b/.github/workflows/publish-worker-v4.yml
@@ -13,6 +13,13 @@ on:
         type: string
         required: false
         default: ""
+    outputs:
+      version:
+        description: The published image tag
+        value: ${{ jobs.build.outputs.version }}
+      image_repo:
+        description: The image repository the build was published to (without tag)
+        value: ${{ jobs.build.outputs.image_repo }}
   push:
     tags:
       - "re2-test-*"
@@ -38,6 +45,11 @@ jobs:
       matrix:
         package: [supervisor]
     runs-on: warp-ubuntu-latest-x64-2x
+    # Single-entry matrix, so these job outputs are unambiguous (consumed by the
+    # scan-supervisor job in publish.yml).
+    outputs:
+      version: ${{ steps.get_tag.outputs.tag }}
+      image_repo: ${{ steps.set_tags.outputs.image_repo }}
     env:
       DOCKER_BUILDKIT: "1"
     steps:
@@ -81,6 +93,7 @@ jobs:
           fi
 
           echo "image_tags=${image_tags}" >> "$GITHUB_OUTPUT"
+          echo "image_repo=${ref_without_tag}" >> "$GITHUB_OUTPUT"
         env:
           IMAGE_REGISTRY: ${{ inputs.image_registry || vars.IMAGE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}
           STEPS_GET_REPOSITORY_OUTPUTS_REPO: ${{ steps.get_repository.outputs.repo }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,9 +97,18 @@ jobs:
     permissions:
       contents: read
       packages: read # pull the just-published image from GHCR
-    uses: ./.github/workflows/trivy-image-webapp.yml
+    uses: ./.github/workflows/trivy-image.yml
     with:
       image-ref: ${{ needs.publish-webapp.outputs.image_repo }}:${{ needs.publish-webapp.outputs.version }}
+
+  scan-supervisor:
+    needs: [publish-worker-v4]
+    permissions:
+      contents: read
+      packages: read # pull the just-published image from GHCR
+    uses: ./.github/workflows/trivy-image.yml
+    with:
+      image-ref: ${{ needs.publish-worker-v4.outputs.image_repo }}:${{ needs.publish-worker-v4.outputs.version }}
 
   # Announce the freshly published mutable `main` webapp image to subscriber
   # repos via repository_dispatch, handing them a digest-pinned ref to build or

--- a/.github/workflows/trivy-image.yml
+++ b/.github/workflows/trivy-image.yml
@@ -1,7 +1,7 @@
-name: Trivy Image Scan (webapp)
+name: Trivy Image Scan
 
-# OS-level CVE scan of a published webapp image. Called by the publish pipeline
-# (publish.yml) to scan each build right after it's pushed to GHCR — so every
+# OS-level CVE scan of a published image. Called by the publish pipeline
+# (publish.yml) to scan each image right after it's pushed to GHCR — so every
 # main build and every release is scanned, not rebuilt. Also runnable ad-hoc
 # via workflow_dispatch against any image ref.
 #
@@ -27,7 +27,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: trivy-image-webapp-${{ inputs.image-ref }}
+  group: trivy-image-${{ inputs.image-ref }}
   cancel-in-progress: true
 
 jobs:
@@ -59,7 +59,7 @@ jobs:
           ignore-unfixed: true
           severity: HIGH,CRITICAL
           format: table
-          output: trivy-image-webapp.txt
+          output: trivy-image.txt
 
       - name: Job summary
         if: always()
@@ -67,9 +67,9 @@ jobs:
           IMAGE_REF: ${{ inputs.image-ref }}
         run: |
           {
-            echo "## Trivy Image Scan (webapp) — \`${IMAGE_REF}\`"
+            echo "## Trivy Image Scan — \`${IMAGE_REF}\`"
             echo '```'
             # GitHub step summary is capped at 1 MiB; truncate large reports.
-            head -c 900000 trivy-image-webapp.txt 2>/dev/null || echo "(no report produced)"
+            head -c 900000 trivy-image.txt 2>/dev/null || echo "(no report produced)"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What

Run the shared Trivy image scan on every published image through a single reusable workflow.

## Changes

- Generalise the image-scan workflow (`trivy-image-webapp.yml` -> `trivy-image.yml`) - it was already parameterised by `image-ref`; only the run-summary label was image-specific.
- `publish-worker-v4.yml`: expose `version` + `image_repo` as workflow outputs (single-entry matrix, so unambiguous).
- `publish.yml`: run the shared scan from each publish job (`scan-webapp`, `scan-supervisor`).

Report-only (writes a table to the run summary), OS packages only (`vuln-type: os` - library deps stay with Dependabot), never blocks the publish.
