### PR TITLE
fix(core): sum repeated units in parseNaturalLanguageDurationInMs

### DIFF
--- a/.changeset/duration-repeated-units.md
+++ b/.changeset/duration-repeated-units.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Fix `parseNaturalLanguageDurationInMs` silently dropping repeated units. The validation pattern accepts a unit appearing more than once (e.g. `"1h2h"`), but each unit was read with a single match, so only the first occurrence counted. It now sums every token.

--- a/packages/core/src/v3/isomorphic/duration.ts
+++ b/packages/core/src/v3/isomorphic/duration.ts
@@ -8,66 +8,36 @@
  * parseNaturalLanguageDurationInMs("30m") // 1800000
  * parseNaturalLanguageDurationInMs("2h") // 7200000
  */
+const DURATION_UNIT_TO_MS: Record<string, number> = {
+  w: 7 * 24 * 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+  hr: 60 * 60 * 1000,
+  h: 60 * 60 * 1000,
+  m: 60 * 1000,
+  s: 1000,
+};
+
 export function parseNaturalLanguageDurationInMs(duration: string): number | undefined {
   // Handle Code scanning alert #44 by limiting the length of the input string
   if (duration.length > 100) {
     return undefined;
   }
 
-  // More flexible regex that captures all units individually regardless of order
-  const weekMatch = duration.match(/(\d+)w/);
-  const dayMatch = duration.match(/(\d+)d/);
-  const hourMatch = duration.match(/(\d+)(?:hr|h)/);
-  const minuteMatch = duration.match(/(\d+)m/);
-  const secondMatch = duration.match(/(\d+)s/);
-
-  // Check if the entire string consists only of valid duration units
+  // The whole string must be a run of "<number><unit>" tokens, in any order.
   const validPattern = /^(\d+(?:w|d|hr|h|m|s))+$/;
   if (!validPattern.test(duration)) {
     return undefined;
   }
 
+  // Sum every token. Reading each unit with a single `.match()` (as this used
+  // to) only picked up the first occurrence, so a repeated unit that the
+  // pattern above accepts - e.g. "1h2h" - silently dropped all but the first.
+  // `hr` is tried before `h` so "1hr" is one hour, not "1h" plus a stray "r".
   let totalMilliseconds = 0;
   let hasMatch = false;
-
-  if (weekMatch) {
-    const weeks = Number(weekMatch[1]);
-    if (weeks >= 0) {
-      totalMilliseconds += weeks * 7 * 24 * 60 * 60 * 1000;
-      hasMatch = true;
-    }
-  }
-
-  if (dayMatch) {
-    const days = Number(dayMatch[1]);
-    if (days >= 0) {
-      totalMilliseconds += days * 24 * 60 * 60 * 1000;
-      hasMatch = true;
-    }
-  }
-
-  if (hourMatch) {
-    const hours = Number(hourMatch[1]);
-    if (hours >= 0) {
-      totalMilliseconds += hours * 60 * 60 * 1000;
-      hasMatch = true;
-    }
-  }
-
-  if (minuteMatch) {
-    const minutes = Number(minuteMatch[1]);
-    if (minutes >= 0) {
-      totalMilliseconds += minutes * 60 * 1000;
-      hasMatch = true;
-    }
-  }
-
-  if (secondMatch) {
-    const seconds = Number(secondMatch[1]);
-    if (seconds >= 0) {
-      totalMilliseconds += seconds * 1000;
-      hasMatch = true;
-    }
+  for (const match of duration.matchAll(/(\d+)(hr|w|d|h|m|s)/g)) {
+    totalMilliseconds += Number(match[1]) * DURATION_UNIT_TO_MS[match[2]];
+    hasMatch = true;
   }
 
   return hasMatch ? totalMilliseconds : undefined;

--- a/packages/core/test/duration.test.ts
+++ b/packages/core/test/duration.test.ts
@@ -1,10 +1,35 @@
 import {
   parseNaturalLanguageDuration,
+  parseNaturalLanguageDurationInMs,
   safeParseNaturalLanguageDuration,
   parseNaturalLanguageDurationAgo,
   safeParseNaturalLanguageDurationAgo,
   stringifyDuration,
 } from "../src/v3/isomorphic/duration.js";
+
+describe("parseNaturalLanguageDurationInMs", () => {
+  const MINUTE = 60 * 1000;
+  const HOUR = 60 * MINUTE;
+
+  it("parses single and combined units in any order", () => {
+    expect(parseNaturalLanguageDurationInMs("15m")).toBe(15 * MINUTE);
+    expect(parseNaturalLanguageDurationInMs("1h30m")).toBe(HOUR + 30 * MINUTE);
+    expect(parseNaturalLanguageDurationInMs("30m1h")).toBe(HOUR + 30 * MINUTE);
+    expect(parseNaturalLanguageDurationInMs("2hr")).toBe(2 * HOUR);
+  });
+
+  it("sums a unit that appears more than once", () => {
+    // The valid-pattern accepts repeated units, but reading each unit with a
+    // single match only counted the first, so "1h2h" used to return 1h.
+    expect(parseNaturalLanguageDurationInMs("1h2h")).toBe(3 * HOUR);
+    expect(parseNaturalLanguageDurationInMs("2m3m")).toBe(5 * MINUTE);
+  });
+
+  it("returns undefined for input that is not a duration", () => {
+    expect(parseNaturalLanguageDurationInMs("notaduration")).toBeUndefined();
+    expect(parseNaturalLanguageDurationInMs("")).toBeUndefined();
+  });
+});
 
 describe("parseNaturalLanguageDuration", () => {
   let baseTime: Date;


### PR DESCRIPTION
`parseNaturalLanguageDurationInMs` silently drops repeated units.

## Problem

The valid-input check is `/^(\d+(?:w|d|hr|h|m|s))+$/`, whose `+` accepts a unit appearing more than once. But each unit was then read with a single `.match()`, so only the first occurrence counted:

```ts
parseNaturalLanguageDurationInMs("1h2h") // 3600000  (1h) - the 2h is dropped
parseNaturalLanguageDurationInMs("2m3m") // 120000   (2m) - the 3m is dropped
```

So the validation and the parsing disagree: a string the function accepts as valid is parsed to the wrong number.

## Fix

Tokenize the whole string and sum every match. `hr` is matched before `h` so `"1hr"` stays one hour. All existing single-occurrence and combined-unit behaviour is unchanged; repeated units now add up. As a side effect this replaces five near-identical unit blocks with one loop.

If you would rather **reject** duplicates than sum them, that is a one-line change to the pattern instead - happy to switch. Summing seemed the least surprising (it is how `"1h30m"` already combines units).

## Tests

The full `duration.test.ts` suite passes (56 tests). Added cases for the repeated-unit sum; I confirmed the new "sums a unit that appears more than once" case fails against the current code and passes with the fix. Included a changeset (`@trigger.dev/core` patch).