### PR TITLE
chore: ignore local docs/superpowers planning docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ ailogger-output.log
 
 # local git worktree checkouts (not source) — keeps oxfmt/oxlint from descending into them
 .worktrees/
+
+# local planning/design docs, not committed
+**/docs/superpowers/


### PR DESCRIPTION
Adds a gitignore rule for `**/docs/superpowers/` so locally-generated planning and design scratch docs under that path aren't committed; preventive only, no-op for existing tree.
