### PR TITLE
fix(webapp): guard workload auth gate metric against dev HMR re-registration

### DIFF
--- a/apps/webapp/app/v3/services/worker/workerGroupTokenService.server.ts
+++ b/apps/webapp/app/v3/services/worker/workerGroupTokenService.server.ts
@@ -62,12 +62,17 @@ if (workloadCreatedAtGateEnabled && !workloadTokenCutoff) {
 
 type WorkloadGateAction = "start" | "complete" | "continue" | "snapshots_since";
 
-const workloadAuthGateCounter = new Counter({
-  name: "workload_auth_gate_total",
-  help: "Deployment token authorization outcomes on worker actions",
-  labelNames: ["outcome", "action"] as const,
-  registers: [metricsRegister],
-});
+// singleton: module-scope registration double-registers under dev HMR
+const workloadAuthGateCounter = singleton(
+  "workloadAuthGateCounter",
+  () =>
+    new Counter({
+      name: "workload_auth_gate_total",
+      help: "Deployment token authorization outcomes on worker actions",
+      labelNames: ["outcome", "action"] as const,
+      registers: [metricsRegister],
+    })
+);
 
 function createAuthenticatedWorkerInstanceCache() {
   return createCache({


### PR DESCRIPTION
Wraps the workload_auth_gate_total Counter in the singleton helper (same pattern as reloadingRegistry.server.ts) so a dev hot reload doesn't crash with "A metric with the name workload_auth_gate_total has already been registered". No production behavior change.