### PR TITLE
fix(webapp): stop logging every environment on a lookup miss

### DIFF
--- a/apps/webapp/app/presenters/OrganizationsPresenter.server.ts
+++ b/apps/webapp/app/presenters/OrganizationsPresenter.server.ts
@@ -235,7 +235,7 @@ export class OrganizationsPresenter {
       if (!env) {
         logger.info("Not Found: environment", {
           environmentSlug,
-          environments,
+          environmentCount: environments.length,
         });
       }
     }


### PR DESCRIPTION
## Summary

When an environment lookup misses, the diagnostic log now records the requested slug and the number of environments checked instead of serializing the full environment collection.
