### PR TITLE
chore: ignore .worktrees/ in the repo gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ apps/**/public/build
 ailogger-output.log
 # per-package vitest timing capture (transient; merged into root test-timings.json)
 .vitest-timing.json
+
+# local git worktree checkouts (not source) — keeps oxfmt/oxlint from descending into them
+.worktrees/


### PR DESCRIPTION
Add `.worktrees/` to the repo `.gitignore`.

The pre-push hook runs `oxfmt --check .` and `oxlint .` over the whole tree, and those tools only read the in-repo ignore files (not a user's global gitignore). Local git-worktree checkouts placed under `.worktrees/` therefore got linted/formatted, failing the hook on unrelated code. Ignoring the directory keeps both tools out of worktree checkouts. No source changes.