### PR TITLE
fix(events): prevent float precision loss in nanosecond timestamp conversion

### DIFF
--- a/.server-changes/fix-bigint-nanosecond-precision.md
+++ b/.server-changes/fix-bigint-nanosecond-precision.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Timestamp precision is no longer lost when recording nanosecond-resolution span times. Previously, multiplying milliseconds by 1,000,000 in float-land before converting to BigInt produced slightly wrong timestamps for spans and run events.

--- a/apps/webapp/app/v3/eventRepository/common.server.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.ts
@@ -25,7 +25,7 @@ export function extractContextFromCarrier(carrier: Record<string, unknown>) {
 }
 
 export function getNowInNanoseconds(): bigint {
-  return BigInt(new Date().getTime() * 1_000_000);
+  return convertDateToNanoseconds(new Date());
 }
 
 export function getDateFromNanoseconds(nanoseconds: bigint): Date {
@@ -39,7 +39,7 @@ export function calculateDurationFromStart(
 ) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  const duration = Number(BigInt($endtime.getTime() * 1_000_000) - startTime);
+  const duration = Number(convertDateToNanoseconds($endtime) - startTime);
 
   if (minimumDuration && duration < minimumDuration) {
     return minimumDuration;

--- a/apps/webapp/app/v3/eventRepository/index.server.ts
+++ b/apps/webapp/app/v3/eventRepository/index.server.ts
@@ -1,6 +1,7 @@
 import { env } from "~/env.server";
 import { eventRepository } from "./eventRepository.server";
 import { type IEventRepository, type TraceEventOptions } from "./eventRepository.types";
+import { convertDateToNanoseconds } from "./common.server";
 import { prisma } from "~/db.server";
 import { runStore } from "../runStore.server";
 import { controlPlaneResolver } from "~/v3/runOpsMigration/controlPlaneResolver.server";
@@ -240,7 +241,7 @@ async function recordRunEvent(
         runId: foundRun.friendlyId,
         ...attributes,
       },
-      startTime: BigInt((startTime?.getTime() ?? Date.now()) * 1_000_000),
+      startTime: convertDateToNanoseconds(startTime ?? new Date()),
       ...optionsRest,
     });
 


### PR DESCRIPTION
Fixes #3292

`new Date().getTime() * 1_000_000` is computed as a JS number before being passed to `BigInt()`. The result (~1.7e18) exceeds `Number.MAX_SAFE_INTEGER` (9.007e15), so IEEE 754 precision loss corrupts the timestamp before the BigInt is even created.

The correct helper `convertDateToNanoseconds()` already exists in `common.server.ts` and uses `BigInt(date.getTime()) * BigInt(1_000_000)` — converting to BigInt first, then multiplying — which preserves full precision.

**Changes:**

- `common.server.ts` `getNowInNanoseconds`: replace inline multiply with `convertDateToNanoseconds(new Date())`
- `common.server.ts` `calculateDurationFromStart`: replace inline multiply with `convertDateToNanoseconds($endtime)`
- `index.server.ts` `recordRunEvent`: replace inline multiply with `convertDateToNanoseconds(startTime ?? new Date())` + import the helper