### PR TITLE
ci: let the claude bot trigger the PR audit workflows

### DIFF
--- a/.github/workflows/check-review-md.yml
+++ b/.github/workflows/check-review-md.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           use_sticky_comment: true
-          allowed_bots: "devin-ai-integration[bot]"
+          allowed_bots: "devin-ai-integration[bot],claude[bot]"
 
           claude_args: |
             --max-turns 30

--- a/.github/workflows/claude-md-audit.yml
+++ b/.github/workflows/claude-md-audit.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           use_sticky_comment: true
-          allowed_bots: "devin-ai-integration[bot]"
+          allowed_bots: "devin-ai-integration[bot],claude[bot]"
 
           claude_args: |
             --max-turns 25


### PR DESCRIPTION
## Summary

PRs opened by the claude GitHub app fail both the agent instructions audit and the REVIEW.md drift audit before Claude gets a chance to run. `claude-code-action` refuses any actor whose account type is not `User` unless the actor is listed in `allowed_bots`:

```
Workflow initiated by non-human actor: claude (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

So those PRs land with two permanently red checks and no audit coverage at all. Both workflows already allowlist Devin; this adds the claude app alongside it.

## Why this does not open the workflows up to outside contributors

`allowed_bots` is only consulted for non-`User` actors. Humans, contributor or maintainer, take the separate write-permission path and are unaffected by what is in the list.

Beyond that, both jobs are guarded by `github.event.pull_request.head.repo.full_name == github.repository`, so a fork PR skips the job entirely, and they trigger on `pull_request` rather than `pull_request_target`, so a fork-triggered run would get no API key and a read-only token anyway.

The bot is named explicitly instead of using `"*"`, which would let every bot trigger these audits, dependabot's PR stream included.
