### PR TITLE
fix(docker): stop the container entrypoint printing database connection strings in logs

### DIFF
--- a/.server-changes/entrypoint-no-log-db-connection-strings.md
+++ b/.server-changes/entrypoint-no-log-db-connection-strings.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Container startup no longer prints database and ClickHouse connection strings (with credentials) to the logs.

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -15,7 +15,9 @@ fi
 
 # Run-ops split: migrate the dedicated NEW run-ops database only when it is configured. Single-DB
 # installs never set the URL, so this is a no-op there.
+{ set +x; } 2>/dev/null
 if [ -n "$RUN_OPS_DATABASE_URL" ]; then
+  set -x
   if [ "$SKIP_RUN_OPS_MIGRATIONS" != "1" ]; then
     echo "Running run-ops migrations"
     pnpm --filter @internal/run-ops-database db:migrate:deploy
@@ -24,13 +26,16 @@ if [ -n "$RUN_OPS_DATABASE_URL" ]; then
     echo "SKIP_RUN_OPS_MIGRATIONS=1, skipping run-ops migrations."
   fi
 else
+  set -x
   echo "RUN_OPS_DATABASE_URL not set, skipping run-ops migrations."
 fi
 
 # Run-ops split: keep the legacy runs DB's schema current by applying the full @trigger.dev/database
 # migrations to it too, pointed at its direct (non-pooled) URL. Only runs when that URL is configured;
 # installs that never set it skip this entirely.
+{ set +x; } 2>/dev/null
 if [ -n "$RUN_OPS_LEGACY_DIRECT_URL" ]; then
+  set -x
   if [ "$SKIP_RUN_OPS_LEGACY_MIGRATIONS" != "1" ]; then
     echo "Running legacy run-ops migrations"
     # Subshell with tracing off so `set -x` does not print the DSN (with credentials) to the logs.
@@ -40,6 +45,7 @@ if [ -n "$RUN_OPS_LEGACY_DIRECT_URL" ]; then
     echo "SKIP_RUN_OPS_LEGACY_MIGRATIONS=1, skipping legacy run-ops migrations."
   fi
 else
+  set -x
   echo "RUN_OPS_LEGACY_DIRECT_URL not set, skipping legacy run-ops migrations."
 fi
 
@@ -51,6 +57,7 @@ else
   echo "SKIP_DASHBOARD_AGENT_MIGRATIONS=1, skipping dashboard agent migrations."
 fi
 
+{ set +x; } 2>/dev/null
 if [ -n "$CLICKHOUSE_URL" ] && [ "$SKIP_CLICKHOUSE_MIGRATIONS" != "1" ]; then
   # Run ClickHouse migrations
   echo "Running ClickHouse migrations..."
@@ -76,6 +83,7 @@ elif [ "$SKIP_CLICKHOUSE_MIGRATIONS" = "1" ]; then
 else
   echo "CLICKHOUSE_URL not set, skipping ClickHouse migrations."
 fi
+set -x
 
 # Copy over required prisma files
 cp internal-packages/database/prisma/schema.prisma apps/webapp/prisma/


### PR DESCRIPTION
## Summary

The container entrypoint runs under `set -x`, which echoes every command to the logs with its variables expanded. Several startup guards reference full database connection strings, so the DSN (including the password) was printed to the container logs on every boot. This turns tracing off around those lines so connection strings are never traced, while leaving migration behavior and ordinary startup logging unchanged.

## Fix

The leaking lines are the `[ -n "$RUN_OPS_DATABASE_URL" ]` and `[ -n "$RUN_OPS_LEGACY_DIRECT_URL" ]` guards, and the ClickHouse block (its `[ -n "$CLICKHOUSE_URL" ]` guard plus the lines that build `GOOSE_DBSTRING` from `CLICKHOUSE_URL`). `set -x` prints each of these with the credential expanded. Tracing is now disabled around each region and restored afterward, so non-secret tracing is preserved everywhere else. The existing legacy-migration subshell already protected its own command body; this adds the missing protection for the guards and the ClickHouse block.

```sh
{ set +x; } 2>/dev/null
if [ -n "$RUN_OPS_DATABASE_URL" ]; then
  set -x
  ...
```

## Verification

Built the webapp image and ran it with dummy sentinel connection strings whose password token is `S3NTINEL_PW_DoNotLog`, then grepped the boot logs.

Before (unmodified), the token appears in the traced guards:

```
+ [ -n postgresql://user:S3NTINEL_PW_DoNotLog@fake-host:6432/run-ops ]
+ [ -n postgresql://user:S3NTINEL_PW_DoNotLog@fake-host:5432/legacy ]
+ [ -n https://default:S3NTINEL_PW_DoNotLog@fake-host:8443 ]
```

After, `grep S3NTINEL_PW_DoNotLog` on the same run returns nothing, and the normal "skipping ... migrations" lines still log.
