### PR TITLE
fix(cli): terminate github actions command files

### DIFF
--- a/packages/cli-v3/src/utilities/githubActions.test.ts
+++ b/packages/cli-v3/src/utilities/githubActions.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { setGithubActionsOutputAndEnvVars } from "./githubActions.js";
+
+describe("setGithubActionsOutputAndEnvVars", () => {
+  const originalGithubEnv = process.env.GITHUB_ENV;
+  const originalGithubOutput = process.env.GITHUB_OUTPUT;
+  let tmpDir: string | undefined;
+
+  afterEach(() => {
+    if (originalGithubEnv === undefined) {
+      delete process.env.GITHUB_ENV;
+    } else {
+      process.env.GITHUB_ENV = originalGithubEnv;
+    }
+
+    if (originalGithubOutput === undefined) {
+      delete process.env.GITHUB_OUTPUT;
+    } else {
+      process.env.GITHUB_OUTPUT = originalGithubOutput;
+    }
+
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it("terminates GitHub Actions env and output entries with newlines", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "trigger-github-actions-"));
+    const envFile = join(tmpDir, "env");
+    const outputFile = join(tmpDir, "output");
+    process.env.GITHUB_ENV = envFile;
+    process.env.GITHUB_OUTPUT = outputFile;
+
+    setGithubActionsOutputAndEnvVars({
+      envVars: {
+        deploymentId: "dep_123",
+        imageTag: "v1",
+      },
+      outputs: {
+        deploymentId: "dep_123",
+        needsPromotion: "true",
+      },
+    });
+
+    expect(readFileSync(envFile, "utf8")).toMatch(/^deploymentId=dep_123\r?\nimageTag=v1\r?\n$/);
+    expect(readFileSync(outputFile, "utf8")).toMatch(
+      /^deploymentId=dep_123\r?\nneedsPromotion=true\r?\n$/
+    );
+  });
+
+  it("does not append content when there are no env vars or outputs", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "trigger-github-actions-"));
+    const envFile = join(tmpDir, "env");
+    const outputFile = join(tmpDir, "output");
+    writeFileSync(envFile, "");
+    writeFileSync(outputFile, "");
+    process.env.GITHUB_ENV = envFile;
+    process.env.GITHUB_OUTPUT = outputFile;
+
+    setGithubActionsOutputAndEnvVars({
+      envVars: {},
+      outputs: {},
+    });
+
+    expect(readFileSync(envFile, "utf8")).toBe("");
+    expect(readFileSync(outputFile, "utf8")).toBe("");
+  });
+});

--- a/packages/cli-v3/src/utilities/githubActions.ts
+++ b/packages/cli-v3/src/utilities/githubActions.ts
@@ -1,4 +1,11 @@
 import { appendFileSync } from "node:fs";
+import { EOL } from "node:os";
+
+function formatGithubActionsCommandFile(entries: Record<string, string>) {
+  const lines = Object.entries(entries).map(([key, value]) => `${key}=${value}`);
+
+  return lines.length > 0 ? `${lines.join(EOL)}${EOL}` : "";
+}
 
 export function setGithubActionsOutputAndEnvVars({
   envVars,
@@ -9,19 +16,11 @@ export function setGithubActionsOutputAndEnvVars({
 }) {
   // Set environment variables
   if (process.env.GITHUB_ENV) {
-    const contents = Object.entries(envVars)
-      .map(([key, value]) => `${key}=${value}`)
-      .join("\n");
-
-    appendFileSync(process.env.GITHUB_ENV, contents);
+    appendFileSync(process.env.GITHUB_ENV, formatGithubActionsCommandFile(envVars));
   }
 
   // Set outputs
   if (process.env.GITHUB_OUTPUT) {
-    const contents = Object.entries(outputs)
-      .map(([key, value]) => `${key}=${value}`)
-      .join("\n");
-
-    appendFileSync(process.env.GITHUB_OUTPUT, contents);
+    appendFileSync(process.env.GITHUB_OUTPUT, formatGithubActionsCommandFile(outputs));
   }
 }


### PR DESCRIPTION
## Summary

Fixes #4003.

GitHub Actions command files (`GITHUB_ENV` and `GITHUB_OUTPUT`) expect each command entry to be newline-terminated. The CLI helper previously joined entries with newlines but did not terminate the final entry, which could let a later append concatenate onto the last output value.

This changes the helper to format command-file writes with a trailing platform line separator when there is at least one entry, while preserving empty writes as empty. It also adds a focused regression test for both env vars and outputs.

## Validation

Passed:

- `pnpm --filter trigger.dev exec vitest run src/utilities/githubActions.test.ts`
- `pnpm --filter trigger.dev exec vitest run src/utilities/colorMarkup.test.ts src/utilities/discoveryCheck.test.ts src/utilities/githubActions.test.ts`
- `pnpm --filter trigger.dev run typecheck`
- `pnpm --filter trigger.dev run build`
- `pnpm exec oxlint packages/cli-v3/src/utilities/githubActions.ts packages/cli-v3/src/utilities/githubActions.test.ts`
- `pnpm exec oxfmt --check packages/cli-v3/src/utilities/githubActions.ts packages/cli-v3/src/utilities/githubActions.test.ts`
- `git diff --check`

Also ran `pnpm --filter trigger.dev test -- --run` after building local workspace dependencies. It still fails on unrelated existing issues in this Windows checkout:

- `src/mcp/smoke.test.ts` and `src/mcp/tools.test.ts` are executable smoke scripts with no Vitest suites.
- `src/commands/skills.test.ts` expects Windows backslash paths but receives normalized slash paths.
- `src/entryPoints/managed/snapshot.test.ts` increments `handlerExecutionCount` while the local variable is named `_handlerExecutionCount`.