### PR TITLE
fix(core): escape dots in object keys when flattening to prevent path collision

### DIFF
--- a/packages/core/src/v3/utils/flattenAttributes.ts
+++ b/packages/core/src/v3/utils/flattenAttributes.ts
@@ -119,8 +119,9 @@ class AttributeFlattener {
     if (obj instanceof Map) {
       for (const [key, value] of obj) {
         if (!this.canAddMoreAttributes()) break;
-        // Use the key directly if it's a string, otherwise convert it
-        const keyStr = typeof key === "string" ? key : String(key);
+        // Use the key directly if it's a string, otherwise convert it.
+        // Escape dots so keys containing "." are not mistaken for path separators.
+        const keyStr = typeof key === "string" ? key.replace(/\./g, "\\.") : String(key);
         this.#processValue(value, `${prefix || "map"}.${keyStr}`, depth);
       }
       return;
@@ -204,7 +205,10 @@ class AttributeFlattener {
         break;
       }
 
-      const newPrefix = `${prefix ? `${prefix}.` : ""}${Array.isArray(obj) ? `[${key}]` : key}`;
+      // Escape dots in string keys so they are not mistaken for path separators
+      // when unflattening. Array indices use bracket notation and need no escaping.
+      const escapedKey = Array.isArray(obj) ? `[${key}]` : key.replace(/\./g, "\\.");
+      const newPrefix = `${prefix ? `${prefix}.` : ""}${escapedKey}`;
 
       if (Array.isArray(value)) {
         for (let i = 0; i < value.length; i++) {
@@ -248,6 +252,31 @@ class AttributeFlattener {
     }
   }
 }
+/**
+ * Splits a flattened attribute key on dots that are NOT escaped with a backslash,
+ * then unescapes any `\.` sequences in each part back to `.`.
+ *
+ * This allows object keys that contain literal dots (e.g. "Key 0.002mm") to
+ * round-trip through flatten/unflatten without being treated as path separators.
+ */
+function splitOnUnescapedDots(key: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  for (let i = 0; i < key.length; i++) {
+    if (key[i] === "\\" && i + 1 < key.length && key[i + 1] === ".") {
+      current += ".";
+      i++; // skip the escaped dot
+    } else if (key[i] === ".") {
+      parts.push(current);
+      current = "";
+    } else {
+      current += key[i];
+    }
+  }
+  parts.push(current);
+  return parts;
+}
+
 export function unflattenAttributes(
   obj: Attributes,
   filteredKeys?: string[],
@@ -277,7 +306,7 @@ export function unflattenAttributes(
       continue;
     }
 
-    const parts = key.split(".").reduce(
+    const parts = splitOnUnescapedDots(key).reduce(
       (acc, part) => {
         if (part.startsWith("[") && part.endsWith("]")) {
           // Handle array indices more precisely

--- a/packages/core/test/flattenAttributes.test.ts
+++ b/packages/core/test/flattenAttributes.test.ts
@@ -1,6 +1,21 @@
 import { flattenAttributes, unflattenAttributes } from "../src/v3/utils/flattenAttributes.js";
 
 describe("flattenAttributes", () => {
+  it("round-trips object keys that contain dots", () => {
+    // Keys with dots were previously split on the dot, turning "Key 0.002mm" into
+    // a nested path { "Key 0": { "002mm": ... } } on unflatten.
+    const input = { "Key 0.002mm": 31.4 };
+    const flattened = flattenAttributes(input);
+    expect(flattened).toEqual({ "Key 0\\.002mm": 31.4 });
+    expect(unflattenAttributes(flattened)).toEqual(input);
+
+    // Nested object where an intermediate key contains a dot
+    const nested = { outer: { "a.b": { inner: 1 } } };
+    const flatNested = flattenAttributes(nested);
+    expect(flatNested).toEqual({ "outer.a\\.b.inner": 1 });
+    expect(unflattenAttributes(flatNested)).toEqual(nested);
+  });
+
   it("handles number keys correctly", () => {
     expect(flattenAttributes({ bar: { "25": "foo" } })).toEqual({ "bar.25": "foo" });
     expect(unflattenAttributes({ "bar.25": "foo" })).toEqual({ bar: { "25": "foo" } });


### PR DESCRIPTION
## Problem

Object keys that contain literal dots are misinterpreted as path separators when logs are stored and then displayed. For example:

```js
logger.log("dimensions", { "Key 0.002mm": 31.4 })
```

Shows up in the dashboard as:

```json
{ "Key 0": { "002mm": 31.4 } }
```

because the flatten step produces `"Key 0.002mm": 31.4` and the unflatten step naively splits on every `.`.

Fixes #1510

## Changes

**`packages/core/src/v3/utils/flattenAttributes.ts`**

- When building the flattened path key for plain object entries (line 208), escape dots in non-array keys: `key.replace(/\./g, "\\.")`. Array indices use bracket notation and don't need escaping.
- Same escaping applied to Map string keys (line 123).
- Add `splitOnUnescapedDots()` helper that tokenizes a flattened key on unescaped dots and unescapes `\.` back to `.` in each segment.
- Switch `unflattenAttributes` to use `splitOnUnescapedDots(key)` instead of `key.split(".")`.

**`packages/core/test/flattenAttributes.test.ts`**

- Add a regression test: `{ "Key 0.002mm": 31.4 }` round-trips correctly through flatten → unflatten.
- Add a nested-key variant: `{ outer: { "a.b": { inner: 1 } } }`.

## How did you test this code?

Added two test cases in the existing `flattenAttributes.test.ts` that reproduce the exact scenario from the issue.