### PR TITLE
fix(webapp): remove Enterprise badge from SSO & Directory Sync menu item

### DIFF
--- a/apps/webapp/app/components/navigation/OrganizationSettingsSideMenu.tsx
+++ b/apps/webapp/app/components/navigation/OrganizationSettingsSideMenu.tsx
@@ -163,11 +163,6 @@ export function OrganizationSettingsSideMenu({
               inactiveIconColor="text-text-dimmed"
               to={organizationSsoPath(organization)}
               data-action="sso"
-              badge={
-                currentPlan?.v3Subscription?.plan?.code === "enterprise" ? undefined : (
-                  <Badge variant="extra-small">Enterprise</Badge>
-                )
-              }
             />
           )}
         </div>


### PR DESCRIPTION
## What

The organization side menu previously showed an "Enterprise" badge next to the SSO & Directory Sync item for any org not on the enterprise plan. That badge is now removed so the item renders without it.

## Screenshot (before)

<img width="1428" height="649" alt="CleanShot 2026-07-10 at 08 24 41" src="https://github.com/user-attachments/assets/b9787363-972f-4dd5-bf61-486680f49f4c" />
