### PR TITLE
Queue metrics & health: UI polish (TRI-12068)

### DIFF
--- a/.server-changes/paginate-concurrency-keys-table.md
+++ b/.server-changes/paginate-concurrency-keys-table.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+The concurrency keys table on a queue's page is now paginated, so queues with thousands of keys can page through all of them instead of only showing the top 50.

--- a/.server-changes/queue-metrics-dashboard.md
+++ b/.server-changes/queue-metrics-dashboard.md
@@ -3,4 +3,4 @@ area: webapp
 type: feature
 ---
 
-Queue metrics and health on the Queues page: per-queue depth, throughput, concurrency, throttling, and scheduling-delay charts, plus a per-queue detail view, live queue stats and a backlog chart on the task detail page, and a waiting-in-queue explainer in the run inspector for runs that have not started yet. Off by default; enabled per organization.
+New Queue metrics & health dashboard (per-org opt-in): per-queue depth, throughput, concurrency, throttling and scheduling-delay charts, a per-queue detail view, and live queue stats. Queue concurrency limits set above the environment limit are now rejected instead of being silently capped.

--- a/.server-changes/queue-override-reject-above-limit.md
+++ b/.server-changes/queue-override-reject-above-limit.md
@@ -1,6 +1,0 @@
----
-area: webapp
-type: breaking
----
-
-Setting a queue's concurrency limit above the environment limit is now rejected with a clear error instead of being silently capped. Existing overrides are unaffected.

--- a/.server-changes/queue-pages-live-and-clarity.md
+++ b/.server-changes/queue-pages-live-and-clarity.md
@@ -1,6 +1,0 @@
----
-area: webapp
-type: improvement
----
-
-Queue pages now refresh their live numbers automatically, and the charts are clearer: better axis labels, hover explanations for the headline stats, and the busiest concurrency key named on the chart.

--- a/apps/webapp/app/components/layout/MetricsLayout.tsx
+++ b/apps/webapp/app/components/layout/MetricsLayout.tsx
@@ -178,7 +178,7 @@ function MetricsLayoutMain({ children, scroll }: { children: ReactNode; scroll: 
       <div
         className={
           scroll === "page"
-            ? "flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto py-1.5 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-surface-control"
+            ? "flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto py-3 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-surface-control"
             : "flex min-h-0 flex-1 flex-col overflow-hidden"
         }
       >
@@ -318,7 +318,7 @@ function MetricsLayoutGrid({
   return (
     <div
       className={cn(
-        "grid gap-1.5 px-1.5",
+        "grid gap-3 px-3",
         // `shrink-0` is load-bearing: the grid sits in Root's flex-col scroll container, where the
         // default flex-shrink would collapse a fixed-height row whose chart cards have ~no
         // intrinsic height. Pin it so the charts keep their row height and the page scrolls past.
@@ -348,7 +348,7 @@ function MetricsLayoutContent({
   /** Pad the content into a column (page gutter) instead of letting it span edge to edge. */
   inset?: boolean;
 }) {
-  return <div className={cn("mt-1.5 flex flex-col gap-1.5", inset && "px-1.5")}>{children}</div>;
+  return <div className={cn("mt-3 flex flex-col gap-3", inset && "px-3")}>{children}</div>;
 }
 
 export const MetricsLayout = {

--- a/apps/webapp/app/components/layout/MetricsLayout.tsx
+++ b/apps/webapp/app/components/layout/MetricsLayout.tsx
@@ -178,7 +178,7 @@ function MetricsLayoutMain({ children, scroll }: { children: ReactNode; scroll: 
       <div
         className={
           scroll === "page"
-            ? "flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto py-3 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-surface-control"
+            ? "flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto py-3 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-surface-control"
             : "flex min-h-0 flex-1 flex-col overflow-hidden"
         }
       >
@@ -306,7 +306,7 @@ function MetricsLayoutGrid({
   return (
     <div
       className={cn(
-        "grid gap-3 px-3",
+        "grid gap-2 px-3",
         // `shrink-0` is load-bearing: the grid sits in Root's flex-col scroll container, where the
         // default flex-shrink would collapse a fixed-height row whose chart cards have ~no
         // intrinsic height. Pin it so the charts keep their row height and the page scrolls past.
@@ -336,7 +336,7 @@ function MetricsLayoutContent({
   /** Pad the content into a column (page gutter) instead of letting it span edge to edge. */
   inset?: boolean;
 }) {
-  return <div className={cn("mt-3 flex flex-col gap-3", inset && "px-3")}>{children}</div>;
+  return <div className={cn("mt-2 flex flex-col gap-2", inset && "px-3")}>{children}</div>;
 }
 
 export const MetricsLayout = {

--- a/apps/webapp/app/components/layout/MetricsLayout.tsx
+++ b/apps/webapp/app/components/layout/MetricsLayout.tsx
@@ -275,9 +275,21 @@ function MetricsLayoutRoot({
  * standard page insets. Compose left/right clusters as child divs — `justify-between` spreads them
  * (a single child sits at the start).
  */
-function MetricsLayoutFilters({ children }: { children: ReactNode }) {
+function MetricsLayoutFilters({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  /** Override the baked horizontal padding (the two queue pages want slightly different insets). */
+  className?: string;
+}) {
   return (
-    <div className="flex h-10 shrink-0 items-center justify-between gap-2 border-b border-grid-dimmed pl-2.5 pr-3">
+    <div
+      className={cn(
+        "flex h-10 shrink-0 items-center justify-between gap-2 border-b border-grid-dimmed pl-2.5 pr-3",
+        className
+      )}
+    >
       {children}
     </div>
   );

--- a/apps/webapp/app/components/layout/MetricsLayout.tsx
+++ b/apps/webapp/app/components/layout/MetricsLayout.tsx
@@ -178,7 +178,7 @@ function MetricsLayoutMain({ children, scroll }: { children: ReactNode; scroll: 
       <div
         className={
           scroll === "page"
-            ? "flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto py-3 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-surface-control"
+            ? "flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto py-1.5 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-surface-control"
             : "flex min-h-0 flex-1 flex-col overflow-hidden"
         }
       >
@@ -306,7 +306,7 @@ function MetricsLayoutGrid({
   return (
     <div
       className={cn(
-        "grid gap-2 px-3",
+        "grid gap-1.5 px-1.5",
         // `shrink-0` is load-bearing: the grid sits in Root's flex-col scroll container, where the
         // default flex-shrink would collapse a fixed-height row whose chart cards have ~no
         // intrinsic height. Pin it so the charts keep their row height and the page scrolls past.
@@ -336,7 +336,7 @@ function MetricsLayoutContent({
   /** Pad the content into a column (page gutter) instead of letting it span edge to edge. */
   inset?: boolean;
 }) {
-  return <div className={cn("mt-2 flex flex-col gap-2", inset && "px-3")}>{children}</div>;
+  return <div className={cn("mt-1.5 flex flex-col gap-1.5", inset && "px-1.5")}>{children}</div>;
 }
 
 export const MetricsLayout = {

--- a/apps/webapp/app/components/layout/MetricsLayout.tsx
+++ b/apps/webapp/app/components/layout/MetricsLayout.tsx
@@ -178,7 +178,7 @@ function MetricsLayoutMain({ children, scroll }: { children: ReactNode; scroll: 
       <div
         className={
           scroll === "page"
-            ? "flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto py-3 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-surface-control"
+            ? "flex min-h-0 flex-1 flex-col gap-2.5 overflow-y-auto py-2.5 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-surface-control"
             : "flex min-h-0 flex-1 flex-col overflow-hidden"
         }
       >
@@ -318,7 +318,7 @@ function MetricsLayoutGrid({
   return (
     <div
       className={cn(
-        "grid gap-3 px-3",
+        "grid gap-2.5 px-2.5",
         // `shrink-0` is load-bearing: the grid sits in Root's flex-col scroll container, where the
         // default flex-shrink would collapse a fixed-height row whose chart cards have ~no
         // intrinsic height. Pin it so the charts keep their row height and the page scrolls past.
@@ -337,8 +337,8 @@ function MetricsLayoutGrid({
 /**
  * The content region below the tiles (tabs / table / list). Full-bleed by default so a list table
  * spans edge to edge with its own top border; pass `inset` for a padded column (the detail page's
- * tabs + charts). Either way Content bakes a doubled separation above it, so the tile blocks read
- * as a distinct band from the content below.
+ * tabs + charts). Separation from the tiles above comes from the scroll column's gap alone (no
+ * extra top margin), so the tile → content step matches the gap between tile rows.
  */
 function MetricsLayoutContent({
   children,
@@ -348,7 +348,7 @@ function MetricsLayoutContent({
   /** Pad the content into a column (page gutter) instead of letting it span edge to edge. */
   inset?: boolean;
 }) {
-  return <div className={cn("mt-3 flex flex-col gap-3", inset && "px-3")}>{children}</div>;
+  return <div className={cn("flex flex-col gap-2.5", inset && "px-2.5")}>{children}</div>;
 }
 
 export const MetricsLayout = {

--- a/apps/webapp/app/components/metrics/BigNumber.tsx
+++ b/apps/webapp/app/components/metrics/BigNumber.tsx
@@ -40,7 +40,7 @@ export function BigNumber({
     typeof compactThreshold === "number" && v !== undefined && v >= compactThreshold;
 
   return (
-    <div className="flex flex-col justify-between gap-4 rounded-lg border border-grid-bright bg-background-bright p-4">
+    <div className="group flex flex-col justify-between gap-4 rounded-lg border border-grid-bright bg-background-bright pb-4 pl-4 pr-3 pt-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <Header3 className="leading-6">{title}</Header3>
         {accessory && <div className="shrink-0">{accessory}</div>}

--- a/apps/webapp/app/components/metrics/BigNumber.tsx
+++ b/apps/webapp/app/components/metrics/BigNumber.tsx
@@ -56,7 +56,7 @@ export function BigNumber({
         ) : formattedValue !== undefined ? (
           <div className="flex flex-wrap items-baseline gap-2">
             {formattedValue}
-            {suffix && <div className={cn("text-xs", suffixClassName)}>{suffix}</div>}
+            {suffix && <div className={cn("text-xs tabular-nums", suffixClassName)}>{suffix}</div>}
           </div>
         ) : v !== undefined ? (
           <div className="flex flex-wrap items-baseline gap-2">
@@ -70,7 +70,7 @@ export function BigNumber({
             ) : (
               formatNumber(v)
             )}
-            {suffix && <div className={cn("text-xs", suffixClassName)}>{suffix}</div>}
+            {suffix && <div className={cn("text-xs tabular-nums", suffixClassName)}>{suffix}</div>}
           </div>
         ) : (
           "–"

--- a/apps/webapp/app/components/metrics/BigNumber.tsx
+++ b/apps/webapp/app/components/metrics/BigNumber.tsx
@@ -40,7 +40,7 @@ export function BigNumber({
     typeof compactThreshold === "number" && v !== undefined && v >= compactThreshold;
 
   return (
-    <div className="flex flex-col justify-between gap-4 rounded-sm border border-grid-dimmed bg-background-bright p-4">
+    <div className="flex flex-col justify-between gap-4 rounded-lg border border-grid-bright bg-background-bright p-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <Header3 className="leading-6">{title}</Header3>
         {accessory && <div className="shrink-0">{accessory}</div>}

--- a/apps/webapp/app/components/metrics/MiniLineChart.tsx
+++ b/apps/webapp/app/components/metrics/MiniLineChart.tsx
@@ -138,7 +138,7 @@ export function MiniLineChart({
         type="monotone"
         dataKey="count"
         stroke={color}
-        strokeWidth={1.5}
+        strokeWidth={1}
         dot={false}
         activeDot={{ r: 2.5, fill: color, strokeWidth: 0 }}
         isAnimationActive={false}
@@ -148,7 +148,7 @@ export function MiniLineChart({
           type="monotone"
           dataKey="throttledOverlay"
           stroke="var(--color-warning)"
-          strokeWidth={1.5}
+          strokeWidth={1}
           dot={false}
           activeDot={{ r: 2.5, fill: "var(--color-warning)", strokeWidth: 0 }}
           connectNulls={false}

--- a/apps/webapp/app/components/primitives/SegmentedControl.tsx
+++ b/apps/webapp/app/components/primitives/SegmentedControl.tsx
@@ -76,6 +76,8 @@ type SegmentedControlProps = {
   variant?: VariantType;
   fullWidth?: boolean;
   onChange?: (value: string) => void;
+  /** Override the control's outer styling (e.g. a height that matches an adjacent input). */
+  className?: string;
 };
 
 export default function SegmentedControl({
@@ -86,6 +88,7 @@ export default function SegmentedControl({
   variant = "secondary/medium",
   fullWidth,
   onChange,
+  className,
 }: SegmentedControlProps) {
   const variantStyle = variants[variant];
   const _isPrimary = variant.startsWith("primary");
@@ -95,7 +98,8 @@ export default function SegmentedControl({
       className={cn(
         "flex rounded text-text-bright",
         variantStyle.base,
-        fullWidth ? "w-full" : "w-fit"
+        fullWidth ? "w-full" : "w-fit",
+        className
       )}
     >
       <RadioGroup

--- a/apps/webapp/app/components/primitives/Table.tsx
+++ b/apps/webapp/app/components/primitives/Table.tsx
@@ -271,40 +271,19 @@ export const TableHeaderCell = forwardRef<HTMLTableCellElement, TableHeaderCellP
         tabIndex={-1}
       >
         {sortable ? (
-          // Order is always title → info icon → sort arrows. The info trigger is itself a <button>,
-          // so it can't nest inside the sort <button> (invalid DOM). Without a tooltip the arrows
-          // ride inside the full-width label button (unchanged). With a tooltip, the info sits
-          // between the label and a separate arrows button — both buttons toggle the sort.
+          // Only the sort arrows toggle sorting — the label (and info tooltip) are not clickable, so
+          // clicking the header text does nothing. Order is always title → info icon → sort arrows.
           <div className={rowClassName}>
+            {label}
+            {tooltip ? tooltipNode : null}
             <button
               type="button"
               onClick={onSort}
-              className={cn(
-                "group/sort flex cursor-pointer select-none items-center gap-1 rounded-sm font-medium text-text-bright focus-custom",
-                tooltip
-                  ? undefined
-                  : cn("w-full", {
-                      "justify-center": alignment === "center",
-                      "justify-end": alignment === "right",
-                    })
-              )}
+              aria-label="Toggle sort"
+              className="group/sort flex cursor-pointer select-none items-center rounded-sm focus-custom"
             >
-              {label}
-              {!tooltip && sortIndicator}
+              {sortIndicator}
             </button>
-            {tooltip ? (
-              <>
-                {tooltipNode}
-                <button
-                  type="button"
-                  onClick={onSort}
-                  aria-label="Toggle sort"
-                  className="group/sort flex cursor-pointer select-none items-center rounded-sm focus-custom"
-                >
-                  {sortIndicator}
-                </button>
-              </>
-            ) : null}
           </div>
         ) : tooltip ? (
           <div className={rowClassName}>

--- a/apps/webapp/app/components/primitives/Table.tsx
+++ b/apps/webapp/app/components/primitives/Table.tsx
@@ -386,19 +386,27 @@ export const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(
           // With leading/trailing content, the link is content-sized and the adornments sit beside
           // it (still inside the td) so interactive triggers never nest inside the <a>.
           leadingContent || trailingContent ? (
-            <div className={cn(flexClasses, "gap-2")}>
-              {leadingContent}
+            // Stretched link: the <a> covers the whole cell via an inset ::before overlay, so the
+            // entire cell is clickable — not just the text. The interactive adornments (tooltip
+            // icons, badge buttons) sit above the overlay (relative z-10) and stay clickable, and
+            // never nest inside the <a>.
+            <div className={cn(flexClasses, "relative gap-2")}>
+              {leadingContent ? (
+                <span className="relative z-10 flex items-center">{leadingContent}</span>
+              ) : null}
               <Link
                 to={to}
                 className={cn(
-                  "inline-flex items-center gap-2 focus:outline-hidden",
+                  "inline-flex items-center gap-2 before:absolute before:inset-0 before:content-[''] focus:outline-hidden",
                   actionClassName
                 )}
                 tabIndex={isTabbableCell ? 0 : -1}
               >
                 {children}
               </Link>
-              {trailingContent}
+              {trailingContent ? (
+                <span className="relative z-10 flex items-center">{trailingContent}</span>
+              ) : null}
             </div>
           ) : (
             <Link

--- a/apps/webapp/app/components/primitives/Table.tsx
+++ b/apps/webapp/app/components/primitives/Table.tsx
@@ -181,6 +181,8 @@ type TableCellBasicProps = {
 type TableHeaderCellProps = TableCellBasicProps & {
   hiddenLabel?: boolean;
   tooltip?: ReactNode;
+  /** Extra class merged onto the tooltip content — e.g. widen it past the default max-width. */
+  tooltipContentClassName?: string;
   disableTooltipHoverableContent?: boolean;
   /**
    * When set (together with `onSort`), the header renders a sort indicator and becomes clickable.
@@ -202,6 +204,7 @@ export const TableHeaderCell = forwardRef<HTMLTableCellElement, TableHeaderCellP
       colSpan,
       hiddenLabel = false,
       tooltip,
+      tooltipContentClassName,
       disableTooltipHoverableContent = false,
       sortDirection,
       onSort,
@@ -226,7 +229,7 @@ export const TableHeaderCell = forwardRef<HTMLTableCellElement, TableHeaderCellP
     const tooltipNode = tooltip ? (
       <InfoIconTooltip
         content={tooltip}
-        contentClassName="normal-case tracking-normal"
+        contentClassName={cn("normal-case tracking-normal", tooltipContentClassName)}
         disableHoverableContent={disableTooltipHoverableContent}
       />
     ) : null;

--- a/apps/webapp/app/components/primitives/Tooltip.tsx
+++ b/apps/webapp/app/components/primitives/Tooltip.tsx
@@ -42,7 +42,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden animate-in data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1 focus-visible:outline-hidden",
+        "z-50 max-w-[230px] overflow-hidden animate-in data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1 focus-visible:outline-hidden",
         variantClasses[variant],
         className
       )}

--- a/apps/webapp/app/components/primitives/charts/Card.tsx
+++ b/apps/webapp/app/components/primitives/charts/Card.tsx
@@ -19,7 +19,7 @@ const CardHeader = ({ children, draggable }: { children: ReactNode; draggable?: 
   return (
     <Header3
       className={cn(
-        "drag-handle mb-3 flex items-center justify-between gap-2 pl-4 pr-3",
+        "drag-handle mb-3 flex items-start justify-between gap-2 pl-4 pr-3",
         draggable && "cursor-grab active:cursor-grabbing"
       )}
     >

--- a/apps/webapp/app/components/primitives/charts/Chart.tsx
+++ b/apps/webapp/app/components/primitives/charts/Chart.tsx
@@ -179,8 +179,7 @@ const ChartTooltipContent = React.forwardRef<
               // Prefer the series' configured colour over item.color: a threshold/gradient line's
               // recharts colour is a `url(#…)` gradient ref, which is invalid as a CSS background and
               // renders no swatch. The config colour is the intended solid series colour.
-              const indicatorColor =
-                color || itemConfig?.color || item.payload.fill || item.color;
+              const indicatorColor = color || itemConfig?.color || item.payload.fill || item.color;
 
               return (
                 <div

--- a/apps/webapp/app/components/primitives/charts/Chart.tsx
+++ b/apps/webapp/app/components/primitives/charts/Chart.tsx
@@ -176,7 +176,11 @@ const ChartTooltipContent = React.forwardRef<
             {payload.map((item, index) => {
               const key = `${nameKey || item.name || item.dataKey || "value"}`;
               const itemConfig = getPayloadConfigFromPayload(config, item, key);
-              const indicatorColor = color || item.payload.fill || item.color;
+              // Prefer the series' configured colour over item.color: a threshold/gradient line's
+              // recharts colour is a `url(#…)` gradient ref, which is invalid as a CSS background and
+              // renders no swatch. The config colour is the intended solid series colour.
+              const indicatorColor =
+                color || itemConfig?.color || item.payload.fill || item.color;
 
               return (
                 <div

--- a/apps/webapp/app/components/primitives/charts/ChartBar.tsx
+++ b/apps/webapp/app/components/primitives/charts/ChartBar.tsx
@@ -260,7 +260,7 @@ export function ChartBarRenderer({
       {/* When legend is shown below the chart, render tooltip with cursor only (no content popup).
           Otherwise render the full tooltip with zoom instructions. */}
       <ChartTooltip
-        cursor={{ fill: "rgba(255, 255, 255, 0.06)" }}
+        cursor={{ fill: "rgba(255, 255, 255, 0.12)" }}
         content={
           syncZoomSelection && zoomFrom != null && zoomTo != null ? (
             <ZoomRangeTooltip from={zoomFrom} to={zoomTo} />

--- a/apps/webapp/app/components/primitives/charts/ChartCard.tsx
+++ b/apps/webapp/app/components/primitives/charts/ChartCard.tsx
@@ -88,7 +88,9 @@ export function ChartCard({
       {maximizable && (
         <Dialog open={isFullscreen} onOpenChange={setIsFullscreen}>
           <DialogContent fullscreen className="flex flex-col bg-background-bright">
-            <DialogHeader>{title}</DialogHeader>
+            {/* In fullscreen, space the title's legend (the flex-col title node) further from the
+                title — gap-6 instead of the card's gap-1. */}
+            <DialogHeader className="[&>span]:gap-6">{title}</DialogHeader>
             <div className="min-h-0 w-full flex-1 overflow-hidden pt-4">
               {parentSync ? (
                 <ChartSyncProvider onZoom={parentSync.onZoom}>

--- a/apps/webapp/app/components/primitives/charts/ChartLine.tsx
+++ b/apps/webapp/app/components/primitives/charts/ChartLine.tsx
@@ -597,14 +597,14 @@ export function ChartLineRenderer({
         // Drawn after the base line so the warning colour sits on top. connectNulls={false} keeps
         // the mask to over-threshold stretches; excluded from the legend and (above) the tooltip.
         // Its active dot inherits the warning colour so the hover dot is yellow over yellow.
-        // Slightly wider than the base line so it fully covers it — otherwise the base colour peeks
-        // out along the edges and the warning stretch reads as an outlined line.
+        // Same 1px width as the base line so the warning stretch matches the other lines — it traces
+        // the same points over its over-threshold buckets, so it covers the base exactly.
         <Line
           key={WARNING_OVERLAY_KEY}
           dataKey={WARNING_OVERLAY_KEY}
           type={lineType}
           stroke={warningOverlay!.color ?? "var(--color-warning)"}
-          strokeWidth={2}
+          strokeWidth={1}
           dot={false}
           activeDot={{
             r: 4,

--- a/apps/webapp/app/components/primitives/charts/ChartLine.tsx
+++ b/apps/webapp/app/components/primitives/charts/ChartLine.tsx
@@ -488,7 +488,7 @@ export function ChartLineRenderer({
         <YAxis {...yAxisConfig} />
         {/* When legend is shown below, render tooltip with cursor only (no content popup) */}
         <ChartTooltip
-          cursor={{ stroke: "rgba(255, 255, 255, 0.1)", strokeWidth: 1 }}
+          cursor={{ stroke: SYNC_LINE_COLOR, strokeWidth: 1 }}
           content={stackedTooltipContent}
           labelFormatter={tooltipLabelFormatter}
           isAnimationActive={false}
@@ -536,7 +536,7 @@ export function ChartLineRenderer({
       <YAxis {...yAxisConfig} />
       {/* When legend is shown below, render tooltip with cursor only (no content popup) */}
       <ChartTooltip
-        cursor={{ stroke: "rgba(255, 255, 255, 0.1)", strokeWidth: 1 }}
+        cursor={{ stroke: SYNC_LINE_COLOR, strokeWidth: 1 }}
         content={tooltipContent}
         labelFormatter={tooltipLabelFormatter}
         isAnimationActive={false}

--- a/apps/webapp/app/components/primitives/charts/ChartLine.tsx
+++ b/apps/webapp/app/components/primitives/charts/ChartLine.tsx
@@ -255,18 +255,13 @@ export function ChartLineRenderer({
     return <ChartLineInvalid />;
   }
 
-  // Get the x-axis ticks based on tooltip state
-  const xAxisTicks =
-    highlight.tooltipActive && data.length > 2
-      ? [data[0]?.[dataKey], data[data.length - 1]?.[dataKey]]
-      : undefined;
-
   const xAxisConfig = {
     dataKey,
     tickLine: false,
     axisLine: false,
     tickMargin: 10,
-    ticks: xAxisTicks,
+    // Keep every x-axis label visible at all times, including on hover. Previously the axis
+    // collapsed to just the first + last tick while the tooltip was active.
     interval: "preserveStartEnd" as const,
     tick: {
       fill: "var(--color-text-dimmed)",

--- a/apps/webapp/app/components/primitives/charts/ChartLine.tsx
+++ b/apps/webapp/app/components/primitives/charts/ChartLine.tsx
@@ -118,11 +118,12 @@ export type ChartLineRendererProps = {
    * pinned so the gradient split lines up exactly with the plotted values and reference lines.
    * Single-series (non-stacked) line charts only.
    *
-   * Prefer {@link warningOverlay} when the threshold sits far below the data maximum: a gradient
-   * split whose boundary collapses onto the baseline paints zero/near-zero buckets the warning
-   * colour. The overlay retraces per-bucket instead, so under-threshold buckets always stay blue.
+   * The gradient offset is derived from the plotted line's own value range (objectBoundingBox maps
+   * 0..1 to the path's bounding box, not the y-axis), so the colour change lands exactly at the
+   * threshold value however the domain is padded for reference lines. `series` targets which line
+   * the gradient applies to (others keep their own colour); defaults to the first series.
    */
-  thresholdStroke?: { value: number; aboveColor: string };
+  thresholdStroke?: { value: number; aboveColor: string; series?: string };
   /**
    * Per-bucket warning recolour: a series is retraced in the warning colour only across buckets
    * where it crosses a limit — either strictly above a constant `threshold` (single-series case,
@@ -273,24 +274,36 @@ export function ChartLineRenderer({
 
   // A threshold stroke needs an exact, fixed y-domain so the gradient split aligns with the
   // plotted values and the reference lines. Compute it from the data + reference/threshold ys.
-  let thresholdDomain: [number, number] | undefined;
+  let thresholdActive = false;
   let thresholdOffset = 0;
   if (thresholdStroke && !stacked) {
-    let dataMax = thresholdStroke.value;
+    thresholdActive = true;
+    // The gradient is objectBoundingBox — its 0..1 maps to the plotted line's own bounding box
+    // (lineMax at the top, lineMin at the bottom), NOT the y-axis. So derive the split from the
+    // target line's value range: offset = (lineMax - threshold) / (lineMax - lineMin) lands the
+    // colour change exactly at the threshold value's pixel, whatever the axis domain is. That means
+    // we don't pin the domain (which coarsened the ticks) — it auto-scales as usual.
+    const gradientKey = thresholdStroke.series ?? visibleSeries[0];
+    let lineMin = Infinity;
+    let lineMax = -Infinity;
     for (const row of data) {
-      for (const key of visibleSeries) {
-        const v = Number(row[key]);
-        if (Number.isFinite(v) && v > dataMax) dataMax = v;
+      const v = Number(row[gradientKey]);
+      if (Number.isFinite(v)) {
+        if (v < lineMin) lineMin = v;
+        if (v > lineMax) lineMax = v;
       }
     }
-    for (const line of referenceLines ?? []) {
-      if (Number.isFinite(line.y) && line.y > dataMax) dataMax = line.y;
+    if (!Number.isFinite(lineMin)) {
+      lineMin = 0;
+      lineMax = thresholdStroke.value;
     }
-    const domainMax = dataMax > 0 ? dataMax * 1.1 : 1;
-    thresholdDomain = [0, domainMax];
-    // Gradient runs top (offset 0 = domainMax) to bottom (offset 1 = 0); the split sits where
-    // the threshold value falls within the domain.
-    thresholdOffset = Math.min(1, Math.max(0, (domainMax - thresholdStroke.value) / domainMax));
+    const range = lineMax - lineMin;
+    thresholdOffset =
+      range > 0
+        ? Math.min(1, Math.max(0, (lineMax - thresholdStroke.value) / range))
+        : lineMax >= thresholdStroke.value
+          ? 0
+          : 1;
   }
 
   // Per-bucket warning overlay: single-series line charts only. Retrace the primary series in the
@@ -339,7 +352,6 @@ export function ChartLineRenderer({
       style: { fontVariantNumeric: "tabular-nums" },
     },
     tickFormatter: yAxisTickFormatter,
-    ...(thresholdDomain ? { domain: thresholdDomain } : {}),
     ...yAxisPropsProp,
   };
 
@@ -523,11 +535,14 @@ export function ChartLineRenderer({
       margin={chartMargin}
       {...sharedMouseHandlers}
     >
-      {thresholdStroke && thresholdDomain ? (
+      {thresholdActive ? (
         <defs>
           <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-            <stop offset={thresholdOffset} stopColor={thresholdStroke.aboveColor} />
-            <stop offset={thresholdOffset} stopColor={config[visibleSeries[0]]?.color} />
+            <stop offset={thresholdOffset} stopColor={thresholdStroke!.aboveColor} />
+            <stop
+              offset={thresholdOffset}
+              stopColor={config[thresholdStroke!.series ?? visibleSeries[0]]?.color}
+            />
           </linearGradient>
         </defs>
       ) : null}
@@ -545,33 +560,39 @@ export function ChartLineRenderer({
       />
       {/* Note: Legend is now rendered by ChartRoot outside the chart container */}
       {referenceOverlays}
-      {visibleSeries.map((key) => (
-        <Line
-          key={key}
-          dataKey={key}
-          type={lineType}
-          stroke={thresholdStroke && thresholdDomain ? `url(#${gradientId})` : config[key]?.color}
-          strokeWidth={1}
-          dot={showDots ? { r: 1.5, fill: config[key]?.color, strokeWidth: 0 } : false}
-          // The hover dot matches the line colour under it: for a gradient (threshold) line it
-          // flips at the split; otherwise it's the series colour. The warning overlay draws its
-          // own dot on top where it's active.
-          activeDot={
-            thresholdStroke && thresholdDomain
-              ? (props: ActiveDotProps) => (
-                  <ThresholdActiveDot
-                    {...props}
-                    dataKey={key}
-                    threshold={thresholdStroke.value}
-                    aboveColor={thresholdStroke.aboveColor}
-                    baseColor={config[key]?.color ?? "var(--color-tasks)"}
-                  />
-                )
-              : { r: 4, fill: config[key]?.color, strokeWidth: 0 }
-          }
-          isAnimationActive={false}
-        />
-      ))}
+      {visibleSeries.map((key) => {
+        // The gradient stroke only applies to the threshold's target series (default: the first);
+        // other series (e.g. the grey limit line) keep their own colour.
+        const gradientLine =
+          thresholdActive && (thresholdStroke!.series == null || thresholdStroke!.series === key);
+        return (
+          <Line
+            key={key}
+            dataKey={key}
+            type={lineType}
+            stroke={gradientLine ? `url(#${gradientId})` : config[key]?.color}
+            strokeWidth={1}
+            dot={showDots ? { r: 1.5, fill: config[key]?.color, strokeWidth: 0 } : false}
+            // The hover dot matches the line colour under it: for a gradient (threshold) line it
+            // flips at the split; otherwise it's the series colour. The warning overlay draws its
+            // own dot on top where it's active.
+            activeDot={
+              gradientLine
+                ? (props: ActiveDotProps) => (
+                    <ThresholdActiveDot
+                      {...props}
+                      dataKey={key}
+                      threshold={thresholdStroke!.value}
+                      aboveColor={thresholdStroke!.aboveColor}
+                      baseColor={config[key]?.color ?? "var(--color-tasks)"}
+                    />
+                  )
+                : { r: 4, fill: config[key]?.color, strokeWidth: 0 }
+            }
+            isAnimationActive={false}
+          />
+        );
+      })}
       {overlayActive && (
         // Drawn after the base line so the warning colour sits on top. connectNulls={false} keeps
         // the mask to over-threshold stretches; excluded from the legend and (above) the tooltip.

--- a/apps/webapp/app/components/queues/QueueControls.tsx
+++ b/apps/webapp/app/components/queues/QueueControls.tsx
@@ -134,7 +134,7 @@ export function QueuePauseResumeButton({
               }
               cancelButton={
                 <DialogClose asChild>
-                  <Button type="button" variant="tertiary/medium">
+                  <Button type="button" variant="secondary/medium">
                     Cancel
                   </Button>
                 </DialogClose>

--- a/apps/webapp/app/components/queues/QueueControls.tsx
+++ b/apps/webapp/app/components/queues/QueueControls.tsx
@@ -48,8 +48,8 @@ export function QueuePauseResumeButton({
   const [isOpen, setIsOpen] = useState(false);
 
   const label = queue.paused
-    ? `Resume processing runs in queue "${queue.name}"`
-    : `Pause processing runs in queue "${queue.name}"`;
+    ? `Resume the "${queue.name}" queue so its runs can be dequeued again`
+    : `Pause the "${queue.name}" queue — its runs stay queued until you resume it`;
 
   const trigger = showTooltip ? (
     <div>
@@ -66,11 +66,20 @@ export function QueuePauseResumeButton({
                   fullWidth={fullWidth}
                   textAlignLeft={fullWidth}
                   aria-label={label}
+                  className={
+                    withQueueName
+                      ? queue.paused
+                        ? "border-success/60 hover:border-success"
+                        : "border-warning/60 hover:border-warning"
+                      : undefined
+                  }
                 >
                   {iconOnly
                     ? undefined
                     : withQueueName
-                      ? `${queue.paused ? "Resume" : "Pause"} ${queue.name} queue`
+                      ? queue.paused
+                        ? "Resume this queue…"
+                        : "Pause this queue…"
                       : queue.paused
                         ? "Resume"
                         : "Pause"}
@@ -314,6 +323,7 @@ export function QueueOverrideConcurrencyButton({
                 <SegmentedControl
                   name="unit"
                   value={mode}
+                  className="h-8"
                   options={[
                     { label: "Number", value: "absolute" },
                     { label: "Percent", value: "percent" },
@@ -322,7 +332,7 @@ export function QueueOverrideConcurrencyButton({
                 />
               </div>
               {mode === "percent" ? (
-                <Hint>
+                <Hint className="tabular-nums">
                   {materializedFromPercent !== null
                     ? `${percentNumber}% = ${materializedFromPercent} concurrent ${
                         materializedFromPercent === 1 ? "run" : "runs"
@@ -330,10 +340,10 @@ export function QueueOverrideConcurrencyButton({
                     : "Enter a percentage between 1 and 100."}
                 </Hint>
               ) : (
-                <Hint className={limitOverCap ? "text-warning" : undefined}>
+                <Hint className={limitOverCap ? "text-warning tabular-nums" : "tabular-nums"}>
                   {limitOverCap
                     ? `Can't exceed the environment limit of ${environmentConcurrencyLimit}.`
-                    : `Up to the environment limit of ${environmentConcurrencyLimit}.`}
+                    : `The most concurrent runs this queue can use at once. It can't exceed the environment limit of ${environmentConcurrencyLimit}.`}
                 </Hint>
               )}
             </InputGroup>
@@ -371,7 +381,7 @@ export function QueueOverrideConcurrencyButton({
                     </Button>
                   )}
                   <DialogClose asChild>
-                    <Button type="button" variant="tertiary/medium">
+                    <Button type="button" variant="secondary/medium">
                       Cancel
                     </Button>
                   </DialogClose>

--- a/apps/webapp/app/components/queues/QueueControls.tsx
+++ b/apps/webapp/app/components/queues/QueueControls.tsx
@@ -48,8 +48,8 @@ export function QueuePauseResumeButton({
   const [isOpen, setIsOpen] = useState(false);
 
   const label = queue.paused
-    ? `Resume the "${queue.name}" queue so its runs can be dequeued again`
-    : `Pause the "${queue.name}" queue — its runs stay queued until you resume it`;
+    ? `Resume the "${queue.name}" queue so its runs can start again`
+    : `Pause the "${queue.name}" queue. Its runs wait until you resume it`;
 
   const trigger = showTooltip ? (
     <div>
@@ -248,8 +248,8 @@ export function QueueOverrideConcurrencyButton({
               </div>
             </TooltipTrigger>
             <TooltipContent side="bottom" className="max-w-[230px] text-xs">
-              Set a custom concurrency limit for this queue, overriding the environment default — as
-              an absolute number or a percentage of the environment limit.
+              Give this queue its own concurrency limit instead of the environment default. Set it as
+              a number or a percentage of the environment limit.
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/apps/webapp/app/components/queues/QueueControls.tsx
+++ b/apps/webapp/app/components/queues/QueueControls.tsx
@@ -32,6 +32,7 @@ export function QueuePauseResumeButton({
   fullWidth = false,
   showTooltip = true,
   iconOnly = false,
+  withQueueName = false,
 }: {
   /** The "id" here is a friendlyId */
   queue: { id: string; name: string; paused: boolean };
@@ -41,6 +42,8 @@ export function QueuePauseResumeButton({
   /** Icon-only trigger (label moves to the tooltip). For compact placements like the detail-page
    * live blocks. */
   iconOnly?: boolean;
+  /** Render the full "Pause/Resume {name} queue" label instead of the short "Pause"/"Resume". */
+  withQueueName?: boolean;
 }) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -64,7 +67,13 @@ export function QueuePauseResumeButton({
                   textAlignLeft={fullWidth}
                   aria-label={label}
                 >
-                  {iconOnly ? undefined : queue.paused ? "Resume" : "Pause"}
+                  {iconOnly
+                    ? undefined
+                    : withQueueName
+                      ? `${queue.paused ? "Resume" : "Pause"} ${queue.name} queue`
+                      : queue.paused
+                        ? "Resume"
+                        : "Pause"}
                 </Button>
               </DialogTrigger>
             </div>
@@ -209,24 +218,38 @@ export function QueueOverrideConcurrencyButton({
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
+      ) : trigger === "button" ? (
+        <TooltipProvider disableHoverableContent={true}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="cursor-pointer [&_button]:cursor-pointer">
+                <DialogTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="secondary/small"
+                    LeadingIcon={AdjustmentsHorizontalIcon}
+                    leadingIconClassName="text-text-dimmed"
+                    aria-label={
+                      isOverridden ? "Edit concurrency override" : "Override concurrency limit"
+                    }
+                  >
+                    {isOverridden ? "Edit override" : "Override limit"}
+                  </Button>
+                </DialogTrigger>
+              </div>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="max-w-[230px] text-xs">
+              Set a custom concurrency limit for this queue, overriding the environment default — as
+              an absolute number or a percentage of the environment limit.
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       ) : (
         <DialogTrigger asChild>
-          {trigger === "button" ? (
-            <Button
-              type="button"
-              variant="minimal/small"
-              LeadingIcon={AdjustmentsHorizontalIcon}
-              leadingIconClassName="text-text-dimmed"
-              aria-label={isOverridden ? "Edit concurrency override" : "Override concurrency limit"}
-            >
-              {isOverridden ? "Edit override" : "Override"}
-            </Button>
-          ) : (
-            <PopoverMenuItem
-              icon={AdjustmentsHorizontalIcon}
-              title={isOverridden ? "Edit override…" : "Override limit…"}
-            />
-          )}
+          <PopoverMenuItem
+            icon={AdjustmentsHorizontalIcon}
+            title={isOverridden ? "Edit override…" : "Override limit…"}
+          />
         </DialogTrigger>
       )}
       <DialogContent>

--- a/apps/webapp/app/components/queues/QueueControls.tsx
+++ b/apps/webapp/app/components/queues/QueueControls.tsx
@@ -248,8 +248,8 @@ export function QueueOverrideConcurrencyButton({
               </div>
             </TooltipTrigger>
             <TooltipContent side="bottom" className="max-w-[230px] text-xs">
-              Give this queue its own concurrency limit instead of the environment default. Set it as
-              a number or a percentage of the environment limit.
+              Give this queue its own concurrency limit instead of the environment default. Set it
+              as a number or a percentage of the environment limit.
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/apps/webapp/app/components/queues/QueueControls.tsx
+++ b/apps/webapp/app/components/queues/QueueControls.tsx
@@ -69,8 +69,8 @@ export function QueuePauseResumeButton({
                   className={
                     withQueueName
                       ? queue.paused
-                        ? "border-success/60 text-success hover:border-success"
-                        : "border-warning/60 text-warning hover:border-warning"
+                        ? "border-success/60 text-success [&_span]:text-success hover:border-success"
+                        : "border-warning/60 text-warning [&_span]:text-warning hover:border-warning"
                       : undefined
                   }
                 >

--- a/apps/webapp/app/components/queues/QueueControls.tsx
+++ b/apps/webapp/app/components/queues/QueueControls.tsx
@@ -48,8 +48,8 @@ export function QueuePauseResumeButton({
   const [isOpen, setIsOpen] = useState(false);
 
   const label = queue.paused
-    ? `Resume the "${queue.name}" queue so its runs can start again`
-    : `Pause the "${queue.name}" queue. Its runs wait until you resume it`;
+    ? `Resumes the "${queue.name}" queue so its runs can be dequeued again.`
+    : `Pauses all runs from being dequeued in the "${queue.name}" queue. Any executing runs will continue to run.`;
 
   const trigger = showTooltip ? (
     <div>
@@ -69,8 +69,8 @@ export function QueuePauseResumeButton({
                   className={
                     withQueueName
                       ? queue.paused
-                        ? "border-success/60 hover:border-success"
-                        : "border-warning/60 hover:border-warning"
+                        ? "border-success/60 text-success hover:border-success"
+                        : "border-warning/60 text-warning hover:border-warning"
                       : undefined
                   }
                 >

--- a/apps/webapp/app/components/queues/QueueControls.tsx
+++ b/apps/webapp/app/components/queues/QueueControls.tsx
@@ -258,7 +258,7 @@ export function QueueOverrideConcurrencyButton({
         </DialogHeader>
         <div className="flex flex-col gap-3 pt-3">
           {isOverridden ? (
-            <Paragraph>
+            <Paragraph variant="small">
               This queue's concurrency limit is currently overridden to {currentLimit}.
               {typeof queue.concurrency?.base === "number" &&
                 ` The original limit set in code was ${queue.concurrency.base}.`}{" "}
@@ -269,7 +269,7 @@ export function QueueOverrideConcurrencyButton({
               .
             </Paragraph>
           ) : (
-            <Paragraph>
+            <Paragraph variant="small">
               Override this queue's concurrency limit. The current limit is {currentLimit}, which is
               set {queue.concurrencyLimit !== null ? "in code" : "by the environment"}.
             </Paragraph>
@@ -278,10 +278,39 @@ export function QueueOverrideConcurrencyButton({
             <input type="hidden" name="friendlyId" value={queue.id} />
             <input type="hidden" name="mode" value={mode} />
             <InputGroup fullWidth>
-              <div className="flex items-center justify-between gap-2">
-                <Label htmlFor={mode === "percent" ? "percent" : "concurrencyLimit"}>
-                  Concurrency limit
-                </Label>
+              <Label htmlFor={mode === "percent" ? "percent" : "concurrencyLimit"}>
+                Concurrency limit
+              </Label>
+              <div className="flex items-center gap-2">
+                <div className="flex-1">
+                  {mode === "percent" ? (
+                    <Input
+                      type="number"
+                      name="percent"
+                      id="percent"
+                      min="1"
+                      max="100"
+                      step="0.01"
+                      value={percent}
+                      onChange={(e) => setPercent(e.target.value)}
+                      placeholder="100"
+                      autoFocus
+                      accessory={<span className="pr-1 text-text-dimmed">%</span>}
+                    />
+                  ) : (
+                    <Input
+                      type="number"
+                      name="concurrencyLimit"
+                      id="concurrencyLimit"
+                      min="0"
+                      max={environmentConcurrencyLimit}
+                      value={concurrencyLimit}
+                      onChange={(e) => setConcurrencyLimit(e.target.value)}
+                      placeholder={currentLimit.toString()}
+                      autoFocus
+                    />
+                  )}
+                </div>
                 <SegmentedControl
                   name="unit"
                   value={mode}
@@ -293,46 +322,19 @@ export function QueueOverrideConcurrencyButton({
                 />
               </div>
               {mode === "percent" ? (
-                <>
-                  <Input
-                    type="number"
-                    name="percent"
-                    id="percent"
-                    min="1"
-                    max="100"
-                    step="0.01"
-                    value={percent}
-                    onChange={(e) => setPercent(e.target.value)}
-                    placeholder="100"
-                    autoFocus
-                  />
-                  <Hint>
-                    {materializedFromPercent !== null
-                      ? `${percentNumber}% = ${materializedFromPercent} concurrent ${
-                          materializedFromPercent === 1 ? "run" : "runs"
-                        } of the environment's ${environmentConcurrencyLimit}. Recalculates automatically when the environment limit changes.`
-                      : "Enter a percentage between 1 and 100."}
-                  </Hint>
-                </>
+                <Hint>
+                  {materializedFromPercent !== null
+                    ? `${percentNumber}% = ${materializedFromPercent} concurrent ${
+                        materializedFromPercent === 1 ? "run" : "runs"
+                      } of the environment's ${environmentConcurrencyLimit}. Recalculates automatically when the environment limit changes.`
+                    : "Enter a percentage between 1 and 100."}
+                </Hint>
               ) : (
-                <>
-                  <Input
-                    type="number"
-                    name="concurrencyLimit"
-                    id="concurrencyLimit"
-                    min="0"
-                    max={environmentConcurrencyLimit}
-                    value={concurrencyLimit}
-                    onChange={(e) => setConcurrencyLimit(e.target.value)}
-                    placeholder={currentLimit.toString()}
-                    autoFocus
-                  />
-                  <Hint className={limitOverCap ? "text-warning" : undefined}>
-                    {limitOverCap
-                      ? `Can't exceed the environment limit of ${environmentConcurrencyLimit}.`
-                      : `Up to the environment limit of ${environmentConcurrencyLimit}.`}
-                  </Hint>
-                </>
+                <Hint className={limitOverCap ? "text-warning" : undefined}>
+                  {limitOverCap
+                    ? `Can't exceed the environment limit of ${environmentConcurrencyLimit}.`
+                    : `Up to the environment limit of ${environmentConcurrencyLimit}.`}
+                </Hint>
               )}
             </InputGroup>
 

--- a/apps/webapp/app/components/queues/QueueControls.tsx
+++ b/apps/webapp/app/components/queues/QueueControls.tsx
@@ -237,7 +237,7 @@ export function QueueOverrideConcurrencyButton({
                     type="button"
                     variant="secondary/small"
                     LeadingIcon={AdjustmentsHorizontalIcon}
-                    leadingIconClassName="text-text-dimmed"
+                    leadingIconClassName="text-text-bright"
                     aria-label={
                       isOverridden ? "Edit concurrency override" : "Override concurrency limit"
                     }

--- a/apps/webapp/app/components/queues/QueueMetricCards.tsx
+++ b/apps/webapp/app/components/queues/QueueMetricCards.tsx
@@ -204,7 +204,7 @@ export function QueueMetricChartCard({
       <ChartCard
         title={
           info || titleAccessory ? (
-            <span className="flex items-center gap-1.5">
+            <span className="flex items-center gap-1">
               {title}
               {info ? <InfoIconTooltip content={info} contentClassName="max-w-[230px]" /> : null}
               {titleAccessory}
@@ -322,7 +322,7 @@ export function QueueSparklineStat({
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex items-center gap-1.5">
+      <div className="flex items-center gap-1">
         <Header3 className="leading-6">{title}</Header3>
         {info || (data.length > 0 && peak > 0) ? (
           <InfoIconTooltip

--- a/apps/webapp/app/components/queues/QueueMetricCards.tsx
+++ b/apps/webapp/app/components/queues/QueueMetricCards.tsx
@@ -227,6 +227,7 @@ export function QueueMetricChartCard({
   info,
   titleAccessory,
   className,
+  extraLegend,
   ...chart
 }: QueueMetricChartProps & {
   title: string;
@@ -234,6 +235,9 @@ export function QueueMetricChartCard({
   /** Extra content rendered after the info icon inside the title row (e.g. a live readout). */
   titleAccessory?: ReactNode;
   className?: string;
+  /** Extra legend entries appended after the series — e.g. a warning state that isn't its own
+   * series (the orange "over threshold" colour). */
+  extraLegend?: Array<{ color: string; label: string }>;
 }) {
   return (
     <div className={className ?? "h-64"}>
@@ -253,7 +257,7 @@ export function QueueMetricChartCard({
             </span>
             {/* Inline legend below the title (swatch + label per series), matching the list-page
                 charts — instead of the Chart.Root legend with per-series totals. */}
-            {chart.showLegend && chart.series.length > 0 ? (
+            {chart.showLegend && (chart.series.length > 0 || (extraLegend?.length ?? 0) > 0) ? (
               <span className="flex flex-wrap items-center gap-2">
                 {chart.series.map((s) => (
                   <span
@@ -265,6 +269,18 @@ export function QueueMetricChartCard({
                       style={{ backgroundColor: s.color }}
                     />
                     {s.label}
+                  </span>
+                ))}
+                {extraLegend?.map((e) => (
+                  <span
+                    key={e.label}
+                    className="flex items-center gap-1 text-xs font-normal text-text-dimmed"
+                  >
+                    <span
+                      className="size-2.5 rounded-[2px]"
+                      style={{ backgroundColor: e.color }}
+                    />
+                    {e.label}
                   </span>
                 ))}
               </span>

--- a/apps/webapp/app/components/queues/QueueMetricCards.tsx
+++ b/apps/webapp/app/components/queues/QueueMetricCards.tsx
@@ -132,7 +132,6 @@ export function QueueMetricChart({
   defaultPeriod,
   warningOverlay,
   carryBackfill,
-  showLegend,
   thresholdStroke,
 }: QueueMetricChartProps) {
   const { rows, showLoading, failed } = useQueueMetric(query, {
@@ -209,7 +208,6 @@ export function QueueMetricChart({
       series={series.map((s) => s.key)}
       state={state}
       fillContainer
-      showLegend={showLegend}
     >
       <Chart.Line
         lineType="monotone"
@@ -241,7 +239,7 @@ export function QueueMetricChartCard({
     <div className={className ?? "h-64"}>
       <ChartCard
         title={
-          info || titleAccessory ? (
+          <span className="flex flex-col gap-1">
             <span className="flex items-center gap-1">
               {title}
               {info ? (
@@ -253,9 +251,25 @@ export function QueueMetricChartCard({
               ) : null}
               {titleAccessory}
             </span>
-          ) : (
-            title
-          )
+            {/* Inline legend below the title (swatch + label per series), matching the list-page
+                charts — instead of the Chart.Root legend with per-series totals. */}
+            {chart.showLegend && chart.series.length > 0 ? (
+              <span className="flex flex-wrap items-center gap-2">
+                {chart.series.map((s) => (
+                  <span
+                    key={s.key}
+                    className="flex items-center gap-1 text-xs font-normal text-text-dimmed"
+                  >
+                    <span
+                      className="size-2.5 rounded-[2px]"
+                      style={{ backgroundColor: s.color }}
+                    />
+                    {s.label}
+                  </span>
+                ))}
+              </span>
+            ) : null}
+          </span>
         }
       >
         <QueueMetricChart {...chart} />

--- a/apps/webapp/app/components/queues/QueueMetricCards.tsx
+++ b/apps/webapp/app/components/queues/QueueMetricCards.tsx
@@ -206,7 +206,7 @@ export function QueueMetricChartCard({
           info || titleAccessory ? (
             <span className="flex items-center gap-1.5">
               {title}
-              {info ? <InfoIconTooltip content={info} contentClassName="max-w-xs" /> : null}
+              {info ? <InfoIconTooltip content={info} contentClassName="max-w-[230px]" /> : null}
               {titleAccessory}
             </span>
           ) : (
@@ -336,7 +336,7 @@ export function QueueSparklineStat({
                 ) : null}
               </div>
             }
-            contentClassName="max-w-xs"
+            contentClassName="max-w-[230px]"
           />
         ) : null}
       </div>

--- a/apps/webapp/app/components/queues/QueueMetricCards.tsx
+++ b/apps/webapp/app/components/queues/QueueMetricCards.tsx
@@ -206,7 +206,13 @@ export function QueueMetricChartCard({
           info || titleAccessory ? (
             <span className="flex items-center gap-1">
               {title}
-              {info ? <InfoIconTooltip content={info} contentClassName="max-w-[230px]" /> : null}
+              {info ? (
+                <InfoIconTooltip
+                  content={info}
+                  contentClassName="max-w-[230px]"
+                  disableHoverableContent
+                />
+              ) : null}
               {titleAccessory}
             </span>
           ) : (
@@ -337,6 +343,7 @@ export function QueueSparklineStat({
               </div>
             }
             contentClassName="max-w-[230px]"
+            disableHoverableContent
           />
         ) : null}
       </div>

--- a/apps/webapp/app/components/queues/QueueMetricCards.tsx
+++ b/apps/webapp/app/components/queues/QueueMetricCards.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { buildActivityTimeAxis } from "~/components/primitives/charts/activityTimeAxis";
 import {
   Chart,
@@ -118,6 +118,9 @@ type QueueMetricChartProps = {
     value?: number;
     valueFromSeries?: string;
   };
+  /** Reports whether the chart has data to plot (false once it settles on the "no activity" state),
+   * so a wrapping card can hide the legend to match. */
+  onHasDataChange?: (hasData: boolean) => void;
 };
 
 // Bare chart (no card chrome) so it can live inside a shared card, e.g. a tabbed panel.
@@ -133,6 +136,7 @@ export function QueueMetricChart({
   warningOverlay,
   carryBackfill,
   thresholdStroke,
+  onHasDataChange,
 }: QueueMetricChartProps) {
   const { rows, showLoading, failed } = useQueueMetric(query, {
     ids,
@@ -200,6 +204,12 @@ export function QueueMetricChart({
 
   const state: ChartState = showLoading ? "loading" : failed ? "invalid" : undefined;
 
+  // Report data presence so a wrapping card can hide its legend when the chart settles on the
+  // "no activity" state. Only report once loaded, so the legend stays put while loading.
+  useEffect(() => {
+    if (!showLoading) onHasDataChange?.(!failed && data.length > 0);
+  }, [showLoading, failed, data.length, onHasDataChange]);
+
   return (
     <Chart.Root
       config={chartConfig}
@@ -239,6 +249,8 @@ export function QueueMetricChartCard({
    * series (the orange "over threshold" colour). */
   extraLegend?: Array<{ color: string; label: string }>;
 }) {
+  // Hide the legend once the chart settles on the "no activity" state (reported by the chart).
+  const [hasData, setHasData] = useState(true);
   return (
     <div className={className ?? "h-64"}>
       <ChartCard
@@ -257,7 +269,9 @@ export function QueueMetricChartCard({
             </span>
             {/* Inline legend below the title (swatch + label per series), matching the list-page
                 charts — instead of the Chart.Root legend with per-series totals. */}
-            {chart.showLegend && (chart.series.length > 0 || (extraLegend?.length ?? 0) > 0) ? (
+            {chart.showLegend &&
+            hasData &&
+            (chart.series.length > 0 || (extraLegend?.length ?? 0) > 0) ? (
               <span className="flex flex-wrap items-center gap-2">
                 {chart.series.map((s) => (
                   <span
@@ -288,7 +302,7 @@ export function QueueMetricChartCard({
           </span>
         }
       >
-        <QueueMetricChart {...chart} />
+        <QueueMetricChart {...chart} onHasDataChange={setHasData} />
       </ChartCard>
     </div>
   );

--- a/apps/webapp/app/components/queues/QueueMetricCards.tsx
+++ b/apps/webapp/app/components/queues/QueueMetricCards.tsx
@@ -278,10 +278,7 @@ export function QueueMetricChartCard({
                     key={s.key}
                     className="flex items-center gap-1 text-xs font-normal text-text-dimmed"
                   >
-                    <span
-                      className="size-2.5 rounded-[2px]"
-                      style={{ backgroundColor: s.color }}
-                    />
+                    <span className="size-2.5 rounded-[2px]" style={{ backgroundColor: s.color }} />
                     {s.label}
                   </span>
                 ))}
@@ -290,10 +287,7 @@ export function QueueMetricChartCard({
                     key={e.label}
                     className="flex items-center gap-1 text-xs font-normal text-text-dimmed"
                   >
-                    <span
-                      className="size-2.5 rounded-[2px]"
-                      style={{ backgroundColor: e.color }}
-                    />
+                    <span className="size-2.5 rounded-[2px]" style={{ backgroundColor: e.color }} />
                     {e.label}
                   </span>
                 ))}

--- a/apps/webapp/app/components/queues/QueueMetricCards.tsx
+++ b/apps/webapp/app/components/queues/QueueMetricCards.tsx
@@ -104,6 +104,20 @@ type QueueMetricChartProps = {
    * are config values that existed all along, so carry the first value backward instead.
    */
   carryBackfill?: string[];
+  /** Show the series legend below the chart (use for multi-series charts). */
+  showLegend?: boolean;
+  /**
+   * Recolour a series' stroke above a threshold with a gradient split (colour only above the
+   * line). `value` sets a constant threshold; `valueFromSeries` reads a (roughly constant)
+   * threshold off another series — e.g. the concurrency limit. `series` targets which line is
+   * recoloured; the others keep their own colour.
+   */
+  thresholdStroke?: {
+    aboveColor: string;
+    series?: string;
+    value?: number;
+    valueFromSeries?: string;
+  };
 };
 
 // Bare chart (no card chrome) so it can live inside a shared card, e.g. a tabbed panel.
@@ -118,6 +132,8 @@ export function QueueMetricChart({
   defaultPeriod,
   warningOverlay,
   carryBackfill,
+  showLegend,
+  thresholdStroke,
 }: QueueMetricChartProps) {
   const { rows, showLoading, failed } = useQueueMetric(query, {
     ids,
@@ -163,6 +179,26 @@ export function QueueMetricChart({
     [data]
   );
 
+  // Resolve the threshold value: a constant, or the max of another series (e.g. the limit line,
+  // which is effectively constant). A gradient split then colours the target series only above it.
+  // `valueFromSeries` targets integer-count series (concurrency limit), so split half a unit below
+  // the limit — that way the line renders warning *at or above* the limit (saturated), matching
+  // "turns yellow at the limit", rather than only when it strictly exceeds it.
+  const resolvedThresholdStroke = useMemo(() => {
+    if (!thresholdStroke) return undefined;
+    let value = thresholdStroke.value;
+    if (value == null && thresholdStroke.valueFromSeries) {
+      let max = -Infinity;
+      for (const p of data) {
+        const v = Number(p[thresholdStroke.valueFromSeries]);
+        if (Number.isFinite(v) && v > max) max = v;
+      }
+      value = max > 0 ? max - 0.5 : undefined;
+    }
+    if (value == null || !Number.isFinite(value)) return undefined;
+    return { value, aboveColor: thresholdStroke.aboveColor, series: thresholdStroke.series };
+  }, [thresholdStroke, data]);
+
   const state: ChartState = showLoading ? "loading" : failed ? "invalid" : undefined;
 
   return (
@@ -173,6 +209,7 @@ export function QueueMetricChart({
       series={series.map((s) => s.key)}
       state={state}
       fillContainer
+      showLegend={showLegend}
     >
       <Chart.Line
         lineType="monotone"
@@ -181,6 +218,7 @@ export function QueueMetricChart({
         tooltipLabelFormatter={tooltipLabelFormatter}
         tooltipValueFormatter={valueFormat}
         warningOverlay={warningOverlay}
+        thresholdStroke={resolvedThresholdStroke}
       />
     </Chart.Root>
   );

--- a/apps/webapp/app/hooks/useMetricResourceQuery.ts
+++ b/apps/webapp/app/hooks/useMetricResourceQuery.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useInterval } from "./useInterval";
 
 export type MetricResourceRow = Record<string, number | string | null>;
@@ -24,16 +24,32 @@ export type MetricResourceQueryOptions = {
   refreshIntervalMs?: number;
 };
 
+// Module-level cache of the last successful rows per query signature. Lets a remounted chart
+// (switching tabs, or navigating back to the queues list) paint its previous data immediately
+// instead of flashing a loading skeleton every time, while it revalidates in the background.
+// Bounded so it can't grow without limit over a long session.
+const responseCache = new Map<string, MetricResourceRow[]>();
+const RESPONSE_CACHE_MAX = 200;
+
+function cacheSet(key: string, rows: MetricResourceRow[]) {
+  // Re-insert so the key becomes the most-recently-used (Map preserves insertion order).
+  responseCache.delete(key);
+  responseCache.set(key, rows);
+  if (responseCache.size > RESPONSE_CACHE_MAX) {
+    const oldest = responseCache.keys().next().value;
+    if (oldest !== undefined) responseCache.delete(oldest);
+  }
+}
+
 /**
  * Client-fetch a TRQL query from the metric resource route (like the dashboard
  * widgets): own loading state, interval + on-focus refresh, abort on change/unmount.
+ *
+ * Successful results are cached per query signature, so a chart that remounts (tab switch, or
+ * back-navigation to the queues list) shows its last data immediately and revalidates in the
+ * background rather than flashing a loading skeleton.
  */
 export function useMetricResourceQuery(query: string, opts: MetricResourceQueryOptions) {
-  const [rows, setRows] = useState<MetricResourceRow[] | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [failed, setFailed] = useState(false);
-  const abortRef = useRef<AbortController | null>(null);
-
   const {
     organizationId,
     projectId,
@@ -44,11 +60,37 @@ export function useMetricResourceQuery(query: string, opts: MetricResourceQueryO
   } = opts;
   const { period, from, to } = opts.timeRange;
   const queuesKey = opts.queues && opts.queues.length > 0 ? opts.queues.join(",") : undefined;
+  const resolvedPeriod = period ?? (from || to ? null : defaultPeriod);
+  const cacheKey = useMemo(
+    () =>
+      [
+        organizationId,
+        projectId,
+        environmentId,
+        resolvedPeriod ?? "",
+        from ?? "",
+        to ?? "",
+        fillGaps ? 1 : 0,
+        queuesKey ?? "",
+        query,
+      ].join("|"),
+    [organizationId, projectId, environmentId, resolvedPeriod, from, to, fillGaps, queuesKey, query]
+  );
+
+  const [rows, setRows] = useState<MetricResourceRow[] | null>(
+    () => responseCache.get(cacheKey) ?? null
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
 
   const load = useCallback(() => {
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
+    // Paint cached rows immediately (no skeleton) on remount / key change while we revalidate.
+    const cached = responseCache.get(cacheKey);
+    if (cached) setRows(cached);
     setIsLoading(true);
     fetch("/resources/metric", {
       method: "POST",
@@ -56,7 +98,7 @@ export function useMetricResourceQuery(query: string, opts: MetricResourceQueryO
       body: JSON.stringify({
         query,
         scope: "environment",
-        period: period ?? (from || to ? null : defaultPeriod),
+        period: resolvedPeriod,
         from,
         to,
         fillGaps: !!fillGaps,
@@ -71,6 +113,7 @@ export function useMetricResourceQuery(query: string, opts: MetricResourceQueryO
       .then((data) => {
         if (controller.signal.aborted) return;
         if (data.success) {
+          cacheSet(cacheKey, data.data.rows);
           setRows(data.data.rows);
           setFailed(false);
         } else {
@@ -86,11 +129,11 @@ export function useMetricResourceQuery(query: string, opts: MetricResourceQueryO
         }
       });
   }, [
+    cacheKey,
     query,
-    period,
+    resolvedPeriod,
     from,
     to,
-    defaultPeriod,
     fillGaps,
     organizationId,
     projectId,

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -11,6 +11,7 @@ import { Form, useNavigation, type MetaFunction } from "@remix-run/react";
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import type { RuntimeEnvironmentType } from "@trigger.dev/database";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { QueuesIcon } from "~/assets/icons/QueuesIcon";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { z } from "zod";
 import { ConcurrencyIcon } from "~/assets/icons/ConcurrencyIcon";
@@ -783,7 +784,7 @@ function QueuesWithMetricsView() {
                                     )}
                                   />
                                 ) : (
-                                  <RectangleStackIcon
+                                  <QueuesIcon
                                     className={cn(
                                       "size-[1.125rem] text-purple-500",
                                       queue.paused && "opacity-50"

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -669,15 +669,16 @@ function QueuesWithMetricsView() {
                     tooltip={
                       <div className="max-w-xs space-y-1 p-1 text-left text-xs text-text-dimmed">
                         <p>
-                          <span className="text-text-bright">Environment</span>: the environment's
-                          limit of {environment.concurrencyLimit}.
+                          <span className="text-text-bright">Environment</span>: uses the
+                          environment limit of {environment.concurrencyLimit}.
                         </p>
                         <p>
-                          <span className="text-text-bright">User</span>: a limit set in your code.
+                          <span className="text-text-bright">User</span>: a limit you set in your
+                          code.
                         </p>
                         <p>
-                          <span className="text-text-bright">Override</span>: set manually from the
-                          dashboard or API.
+                          <span className="text-text-bright">Override</span>: a limit you set here or
+                          via the API.
                         </p>
                       </div>
                     }
@@ -689,7 +690,7 @@ function QueuesWithMetricsView() {
                   </TableHeaderCell>
                   <TableHeaderCell
                     alignment="right"
-                    tooltip="p95 wait from eligible to dequeued, over the selected window."
+                    tooltip="How long runs waited before starting (95% were faster), over the selected time."
                   >
                     Delay p95
                   </TableHeaderCell>
@@ -697,7 +698,8 @@ function QueuesWithMetricsView() {
                     alignment="right"
                     tooltip={
                       <>
-                        Runs waiting over the selected window. <WarningSwatch /> where throttled.
+                        How many runs were waiting, over the selected time. <WarningSwatch /> marks
+                        where the queue was throttled.
                       </>
                     }
                   >
@@ -1244,8 +1246,8 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
     label: "Env saturation",
     description: (
       <>
-        Running as a share of the environment limit. Turns <WarningSwatch /> over 100% (burst
-        headroom).
+        How much of the environment's concurrency these queues are using. Turns{" "}
+        <WarningSwatch /> above 100%, when they're into burst capacity.
       </>
     ),
     color: "var(--color-queues)",
@@ -1272,7 +1274,7 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
   {
     id: "backlog",
     label: "Backlog",
-    description: "Runs waiting across these queues over time.",
+    description: "How many runs are waiting across these queues, over time.",
     color: "var(--color-queues)",
     query: `SELECT timeBucket() AS t,\n  queue,\n  max(max_queued) AS queued\nFROM queue_metrics\nGROUP BY t, queue\nORDER BY t`,
     derive: (rows) => {
@@ -1289,7 +1291,8 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
     label: "Scheduling delay p95",
     description: (
       <>
-        p95 wait from eligible to dequeued. Turns <WarningSwatch /> over 1 min.
+        How long runs wait before they start (95% start faster than this). Turns{" "}
+        <WarningSwatch /> above 1 minute.
       </>
     ),
     totalTooltip: "The worst p95 in the selected window.",
@@ -1317,7 +1320,7 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
   {
     id: "throttled",
     label: "Throttled",
-    description: "Times dequeuing was blocked by a limit.",
+    description: "How often runs were held back by a limit.",
     totalTooltip: "The share of the selected window with at least one blocked dequeue.",
     color: "var(--color-queues)",
     legend: [{ color: "var(--color-warning)", label: "Throttled" }],

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -846,8 +846,7 @@ function QueuesWithMetricsView() {
                           actionClassName="pl-16"
                           className={cn(
                             "w-[1%]",
-                            queue.paused ? "opacity-50" : undefined,
-                            queue.concurrency?.overriddenAt && "font-medium text-text-bright"
+                            queue.paused ? "opacity-50" : undefined
                           )}
                           // Keep the whole row navigable: the override explainer is a tooltip
                           // button, so it renders beside the link (trailing) rather than nested
@@ -872,7 +871,7 @@ function QueuesWithMetricsView() {
                           }
                         >
                           {queue.concurrency?.overriddenAt ? (
-                            <span className="text-text-bright">Override</span>
+                            "Override"
                           ) : queue.concurrencyLimit ? (
                             "User"
                           ) : (

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -1469,7 +1469,7 @@ function QueueEnvMetricChart({
   return (
     <ChartCard
       title={
-        <span className="flex flex-col gap-0.5">
+        <span className="flex flex-col gap-1">
           <span className="flex items-baseline gap-2">
             <span className="flex items-center gap-1.5">
               {tile.label}
@@ -1509,7 +1509,7 @@ function QueueEnvMetricChart({
                   className="flex items-center gap-1 text-xs font-normal text-text-dimmed"
                 >
                   <span
-                    className="size-2.5 rounded-[3px]"
+                    className="size-2.5 rounded-[2px]"
                     style={{ backgroundColor: item.color }}
                   />
                   {item.label}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -542,7 +542,7 @@ function QueuesWithMetricsView() {
             />
             <BigNumber
               title={
-                <span className="flex items-center gap-1.5">
+                <span className="flex items-center gap-1">
                   Allocated
                   {allocation && overAllocated ? (
                     <InfoIconTooltip
@@ -1441,7 +1441,7 @@ function QueueEnvMetricChart({
       title={
         <span className="flex flex-col gap-1">
           <span className="flex items-baseline gap-2">
-            <span className="flex items-center gap-1.5">
+            <span className="flex items-center gap-1">
               {tile.label}
               <InfoIconTooltip content={tile.description} contentClassName="max-w-[230px]" />
             </span>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -1103,7 +1103,7 @@ function EnvironmentPauseResumeButton({
               }
               cancelButton={
                 <DialogClose asChild>
-                  <Button type="button" variant="tertiary/medium">
+                  <Button type="button" variant="secondary/medium">
                     Cancel
                   </Button>
                 </DialogClose>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -491,7 +491,7 @@ function QueuesWithMetricsView() {
             cluster = pagination. */}
         {success ? (
           <MetricsLayout.Filters>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1.5">
               <QueueFilters />
               <TimeFilter
                 defaultPeriod={QUEUE_METRICS_DEFAULT_PERIOD}
@@ -502,7 +502,7 @@ function QueuesWithMetricsView() {
                 shortcut={{ key: "d" }}
               />
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1.5">
               {environment.runsEnabled &&
               env.pauseSource !== ENVIRONMENT_PAUSE_SOURCE_BILLING_LIMIT ? (
                 <EnvironmentPauseResumeButton env={env} />

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -670,8 +670,9 @@ function QueuesWithMetricsView() {
                   </TableHeaderCell>
                   <TableHeaderCell
                     alignment="right"
+                    tooltipContentClassName="max-w-max"
                     tooltip={
-                      <div className="max-w-xs space-y-1 p-1 text-left text-xs text-text-dimmed">
+                      <div className="max-w-max space-y-1 p-1 text-left text-xs text-text-dimmed">
                         <p>
                           <span className="text-text-bright">Environment</span>: uses the
                           environment limit of {environment.concurrencyLimit}.

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -673,6 +673,7 @@ function QueuesWithMetricsView() {
                   <TableHeaderCell
                     alignment="right"
                     tooltipContentClassName="max-w-max"
+                    disableTooltipHoverableContent
                     tooltip={
                       <div className="max-w-max space-y-1 p-1 text-left text-xs text-text-dimmed">
                         <p>
@@ -697,12 +698,14 @@ function QueuesWithMetricsView() {
                   </TableHeaderCell>
                   <TableHeaderCell
                     alignment="right"
+                    disableTooltipHoverableContent
                     tooltip="How long runs waited before starting (95% were faster), over the selected time."
                   >
                     Delay p95
                   </TableHeaderCell>
                   <TableHeaderCell
                     alignment="right"
+                    disableTooltipHoverableContent
                     tooltip={
                       <>
                         How many runs were waiting, over the selected time. <WarningSwatch /> marks

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -951,7 +951,7 @@ function QueuesWithMetricsView() {
                                 })}
                               />
                               <PopoverMenuItem
-                                icon={RectangleStackIcon}
+                                icon={QueuesIcon}
                                 leadingIconClassName="text-queues"
                                 title="View queued runs"
                                 to={v3RunsPath(organization, project, env, {

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -453,19 +453,17 @@ function QueuesWithMetricsView() {
         {/* Filters — pinned bar directly under the NavBar. Left cluster = search + period; right
             cluster = pagination. */}
         {success ? (
-          <MetricsLayout.Filters>
+          <MetricsLayout.Filters className="px-2">
             <div className="flex items-center gap-1.5">
               <QueueFilters />
+            </div>
+            <div className="flex items-center gap-1.5">
               <TimeFilter
                 defaultPeriod={QUEUE_METRICS_DEFAULT_PERIOD}
                 labelName="Period"
-                hideLabel
                 maxPeriodDays={maxPeriodDays}
-                valueClassName="text-text-bright"
                 shortcut={{ key: "d" }}
               />
-            </div>
-            <div className="flex items-center gap-1.5">
               {environment.runsEnabled &&
               env.pauseSource !== ENVIRONMENT_PAUSE_SOURCE_BILLING_LIMIT ? (
                 <EnvironmentPauseResumeButton env={env} />

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -603,19 +603,21 @@ function QueuesWithMetricsView() {
                   plan?.v3Subscription?.plan?.limits.concurrentRuns.canExceed ? (
                     <LinkButton
                       to={concurrencyPath(organization, project, env)}
-                      variant="secondary/small-icon"
+                      variant="secondary/small"
                       LeadingIcon={ConcurrencyIcon}
                       leadingIconClassName="text-amber-500"
-                      tooltip="Increase limit"
-                    />
+                    >
+                      Increase limit
+                    </LinkButton>
                   ) : (
                     <LinkButton
                       to={v3BillingPath(organization, "Upgrade your plan for more concurrency")}
-                      variant="secondary/small-icon"
+                      variant="secondary/small"
                       LeadingIcon={ArrowUpCircleIcon}
                       leadingIconClassName="text-indigo-500"
-                      tooltip="Increase limit"
-                    />
+                    >
+                      Increase limit
+                    </LinkButton>
                   )
                 ) : undefined
               }

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -1047,8 +1047,8 @@ function EnvironmentPauseResumeButton({
                     leadingIconClassName={env.paused ? "text-success" : "text-warning"}
                     className={
                       env.paused
-                        ? "border-success/60 text-success hover:border-success"
-                        : "border-warning/60 text-warning hover:border-warning"
+                        ? "border-success/60 text-success [&_span]:text-success hover:border-success"
+                        : "border-warning/60 text-warning [&_span]:text-warning hover:border-warning"
                     }
                     aria-label={
                       env.paused

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -1484,7 +1484,7 @@ function QueueEnvMetricChart({
               )
             ) : null}
           </span>
-          {tile.legend ? (
+          {tile.legend && (showLoading || hasData) ? (
             <span className="flex items-center gap-2">
               {tile.legend.map((item) => (
                 <span

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -493,7 +493,8 @@ function QueuesWithMetricsView() {
               accessory={
                 <span className="opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
                   <LinkButton
-                    variant="secondary/small-icon"
+                    variant="minimal/small"
+                    className="aspect-square px-1!"
                     LeadingIcon={RunsIcon}
                     leadingIconClassName="text-text-dimmed group-hover/button:text-text-bright"
                     to={v3RunsPath(organization, project, env, {
@@ -526,7 +527,8 @@ function QueuesWithMetricsView() {
               accessory={
                 <span className="opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
                   <LinkButton
-                    variant="secondary/small-icon"
+                    variant="minimal/small"
+                    className="aspect-square px-1!"
                     LeadingIcon={RunsIcon}
                     leadingIconClassName="text-text-dimmed group-hover/button:text-text-bright"
                     to={v3RunsPath(organization, project, env, {
@@ -826,8 +828,8 @@ function QueuesWithMetricsView() {
                         >
                           {queue.concurrencyLimitOverridePercent !== null ? (
                             <>
-                              {limit}{" "}
-                              <span className="text-text-dimmed">
+                              {limit}
+                              <span className="ml-1 text-text-dimmed group-hover/table-row:text-text-bright">
                                 ({formatOverridePercent(queue.concurrencyLimitOverridePercent)}%)
                               </span>
                             </>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -661,15 +661,9 @@ function QueuesWithMetricsView() {
               <TableHeader>
                 <TableRow>
                   <TableHeaderCell>Name</TableHeaderCell>
-                  <TableHeaderCell alignment="right">
-                    Queued
-                  </TableHeaderCell>
-                  <TableHeaderCell alignment="right">
-                    Running
-                  </TableHeaderCell>
-                  <TableHeaderCell alignment="right">
-                    Limit
-                  </TableHeaderCell>
+                  <TableHeaderCell alignment="right">Queued</TableHeaderCell>
+                  <TableHeaderCell alignment="right">Running</TableHeaderCell>
+                  <TableHeaderCell alignment="right">Limit</TableHeaderCell>
                   <TableHeaderCell
                     alignment="right"
                     tooltipContentClassName="max-w-max"
@@ -685,17 +679,15 @@ function QueuesWithMetricsView() {
                           code.
                         </p>
                         <p>
-                          <span className="text-text-bright">Override</span>: a limit you set here or
-                          via the API.
+                          <span className="text-text-bright">Override</span>: a limit you set here
+                          or via the API.
                         </p>
                       </div>
                     }
                   >
                     Limited by
                   </TableHeaderCell>
-                  <TableHeaderCell alignment="right">
-                    Health
-                  </TableHeaderCell>
+                  <TableHeaderCell alignment="right">Health</TableHeaderCell>
                   <TableHeaderCell
                     alignment="right"
                     disableTooltipHoverableContent
@@ -844,10 +836,7 @@ function QueuesWithMetricsView() {
                           to={queueDetailPath}
                           alignment="right"
                           actionClassName="pl-16"
-                          className={cn(
-                            "w-[1%]",
-                            queue.paused ? "opacity-50" : undefined
-                          )}
+                          className={cn("w-[1%]", queue.paused ? "opacity-50" : undefined)}
                           // Keep the whole row navigable: the override explainer is a tooltip
                           // button, so it renders beside the link (trailing) rather than nested
                           // inside the <a>, and the label itself stays the link.
@@ -870,13 +859,11 @@ function QueuesWithMetricsView() {
                             ) : undefined
                           }
                         >
-                          {queue.concurrency?.overriddenAt ? (
-                            "Override"
-                          ) : queue.concurrencyLimit ? (
-                            "User"
-                          ) : (
-                            "Environment"
-                          )}
+                          {queue.concurrency?.overriddenAt
+                            ? "Override"
+                            : queue.concurrencyLimit
+                              ? "User"
+                              : "Environment"}
                         </TableCell>
                         <TableCell
                           to={queueDetailPath}
@@ -1258,8 +1245,8 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
     label: "Env saturation",
     description: (
       <>
-        How much of the environment's concurrency these queues are using. Turns{" "}
-        <WarningSwatch /> above 100%, when they're into burst capacity.
+        How much of the environment's concurrency these queues are using. Turns <WarningSwatch />{" "}
+        above 100%, when they're into burst capacity.
       </>
     ),
     color: "var(--color-queues)",
@@ -1303,8 +1290,8 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
     label: "Scheduling delay p95",
     description: (
       <>
-        How long runs wait before they start (95% start faster than this). Turns{" "}
-        <WarningSwatch /> above 1 minute.
+        How long runs wait before they start (95% start faster than this). Turns <WarningSwatch />{" "}
+        above 1 minute.
       </>
     ),
     totalTooltip: "The worst p95 in the selected window.",
@@ -1476,7 +1463,10 @@ function QueueEnvMetricChart({
                 />
               ) : (
                 <span
-                  className={cn("text-xs font-normal tabular-nums text-text-dimmed", totalClassName)}
+                  className={cn(
+                    "text-xs font-normal tabular-nums text-text-dimmed",
+                    totalClassName
+                  )}
                 >
                   {peak}
                 </span>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -1444,7 +1444,11 @@ function QueueEnvMetricChart({
           <span className="flex items-baseline gap-2">
             <span className="flex items-center gap-1">
               {tile.label}
-              <InfoIconTooltip content={tile.description} contentClassName="max-w-[230px]" />
+              <InfoIconTooltip
+                content={tile.description}
+                contentClassName="max-w-[230px]"
+                disableHoverableContent
+              />
             </span>
             {peak != null ? (
               tile.totalTooltip && !showLoading ? (

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -121,6 +121,10 @@ const QUEUE_METRICS_DEFAULT_PERIOD = "1d";
 const QUEUE_LIVE_BLOCKS_PERIOD = "15m";
 const QUEUE_LIVE_BLOCKS_QUERY =
   "SELECT timeBucket() AS t, max(max_env_queued) AS env_queued, max(max_env_running) AS env_running FROM env_metrics GROUP BY t ORDER BY t";
+// Trust the ClickHouse gauge only while its newest bucket is this recent; otherwise fall back to
+// the loader's Redis-exact live values (matches LIVE_GAUGE_FRESH_MS on the queue detail page / run
+// inspector).
+const LIVE_GAUGE_FRESH_MS = 90_000;
 
 export const meta: MetaFunction = () => {
   return [
@@ -408,11 +412,21 @@ function QueuesWithMetricsView() {
   });
   const lastLiveBlockRow =
     liveBlockRows.length > 0 ? liveBlockRows[liveBlockRows.length - 1] : null;
-  const envQueuedLive = lastLiveBlockRow
-    ? tileNumber(lastLiveBlockRow.env_queued)
+  // Only trust the gauge while its newest bucket is fresh. A row painted from the hook's cache on
+  // client-side nav-back (responseCache), or a quiet env whose latest bucket is minutes old, must
+  // not override the loader's Redis-exact live values with a stale count.
+  const lastLiveBucketMs = lastLiveBlockRow ? tileTimeToMs(lastLiveBlockRow.t) : NaN;
+  const freshLiveBlockRow =
+    lastLiveBlockRow &&
+    Number.isFinite(lastLiveBucketMs) &&
+    Date.now() - lastLiveBucketMs < LIVE_GAUGE_FRESH_MS
+      ? lastLiveBlockRow
+      : null;
+  const envQueuedLive = freshLiveBlockRow
+    ? tileNumber(freshLiveBlockRow.env_queued)
     : environment.queued;
-  const envRunningLive = lastLiveBlockRow
-    ? tileNumber(lastLiveBlockRow.env_running)
+  const envRunningLive = freshLiveBlockRow
+    ? tileNumber(freshLiveBlockRow.env_running)
     : environment.running;
 
   // Allocation summary tiles. The presenter computes the env-wide allocated total (sum of

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -1038,6 +1038,11 @@ function EnvironmentPauseResumeButton({
                     variant="secondary/small"
                     LeadingIcon={env.paused ? PlayIcon : PauseIcon}
                     leadingIconClassName={env.paused ? "text-success" : "text-warning"}
+                    className={
+                      env.paused
+                        ? "border-success/60 hover:border-success"
+                        : "border-warning/60 hover:border-warning"
+                    }
                     aria-label={
                       env.paused
                         ? `Resume processing runs in ${environmentFullTitle(env)}`
@@ -1045,8 +1050,8 @@ function EnvironmentPauseResumeButton({
                     }
                   >
                     {env.paused
-                      ? `Resume ${environmentFullTitle(env)} environment`
-                      : `Pause ${environmentFullTitle(env)} environment`}
+                      ? `Resume ${environmentFullTitle(env)} environment…`
+                      : `Pause ${environmentFullTitle(env)} environment…`}
                   </Button>
                 </DialogTrigger>
               </div>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -861,6 +861,9 @@ function QueuesWithMetricsView() {
                                 }
                                 contentClassName="max-w-[230px]"
                                 disableHoverableContent
+                                // Tighten the gap from the "Override" label to gap-1 (the cell's
+                                // trailing adornment gap is gap-2; -ml-1 pulls the icon in 4px).
+                                buttonClassName="-ml-1"
                               />
                             ) : undefined
                           }
@@ -1197,8 +1200,8 @@ type QueueHeaderTile = {
   /** Formats the y-axis tick labels. Without it the axis shows raw numbers (bad for durations
    * in ms or percent scales). Passed through to Chart.Line's yAxisProps.tickFormatter. */
   formatAxis?: (value: number) => string;
-  /** Hover tooltip explaining the headline readout next to the title (e.g. what "9% of window"
-   * means). Without it the readout has no tooltip. */
+  /** Hover tooltip explaining the headline readout next to the title (e.g. what "9% of current
+   * period" means). Without it the readout has no tooltip. */
   totalTooltip?: string;
   // Rows can be one-per-bucket (p95, throttled: aggregated across the set in ClickHouse) or
   // one-per-(bucket, queue) (saturation, backlog: summed across the set here, since summing a
@@ -1346,7 +1349,7 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
       return {
         points,
         total: pct,
-        formatTotal: (v) => `${v}% of window`,
+        formatTotal: (v) => `${v}% of current period`,
         totalClassName: pct > 0 ? "text-warning" : undefined,
       };
     },

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -627,23 +627,23 @@ function QueuesWithMetricsView() {
                         ]
                       : undefined
                   }
-                  // Saturation and p95 "step over the line": a per-bucket overlay retraces only
-                  // the over-threshold stretches in warning colour, so under-threshold values stay
-                  // blue. (A gradient split can't do this reliably — an SVG objectBoundingBox
-                  // gradient tracks the line's own bbox, not the y-axis, so a low/flat line reads
-                  // as entirely warning-coloured.)
-                  // All thresholded lines colour warning where they step over the threshold: the
-                  // per-bucket overlay retraces only the over-threshold stretches, so the colour
-                  // change tracks the axis crossing.
-                  warningOverlay={
+                  // Saturation recolours the line above its 100% limit with a gradient split, so
+                  // only the portion over the line is orange (the offset is derived from the line's
+                  // own value range, so the split lands exactly at 100% regardless of domain
+                  // padding). p95 and throttled use a per-bucket overlay: it retraces only the
+                  // over-threshold stretches, so under-threshold buckets stay blue.
+                  thresholdStroke={
                     tile.id === "saturation"
-                      ? { threshold: 100 }
-                      : tile.id === "p95"
-                        ? { threshold: 60_000 }
-                        : tile.id === "throttled"
-                          ? // Integer counts: threshold 0 warns once a bucket has ≥1 throttle.
-                            { threshold: 0 }
-                          : undefined
+                      ? { value: 100, aboveColor: "var(--color-warning)" }
+                      : undefined
+                  }
+                  warningOverlay={
+                    tile.id === "p95"
+                      ? { threshold: 60_000 }
+                      : tile.id === "throttled"
+                        ? // Integer counts: threshold 0 warns once a bucket has ≥1 throttle.
+                          { threshold: 0 }
+                        : undefined
                   }
                 />
               ))}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -1198,6 +1198,9 @@ type QueueHeaderTile = {
   /** Info-icon copy explaining what the chart shows, rendered next to the card title. */
   description: string;
   color: string;
+  /** Optional inline legend rendered below the card title: a fixed set of {colored square, label}
+   * entries, for charts where a colour (e.g. the orange warning line) needs explaining. */
+  legend?: Array<{ color: string; label: string }>;
   query: string;
   /** Formats a single bucket's value in the chart tooltip. */
   formatValue?: (value: number) => string;
@@ -1260,6 +1263,10 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
     label: "Env saturation",
     description: "Running as a share of the environment limit. Yellow over 100% (burst headroom).",
     color: "var(--color-queues)",
+    legend: [
+      { color: "var(--color-queues)", label: "Saturation" },
+      { color: "var(--color-warning)", label: "Over limit" },
+    ],
     // Numerator: running summed across the visible set. Denominator: the env-wide limit (same for
     // every queue in a bucket), so the line reads as the set's share of the environment capacity.
     query: `SELECT timeBucket() AS t,\n  queue,\n  max(max_running) AS running,\n  max(max_env_limit) AS env_limit\nFROM queue_metrics\nGROUP BY t, queue\nORDER BY t`,
@@ -1297,6 +1304,10 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
     description: "p95 wait from eligible to dequeued. Yellow over 1 min.",
     totalTooltip: "The worst p95 in the selected window.",
     color: "var(--color-queues)",
+    legend: [
+      { color: "var(--color-queues)", label: "p95" },
+      { color: "var(--color-warning)", label: "Over 1 min" },
+    ],
     // quantilesMerge over the set's rows in a bucket is the true p95 across the union of samples
     // (merging quantile states is valid; averaging per-queue percentiles would not be).
     query: `SELECT timeBucket() AS t,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[3]) AS p95\nFROM queue_metrics\nGROUP BY t\nORDER BY t`,
@@ -1319,6 +1330,7 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
     description: "Times dequeuing was blocked by a limit.",
     totalTooltip: "The share of the selected window with at least one blocked dequeue.",
     color: "var(--color-queues)",
+    legend: [{ color: "var(--color-warning)", label: "Throttled" }],
     query: `SELECT timeBucket() AS t,\n  sum(throttled_count) AS throttled\nFROM queue_metrics\nGROUP BY t\nORDER BY t`,
     derive: (rows) => {
       const points = rows.map((r) => ({
@@ -1430,35 +1442,53 @@ function QueueEnvMetricChart({
   return (
     <ChartCard
       title={
-        <span className="flex items-baseline gap-2">
-          <span className="flex items-center gap-1.5">
-            {tile.label}
-            <InfoIconTooltip content={tile.description} contentClassName="max-w-xs" />
+        <span className="flex flex-col gap-0.5">
+          <span className="flex items-baseline gap-2">
+            <span className="flex items-center gap-1.5">
+              {tile.label}
+              <InfoIconTooltip content={tile.description} contentClassName="max-w-xs" />
+            </span>
+            {peak != null ? (
+              tile.totalTooltip && !showLoading ? (
+                <SimpleTooltip
+                  button={
+                    <span
+                      className={cn(
+                        "text-xs font-normal tabular-nums text-text-dimmed",
+                        totalClassName
+                      )}
+                    >
+                      {peak}
+                    </span>
+                  }
+                  content={tile.totalTooltip}
+                  className="max-w-xs"
+                  disableHoverableContent
+                />
+              ) : (
+                <span
+                  className={cn("text-xs font-normal tabular-nums text-text-dimmed", totalClassName)}
+                >
+                  {peak}
+                </span>
+              )
+            ) : null}
           </span>
-          {peak != null ? (
-            tile.totalTooltip && !showLoading ? (
-              <SimpleTooltip
-                button={
+          {tile.legend ? (
+            <span className="flex items-center gap-2">
+              {tile.legend.map((item) => (
+                <span
+                  key={item.label}
+                  className="flex items-center gap-1 text-xs font-normal text-text-dimmed"
+                >
                   <span
-                    className={cn(
-                      "text-xs font-normal tabular-nums text-text-dimmed",
-                      totalClassName
-                    )}
-                  >
-                    {peak}
-                  </span>
-                }
-                content={tile.totalTooltip}
-                className="max-w-xs"
-                disableHoverableContent
-              />
-            ) : (
-              <span
-                className={cn("text-xs font-normal tabular-nums text-text-dimmed", totalClassName)}
-              >
-                {peak}
-              </span>
-            )
+                    className="size-2.5 rounded-[3px]"
+                    style={{ backgroundColor: item.color }}
+                  />
+                  {item.label}
+                </span>
+              ))}
+            </span>
           ) : null}
         </span>
       }

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -949,7 +949,7 @@ function QueuesWithMetricsView() {
 
                               <PopoverMenuItem
                                 icon={RunsIcon}
-                                leadingIconClassName="text-runs"
+                                leadingIconClassName="text-runs size-[1.125rem]"
                                 title="View all runs"
                                 to={v3RunsPath(organization, project, env, {
                                   queues: [queueFilterableName],
@@ -959,7 +959,7 @@ function QueuesWithMetricsView() {
                               />
                               <PopoverMenuItem
                                 icon={QueuesIcon}
-                                leadingIconClassName="text-queues"
+                                leadingIconClassName="text-queues size-[1.125rem]"
                                 title="View queued runs"
                                 to={v3RunsPath(organization, project, env, {
                                   queues: [queueFilterableName],

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -797,7 +797,7 @@ function QueuesWithMetricsView() {
                               <SimpleTooltip
                                 button={<ExclamationTriangleIcon className="size-4 text-warning" />}
                                 content="At concurrency limit: this queue is running as many runs as its limit allows; new runs wait in the backlog."
-                                className="max-w-xs"
+                                className="max-w-[230px]"
                                 disableHoverableContent
                               />
                             ) : null
@@ -886,7 +886,7 @@ function QueuesWithMetricsView() {
                                       )}% of the environment limit.`
                                     : `This queue's concurrency limit has been manually overridden to ${limit}.`
                                 }
-                                contentClassName="max-w-xs"
+                                contentClassName="max-w-[230px]"
                                 disableHoverableContent
                               />
                             ) : undefined
@@ -1446,7 +1446,7 @@ function QueueEnvMetricChart({
           <span className="flex items-baseline gap-2">
             <span className="flex items-center gap-1.5">
               {tile.label}
-              <InfoIconTooltip content={tile.description} contentClassName="max-w-xs" />
+              <InfoIconTooltip content={tile.description} contentClassName="max-w-[230px]" />
             </span>
             {peak != null ? (
               tile.totalTooltip && !showLoading ? (
@@ -1462,7 +1462,7 @@ function QueueEnvMetricChart({
                     </span>
                   }
                   content={tile.totalTooltip}
-                  className="max-w-xs"
+                  className="max-w-[230px]"
                   disableHoverableContent
                 />
               ) : (
@@ -1828,7 +1828,7 @@ function ClassicQueuesView() {
                                     </Badge>
                                   }
                                   content="This queue's concurrency limit has been manually overridden from the dashboard or API."
-                                  className="max-w-xs"
+                                  className="max-w-[230px]"
                                   disableHoverableContent
                                 />
                               ) : null}
@@ -2012,7 +2012,7 @@ function BurstFactorTooltip({
       }, but you can burst up to ${
         environment.burstFactor * environment.concurrencyLimit
       } when across multiple queues/tasks.`}
-      contentClassName="max-w-xs"
+      contentClassName="max-w-[230px]"
     />
   );
 }

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -591,7 +591,7 @@ function QueuesWithMetricsView() {
               formattedValue={allocation ? undefined : "–"}
               valueClassName={cn(allocation && overAllocated && "text-warning")}
               suffix={allocation ? `${allocationPct}% of the environment limit` : undefined}
-              suffixClassName="text-text-bright"
+              suffixClassName="text-text-dimmed"
             />
             <BigNumber
               title="Environment limit"

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -491,17 +491,19 @@ function QueuesWithMetricsView() {
               suffix={env.paused ? <span className="text-warning">paused</span> : undefined}
               animate
               accessory={
-                <LinkButton
-                  variant="secondary/small-icon"
-                  LeadingIcon={RunsIcon}
-                  leadingIconClassName="text-runs"
-                  to={v3RunsPath(organization, project, env, {
-                    statuses: ["PENDING"],
-                    period: "30d",
-                    rootOnly: false,
-                  })}
-                  tooltip="View queued runs"
-                />
+                <span className="opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+                  <LinkButton
+                    variant="secondary/small-icon"
+                    LeadingIcon={RunsIcon}
+                    leadingIconClassName="text-text-dimmed group-hover/button:text-text-bright"
+                    to={v3RunsPath(organization, project, env, {
+                      statuses: ["PENDING"],
+                      period: "30d",
+                      rootOnly: false,
+                    })}
+                    tooltip="View queued runs"
+                  />
+                </span>
               }
               valueClassName={env.paused ? "text-warning tabular-nums" : "tabular-nums"}
               compactThreshold={1000000}
@@ -522,17 +524,19 @@ function QueuesWithMetricsView() {
                 ) : undefined
               }
               accessory={
-                <LinkButton
-                  variant="secondary/small-icon"
-                  LeadingIcon={RunsIcon}
-                  leadingIconClassName="text-runs"
-                  to={v3RunsPath(organization, project, env, {
-                    statuses: ["DEQUEUED", "EXECUTING"],
-                    period: "30d",
-                    rootOnly: false,
-                  })}
-                  tooltip="View in-progress runs"
-                />
+                <span className="opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+                  <LinkButton
+                    variant="secondary/small-icon"
+                    LeadingIcon={RunsIcon}
+                    leadingIconClassName="text-text-dimmed group-hover/button:text-text-bright"
+                    to={v3RunsPath(organization, project, env, {
+                      statuses: ["DEQUEUED", "EXECUTING"],
+                      period: "30d",
+                      rootOnly: false,
+                    })}
+                    tooltip="View in-progress runs"
+                  />
+                </span>
               }
               compactThreshold={1000000}
             />

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -43,7 +43,6 @@ import {
   TableHeaderCell,
   TableRow,
 } from "~/components/primitives/Table";
-import { useTableSort, type SortColumn } from "~/components/primitives/useTableSort";
 import {
   InfoIconTooltip,
   SimpleTooltip,
@@ -434,43 +433,6 @@ function QueuesWithMetricsView() {
   // Client-side, header-click sorting over the current page's rows. Server pagination and the
   // default busiest order are unchanged; clearing a sort returns to that server order.
   const queueRows = queues ?? [];
-  type QueueRow = (typeof queueRows)[number];
-  const sortColumns = useMemo<SortColumn<QueueRow>[]>(
-    () => [
-      { key: "name", type: "alpha", value: (q) => q.name },
-      { key: "queued", type: "number", value: (q) => q.queued },
-      { key: "running", type: "number", value: (q) => q.running },
-      {
-        key: "limit",
-        type: "number",
-        value: (q) => q.concurrencyLimit ?? environment.concurrencyLimit,
-      },
-      { key: "limitedBy", type: "alpha", value: (q) => queueLimitedByLabel(q) },
-      {
-        key: "health",
-        type: "alpha",
-        value: (q) =>
-          queueHealthLabel({
-            paused: q.paused,
-            running: q.running,
-            queued: q.queued,
-            limit: q.concurrencyLimit ?? environment.concurrencyLimit,
-          }),
-      },
-      {
-        key: "delayP95",
-        type: "number",
-        value: (q) => metricsByQueue[queueMetricsKey(q)]?.p95WaitMs ?? null,
-      },
-      {
-        key: "backlog",
-        type: "number",
-        value: (q) => metricsByQueue[queueMetricsKey(q)]?.peakQueued ?? null,
-      },
-    ],
-    [environment.concurrencyLimit, metricsByQueue]
-  );
-  const { sortedRows: sortedQueues, getSortProps } = useTableSort(queueRows, sortColumns);
 
   return (
     <PageContainer>
@@ -694,19 +656,18 @@ function QueuesWithMetricsView() {
             <Table containerClassName="border-t">
               <TableHeader>
                 <TableRow>
-                  <TableHeaderCell {...getSortProps("name")}>Name</TableHeaderCell>
-                  <TableHeaderCell alignment="right" {...getSortProps("queued")}>
+                  <TableHeaderCell>Name</TableHeaderCell>
+                  <TableHeaderCell alignment="right">
                     Queued
                   </TableHeaderCell>
-                  <TableHeaderCell alignment="right" {...getSortProps("running")}>
+                  <TableHeaderCell alignment="right">
                     Running
                   </TableHeaderCell>
-                  <TableHeaderCell alignment="right" {...getSortProps("limit")}>
+                  <TableHeaderCell alignment="right">
                     Limit
                   </TableHeaderCell>
                   <TableHeaderCell
                     alignment="right"
-                    {...getSortProps("limitedBy")}
                     tooltip={
                       <div className="max-w-xs space-y-1 p-1 text-left text-xs text-text-dimmed">
                         <p>
@@ -725,19 +686,17 @@ function QueuesWithMetricsView() {
                   >
                     Limited by
                   </TableHeaderCell>
-                  <TableHeaderCell alignment="right" {...getSortProps("health")}>
+                  <TableHeaderCell alignment="right">
                     Health
                   </TableHeaderCell>
                   <TableHeaderCell
                     alignment="right"
-                    {...getSortProps("delayP95")}
                     tooltip="p95 wait from eligible to dequeued, over the selected window."
                   >
                     Delay p95
                   </TableHeaderCell>
                   <TableHeaderCell
                     alignment="right"
-                    {...getSortProps("backlog")}
                     tooltip={
                       <>
                         Runs waiting over the selected window. <WarningSwatch /> where throttled.
@@ -752,8 +711,8 @@ function QueuesWithMetricsView() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {sortedQueues.length > 0 ? (
-                  sortedQueues.map((queue) => {
+                {queueRows.length > 0 ? (
+                  queueRows.map((queue) => {
                     const limit = queue.concurrencyLimit ?? environment.concurrencyLimit;
                     const isAtConcurrencyLimit = queue.running >= limit;
                     const isAtQueueLimit =
@@ -1600,16 +1559,6 @@ function QueueHealthBadge(health: QueueHealth) {
       {label}
     </Badge>
   );
-}
-
-// The label rendered in the "Limited by" cell, also used to sort that column.
-function queueLimitedByLabel(queue: {
-  concurrency?: { overriddenAt?: Date | string | null } | null;
-  concurrencyLimit?: number | null;
-}): "Override" | "User" | "Environment" {
-  if (queue.concurrency?.overriddenAt) return "Override";
-  if (queue.concurrencyLimit) return "User";
-  return "Environment";
 }
 
 // The `queue_metrics`-prefixed key a queue is stored under (task queues are prefixed `task/`).

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -10,7 +10,7 @@ import { DialogClose } from "@radix-ui/react-dialog";
 import { Form, useNavigation, type MetaFunction } from "@remix-run/react";
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import type { RuntimeEnvironmentType } from "@trigger.dev/database";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { z } from "zod";
 import { ConcurrencyIcon } from "~/assets/icons/ConcurrencyIcon";
@@ -709,14 +709,14 @@ function QueuesWithMetricsView() {
                     tooltip={
                       <div className="max-w-xs space-y-1 p-1 text-left text-xs text-text-dimmed">
                         <p>
-                          <span className="text-text-bright">Environment</span> — the environment's
+                          <span className="text-text-bright">Environment</span>: the environment's
                           limit of {environment.concurrencyLimit}.
                         </p>
                         <p>
-                          <span className="text-text-bright">User</span> — a limit set in your code.
+                          <span className="text-text-bright">User</span>: a limit set in your code.
                         </p>
                         <p>
-                          <span className="text-text-bright">Override</span> — set manually from the
+                          <span className="text-text-bright">Override</span>: set manually from the
                           dashboard or API.
                         </p>
                       </div>
@@ -737,7 +737,11 @@ function QueuesWithMetricsView() {
                   <TableHeaderCell
                     alignment="right"
                     {...getSortProps("backlog")}
-                    tooltip="Runs waiting over the selected window. Yellow where throttled."
+                    tooltip={
+                      <>
+                        Runs waiting over the selected window. <WarningSwatch /> where throttled.
+                      </>
+                    }
                   >
                     Backlog
                   </TableHeaderCell>
@@ -1194,11 +1198,23 @@ type MetricTileRow = Record<string, number | string | null>;
 /** One charted point per time bucket, already aggregated across the visible queue set. */
 type TilePoint = { bucket: number; value: number };
 
+// Inline colour swatch matching the chart's warning ("yellow") line — used in tooltip copy that
+// refers to that colour instead of naming it, so the swatch always matches the chart.
+function WarningSwatch() {
+  return (
+    <span
+      className="mx-0.5 inline-block size-2.5 rounded-[3px] align-middle"
+      style={{ backgroundColor: "var(--color-warning)" }}
+      aria-label="yellow"
+    />
+  );
+}
+
 type QueueHeaderTile = {
   id: string;
   label: string;
   /** Info-icon copy explaining what the chart shows, rendered next to the card title. */
-  description: string;
+  description: ReactNode;
   color: string;
   /** Optional inline legend rendered below the card title: a fixed set of {colored square, label}
    * entries, for charts where a colour (e.g. the orange warning line) needs explaining. */
@@ -1263,7 +1279,12 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
   {
     id: "saturation",
     label: "Env saturation",
-    description: "Running as a share of the environment limit. Yellow over 100% (burst headroom).",
+    description: (
+      <>
+        Running as a share of the environment limit. Turns <WarningSwatch /> over 100% (burst
+        headroom).
+      </>
+    ),
     color: "var(--color-queues)",
     legend: [
       { color: "var(--color-queues)", label: "Saturation" },
@@ -1303,7 +1324,11 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
   {
     id: "p95",
     label: "Scheduling delay p95",
-    description: "p95 wait from eligible to dequeued. Yellow over 1 min.",
+    description: (
+      <>
+        p95 wait from eligible to dequeued. Turns <WarningSwatch /> over 1 min.
+      </>
+    ),
     totalTooltip: "The worst p95 in the selected window.",
     color: "var(--color-queues)",
     legend: [

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -865,26 +865,35 @@ function QueuesWithMetricsView() {
                           )}
                         </TableCell>
                         <TableCell
+                          to={queueDetailPath}
                           alignment="right"
+                          actionClassName="pl-16"
                           className={cn(
-                            "w-[1%] pl-16",
+                            "w-[1%]",
                             queue.paused ? "opacity-50" : undefined,
                             queue.concurrency?.overriddenAt && "font-medium text-text-bright"
                           )}
+                          // Keep the whole row navigable: the override explainer is a tooltip
+                          // button, so it renders beside the link (trailing) rather than nested
+                          // inside the <a>, and the label itself stays the link.
+                          trailingContent={
+                            queue.concurrency?.overriddenAt ? (
+                              <InfoIconTooltip
+                                content={
+                                  queue.concurrencyLimitOverridePercent !== null
+                                    ? `Overridden at ${formatOverridePercent(
+                                        queue.concurrencyLimitOverridePercent
+                                      )}% of the environment limit.`
+                                    : `This queue's concurrency limit has been manually overridden to ${limit}.`
+                                }
+                                contentClassName="max-w-xs"
+                                disableHoverableContent
+                              />
+                            ) : undefined
+                          }
                         >
                           {queue.concurrency?.overriddenAt ? (
-                            <SimpleTooltip
-                              button={<span className="text-text-bright">Override</span>}
-                              content={
-                                queue.concurrencyLimitOverridePercent !== null
-                                  ? `Overridden at ${formatOverridePercent(
-                                      queue.concurrencyLimitOverridePercent
-                                    )}% of the environment limit.`
-                                  : `This queue's concurrency limit has been manually overridden to ${limit}.`
-                              }
-                              className="max-w-xs"
-                              disableHoverableContent
-                            />
+                            <span className="text-text-bright">Override</span>
                           ) : queue.concurrencyLimit ? (
                             "User"
                           ) : (

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -1168,7 +1168,7 @@ type TilePoint = { bucket: number; value: number };
 function WarningSwatch() {
   return (
     <span
-      className="mx-0.5 inline-block size-2.5 rounded-[3px] align-middle"
+      className="mx-0.5 inline-block size-2.5 -translate-y-px rounded-[2px] align-middle"
       style={{ backgroundColor: "var(--color-warning)" }}
       aria-label="yellow"
     />

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -1042,13 +1042,13 @@ function EnvironmentPauseResumeButton({
                     leadingIconClassName={env.paused ? "text-success" : "text-warning"}
                     className={
                       env.paused
-                        ? "border-success/60 hover:border-success"
-                        : "border-warning/60 hover:border-warning"
+                        ? "border-success/60 text-success hover:border-success"
+                        : "border-warning/60 text-warning hover:border-warning"
                     }
                     aria-label={
                       env.paused
-                        ? `Resume processing runs in ${environmentFullTitle(env)}`
-                        : `Pause processing runs in ${environmentFullTitle(env)}`
+                        ? `Resumes ${environmentFullTitle(env)} so its runs can be dequeued again.`
+                        : `Pauses all runs from being dequeued in ${environmentFullTitle(env)}. Any executing runs will continue to run.`
                     }
                   >
                     {env.paused
@@ -1060,8 +1060,8 @@ function EnvironmentPauseResumeButton({
             </TooltipTrigger>
             <TooltipContent className={"text-xs"}>
               {env.paused
-                ? `Resume processing runs in ${environmentFullTitle(env)}`
-                : `Pause processing runs in ${environmentFullTitle(env)}`}
+                ? `Resumes ${environmentFullTitle(env)} so its runs can be dequeued again.`
+                : `Pauses all runs from being dequeued in ${environmentFullTitle(env)}. Any executing runs will continue to run.`}
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -502,12 +502,18 @@ function QueuesWithMetricsView() {
                 shortcut={{ key: "d" }}
               />
             </div>
-            <PaginationControls
-              currentPage={pagination.currentPage}
-              totalPages={pagination.mode === "unfiltered" ? pagination.totalPages : 1}
-              hasNextPage={pagination.mode === "filtered" ? pagination.hasMore : undefined}
-              showPageNumbers={false}
-            />
+            <div className="flex items-center gap-2">
+              {environment.runsEnabled &&
+              env.pauseSource !== ENVIRONMENT_PAUSE_SOURCE_BILLING_LIMIT ? (
+                <EnvironmentPauseResumeButton env={env} />
+              ) : null}
+              <PaginationControls
+                currentPage={pagination.currentPage}
+                totalPages={pagination.mode === "unfiltered" ? pagination.totalPages : 1}
+                hasNextPage={pagination.mode === "filtered" ? pagination.hasMore : undefined}
+                showPageNumbers={false}
+              />
+            </div>
           </MetricsLayout.Filters>
         ) : null}
 
@@ -524,23 +530,17 @@ function QueuesWithMetricsView() {
               suffix={env.paused ? <span className="text-warning">paused</span> : undefined}
               animate
               accessory={
-                <div className="flex items-start gap-1">
-                  {environment.runsEnabled &&
-                  env.pauseSource !== ENVIRONMENT_PAUSE_SOURCE_BILLING_LIMIT ? (
-                    <EnvironmentPauseResumeButton env={env} />
-                  ) : null}
-                  <LinkButton
-                    variant="secondary/small-icon"
-                    LeadingIcon={RunsIcon}
-                    leadingIconClassName="text-runs"
-                    to={v3RunsPath(organization, project, env, {
-                      statuses: ["PENDING"],
-                      period: "30d",
-                      rootOnly: false,
-                    })}
-                    tooltip="View queued runs"
-                  />
-                </div>
+                <LinkButton
+                  variant="secondary/small-icon"
+                  LeadingIcon={RunsIcon}
+                  leadingIconClassName="text-runs"
+                  to={v3RunsPath(organization, project, env, {
+                    statuses: ["PENDING"],
+                    period: "30d",
+                    rootOnly: false,
+                  })}
+                  tooltip="View queued runs"
+                />
               }
               valueClassName={env.paused ? "text-warning tabular-nums" : "tabular-nums"}
               compactThreshold={1000000}
@@ -1062,7 +1062,7 @@ function EnvironmentPauseResumeButton({
                 <DialogTrigger asChild>
                   <Button
                     type="button"
-                    variant="secondary/small-icon"
+                    variant="secondary/small"
                     LeadingIcon={env.paused ? PlayIcon : PauseIcon}
                     leadingIconClassName={env.paused ? "text-success" : "text-warning"}
                     aria-label={
@@ -1070,7 +1070,11 @@ function EnvironmentPauseResumeButton({
                         ? `Resume processing runs in ${environmentFullTitle(env)}`
                         : `Pause processing runs in ${environmentFullTitle(env)}`
                     }
-                  />
+                  >
+                    {env.paused
+                      ? `Resume ${environmentFullTitle(env)} environment`
+                      : `Pause ${environmentFullTitle(env)} environment`}
+                  </Button>
                 </DialogTrigger>
               </div>
             </TooltipTrigger>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -245,7 +245,7 @@ export default function Page() {
             everything, like the Queues list. The time filter scopes the tab charts; search filters
             the keys table. The bar is pinned by the layout while the page scrolls. */}
         <MetricsLayout.Filters className="pl-1.5 pr-2">
-          <div className="self-end pl-2">
+          <div className="translate-y-px self-end pl-2">
             <TabContainer>
               <TabButton
                 isActive={view === "overview"}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -1073,7 +1073,9 @@ function ConcurrencyBlock({
               / {limit !== null ? limit.toLocaleString() : "∞"}
             </span>
             {limit !== null && limit > 0 && (
-              <span className={cn("text-xs", atLimit ? "text-warning" : "text-text-dimmed")}>
+              <span
+                className={cn("text-xs tabular-nums", atLimit ? "text-warning" : "text-text-dimmed")}
+              >
                 {/* Separator so the limit and the percentage don't read as one number
                     (e.g. "/ 25" + "44%" mashing into "2544%"). */}
                 <span className="mr-1 text-text-dimmed">·</span>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -348,6 +348,17 @@ export default function Page() {
   );
 }
 
+// Inline colour swatch for tooltip copy — matches the chart legend swatch (rounded-[2px]) and is
+// nudged up 1px so it sits on the text baseline.
+function ColorSwatch({ color }: { color: string }) {
+  return (
+    <span
+      className="mx-0.5 inline-block size-2.5 -translate-y-px rounded-[2px] align-middle"
+      style={{ backgroundColor: color }}
+    />
+  );
+}
+
 function OverviewCharts({
   ids,
   timeRange,
@@ -363,7 +374,14 @@ function OverviewCharts({
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <QueueDetailChartCard
           title="Concurrency"
-          info="How many runs are going at once (purple) versus the queue's limit (grey). Turns yellow at the limit."
+          info={
+            <>
+              How many runs are going at once (<ColorSwatch color={COLORS.running} /> color) versus
+              the queue's limit (<ColorSwatch color={COLORS.limit} /> color). Turns{" "}
+              <ColorSwatch color="var(--color-warning)" /> color when it reaches the limit.
+            </>
+          }
+          showLegend
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t, max(max_running) AS running, max(max_limit) AS limit\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps
@@ -375,15 +393,26 @@ function OverviewCharts({
             { key: "limit", label: "Limit", color: COLORS.limit },
             { key: "running", label: "Running", color: COLORS.running },
           ]}
-          // Recolour Running warning where it reaches the limit (saturated), matching the tooltip.
-          warningOverlay={{ series: "running", atOrAbove: "limit" }}
+          // Recolour Running above the limit line with a gradient split, so it's orange only where
+          // it's actually over the limit — not on the way up. The threshold reads off the (roughly
+          // constant) limit series.
+          thresholdStroke={{
+            series: "running",
+            valueFromSeries: "limit",
+            aboveColor: "var(--color-warning)",
+          }}
           // The limit is a config value emitted only while the queue is active; back-fill its
           // leading zeros so the reference line doesn't start with a false 0→limit step.
           carryBackfill={["limit"]}
         />
         <QueueDetailChartCard
           title="Queue depth"
-          info="How many runs are waiting in this queue, over time."
+          info={
+            <>
+              How many runs are waiting in this queue over time (
+              <ColorSwatch color={COLORS.queued} /> color).
+            </>
+          }
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t, max(max_queued) AS queued\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps
@@ -394,7 +423,14 @@ function OverviewCharts({
         />
         <QueueDetailChartCard
           title="Throughput"
-          info="Runs arriving (Enqueued, grey) versus starting (Started, purple). Turns yellow when Started falls behind."
+          info={
+            <>
+              Runs arriving (Enqueued, <ColorSwatch color={COLORS.limit} /> color) versus starting
+              (Started, <ColorSwatch color={COLORS.running} /> color). Turns{" "}
+              <ColorSwatch color="var(--color-warning)" /> color when Started falls behind.
+            </>
+          }
+          showLegend
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t,\n  deltaSumTimestampMerge(enqueue_delta) AS enqueued,\n  deltaSumTimestampMerge(started_delta) AS started\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps
@@ -411,7 +447,14 @@ function OverviewCharts({
         />
         <QueueDetailChartCard
           title="Scheduling delay"
-          info="How long runs wait before they start (p50/p95/p99)."
+          info={
+            <>
+              How long runs wait before they start: p50 (<ColorSwatch color={COLORS.p50} /> color),
+              p95 (<ColorSwatch color={COLORS.p95} /> color), and p99 (
+              <ColorSwatch color={COLORS.p99} /> color).
+            </>
+          }
+          showLegend
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[1]) AS p50,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[3]) AS p95,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[4]) AS p99\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps
@@ -427,7 +470,12 @@ function OverviewCharts({
         />
         <QueueDetailChartCard
           title="Throttled"
-          info="How often runs were held back by a limit."
+          info={
+            <>
+              How often runs were held back by a limit (<ColorSwatch color={COLORS.throttled} />{" "}
+              color).
+            </>
+          }
           className="aspect-[2/1] sm:col-span-2 sm:aspect-[4/1]"
           query={`SELECT timeBucket() AS t, sum(throttled_count) AS throttled\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps
@@ -844,7 +892,12 @@ function KeyDrilldown({
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <QueueDetailChartCard
           title={`Key ${keyName}: backlog and running`}
-          info="This key: waiting (Queued, purple) vs running (grey)."
+          info={
+            <>
+              This key: waiting (Queued, <ColorSwatch color={COLORS.queued} /> color) vs running (
+              <ColorSwatch color={COLORS.limit} /> color).
+            </>
+          }
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t, max(max_queued) AS queued, max(max_running) AS running\nFROM queue_metrics_by_key\nWHERE ${pin}\nGROUP BY t\nORDER BY t`}
           fillGaps

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -1050,7 +1050,7 @@ function ConcurrencyBlock({
   const atLimit = limit !== null && limit > 0 && running >= limit;
   const pct = limit && limit > 0 ? Math.min(100, Math.round((running / limit) * 100)) : 0;
   return (
-    <div className="flex flex-col justify-between gap-4 rounded-sm border border-grid-dimmed bg-background-bright p-4">
+    <div className="flex flex-col justify-between gap-4 rounded-lg border border-grid-bright bg-background-bright p-4">
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <Header3 className="leading-6">Concurrency</Header3>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -245,7 +245,7 @@ export default function Page() {
             everything, like the Queues list. The time filter scopes the tab charts; search filters
             the keys table. The bar is pinned by the layout while the page scrolls. */}
         <MetricsLayout.Filters className="pl-1.5 pr-2">
-          <div className="pl-2">
+          <div className="self-end pl-2">
             <TabContainer>
               <TabButton
                 isActive={view === "overview"}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -603,7 +603,7 @@ function chartTitleWithInfo(title: string, info: string) {
   return (
     <span className="flex items-center gap-1.5">
       {title}
-      <InfoIconTooltip content={info} contentClassName="max-w-xs" />
+      <InfoIconTooltip content={info} contentClassName="max-w-[230px]" />
     </span>
   );
 }

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -245,7 +245,25 @@ export default function Page() {
             everything, like the Queues list. The time filter scopes the tab charts; search filters
             the keys table. The bar is pinned by the layout while the page scrolls. */}
         <MetricsLayout.Filters>
-          <div className="flex items-center gap-2">
+          <div className="pl-2">
+            <TabContainer>
+              <TabButton
+                isActive={view === "overview"}
+                layoutId="queue-detail-view"
+                onClick={() => replace({ view: undefined, key: undefined })}
+              >
+                Overview
+              </TabButton>
+              <TabButton
+                isActive={view === "keys"}
+                layoutId="queue-detail-view"
+                onClick={() => replace({ view: "keys" })}
+              >
+                Concurrency keys
+              </TabButton>
+            </TabContainer>
+          </div>
+          <div className="flex items-center gap-1.5">
             {view === "keys" && hasKeys ? (
               <SearchInput placeholder="Search keys…" paramName="query" resetParams={["key"]} />
             ) : null}
@@ -256,6 +274,16 @@ export default function Page() {
               maxPeriodDays={maxPeriodDays}
               valueClassName="text-text-bright"
               shortcut={{ key: "d" }}
+            />
+            <QueueOverrideConcurrencyButton
+              queue={queue}
+              environmentConcurrencyLimit={environmentConcurrencyLimit}
+              trigger="button"
+            />
+            <QueuePauseResumeButton
+              queue={{ id: queue.id, name: queue.name, paused: queue.paused }}
+              variant="secondary/small"
+              withQueueName
             />
           </div>
         </MetricsLayout.Filters>
@@ -275,23 +303,6 @@ export default function Page() {
         {/* Tabs + charts share the padded (inset) column. Both tabs always render; the keys tab
             shows an empty state when the queue has no concurrency keys. */}
         <MetricsLayout.Content inset>
-          <TabContainer>
-            <TabButton
-              isActive={view === "overview"}
-              layoutId="queue-detail-view"
-              onClick={() => replace({ view: undefined, key: undefined })}
-            >
-              Overview
-            </TabButton>
-            <TabButton
-              isActive={view === "keys"}
-              layoutId="queue-detail-view"
-              onClick={() => replace({ view: "keys" })}
-            >
-              Concurrency keys
-            </TabButton>
-          </TabContainer>
-
           {view === "keys" ? (
             hasKeys ? (
               <ConcurrencyKeyCharts
@@ -983,25 +994,7 @@ function QueueStats({
 
   return (
     <MetricsLayout.Grid>
-      <ConcurrencyBlock
-        running={runningDisplay}
-        limit={limitDisplay}
-        paused={queue.paused}
-        accessory={
-          <div className="flex items-center gap-1">
-            <QueuePauseResumeButton
-              queue={{ id: queue.id, name: queue.name, paused: queue.paused }}
-              variant="secondary/small-icon"
-              iconOnly
-            />
-            <QueueOverrideConcurrencyButton
-              queue={queue}
-              environmentConcurrencyLimit={environmentConcurrencyLimit}
-              trigger="icon"
-            />
-          </div>
-        }
-      />
+      <ConcurrencyBlock running={runningDisplay} limit={limitDisplay} paused={queue.paused} />
       <BigNumber
         title="Queued"
         value={queuedDisplay}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -1,6 +1,6 @@
 import { type MetaFunction } from "@remix-run/react";
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from "@remix-run/server-runtime";
-import { useMemo, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { QueueItem } from "@trigger.dev/core/v3/schemas";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { z } from "zod";
@@ -49,6 +49,12 @@ import { SearchInput } from "~/components/primitives/SearchInput";
 import { engine } from "~/v3/runEngine.server";
 import { TimeFilter } from "~/components/runs/v3/SharedFilters";
 import { useSearchParams } from "~/hooks/useSearchParam";
+import { useInterval } from "~/hooks/useInterval";
+import { PaginationControls } from "~/components/primitives/Pagination";
+import type {
+  ConcurrencyKeyRow,
+  ConcurrencyKeysResponse,
+} from "~/routes/resources.queues.concurrency-keys";
 import { useCurrentPlan } from "../_app.orgs.$organizationSlug/route";
 import { canAccessQueueMetricsUi } from "~/v3/canAccessQueueMetricsUi.server";
 import { requireUserId } from "~/services/session.server";
@@ -270,7 +276,7 @@ export default function Page() {
           </div>
           <div className="flex items-center gap-1.5">
             {view === "keys" && hasKeys ? (
-              <SearchInput placeholder="Search keys…" paramName="query" resetParams={["key"]} />
+              <SearchInput placeholder="Search keys…" paramName="query" resetParams={["key", "page"]} />
             ) : null}
             <TimeFilter
               defaultPeriod={QUEUE_METRICS_DEFAULT_PERIOD}
@@ -329,13 +335,7 @@ export default function Page() {
         {view === "keys" && hasKeys ? (
           <>
             <MetricsLayout.Content>
-              <KeyStatsTable
-                breakdown={ckBreakdown}
-                loadedAt={loadedAt}
-                ids={ids}
-                timeRange={timeRange}
-                queueName={fullName}
-              />
+              <KeyStatsTable ids={ids} timeRange={timeRange} queueName={fullName} />
             </MetricsLayout.Content>
             {selectedKey ? (
               <MetricsLayout.Content inset>
@@ -756,117 +756,171 @@ function GroupedKeySeries({
   );
 }
 
-type KeyRangeStats = { started: number; peakBacklog: number; meanWaitMs: number };
+// One page of the paginated per-key table. The ClickHouse tier is the authority (ranked by peak
+// backlog over the window, with the total on every row so page + count are a single scan); each
+// page's keys are enriched with live "now" counts from Redis server-side. Fetched per page rather
+// than capped at 50, so high-cardinality queues (tens of thousands of keys) page through instead
+// of silently truncating. See resources.queues.concurrency-keys.
+function useConcurrencyKeys(opts: {
+  ids: Ids;
+  timeRange: TimeRangeParams;
+  queueName: string;
+  search: string;
+  page: number;
+}) {
+  const { ids, timeRange, queueName, search, page } = opts;
+  const [data, setData] = useState<ConcurrencyKeysResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const abortRef = useRef<AbortController | null>(null);
 
-// Live breakdown (queued/running now, oldest wait) merged with per-key range stats from
-// the history tier; keys with history but no live backlog still appear. Clicking a key
-// pins the drill-down charts via the `key` search param.
+  const body = useMemo(
+    () =>
+      JSON.stringify({
+        organizationId: ids.organizationId,
+        projectId: ids.projectId,
+        environmentId: ids.environmentId,
+        queueName,
+        period: timeRange.period,
+        from: timeRange.from,
+        to: timeRange.to,
+        search,
+        page,
+      }),
+    [
+      ids.organizationId,
+      ids.projectId,
+      ids.environmentId,
+      queueName,
+      timeRange.period,
+      timeRange.from,
+      timeRange.to,
+      search,
+      page,
+    ]
+  );
+
+  const load = useCallback(() => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setIsLoading(true);
+    fetch("/resources/queues/concurrency-keys", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+      signal: controller.signal,
+    })
+      .then((res) => res.json() as Promise<ConcurrencyKeysResponse>)
+      .then((res) => {
+        if (controller.signal.aborted) return;
+        setData(res);
+        setIsLoading(false);
+      })
+      .catch((error) => {
+        if (error instanceof DOMException && error.name === "AbortError") return;
+        if (!controller.signal.aborted) {
+          setData({ success: false, error: error?.message ?? "Network error" });
+          setIsLoading(false);
+        }
+      });
+  }, [body]);
+
+  useEffect(() => {
+    load();
+    return () => abortRef.current?.abort();
+  }, [load]);
+
+  // Keep the live "now" counts fresh without a manual reload.
+  useInterval({
+    interval: 30_000,
+    onLoad: false,
+    onFocus: true,
+    pauseWhenHidden: true,
+    callback: load,
+  });
+
+  return { data, isLoading };
+}
+
+// Paginated per-key table: which keys hold the backlog / do the work. Clicking a key pins the
+// drill-down charts via the `key` search param.
 function KeyStatsTable({
-  breakdown,
-  loadedAt,
   ids,
   timeRange,
   queueName,
 }: {
-  breakdown: CkBreakdown;
-  loadedAt: number;
   ids: Ids;
   timeRange: TimeRangeParams;
   queueName: string;
 }) {
   const { value, replace, del } = useSearchParams();
   const selectedKey = value("key");
+  const search = value("query")?.trim() ?? "";
+  const page = Math.max(1, Number(value("page")) || 1);
 
-  const { rows, showLoading } = useQueueMetric(
-    `SELECT concurrency_key,\n  deltaSumTimestampMerge(started_delta) AS started,\n  max(max_queued) AS peak_backlog,\n  if(sum(wait_ms_count) > 0, round(sum(wait_ms_sum) / sum(wait_ms_count)), 0) AS mean_wait\nFROM queue_metrics_by_key\nGROUP BY concurrency_key\nORDER BY peak_backlog DESC\nLIMIT 50`,
-    { ids, timeRange, queueName }
-  );
+  const { data, isLoading } = useConcurrencyKeys({ ids, timeRange, queueName, search, page });
 
-  const merged = useMemo(() => {
-    const range = new Map<string, KeyRangeStats>();
-    for (const r of rows) {
-      range.set(String(r.concurrency_key), {
-        started: toNumber(r.started),
-        peakBacklog: toNumber(r.peak_backlog),
-        meanWaitMs: toNumber(r.mean_wait),
-      });
-    }
-    const liveKeys = new Set(breakdown.keys.map((k) => k.concurrencyKey));
-    const live = breakdown.keys.map((k) => ({
-      key: k.concurrencyKey,
-      queued: k.queued,
-      running: k.running,
-      oldestWaitMs: Math.max(0, loadedAt - k.oldestEnqueuedAt),
-      range: range.get(k.concurrencyKey),
-    }));
-    const historyOnly = [...range.entries()]
-      .filter(([key]) => !liveKeys.has(key))
-      .map(([key, stats]) => ({
-        key,
-        queued: 0,
-        running: 0,
-        oldestWaitMs: null as number | null,
-        range: stats,
-      }));
-    return [...live, ...historyOnly].slice(0, 50);
-  }, [rows, breakdown, loadedAt]);
-
-  // The top-bar search filters the key list by substring (case-insensitive), the same idea as the
-  // Queues page search over queue names.
-  const query = value("query")?.trim().toLowerCase();
-  const filtered = useMemo(
-    () => (query ? merged.filter((r) => r.key.toLowerCase().includes(query)) : merged),
-    [merged, query]
-  );
-
-  if (merged.length === 0) return null;
+  const rows: ConcurrencyKeyRow[] = data?.success ? data.rows : [];
+  const total = data?.success ? data.total : 0;
+  const perPage = data?.success ? data.perPage : 50;
+  const totalPages = Math.max(1, Math.ceil(total / perPage));
+  // Only show a skeleton before the first response; keep prior rows visible while revalidating.
+  const showLoading = isLoading && !data;
 
   return (
-    // Full-bleed, edge-to-edge like the Queues list table: a top border, no rounded side box.
-    <Table containerClassName="border-t">
-      <TableHeader>
-        <TableRow>
-          <TableHeaderCell>Key</TableHeaderCell>
-          <TableHeaderCell alignment="right">Queued now</TableHeaderCell>
-          <TableHeaderCell alignment="right">Running now</TableHeaderCell>
-          <TableHeaderCell alignment="right">Oldest wait</TableHeaderCell>
-          <TableHeaderCell alignment="right">Started</TableHeaderCell>
-          <TableHeaderCell alignment="right">Peak backlog</TableHeaderCell>
-          <TableHeaderCell alignment="right">Mean delay</TableHeaderCell>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {filtered.length === 0 ? (
-          <TableBlankRow colSpan={7} className="text-text-dimmed">
-            No keys match “{query}”
-          </TableBlankRow>
-        ) : null}
-        {filtered.map((row) => (
-          <TableRow
-            key={row.key}
-            isSelected={selectedKey === row.key}
-            className="cursor-pointer"
-            onClick={() => (selectedKey === row.key ? del("key") : replace({ key: row.key }))}
-          >
-            <TableCell>{row.key}</TableCell>
-            <TableCell alignment="right">{row.queued.toLocaleString()}</TableCell>
-            <TableCell alignment="right">{row.running.toLocaleString()}</TableCell>
-            <TableCell alignment="right">
-              {row.oldestWaitMs === null ? "–" : formatWaitMs(row.oldestWaitMs)}
-            </TableCell>
-            <TableCell alignment="right">
-              {row.range ? row.range.started.toLocaleString() : showLoading ? "…" : "–"}
-            </TableCell>
-            <TableCell alignment="right">
-              {row.range ? row.range.peakBacklog.toLocaleString() : showLoading ? "…" : "–"}
-            </TableCell>
-            <TableCell alignment="right">
-              {row.range && row.range.meanWaitMs > 0 ? formatWaitMs(row.range.meanWaitMs) : "–"}
-            </TableCell>
+    <div className="flex flex-col">
+      {/* Full-bleed, edge-to-edge like the Queues list table: a top border, no rounded side box. */}
+      <Table containerClassName="border-t">
+        <TableHeader>
+          <TableRow>
+            <TableHeaderCell>Key</TableHeaderCell>
+            <TableHeaderCell alignment="right">Queued now</TableHeaderCell>
+            <TableHeaderCell alignment="right">Running now</TableHeaderCell>
+            <TableHeaderCell alignment="right">Oldest wait</TableHeaderCell>
+            <TableHeaderCell alignment="right">Started</TableHeaderCell>
+            <TableHeaderCell alignment="right">Peak backlog</TableHeaderCell>
+            <TableHeaderCell alignment="right">Mean delay</TableHeaderCell>
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+        </TableHeader>
+        <TableBody>
+          {showLoading ? (
+            <TableBlankRow colSpan={7} className="text-text-dimmed">
+              Loading…
+            </TableBlankRow>
+          ) : rows.length === 0 ? (
+            <TableBlankRow colSpan={7} className="text-text-dimmed">
+              {search ? `No keys match “${search}”` : "No concurrency keys"}
+            </TableBlankRow>
+          ) : (
+            rows.map((row) => (
+              <TableRow
+                key={row.key}
+                isSelected={selectedKey === row.key}
+                className="cursor-pointer"
+                onClick={() => (selectedKey === row.key ? del("key") : replace({ key: row.key }))}
+              >
+                <TableCell>{row.key}</TableCell>
+                <TableCell alignment="right">{row.queued.toLocaleString()}</TableCell>
+                <TableCell alignment="right">{row.running.toLocaleString()}</TableCell>
+                <TableCell alignment="right">
+                  {row.oldestWaitMs === null ? "–" : formatWaitMs(row.oldestWaitMs)}
+                </TableCell>
+                <TableCell alignment="right">{row.started.toLocaleString()}</TableCell>
+                <TableCell alignment="right">{row.peakBacklog.toLocaleString()}</TableCell>
+                <TableCell alignment="right">
+                  {row.meanWaitMs > 0 ? formatWaitMs(row.meanWaitMs) : "–"}
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+      {totalPages > 1 ? (
+        <div className="flex justify-end px-3 py-2">
+          <PaginationControls currentPage={page} totalPages={totalPages} />
+        </div>
+      ) : null}
+    </div>
   );
 }
 

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -429,7 +429,7 @@ function OverviewCharts({
         <QueueDetailChartCard
           title="Throttled"
           info="Times dequeuing was blocked by a limit."
-          className="aspect-[2/1]"
+          className="aspect-[2/1] sm:col-span-2 sm:aspect-[4/1]"
           query={`SELECT timeBucket() AS t, sum(throttled_count) AS throttled\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps
           ids={ids}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -382,8 +382,8 @@ function OverviewCharts({
           title="Concurrency"
           info={
             <>
-              How many runs are going at once (<ColorSwatch color={COLORS.running} /> color) versus
-              the queue's limit (<ColorSwatch color={COLORS.limit} /> color). Turns{" "}
+              How many runs are executing at once (<ColorSwatch color={COLORS.running} />) versus
+              the queue's limit (<ColorSwatch color={COLORS.limit} />). Turns{" "}
               <ColorSwatch color="var(--color-warning)" /> color when it reaches the limit.
             </>
           }
@@ -413,12 +413,7 @@ function OverviewCharts({
         />
         <QueueDetailChartCard
           title="Queue depth"
-          info={
-            <>
-              How many runs are waiting in this queue over time (
-              <ColorSwatch color={COLORS.queued} /> color).
-            </>
-          }
+          info="How many runs are waiting in this queue over time."
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t, max(max_queued) AS queued\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps
@@ -431,8 +426,8 @@ function OverviewCharts({
           title="Throughput"
           info={
             <>
-              Runs arriving (Enqueued, <ColorSwatch color={COLORS.limit} /> color) versus starting
-              (Started, <ColorSwatch color={COLORS.running} /> color). Turns{" "}
+              Runs arriving (<ColorSwatch color={COLORS.limit} /> Enqueued) versus starting
+              (<ColorSwatch color={COLORS.running} /> Started). Turns{" "}
               <ColorSwatch color="var(--color-warning)" /> color when Started falls behind.
             </>
           }
@@ -453,13 +448,7 @@ function OverviewCharts({
         />
         <QueueDetailChartCard
           title="Scheduling delay"
-          info={
-            <>
-              How long runs wait before they start: p50 (<ColorSwatch color={COLORS.p50} /> color),
-              p95 (<ColorSwatch color={COLORS.p95} /> color), and p99 (
-              <ColorSwatch color={COLORS.p99} /> color).
-            </>
-          }
+          info="How long runs wait before they start."
           showLegend
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[1]) AS p50,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[3]) AS p95,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[4]) AS p99\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -48,7 +48,6 @@ import { SearchInput } from "~/components/primitives/SearchInput";
 import { engine } from "~/v3/runEngine.server";
 import { TimeFilter } from "~/components/runs/v3/SharedFilters";
 import { useSearchParams } from "~/hooks/useSearchParam";
-import { useTableSort, type SortColumn } from "~/components/primitives/useTableSort";
 import { useCurrentPlan } from "../_app.orgs.$organizationSlug/route";
 import { canAccessQueueMetricsUi } from "~/v3/canAccessQueueMetricsUi.server";
 import { requireUserId } from "~/services/session.server";
@@ -776,20 +775,6 @@ function KeyStatsTable({
     [merged, query]
   );
 
-  const sortColumns = useMemo<SortColumn<(typeof merged)[number]>[]>(
-    () => [
-      { key: "key", type: "alpha", value: (r) => r.key },
-      { key: "queued", type: "number", value: (r) => r.queued },
-      { key: "running", type: "number", value: (r) => r.running },
-      { key: "oldestWait", type: "number", value: (r) => r.oldestWaitMs },
-      { key: "started", type: "number", value: (r) => r.range?.started },
-      { key: "peakBacklog", type: "number", value: (r) => r.range?.peakBacklog },
-      { key: "meanWait", type: "number", value: (r) => r.range?.meanWaitMs },
-    ],
-    []
-  );
-  const { sortedRows, getSortProps } = useTableSort(filtered, sortColumns);
-
   if (merged.length === 0) return null;
 
   return (
@@ -797,34 +782,22 @@ function KeyStatsTable({
     <Table containerClassName="border-t">
       <TableHeader>
         <TableRow>
-          <TableHeaderCell {...getSortProps("key")}>Key</TableHeaderCell>
-          <TableHeaderCell alignment="right" {...getSortProps("queued")}>
-            Queued now
-          </TableHeaderCell>
-          <TableHeaderCell alignment="right" {...getSortProps("running")}>
-            Running now
-          </TableHeaderCell>
-          <TableHeaderCell alignment="right" {...getSortProps("oldestWait")}>
-            Oldest wait
-          </TableHeaderCell>
-          <TableHeaderCell alignment="right" {...getSortProps("started")}>
-            Started
-          </TableHeaderCell>
-          <TableHeaderCell alignment="right" {...getSortProps("peakBacklog")}>
-            Peak backlog
-          </TableHeaderCell>
-          <TableHeaderCell alignment="right" {...getSortProps("meanWait")}>
-            Mean delay
-          </TableHeaderCell>
+          <TableHeaderCell>Key</TableHeaderCell>
+          <TableHeaderCell alignment="right">Queued now</TableHeaderCell>
+          <TableHeaderCell alignment="right">Running now</TableHeaderCell>
+          <TableHeaderCell alignment="right">Oldest wait</TableHeaderCell>
+          <TableHeaderCell alignment="right">Started</TableHeaderCell>
+          <TableHeaderCell alignment="right">Peak backlog</TableHeaderCell>
+          <TableHeaderCell alignment="right">Mean delay</TableHeaderCell>
         </TableRow>
       </TableHeader>
       <TableBody>
-        {sortedRows.length === 0 ? (
+        {filtered.length === 0 ? (
           <TableBlankRow colSpan={7} className="text-text-dimmed">
             No keys match “{query}”
           </TableBlankRow>
         ) : null}
-        {sortedRows.map((row) => (
+        {filtered.map((row) => (
           <TableRow
             key={row.key}
             isSelected={selectedKey === row.key}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -867,6 +867,16 @@ function KeyStatsTable({
   // Only show a skeleton before the first response; keep prior rows visible while revalidating.
   const showLoading = isLoading && !data;
 
+  // Recover from a page past the end: narrowing the time range (or a stale bookmarked URL) can
+  // leave `page` beyond the result set, which comes back empty with the pagination control — shown
+  // only when there's >1 page — hidden, stranding the reader. Once a response settles empty on a
+  // page > 1, snap back to page 1 (whose data is fetched fresh) so there's always a way out.
+  useEffect(() => {
+    if (!isLoading && data?.success && data.rows.length === 0 && page > 1) {
+      del("page");
+    }
+  }, [isLoading, data, page, del]);
+
   return (
     <div className="flex flex-col">
       {/* Title bar above the table, shown only when there's more than one page: the section title

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -244,7 +244,7 @@ export default function Page() {
         {/* Filters — search (concurrency keys) + time filter in one left cluster, above
             everything, like the Queues list. The time filter scopes the tab charts; search filters
             the keys table. The bar is pinned by the layout while the page scrolls. */}
-        <MetricsLayout.Filters>
+        <MetricsLayout.Filters className="pl-1.5 pr-2">
           <div className="pl-2">
             <TabContainer>
               <TabButton
@@ -270,9 +270,7 @@ export default function Page() {
             <TimeFilter
               defaultPeriod={QUEUE_METRICS_DEFAULT_PERIOD}
               labelName="Period"
-              hideLabel
               maxPeriodDays={maxPeriodDays}
-              valueClassName="text-text-bright"
               shortcut={{ key: "d" }}
             />
             <QueueOverrideConcurrencyButton

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -862,13 +862,21 @@ function KeyStatsTable({
 
   const rows: ConcurrencyKeyRow[] = data?.success ? data.rows : [];
   const total = data?.success ? data.total : 0;
-  const perPage = data?.success ? data.perPage : 50;
+  const perPage = data?.success ? data.perPage : 25;
   const totalPages = Math.max(1, Math.ceil(total / perPage));
   // Only show a skeleton before the first response; keep prior rows visible while revalidating.
   const showLoading = isLoading && !data;
 
   return (
     <div className="flex flex-col">
+      {/* Title bar above the table, shown only when there's more than one page: the section title
+          on the left, prev/next pagination on the right. Hidden entirely for a single page. */}
+      {totalPages > 1 ? (
+        <div className="flex items-center justify-between border-t px-3 py-2">
+          <Header3>Concurrency keys</Header3>
+          <PaginationControls currentPage={page} totalPages={totalPages} showPageNumbers={false} />
+        </div>
+      ) : null}
       {/* Full-bleed, edge-to-edge like the Queues list table: a top border, no rounded side box. */}
       <Table containerClassName="border-t">
         <TableHeader>
@@ -915,11 +923,6 @@ function KeyStatsTable({
           )}
         </TableBody>
       </Table>
-      {totalPages > 1 ? (
-        <div className="flex justify-end px-3 py-2">
-          <PaginationControls currentPage={page} totalPages={totalPages} />
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -364,7 +364,7 @@ function OverviewCharts({
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <QueueDetailChartCard
           title="Concurrency"
-          info="Running (purple) against the queue's concurrency limit (grey). Yellow when at the limit."
+          info="How many runs are going at once (purple) versus the queue's limit (grey). Turns yellow at the limit."
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t, max(max_running) AS running, max(max_limit) AS limit\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps
@@ -384,7 +384,7 @@ function OverviewCharts({
         />
         <QueueDetailChartCard
           title="Queue depth"
-          info="Runs waiting in this queue over time."
+          info="How many runs are waiting in this queue, over time."
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t, max(max_queued) AS queued\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps
@@ -395,7 +395,7 @@ function OverviewCharts({
         />
         <QueueDetailChartCard
           title="Throughput"
-          info="Runs entering the queue (Enqueued, grey) versus leaving it (Started, purple). Yellow when Started falls behind."
+          info="Runs arriving (Enqueued, grey) versus starting (Started, purple). Turns yellow when Started falls behind."
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t,\n  deltaSumTimestampMerge(enqueue_delta) AS enqueued,\n  deltaSumTimestampMerge(started_delta) AS started\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps
@@ -412,7 +412,7 @@ function OverviewCharts({
         />
         <QueueDetailChartCard
           title="Scheduling delay"
-          info="Wait from eligible to dequeued (p50/p95/p99)."
+          info="How long runs wait before they start (p50/p95/p99)."
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[1]) AS p50,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[3]) AS p95,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[4]) AS p99\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps
@@ -428,7 +428,7 @@ function OverviewCharts({
         />
         <QueueDetailChartCard
           title="Throttled"
-          info="Times dequeuing was blocked by a limit."
+          info="How often runs were held back by a limit."
           className="aspect-[2/1] sm:col-span-2 sm:aspect-[4/1]"
           query={`SELECT timeBucket() AS t, sum(throttled_count) AS throttled\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -432,6 +432,7 @@ function OverviewCharts({
             </>
           }
           showLegend
+          extraLegend={[{ color: "var(--color-warning)", label: "Falling behind" }]}
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t,\n  deltaSumTimestampMerge(enqueue_delta) AS enqueued,\n  deltaSumTimestampMerge(started_delta) AS started\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -6,6 +6,7 @@ import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { z } from "zod";
 import { MainCenteredContainer, PageContainer } from "~/components/layout/AppLayout";
 import { MetricsLayout } from "~/components/layout/MetricsLayout";
+import { AnimatedOrgBannerBar } from "~/components/billing/AnimatedOrgBannerBar";
 import { BigNumber } from "~/components/metrics/BigNumber";
 import { Header3 } from "~/components/primitives/Headers";
 import { NavBar, PageTitle } from "~/components/primitives/PageHeader";
@@ -239,6 +240,11 @@ export default function Page() {
       <NavBar>
         <PageTitle title={queue.name} backButton={{ to: backPath, text: "Queues" }} />
       </NavBar>
+      {/* Paused-queue banner — mirrors the environment-paused banner (OrgBanner) at the top of
+          the page when this individual queue is paused. */}
+      <AnimatedOrgBannerBar show={queue.paused} variant="warning">
+        {`"${queue.name}" queue paused. No new runs will be dequeued and executed.`}
+      </AnimatedOrgBannerBar>
       <MetricsLayout.Root>
         {/* Filters — search (concurrency keys) + time filter in one left cluster, above
             everything, like the Queues list. The time filter scopes the tab charts; search filters
@@ -1027,13 +1033,16 @@ function QueueStats({
         suffix={peakQueued > 0 ? `peak ${formatNumberCompact(peakQueued)}` : undefined}
         suffixClassName="text-text-dimmed"
         accessory={
-          <LinkButton
-            variant="secondary/small-icon"
-            LeadingIcon={RunsIcon}
-            leadingIconClassName="text-runs"
-            to={queuedRunsPath}
-            tooltip="View queued runs"
-          />
+          <span className="opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+            <LinkButton
+              variant="minimal/small"
+              className="aspect-square px-1!"
+              LeadingIcon={RunsIcon}
+              leadingIconClassName="text-text-dimmed group-hover/button:text-text-bright"
+              to={queuedRunsPath}
+              tooltip="View queued runs"
+            />
+          </span>
         }
       />
       <BigNumber

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -276,7 +276,11 @@ export default function Page() {
           </div>
           <div className="flex items-center gap-1.5">
             {view === "keys" && hasKeys ? (
-              <SearchInput placeholder="Search keys…" paramName="query" resetParams={["key", "page"]} />
+              <SearchInput
+                placeholder="Search keys…"
+                paramName="query"
+                resetParams={["key", "page"]}
+              />
             ) : null}
             <TimeFilter
               defaultPeriod={QUEUE_METRICS_DEFAULT_PERIOD}
@@ -383,8 +387,8 @@ function OverviewCharts({
           info={
             <>
               How many runs are executing at once (<ColorSwatch color={COLORS.running} />) versus
-              the queue's limit (<ColorSwatch color={COLORS.limit} />). Turns{" "}
-              <ColorSwatch color="var(--color-warning)" /> color when it reaches the limit.
+              the queue's limit (<ColorSwatch color={COLORS.limit} />
+              ). Turns <ColorSwatch color="var(--color-warning)" /> color when it reaches the limit.
             </>
           }
           showLegend
@@ -426,8 +430,8 @@ function OverviewCharts({
           title="Throughput"
           info={
             <>
-              Runs arriving (<ColorSwatch color={COLORS.limit} /> Enqueued) versus starting
-              (<ColorSwatch color={COLORS.running} /> Started). Turns{" "}
+              Runs arriving (<ColorSwatch color={COLORS.limit} /> Enqueued) versus starting (
+              <ColorSwatch color={COLORS.running} /> Started). Turns{" "}
               <ColorSwatch color="var(--color-warning)" /> color when Started falls behind.
             </>
           }
@@ -1166,7 +1170,10 @@ function ConcurrencyBlock({
             </span>
             {limit !== null && limit > 0 && (
               <span
-                className={cn("text-xs tabular-nums", atLimit ? "text-warning" : "text-text-dimmed")}
+                className={cn(
+                  "text-xs tabular-nums",
+                  atLimit ? "text-warning" : "text-text-dimmed"
+                )}
               >
                 {/* Separator so the limit and the percentage don't read as one number
                     (e.g. "/ 25" + "44%" mashing into "2544%"). */}

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -1296,8 +1296,10 @@ function WaitingInQueueBlock({
       : null;
 
   return (
-    <div className="flex flex-col gap-3 border-b border-grid-bright pb-4">
-      <div className="grid grid-cols-3 gap-2">
+    <div className="@container flex flex-col gap-3 border-b border-grid-bright pb-4">
+      {/* Responsive to the side panel width (container query, not viewport): 3-up while there's
+          room, stacking to a single column only once the panel gets narrow. */}
+      <div className="grid grid-cols-1 gap-2 @[22rem]:grid-cols-3">
         <MiniStat
           title={
             <span className="flex items-center gap-1.5">
@@ -1323,7 +1325,10 @@ function WaitingInQueueBlock({
               : "of ∞"
           }
         />
-        <MiniStat title="Waiting for" value={formatWaitMs(waitedMs)} />
+        <MiniStat
+          title="Waiting for"
+          value={formatDurationMilliseconds(waitedMs, { style: "short", maxDecimalPoints: 0 })}
+        />
       </div>
 
       <div className="rounded-sm border border-grid-dimmed bg-background-bright p-3">

--- a/apps/webapp/app/routes/resources.queues.concurrency-keys.ts
+++ b/apps/webapp/app/routes/resources.queues.concurrency-keys.ts
@@ -13,7 +13,7 @@ import { engine } from "~/v3/runEngine.server";
 // paginated authority — ranked by peak backlog over the window with the total on every row
 // (single scan) — and the ≤PER_PAGE keys on the page are enriched with live "now" counts from
 // Redis (O(page), independent of total key cardinality). This replaces the old top-50 cap.
-export const CONCURRENCY_KEYS_PER_PAGE = 50;
+export const CONCURRENCY_KEYS_PER_PAGE = 25;
 
 // Matches QUEUE_METRICS_DEFAULT_PERIOD (the detail page's TimeFilter default).
 const DEFAULT_PERIOD = "1d";

--- a/apps/webapp/app/routes/resources.queues.concurrency-keys.ts
+++ b/apps/webapp/app/routes/resources.queues.concurrency-keys.ts
@@ -1,0 +1,165 @@
+import { type ActionFunctionArgs, json } from "@remix-run/server-runtime";
+import { z } from "zod";
+import { timeFilterFromTo } from "~/components/runs/v3/SharedFilters";
+import { clickhouseFactory } from "~/services/clickhouse/clickhouseFactoryInstance.server";
+import {
+  findEnvironmentById,
+  hasAccessToEnvironment,
+} from "~/models/runtimeEnvironment.server";
+import { requireUserId } from "~/services/session.server";
+import { engine } from "~/v3/runEngine.server";
+
+// One page of a queue's concurrency keys. The ClickHouse tier (queue_metrics_ck_v1) is the
+// paginated authority — ranked by peak backlog over the window with the total on every row
+// (single scan) — and the ≤PER_PAGE keys on the page are enriched with live "now" counts from
+// Redis (O(page), independent of total key cardinality). This replaces the old top-50 cap.
+export const CONCURRENCY_KEYS_PER_PAGE = 50;
+
+// Matches QUEUE_METRICS_DEFAULT_PERIOD (the detail page's TimeFilter default).
+const DEFAULT_PERIOD = "1d";
+
+const Body = z.object({
+  organizationId: z.string(),
+  projectId: z.string(),
+  environmentId: z.string(),
+  /** The queue's full name (e.g. `task/my-task` or a custom queue name). */
+  queueName: z.string(),
+  period: z.string().nullish(),
+  from: z.string().nullish(),
+  to: z.string().nullish(),
+  /** Case-insensitive substring filter on the key. */
+  search: z.string().nullish(),
+  page: z.number().int().min(1).default(1),
+});
+
+export type ConcurrencyKeyRow = {
+  key: string;
+  queued: number;
+  running: number;
+  oldestWaitMs: number | null;
+  started: number;
+  peakBacklog: number;
+  peakRunning: number;
+  meanWaitMs: number;
+};
+
+export type ConcurrencyKeysResponse =
+  | {
+      success: true;
+      rows: ConcurrencyKeyRow[];
+      total: number;
+      page: number;
+      perPage: number;
+      loadedAt: number;
+    }
+  | { success: false; error: string };
+
+// Snap the window to a minute grid so repeated loads within a bucket produce identical query
+// params and share ClickHouse query-cache entries (same trick as the queue-list ranking).
+function formatClickhouseDateTime(date: Date): string {
+  return date.toISOString().slice(0, 19).replace("T", " ");
+}
+function floorToMinute(ms: number): number {
+  return Math.floor(ms / 60_000) * 60_000;
+}
+function ceilToMinute(ms: number): number {
+  return Math.ceil(ms / 60_000) * 60_000;
+}
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const userId = await requireUserId(request);
+
+  const submission = Body.safeParse(await request.json());
+  if (!submission.success) {
+    return json<ConcurrencyKeysResponse>({ success: false, error: "Invalid input" }, { status: 400 });
+  }
+  const { organizationId, projectId, environmentId, queueName, period, from, to, search, page } =
+    submission.data;
+
+  const hasAccess = await hasAccessToEnvironment({
+    environmentId,
+    projectId,
+    organizationId,
+    userId,
+  });
+  if (!hasAccess) {
+    return json<ConcurrencyKeysResponse>(
+      { success: false, error: "You don't have permission for this resource" },
+      { status: 403 }
+    );
+  }
+
+  // Needed as the tenant scope for the live Redis lookup (organization/project/environment ids).
+  const environment = await findEnvironmentById(environmentId);
+  if (!environment) {
+    return json<ConcurrencyKeysResponse>(
+      { success: false, error: "Environment not found" },
+      { status: 404 }
+    );
+  }
+
+  const range = timeFilterFromTo({
+    period: period ?? undefined,
+    from: from ?? undefined,
+    to: to ?? undefined,
+    defaultPeriod: DEFAULT_PERIOD,
+  });
+  const startTime = formatClickhouseDateTime(new Date(floorToMinute(range.from.getTime())));
+  const endTime = formatClickhouseDateTime(new Date(ceilToMinute(range.to.getTime())));
+
+  try {
+    const clickhouse = await clickhouseFactory.getClickhouseForOrganization(organizationId, "query");
+
+    const [rankingError, rankingRows] = await clickhouse.queueMetrics.concurrencyKeyRanking({
+      organizationId,
+      projectId,
+      environmentId,
+      queueName,
+      startTime,
+      endTime,
+      nameContains: search?.trim() ?? "",
+      limit: CONCURRENCY_KEYS_PER_PAGE,
+      offset: (page - 1) * CONCURRENCY_KEYS_PER_PAGE,
+    });
+    if (rankingError) {
+      throw rankingError;
+    }
+
+    const total = rankingRows?.[0]?.ranked_total ?? 0;
+    const keys = (rankingRows ?? []).map((r) => r.concurrency_key);
+
+    // Enrich just this page's keys with live "now" counts from Redis.
+    const live = await engine.concurrencyKeyLiveStats(environment, queueName, keys);
+    const loadedAt = Date.now();
+
+    const rows: ConcurrencyKeyRow[] = (rankingRows ?? []).map((r) => {
+      const l = live.get(r.concurrency_key);
+      const oldestWaitMs =
+        l && l.oldestEnqueuedAt != null ? Math.max(0, loadedAt - l.oldestEnqueuedAt) : null;
+      return {
+        key: r.concurrency_key,
+        queued: l?.queued ?? 0,
+        running: l?.running ?? 0,
+        oldestWaitMs,
+        started: r.started,
+        peakBacklog: r.peak_backlog,
+        peakRunning: r.peak_running,
+        meanWaitMs: r.mean_wait_ms,
+      };
+    });
+
+    return json<ConcurrencyKeysResponse>({
+      success: true,
+      rows,
+      total,
+      page,
+      perPage: CONCURRENCY_KEYS_PER_PAGE,
+      loadedAt,
+    });
+  } catch (error) {
+    return json<ConcurrencyKeysResponse>(
+      { success: false, error: error instanceof Error ? error.message : "Query failed" },
+      { status: 400 }
+    );
+  }
+};

--- a/apps/webapp/app/routes/resources.queues.concurrency-keys.ts
+++ b/apps/webapp/app/routes/resources.queues.concurrency-keys.ts
@@ -7,6 +7,7 @@ import {
   hasAccessToEnvironment,
 } from "~/models/runtimeEnvironment.server";
 import { requireUserId } from "~/services/session.server";
+import { canAccessQueueMetricsUi } from "~/v3/canAccessQueueMetricsUi.server";
 import { engine } from "~/v3/runEngine.server";
 
 // One page of a queue's concurrency keys. The ClickHouse tier (queue_metrics_ck_v1) is the
@@ -96,6 +97,17 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       { success: false, error: "Environment not found" },
       { status: 404 }
     );
+  }
+
+  // Gate on the per-org Queue Metrics UI flag, matching the queue detail page and run inspector, so
+  // this endpoint's data isn't reachable for orgs that can't see the UI. 404 (not 403) to hide it.
+  if (
+    !(await canAccessQueueMetricsUi({
+      userId,
+      organizationSlug: environment.organization.slug,
+    }))
+  ) {
+    return json<ConcurrencyKeysResponse>({ success: false, error: "Not found" }, { status: 404 });
   }
 
   const range = timeFilterFromTo({

--- a/apps/webapp/app/routes/resources.queues.concurrency-keys.ts
+++ b/apps/webapp/app/routes/resources.queues.concurrency-keys.ts
@@ -2,10 +2,7 @@ import { type ActionFunctionArgs, json } from "@remix-run/server-runtime";
 import { z } from "zod";
 import { timeFilterFromTo } from "~/components/runs/v3/SharedFilters";
 import { clickhouseFactory } from "~/services/clickhouse/clickhouseFactoryInstance.server";
-import {
-  findEnvironmentById,
-  hasAccessToEnvironment,
-} from "~/models/runtimeEnvironment.server";
+import { findEnvironmentById, hasAccessToEnvironment } from "~/models/runtimeEnvironment.server";
 import { requireUserId } from "~/services/session.server";
 import { canAccessQueueMetricsUi } from "~/v3/canAccessQueueMetricsUi.server";
 import { engine } from "~/v3/runEngine.server";
@@ -72,7 +69,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   const submission = Body.safeParse(await request.json());
   if (!submission.success) {
-    return json<ConcurrencyKeysResponse>({ success: false, error: "Invalid input" }, { status: 400 });
+    return json<ConcurrencyKeysResponse>(
+      { success: false, error: "Invalid input" },
+      { status: 400 }
+    );
   }
   const { organizationId, projectId, environmentId, queueName, period, from, to, search, page } =
     submission.data;
@@ -120,7 +120,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   const endTime = formatClickhouseDateTime(new Date(ceilToMinute(range.to.getTime())));
 
   try {
-    const clickhouse = await clickhouseFactory.getClickhouseForOrganization(organizationId, "query");
+    const clickhouse = await clickhouseFactory.getClickhouseForOrganization(
+      organizationId,
+      "query"
+    );
 
     const [rankingError, rankingRows] = await clickhouse.queueMetrics.concurrencyKeyRanking({
       organizationId,

--- a/apps/webapp/app/v3/services/worker/workerGroupTokenService.server.ts
+++ b/apps/webapp/app/v3/services/worker/workerGroupTokenService.server.ts
@@ -62,12 +62,20 @@ if (workloadCreatedAtGateEnabled && !workloadTokenCutoff) {
 
 type WorkloadGateAction = "start" | "complete" | "continue" | "snapshots_since";
 
-const workloadAuthGateCounter = new Counter({
-  name: "workload_auth_gate_total",
-  help: "Deployment token authorization outcomes on worker actions",
-  labelNames: ["outcome", "action"] as const,
-  registers: [metricsRegister],
-});
+// Wrapped in singleton() so a dev HMR re-eval of this module reuses the existing counter instead
+// of calling `new Counter` again — prom-client throws "already registered" on the second
+// registration, which crashes the dev server. Matches authenticatedWorkerInstanceCache above; a
+// no-op in prod (the module evaluates once).
+const workloadAuthGateCounter = singleton(
+  "workloadAuthGateCounter",
+  () =>
+    new Counter({
+      name: "workload_auth_gate_total",
+      help: "Deployment token authorization outcomes on worker actions",
+      labelNames: ["outcome", "action"] as const,
+      registers: [metricsRegister],
+    })
+);
 
 function createAuthenticatedWorkerInstanceCache() {
   return createCache({

--- a/internal-packages/clickhouse/src/index.ts
+++ b/internal-packages/clickhouse/src/index.ts
@@ -40,6 +40,7 @@ import {
   getQueueRanking,
   getQueueRankingNames,
   getQueueRankingCount,
+  getConcurrencyKeyRanking,
 } from "./queueMetrics.js";
 import {
   getSessionTagsQueryBuilder,
@@ -279,6 +280,7 @@ export class ClickHouse {
       ranking: getQueueRanking(this.reader),
       rankingNames: getQueueRankingNames(this.reader),
       rankingCount: getQueueRankingCount(this.reader),
+      concurrencyKeyRanking: getConcurrencyKeyRanking(this.reader),
     };
   }
 

--- a/internal-packages/clickhouse/src/queueMetrics.ts
+++ b/internal-packages/clickhouse/src/queueMetrics.ts
@@ -219,4 +219,76 @@ export function getQueueRankingCount(reader: ClickhouseReader) {
   });
 }
 
+// --- Per-concurrency-key ranking (the queue detail "Concurrency keys" table) ---
+
+const ConcurrencyKeyRankingParams = z.object({
+  organizationId: z.string(),
+  projectId: z.string(),
+  environmentId: z.string(),
+  queueName: z.string(),
+  startTime: z.string(),
+  endTime: z.string(),
+  /** Case-insensitive substring filter on the key ('' = no filter). */
+  nameContains: z.string(),
+  limit: z.number(),
+  offset: z.number(),
+});
+
+const ConcurrencyKeyRankingRow = z.object({
+  concurrency_key: z.string(),
+  started: z.coerce.number(),
+  peak_backlog: z.coerce.number(),
+  peak_running: z.coerce.number(),
+  mean_wait_ms: z.coerce.number(),
+  ranked_total: z.coerce.number(),
+});
+
+// The per-key table (queue_metrics_ck_v1) is activity-bound and its ORDER BY starts with the
+// tenant + queue, so filtering to one queue prunes to a contiguous index range — the aggregate
+// is bounded by real activity, never by total key cardinality. There is no per-key 5m rollup,
+// so this reads the 10s tier directly (the pre-existing LIMIT-50 query did the same).
+const CK_RANKING_WHERE = `organization_id = {organizationId: String}
+        AND project_id = {projectId: String}
+        AND environment_id = {environmentId: String}
+        AND queue_name = {queueName: String}
+        AND bucket_start >= {startTime: DateTime}
+        AND bucket_start < {endTime: DateTime}
+        AND ({nameContains: String} = '' OR positionCaseInsensitive(concurrency_key, {nameContains: String}) > 0)`;
+
+/**
+ * One page of a queue's concurrency keys ranked by peak backlog over the window, with the total
+ * ranked-key count on every row (window function) so page + count cost a single scan — the same
+ * shape as getQueueRanking. The `concurrency_key ASC` tiebreak makes OFFSET paging stable across
+ * keys that share a peak. Range stats (started/peak_backlog/peak_running/mean wait) come back on
+ * the same rows; live "now" counts are enriched per page from Redis by the caller.
+ */
+export function getConcurrencyKeyRanking(reader: ClickhouseReader) {
+  return reader.query({
+    name: "getConcurrencyKeyRanking",
+    query: `SELECT
+        concurrency_key,
+        started,
+        peak_backlog,
+        peak_running,
+        mean_wait_ms,
+        count() OVER () AS ranked_total
+      FROM (
+        SELECT
+          concurrency_key,
+          deltaSumTimestampMerge(started_delta) AS started,
+          max(max_queued) AS peak_backlog,
+          max(max_running) AS peak_running,
+          if(sum(wait_ms_count) > 0, round(sum(wait_ms_sum) / sum(wait_ms_count)), 0) AS mean_wait_ms
+        FROM trigger_dev.queue_metrics_ck_v1
+        WHERE ${CK_RANKING_WHERE}
+        GROUP BY concurrency_key
+        ORDER BY peak_backlog DESC, concurrency_key ASC
+      )
+      LIMIT {limit: UInt32} OFFSET {offset: UInt32}`,
+    params: ConcurrencyKeyRankingParams,
+    schema: ConcurrencyKeyRankingRow,
+    settings: QUEUE_METRICS_CACHE_SETTINGS,
+  });
+}
+
 // (per-queue detail series is now fetched via TRQL + fillGaps from the metric resource route)

--- a/internal-packages/run-engine/src/engine/index.ts
+++ b/internal-packages/run-engine/src/engine/index.ts
@@ -1660,6 +1660,14 @@ export class RunEngine {
     return this.runQueue.concurrencyKeyBreakdown(environment, queue, options);
   }
 
+  async concurrencyKeyLiveStats(
+    environment: MinimalAuthenticatedEnvironment,
+    queue: string,
+    concurrencyKeys: string[]
+  ) {
+    return this.runQueue.concurrencyKeyLiveStats(environment, queue, concurrencyKeys);
+  }
+
   async removeEnvironmentQueuesFromMasterQueue({
     runtimeEnvironmentId,
     organizationId,

--- a/internal-packages/run-engine/src/run-queue/index.ts
+++ b/internal-packages/run-engine/src/run-queue/index.ts
@@ -613,6 +613,50 @@ export class RunQueue {
     return { totalBackloggedKeys, keys };
   }
 
+  /**
+   * Live "now" stats for a specific set of concurrency keys — the current page of the paginated
+   * per-key table. Unlike concurrencyKeyBreakdown (which reads the top of the ckIndex), this
+   * targets exactly the given keys, so the table can enrich its ClickHouse-ranked page without
+   * scanning the whole index: O(keys) via one pipeline, independent of total key cardinality.
+   * Keys with no live backlog come back as zeros with a null oldest-enqueue time.
+   */
+  public async concurrencyKeyLiveStats(
+    env: MinimalAuthenticatedEnvironment,
+    queue: string,
+    concurrencyKeys: string[]
+  ): Promise<Map<string, { queued: number; running: number; oldestEnqueuedAt: number | null }>> {
+    const result = new Map<
+      string,
+      { queued: number; running: number; oldestEnqueuedAt: number | null }
+    >();
+    if (concurrencyKeys.length === 0) return result;
+
+    const ckIndexKey = this.keys.ckIndexKeyFromQueue(this.keys.queueKey(env, queue));
+
+    const pipeline = this.redis.pipeline();
+    for (const concurrencyKey of concurrencyKeys) {
+      const member = this.keys.queueKey(env, queue, concurrencyKey);
+      pipeline.zcard(member); // queued in this key's subqueue
+      pipeline.scard(this.keys.queueCurrentConcurrencyKeyFromQueue(member)); // running
+      pipeline.zscore(ckIndexKey, member); // oldest-enqueued score (null once the key drains)
+    }
+    const res = await pipeline.exec();
+    if (!res) return result;
+
+    concurrencyKeys.forEach((concurrencyKey, i) => {
+      const queuedResult = res[i * 3];
+      const runningResult = res[i * 3 + 1];
+      const scoreResult = res[i * 3 + 2];
+      const queued = queuedResult && !queuedResult[0] ? ((queuedResult[1] as number) ?? 0) : 0;
+      const running = runningResult && !runningResult[0] ? ((runningResult[1] as number) ?? 0) : 0;
+      const rawScore = scoreResult && !scoreResult[0] ? scoreResult[1] : null;
+      const oldestEnqueuedAt = rawScore != null ? Number(rawScore) : null;
+      result.set(concurrencyKey, { queued, running, oldestEnqueuedAt });
+    });
+
+    return result;
+  }
+
   public async lengthOfEnvQueue(env: MinimalAuthenticatedEnvironment) {
     return this.redis.zcard(this.keys.envQueueKey(env));
   }


### PR DESCRIPTION
**Stacked on #4131** — targets `feat/queue-metrics-and-health`, not `main`. GitHub will auto-retarget this to `main` once #4131 merges. (Targeting `main` now would wrongly include all of #4131's own commits.)

UI polish for the Queue metrics & health pages (TRI-12068). 49 commits, all under `apps/webapp/app/` — no engine/ClickHouse/package changes.

**Highlights**
- **Layout** — consolidated queue-detail header into one filter bar; shared `MetricsLayout` spacing (2.5 scale); paused-queue banner mirroring the environment-paused banner.
- **Charts** — inline legends under titles; threshold gradient coloring (Env saturation orange only >100%; Concurrency orange only at/over the limit); fullscreen legend spacing; result caching so tab switches don't reload; brighter hover cursor + full x-axis labels.
- **Tables** — whole-row click via stretched link; custom Queues icon; removed column sorting; Limit-cell spacing + hover-bright; "Limited by" tooltip sizing.
- **Controls** — Pause moved into the filter bar (orange label + accurate tooltip copy); restyled override-concurrency modal.
- **Copy** — plain-language pass; inline colour swatches; Throttled reads "% of current period".

Also consolidated the three queue-metrics `.server-changes` notes into one.

**Known follow-up (not in this PR):** the Concurrency-keys table is capped at 50 keys (union of live Redis backlog + ClickHouse history, no single cursor across both) and truncates silently — fine for most queues, a real limit for high-cardinality per-tenant keys.

Verified locally against the `queue-metrics-demo` seed; `pnpm typecheck --filter webapp` passes.
