### PR TITLE
fix(webapp): prevent OTLP nanosecond timestamp overflow (#3292)

### DIFF
--- a/apps/webapp/app/v3/eventRepository/common.server.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.ts
@@ -25,7 +25,7 @@ export function extractContextFromCarrier(carrier: Record<string, unknown>) {
 }
 
 export function getNowInNanoseconds(): bigint {
-  return BigInt(new Date().getTime() * 1_000_000);
+  return BigInt(Date.now()) * 1_000_000n;
 }
 
 export function getDateFromNanoseconds(nanoseconds: bigint): Date {
@@ -39,7 +39,7 @@ export function calculateDurationFromStart(
 ) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  const duration = Number(BigInt($endtime.getTime() * 1_000_000) - startTime);
+  const duration = Number(BigInt($endtime.getTime()) * 1_000_000n - startTime);
 
   if (minimumDuration && duration < minimumDuration) {
     return minimumDuration;

--- a/apps/webapp/app/v3/eventRepository/index.server.ts
+++ b/apps/webapp/app/v3/eventRepository/index.server.ts
@@ -240,7 +240,7 @@ async function recordRunEvent(
         runId: foundRun.friendlyId,
         ...attributes,
       },
-      startTime: BigInt((startTime?.getTime() ?? Date.now()) * 1_000_000),
+      startTime: BigInt(startTime?.getTime() ?? Date.now()) * 1_000_000n,
       ...optionsRest,
     });
 

--- a/apps/webapp/app/v3/runEngineHandlers.server.ts
+++ b/apps/webapp/app/v3/runEngineHandlers.server.ts
@@ -555,7 +555,7 @@ export function registerRunEngineEventBusHandlers() {
         );
 
         await eventRepository.recordEvent(retryMessage, {
-          startTime: BigInt(time.getTime() * 1000000),
+          startTime: BigInt(time.getTime()) * 1_000_000n,
           taskSlug: run.taskIdentifier,
           environment,
           attributes: {

--- a/apps/webapp/seed-ai-spans.mts
+++ b/apps/webapp/seed-ai-spans.mts
@@ -474,7 +474,7 @@ function buildAiSpanTree(params: SpanTreeParams): CreateEventInput[] {
     attemptNumber?: number;
   }): CreateEventInput {
     const startNs = BigInt(opts.startMs) * BigInt(1_000_000);
-    const durationNs = opts.durationMs * 1_000_000;
+    const durationNs = BigInt(opts.durationMs) * BigInt(1_000_000);
     return {
       traceId,
       spanId: opts.spanId,

--- a/packages/core/src/v3/utils/durations.ts
+++ b/packages/core/src/v3/utils/durations.ts
@@ -32,6 +32,11 @@ export function millisecondsToNanoseconds(milliseconds: number): number {
   return milliseconds * 1_000_000;
 }
 
+/** Convert epoch milliseconds to nanoseconds using BigInt to avoid overflow. */
+export function epochMsToNanoseconds(ms: number): bigint {
+  return BigInt(ms) * 1_000_000n;
+}
+
 export function formatDurationNanoseconds(nanoseconds: number, options?: DurationOptions): string {
   return formatDurationMilliseconds(nanosecondsToMilliseconds(nanoseconds), options);
 }


### PR DESCRIPTION
## Problem

Issue #3292: OTLP timestamps use nanoseconds. When converting epoch milliseconds to nanoseconds (\ms * 1_000_000\), the result exceeds \Number.MAX_SAFE_INTEGER\ (~9 quadrillion), causing IEEE 754 floating-point precision loss. After \BigInt()\ wraps the already-corrupt value, the timestamp is silently wrong.

## Fixes

All four HIGH-severity sites follow the same pattern: move \BigInt()\ before the multiplication so it happens in BigInt space.

| File | Before | After |
|------|--------|-------|
| \common.server.ts:28\ | \BigInt(new Date().getTime() * 1_000_000)\ | \BigInt(Date.now()) * 1_000_000n\ |
| \common.server.ts:42\ | \BigInt(\.getTime() * 1_000_000)\ | \BigInt(\.getTime()) * 1_000_000n\ |
| \index.server.ts:243\ | \BigInt((startTime?.getTime() ?? Date.now()) * 1_000_000)\ | \BigInt(startTime?.getTime() ?? Date.now()) * 1_000_000n\ |
| \unEngineHandlers.server.ts:558\ | \BigInt(time.getTime() * 1000000)\ | \BigInt(time.getTime()) * 1_000_000n\ |

Also adds \pochMsToNanoseconds()\ helper to \packages/core/src/v3/utils/durations.ts\ for safe epoch-level conversions, and fixes \seed-ai-spans.mts\ for consistency.

Closes #3292