### PR TITLE
feat(webapp): surface run cell in the run admin panel

### DIFF
--- a/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
@@ -395,13 +395,16 @@ export class SpanPresenter extends BasePresenter {
     let cell: string | undefined;
     if (isAdmin) {
       try {
+        // Use the resolved run's own trace + time window (not the parent's) so
+        // the lookup is correct for cached/linked spans, where `run` is the
+        // original run rather than `parentRun`.
         const rootSpan = await eventRepository.getSpan(
           eventStore,
           environmentId,
           run.spanId,
-          traceId,
-          createdAt,
-          completedAt ?? undefined
+          run.traceId,
+          run.createdAt,
+          run.completedAt ?? undefined
         );
         const resource = rootSpan?.resourceProperties as Record<string, any> | undefined;
         const value = resource?.trigger?.cell ?? resource?.["trigger.cell"];

--- a/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
@@ -395,11 +395,16 @@ export class SpanPresenter extends BasePresenter {
     let cell: string | undefined;
     if (isAdmin) {
       try {
-        // Use the resolved run's own trace + time window (not the parent's) so
-        // the lookup is correct for cached/linked spans, where `run` is the
-        // original run rather than `parentRun`.
-        const rootSpan = await eventRepository.getSpan(
-          eventStore,
+        // Resolve the store + repository from the resolved run itself (not the
+        // parent) so cached/linked spans - where `run` is the original run and
+        // may live in a different event store - resolve correctly.
+        const runEventStore = getTaskEventStoreTableForRun(run);
+        const runEventRepository = await getEventRepositoryForStore(
+          run.taskEventStore,
+          environment.organization.id
+        );
+        const rootSpan = await runEventRepository.getSpan(
+          runEventStore,
           environmentId,
           run.spanId,
           run.traceId,

--- a/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/SpanPresenter.server.ts
@@ -106,6 +106,7 @@ export class SpanPresenter extends BasePresenter {
     spanId,
     runFriendlyId,
     linkedRunId,
+    isAdmin,
   }: {
     userId: string;
     projectSlug: string;
@@ -117,6 +118,7 @@ export class SpanPresenter extends BasePresenter {
     spanId: string;
     runFriendlyId: string;
     linkedRunId?: string;
+    isAdmin?: boolean;
   }) {
     const project = await this._replica.project.findFirst({
       where: {
@@ -197,6 +199,7 @@ export class SpanPresenter extends BasePresenter {
       eventRepository: repository,
       spanId,
       linkedRunId,
+      isAdmin,
       createdAt: parentRun.createdAt,
       completedAt: parentRun.completedAt,
       environmentId: parentRun.runtimeEnvironmentId,
@@ -236,6 +239,7 @@ export class SpanPresenter extends BasePresenter {
     eventRepository,
     spanId,
     linkedRunId,
+    isAdmin,
     createdAt,
     completedAt,
   }: {
@@ -245,6 +249,7 @@ export class SpanPresenter extends BasePresenter {
     eventRepository: IEventRepository;
     spanId: string;
     linkedRunId?: string;
+    isAdmin?: boolean;
     createdAt: Date;
     completedAt: Date | null;
   }) {
@@ -382,6 +387,34 @@ export class SpanPresenter extends BasePresenter {
         }
       : undefined;
 
+    // Cell attribution is telemetry-only - a `trigger.cell` resource attribute
+    // on the run's span, never a DB field. Admin-only + best-effort: the span
+    // may not be in the event store yet (queued/buffered/ingestion lag) and the
+    // store may be unreachable, so any failure degrades to undefined rather than
+    // breaking the panel.
+    let cell: string | undefined;
+    if (isAdmin) {
+      try {
+        const rootSpan = await eventRepository.getSpan(
+          eventStore,
+          environmentId,
+          run.spanId,
+          traceId,
+          createdAt,
+          completedAt ?? undefined
+        );
+        const resource = rootSpan?.resourceProperties as Record<string, any> | undefined;
+        const value = resource?.trigger?.cell ?? resource?.["trigger.cell"];
+        cell = typeof value === "string" ? value : undefined;
+      } catch (error) {
+        logger.warn("Failed to resolve run cell from telemetry", {
+          runId: run.id,
+          spanId: run.spanId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
     return {
       id: run.id,
       friendlyId: run.friendlyId,
@@ -453,6 +486,7 @@ export class SpanPresenter extends BasePresenter {
       isBuffered: false,
       machinePreset: machine?.name,
       taskEventStore: run.taskEventStore,
+      cell,
       externalTraceId,
     };
   }

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -84,7 +84,7 @@ import { useHasAdminAccess } from "~/hooks/useUser";
 import { redirectWithErrorMessage } from "~/models/message.server";
 import { type Span, SpanPresenter, type SpanRun } from "~/presenters/v3/SpanPresenter.server";
 import { logger } from "~/services/logger.server";
-import { requireUserId } from "~/services/session.server";
+import { requireUser } from "~/services/session.server";
 import { cn } from "~/utils/cn";
 import { formatCurrencyAccurate } from "~/utils/numberFormatter";
 import {
@@ -108,7 +108,10 @@ import { RealtimeStreamViewer } from "../resources.orgs.$organizationSlug.projec
 import { CompleteWaitpointForm } from "../resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.waitpoints.$waitpointFriendlyId.complete/route";
 
 export const loader = async ({ request, params }: LoaderFunctionArgs) => {
-  const userId = await requireUserId(request);
+  const user = await requireUser(request);
+  // Admin gate for the telemetry-backed "Cell" field — only admins trigger the
+  // extra event-store read (below), and only admins see the panel.
+  const isAdmin = user.admin || user.isImpersonating;
   const { projectParam, organizationSlug, envParam, runParam, spanParam } =
     v3SpanParamsSchema.parse(params);
 
@@ -123,7 +126,8 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
       envSlug: envParam,
       spanId: spanParam,
       runFriendlyId: runParam,
-      userId,
+      userId: user.id,
+      isAdmin,
       linkedRunId,
     });
 
@@ -1043,6 +1047,10 @@ function RunBody({
                     <Property.Item>
                       <Property.Label>Task event store</Property.Label>
                       <Property.Value>{run.taskEventStore}</Property.Value>
+                    </Property.Item>
+                    <Property.Item>
+                      <Property.Label>Cell</Property.Label>
+                      <Property.Value>{run.cell ?? "-"}</Property.Value>
                     </Property.Item>
                   </div>
                 )}

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -1050,7 +1050,7 @@ function RunBody({
                     </Property.Item>
                     <Property.Item>
                       <Property.Label>Cell</Property.Label>
-                      <Property.Value>{run.cell ?? "-"}</Property.Value>
+                      <Property.Value>{run.cell ?? "–"}</Property.Value>
                     </Property.Item>
                   </div>
                 )}

--- a/apps/webapp/app/v3/mollifier/syntheticSpanRun.server.ts
+++ b/apps/webapp/app/v3/mollifier/syntheticSpanRun.server.ts
@@ -198,6 +198,7 @@ export async function buildSyntheticSpanRun(args: {
     isBuffered: true,
     machinePreset: narrowMachinePreset(run.machinePreset),
     taskEventStore: "taskEvent",
+    cell: undefined,
     externalTraceId: undefined,
   };
 }


### PR DESCRIPTION
Adds a **Cell** field to the run detail page's admin-only panel that surfaces which cell a run executed on, **when that information is present in the run's telemetry**.

### Why
For deployments that spread runs across multiple cells, it's useful to see which cell an individual run landed on. The admin panel shows region but not cell - this surfaces the cell whenever the run's telemetry carries it.

### How
Display-only, sourced entirely from telemetry: **if** the run's execution span carries a `trigger.cell` resource attribute, the panel shows it - read via the existing `getSpan` path from the event store. Nothing is read from or added to the run record or the database.

- **Optional / environment-dependent**: this attribute won't be present in every deployment (e.g. self-hosted, or any run whose telemetry doesn't set it). When it's absent - which is the common case - the field simply shows `-`. This change only *surfaces* the attribute; it does not produce it.
- **Admin-only**: the loader gates on admin access, so only admins trigger the extra event-store read and only admins see the panel. The hot non-admin path is unchanged.
- **Best-effort + graceful**: if the span isn't in the event store yet (queued/buffered/ingestion lag) or the store is briefly unreachable, the field degrades to `-` - it never blocks or breaks the panel. Reads both the nested and flat attribute shapes to be safe.

### Scope
webapp-only. No package changes, no schema or database changes, no changes to the trigger hot path.

### Testing
- Renders `-` for runs with no `trigger.cell` attribute (e.g. local runs, or before the span is ingested).
- Shows the cell value once the run's span is in the event store.
