### PR TITLE
fix(cli): disable OTel in depot child to prevent OTEL_EXPORTER_OTLP_ENDPOINT build failures

### DIFF
--- a/packages/cli-v3/src/deploy/buildImage.ts
+++ b/packages/cli-v3/src/deploy/buildImage.ts
@@ -256,6 +256,13 @@ async function remoteBuildImage(options: DepotBuildImageOptions): Promise<BuildI
       DEPOT_PROJECT_ID: options.buildProjectId,
       DEPOT_NO_SUMMARY_LINK: "1",
       DEPOT_NO_UPDATE_NOTIFIER: "1",
+      // Prevent ambient OTEL env vars (e.g. OTEL_EXPORTER_OTLP_ENDPOINT) from
+      // leaking into the depot child process. The depot CLI initialises its own
+      // OTel exporter and fails during telemetry init when it inherits an
+      // endpoint it can't reach — silently killing the build with a misleading
+      // "Error building image" message. See: triggerdotdev/trigger.dev#4321
+      OTEL_SDK_DISABLED: "1",
+      OTEL_EXPORTER_OTLP_ENDPOINT: "",
     },
   });
 


### PR DESCRIPTION
Fixes #4321.

`OTEL_EXPORTER_OTLP_ENDPOINT` is a standard env var that lots of projects set. If it's in the shell when you run `trigger deploy`, the build fails before it starts - either with `cannot merge resource due to conflicting Schema URL` (valid URL) or `failed to build resolver: passthrough: received empty target in Build()` (invalid value like an encrypted dotenvx blob). Both look like depot outages, not a local env problem.

**Why it happens**

`remoteBuildImage` in `buildImage.ts` spawns the depot CLI via `execa`. Execa's default is `extendEnv: true`, so the `env` object passed to `depot()` is merged onto `process.env` rather than replacing it. Anything in the parent environment - including `OTEL_EXPORTER_OTLP_ENDPOINT` - is inherited by the depot child. The depot CLI reads that variable to initialise its own OTel exporter and dies during telemetry init before the build starts.

**Fix**

Add `OTEL_SDK_DISABLED: "1"` and `OTEL_EXPORTER_OTLP_ENDPOINT: ""` to the env block passed to `depot()`. Since execa merges envs, these explicit values override whatever the parent shell has, keeping ambient OTEL config out of the depot child entirely.

`--local-build` is unaffected (it runs `docker buildx` which tolerates the variable).
