### PR TITLE
fix(cli): redact task run env values from debug log

### DIFF
--- a/.changeset/redact-taskrunprocess-env-log.md
+++ b/.changeset/redact-taskrunprocess-env-log.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Stop logging task run environment variable values at debug level. The `initializing task run process` debug log previously serialized the full worker environment, which includes `TRIGGER_SECRET_KEY`, `TRIGGER_JWT`, and any secret env vars set for the run. It now logs only the env var names, so secrets no longer appear in run logs when debug logging is enabled.

--- a/.changeset/redact-taskrunprocess-env-log.md
+++ b/.changeset/redact-taskrunprocess-env-log.md
@@ -2,4 +2,4 @@
 "trigger.dev": patch
 ---
 
-Stop logging task run environment variable values at debug level. The `initializing task run process` debug log previously serialized the full worker environment, which includes `TRIGGER_SECRET_KEY`, `TRIGGER_JWT`, and any secret env vars set for the run. It now logs only the env var names, so secrets no longer appear in run logs when debug logging is enabled.
+Avoid logging task run environment variable values at debug level

--- a/packages/cli-v3/src/executions/taskRunProcess.ts
+++ b/packages/cli-v3/src/executions/taskRunProcess.ts
@@ -150,8 +150,6 @@ export class TaskRunProcess {
       TRIGGERDOTDEV: "1",
     };
 
-    // Only log env var names, never values: fullEnv contains secrets
-    // (TRIGGER_SECRET_KEY, TRIGGER_JWT, and arbitrary customer secret env vars).
     logger.debug(`initializing task run process`, {
       envKeys: Object.keys(fullEnv),
       path: workerManifest.workerEntryPoint,

--- a/packages/cli-v3/src/executions/taskRunProcess.ts
+++ b/packages/cli-v3/src/executions/taskRunProcess.ts
@@ -150,8 +150,10 @@ export class TaskRunProcess {
       TRIGGERDOTDEV: "1",
     };
 
+    // Only log env var names, never values: fullEnv contains secrets
+    // (TRIGGER_SECRET_KEY, TRIGGER_JWT, and arbitrary customer secret env vars).
     logger.debug(`initializing task run process`, {
-      env: fullEnv,
+      envKeys: Object.keys(fullEnv),
       path: workerManifest.workerEntryPoint,
       cwd,
     });


### PR DESCRIPTION
## What

The `initializing task run process` debug log in `packages/cli-v3/src/executions/taskRunProcess.ts` serialized the full worker environment (`fullEnv`) into the log payload. That object includes `TRIGGER_SECRET_KEY`, `TRIGGER_JWT`, and any secret env vars set for the run, so with debug logging enabled every task secret was emitted in plaintext to the run log pipeline.

This logs only the env var **names** (`Object.keys(fullEnv)`) instead of the values. Debugging still shows which vars are present, without leaking any secrets. The `env: fullEnv` handed to the actual `fork()` call is unchanged.

`TaskRunProcess` is used by both the managed (deployed) and dev run paths, so the fix covers both.

Ref: SEC-25

## Test plan

- [ ] Confirm the `initializing task run process` debug line shows `envKeys` (a list of names) and no secret values.