### PR TITLE
feat(supervisor): configurable warm-start dispatch url

### DIFF
--- a/apps/supervisor/src/env.ts
+++ b/apps/supervisor/src/env.ts
@@ -112,6 +112,7 @@ export const Env = z
 
     // Optional services
     TRIGGER_WARM_START_URL: z.string().optional(),
+    TRIGGER_WARM_START_DISPATCH_URL: z.string().optional(),
     TRIGGER_CHECKPOINT_URL: z.string().optional(),
     TRIGGER_METADATA_URL: z.string().optional(),
 

--- a/apps/supervisor/src/index.ts
+++ b/apps/supervisor/src/index.ts
@@ -95,6 +95,8 @@ class ManagedSupervisor {
 
   private readonly isKubernetes = isKubernetesEnvironment(env.KUBERNETES_FORCE_ENABLED);
   private readonly warmStartUrl = env.TRIGGER_WARM_START_URL;
+  private readonly warmStartDispatchUrl =
+    env.TRIGGER_WARM_START_DISPATCH_URL ?? env.TRIGGER_WARM_START_URL;
 
   private readonly wideEventOpts: WideEventOptions = {
     service: "supervisor",
@@ -698,7 +700,7 @@ class ManagedSupervisor {
       return false;
     }
 
-    const warmStartUrlWithPath = new URL("/warm-start", this.warmStartUrl);
+    const warmStartUrlWithPath = new URL("/warm-start", this.warmStartDispatchUrl);
 
     const headers: Record<string, string> = {
       "Content-Type": "application/json",


### PR DESCRIPTION
Adds an optional `TRIGGER_WARM_START_DISPATCH_URL`. The warm-start dispatch request uses it when set, otherwise falls back to `TRIGGER_WARM_START_URL`, so the dispatch target can differ from the default warm-start URL. No behavior change when unset.