### PR TITLE
fix(database): restrict TypeScript root inputs to src

### DIFF
--- a/internal-packages/database/tsconfig.json
+++ b/internal-packages/database/tsconfig.json
@@ -9,5 +9,6 @@
     "noEmit": true,
     "strict": true
   },
+  "include": ["src/**/*"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

This PR adds an explicit `include` pattern to `internal-packages/database/tsconfig.json` to restrict TypeScript root input files to the `src` directory.

## Problem

Running the following command on Windows:

```bash
pnpm run dev --filter @trigger.dev/database
```

starts TypeScript in watch mode with declaration output enabled. Since the package `tsconfig.json` does not explicitly define an `include` pattern, the compiler may treat generated declaration files inside `dist/` as input files, resulting in the following error:

```text
error TS5055: Cannot write file '.../dist/index.d.ts' because it would overwrite input file.
```

## Solution

Add the following to `internal-packages/database/tsconfig.json`:

```json
"include": ["src/**/*"]
```

This scopes the compiler's root input files to the source directory while preserving normal module resolution for imported files outside `src`, such as the generated Prisma client.

## Testing

Verified locally using:

```bash
pnpm run dev --filter @trigger.dev/database
```

Before this change:

- `TS5055` was reported when starting TypeScript in watch mode.

After this change:

- TypeScript starts successfully.
- Watch mode initializes with `Found 0 errors`.

## Notes

- This change only affects the compiler's root input file selection.
- No runtime behavior, build output, or package APIs are modified.
- The change is limited to a single configuration file.