### PR TITLE
fix(webapp,redis-worker): stop logging raw metadata, alert payloads, and job items

### DIFF
--- a/.changeset/redact-worker-logs.md
+++ b/.changeset/redact-worker-logs.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/redis-worker": patch
+---
+
+Prevent sensitive job data from being included in worker failure logs.

--- a/.changeset/redact-worker-logs.md
+++ b/.changeset/redact-worker-logs.md
@@ -1,5 +1,0 @@
----
-"@trigger.dev/redis-worker": patch
----
-
-Prevent sensitive job data from being included in worker failure logs.

--- a/apps/webapp/app/services/logger.server.ts
+++ b/apps/webapp/app/services/logger.server.ts
@@ -50,7 +50,7 @@ function flattenArgs(args: Array<Record<string, unknown> | undefined>) {
 export const logger = new Logger(
   "webapp",
   (process.env.APP_LOG_LEVEL ?? "info") as LogLevel,
-  ["examples", "output", "connectionString", "payload"],
+  ["examples", "output", "connectionString", "payload", "metadata", "seedMetadata"],
   sensitiveDataReplacer,
   () => {
     const fields = currentFieldsStore.getStore();

--- a/apps/webapp/app/services/metadata/updateMetadata.server.ts
+++ b/apps/webapp/app/services/metadata/updateMetadata.server.ts
@@ -568,8 +568,7 @@ export class UpdateMetadataService {
       return { metadata: {} };
     }
 
-    const { packet: metadataPacket, byteLength: metadataSizeBytes } =
-      metadataPacketWithByteLength;
+    const { packet: metadataPacket, byteLength: metadataSizeBytes } = metadataPacketWithByteLength;
 
     let updatedAtMs: number | undefined;
 

--- a/apps/webapp/app/services/metadata/updateMetadata.server.ts
+++ b/apps/webapp/app/services/metadata/updateMetadata.server.ts
@@ -6,7 +6,11 @@ import type {
 import { applyMetadataOperations, parsePacket } from "@trigger.dev/core/v3";
 import type { PrismaClientOrTransaction } from "~/db.server";
 import type { AuthenticatedEnvironment } from "~/services/apiAuth.server";
-import { handleMetadataPacket, MetadataTooLargeError } from "~/utils/packets";
+import {
+  handleMetadataPacket,
+  handleMetadataPacketWithByteLength,
+  MetadataTooLargeError,
+} from "~/utils/packets";
 import { ServiceValidationError } from "~/v3/services/common.server";
 import { Effect, Schedule, Duration, Fiber } from "effect";
 import { type RuntimeFiber } from "effect/Fiber";
@@ -554,15 +558,18 @@ export class UpdateMetadataService {
     body: UpdateMetadataRequestBody,
     existingMetadata: IOPacket
   ): Promise<{ metadata: Record<string, unknown> | undefined; updatedAtMs?: number }> {
-    const metadataPacket = handleMetadataPacket(
+    const metadataPacketWithByteLength = handleMetadataPacketWithByteLength(
       body.metadata,
       "application/json",
       this.maximumSize
     );
 
-    if (!metadataPacket) {
+    if (!metadataPacketWithByteLength) {
       return { metadata: {} };
     }
+
+    const { packet: metadataPacket, byteLength: metadataSizeBytes } =
+      metadataPacketWithByteLength;
 
     let updatedAtMs: number | undefined;
 
@@ -573,7 +580,7 @@ export class UpdateMetadataService {
       if (this.flushLoggingEnabled) {
         this.logger.debug(`[updateRunMetadataDirectly] Updating metadata directly for run`, {
           runId,
-          metadataSizeBytes: Buffer.byteLength(metadataPacket.data ?? "", "utf8"),
+          metadataSizeBytes,
         });
       }
 

--- a/apps/webapp/app/services/metadata/updateMetadata.server.ts
+++ b/apps/webapp/app/services/metadata/updateMetadata.server.ts
@@ -91,9 +91,14 @@ export class UpdateMetadataService {
         this._bufferedOperations.clear();
 
         yield* Effect.sync(() => {
-          if (this.flushLoggingEnabled) {
+          if (this.flushLoggingEnabled && currentOperations.size > 0) {
+            const operationCount = Array.from(currentOperations.values()).reduce(
+              (sum, ops) => sum + ops.length,
+              0
+            );
             this.logger.debug(`[UpdateMetadataService] Flushing operations`, {
-              operations: Object.fromEntries(currentOperations),
+              runCount: currentOperations.size,
+              operationCount,
             });
           }
         });
@@ -520,9 +525,9 @@ export class UpdateMetadataService {
 
       if (this.flushLoggingEnabled) {
         this.logger.debug(`[updateRunMetadataWithOperations] Updated metadata for run`, {
-          metadata: applyResults.newMetadata,
-          operations: operations,
           runId,
+          metadataKeyCount: Object.keys(applyResults.newMetadata).length,
+          operationCount: operations.length,
         });
       }
 
@@ -567,8 +572,8 @@ export class UpdateMetadataService {
     ) {
       if (this.flushLoggingEnabled) {
         this.logger.debug(`[updateRunMetadataDirectly] Updating metadata directly for run`, {
-          metadata: metadataPacket.data,
           runId,
+          metadataSizeBytes: metadataPacket.data?.length ?? 0,
         });
       }
 
@@ -607,7 +612,7 @@ export class UpdateMetadataService {
     if (this.flushLoggingEnabled) {
       this.logger.debug(`[ingestRunOperations] Ingesting operations for run`, {
         runId,
-        bufferedOperations,
+        operationCount: bufferedOperations.length,
       });
     }
 

--- a/apps/webapp/app/services/metadata/updateMetadata.server.ts
+++ b/apps/webapp/app/services/metadata/updateMetadata.server.ts
@@ -573,7 +573,7 @@ export class UpdateMetadataService {
       if (this.flushLoggingEnabled) {
         this.logger.debug(`[updateRunMetadataDirectly] Updating metadata directly for run`, {
           runId,
-          metadataSizeBytes: metadataPacket.data?.length ?? 0,
+          metadataSizeBytes: Buffer.byteLength(metadataPacket.data ?? "", "utf8"),
         });
       }
 

--- a/apps/webapp/app/utils/packets.ts
+++ b/apps/webapp/app/utils/packets.ts
@@ -13,6 +13,14 @@ export function handleMetadataPacket(
   metadataType: string,
   maximumSize: number
 ): IOPacket | undefined {
+  return handleMetadataPacketWithByteLength(metadata, metadataType, maximumSize)?.packet;
+}
+
+export function handleMetadataPacketWithByteLength(
+  metadata: any,
+  metadataType: string,
+  maximumSize: number
+): { packet: IOPacket; byteLength: number } | undefined {
   let metadataPacket: IOPacket | undefined = undefined;
 
   if (typeof metadata === "string") {
@@ -33,5 +41,5 @@ export function handleMetadataPacket(
     throw new MetadataTooLargeError(`Metadata exceeds maximum size of ${maximumSize} bytes`);
   }
 
-  return metadataPacket;
+  return { packet: metadataPacket, byteLength };
 }

--- a/apps/webapp/app/v3/services/alerts/deliverAlert.server.ts
+++ b/apps/webapp/app/v3/services/alerts/deliverAlert.server.ts
@@ -455,7 +455,7 @@ export class DeliverAlertService extends BaseService {
                 error,
               };
 
-              await this.#deliverWebhook(payload, webhookProperties.data);
+              await this.#deliverWebhook(payload, webhookProperties.data, { webhookId: alert.channel.id, runId: alert.taskRun.friendlyId });
               break;
             }
             case "v2": {
@@ -516,7 +516,7 @@ export class DeliverAlertService extends BaseService {
                 },
               };
 
-              await this.#deliverWebhook(payload, webhookProperties.data);
+              await this.#deliverWebhook(payload, webhookProperties.data, { webhookId: alert.channel.id, runId: alert.taskRun.friendlyId });
 
               break;
             }
@@ -577,7 +577,7 @@ export class DeliverAlertService extends BaseService {
                 vercel: this.#buildWebhookVercelObject(deploymentMeta.vercelDeploymentUrl),
               };
 
-              await this.#deliverWebhook(payload, webhookProperties.data);
+              await this.#deliverWebhook(payload, webhookProperties.data, { webhookId: alert.channel.id });
               break;
             }
             case "v2": {
@@ -616,7 +616,7 @@ export class DeliverAlertService extends BaseService {
                 },
               };
 
-              await this.#deliverWebhook(payload, webhookProperties.data);
+              await this.#deliverWebhook(payload, webhookProperties.data, { webhookId: alert.channel.id });
 
               break;
             }
@@ -671,7 +671,7 @@ export class DeliverAlertService extends BaseService {
                 vercel: this.#buildWebhookVercelObject(deploymentMeta.vercelDeploymentUrl),
               };
 
-              await this.#deliverWebhook(payload, webhookProperties.data);
+              await this.#deliverWebhook(payload, webhookProperties.data, { webhookId: alert.channel.id });
               break;
             }
             case "v2": {
@@ -716,7 +716,7 @@ export class DeliverAlertService extends BaseService {
                 },
               };
 
-              await this.#deliverWebhook(payload, webhookProperties.data);
+              await this.#deliverWebhook(payload, webhookProperties.data, { webhookId: alert.channel.id });
 
               break;
             }
@@ -1017,7 +1017,11 @@ export class DeliverAlertService extends BaseService {
     }
   }
 
-  async #deliverWebhook<T>(payload: T, webhook: ProjectAlertWebhookProperties) {
+  async #deliverWebhook<T>(
+    payload: T,
+    webhook: ProjectAlertWebhookProperties,
+    context: { webhookId: string; runId?: string }
+  ) {
     const rawPayload = JSON.stringify(payload);
     const hashPayload = Buffer.from(rawPayload, "utf-8");
 
@@ -1046,12 +1050,14 @@ export class DeliverAlertService extends BaseService {
     });
 
     if (!response.ok) {
+      // Never log the request/response body here: it is customer-controlled alert
+      // content and may include stack traces or other application data.
       logger.info("[DeliverAlert] Failed to send alert webhook", {
         status: response.status,
         statusText: response.statusText,
-        url: webhook.url,
-        body: payload,
-        signature,
+        urlHost: safeUrlHost(webhook.url),
+        webhookId: context.webhookId,
+        runId: context.runId,
       });
 
       throw new Error(`Failed to send alert webhook to ${webhook.url}`);
@@ -1434,4 +1440,12 @@ function isWebAPIHTTPError(error: unknown): error is WebAPIHTTPError {
 
 function isWebAPIRateLimitedError(error: unknown): error is WebAPIRateLimitedError {
   return (error as WebAPIRateLimitedError).code === ErrorCode.RateLimitedError;
+}
+
+function safeUrlHost(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return "unknown";
+  }
 }

--- a/apps/webapp/app/v3/services/alerts/deliverAlert.server.ts
+++ b/apps/webapp/app/v3/services/alerts/deliverAlert.server.ts
@@ -455,7 +455,10 @@ export class DeliverAlertService extends BaseService {
                 error,
               };
 
-              await this.#deliverWebhook(payload, webhookProperties.data, { webhookId: alert.channel.id, runId: alert.taskRun.friendlyId });
+              await this.#deliverWebhook(payload, webhookProperties.data, {
+                webhookId: alert.channel.id,
+                runId: alert.taskRun.friendlyId,
+              });
               break;
             }
             case "v2": {
@@ -516,7 +519,10 @@ export class DeliverAlertService extends BaseService {
                 },
               };
 
-              await this.#deliverWebhook(payload, webhookProperties.data, { webhookId: alert.channel.id, runId: alert.taskRun.friendlyId });
+              await this.#deliverWebhook(payload, webhookProperties.data, {
+                webhookId: alert.channel.id,
+                runId: alert.taskRun.friendlyId,
+              });
 
               break;
             }
@@ -577,7 +583,9 @@ export class DeliverAlertService extends BaseService {
                 vercel: this.#buildWebhookVercelObject(deploymentMeta.vercelDeploymentUrl),
               };
 
-              await this.#deliverWebhook(payload, webhookProperties.data, { webhookId: alert.channel.id });
+              await this.#deliverWebhook(payload, webhookProperties.data, {
+                webhookId: alert.channel.id,
+              });
               break;
             }
             case "v2": {
@@ -616,7 +624,9 @@ export class DeliverAlertService extends BaseService {
                 },
               };
 
-              await this.#deliverWebhook(payload, webhookProperties.data, { webhookId: alert.channel.id });
+              await this.#deliverWebhook(payload, webhookProperties.data, {
+                webhookId: alert.channel.id,
+              });
 
               break;
             }
@@ -671,7 +681,9 @@ export class DeliverAlertService extends BaseService {
                 vercel: this.#buildWebhookVercelObject(deploymentMeta.vercelDeploymentUrl),
               };
 
-              await this.#deliverWebhook(payload, webhookProperties.data, { webhookId: alert.channel.id });
+              await this.#deliverWebhook(payload, webhookProperties.data, {
+                webhookId: alert.channel.id,
+              });
               break;
             }
             case "v2": {
@@ -716,7 +728,9 @@ export class DeliverAlertService extends BaseService {
                 },
               };
 
-              await this.#deliverWebhook(payload, webhookProperties.data, { webhookId: alert.channel.id });
+              await this.#deliverWebhook(payload, webhookProperties.data, {
+                webhookId: alert.channel.id,
+              });
 
               break;
             }
@@ -1060,7 +1074,7 @@ export class DeliverAlertService extends BaseService {
         runId: context.runId,
       });
 
-      throw new Error(`Failed to send alert webhook to ${webhook.url}`);
+      throw new Error(`Failed to send alert webhook to ${safeUrlHost(webhook.url)}`);
     }
   }
 

--- a/packages/redis-worker/src/worker.ts
+++ b/packages/redis-worker/src/worker.ts
@@ -140,7 +140,7 @@ class Worker<TCatalog extends WorkerCatalog> {
   > = new Map();
 
   constructor(private options: WorkerOptions<TCatalog>) {
-    this.logger = options.logger ?? new Logger("Worker", "debug");
+    this.logger = options.logger ?? new Logger("Worker", "debug", ["item"]);
     this.tracer = options.tracer ?? trace.getTracer(options.name);
     this.meter = options.meter ?? metrics.getMeter(options.name);
 
@@ -608,7 +608,8 @@ class Worker<TCatalog extends WorkerCatalog> {
                 this.logger.error("Unhandled error in processItem:", {
                   error: err,
                   workerId,
-                  item,
+                  id: queueItem.id,
+                  job: queueItem.job,
                 });
               }
             );
@@ -933,11 +934,12 @@ class Worker<TCatalog extends WorkerCatalog> {
       const errorLogLevel =
         error && typeof error === "object" && "logLevel" in error ? error.logLevel : undefined;
 
+      // Never include the raw item/payload here: it is job data that may be
+      // customer-controlled. It is retrievable via `getJob(id)` if needed for triage.
       const logAttributes = {
         name: this.options.name,
         id,
         job,
-        item,
         visibilityTimeoutMs,
         error,
         errorMessage,
@@ -994,7 +996,6 @@ class Worker<TCatalog extends WorkerCatalog> {
           name: this.options.name,
           id,
           job,
-          item,
           retryDate,
           retryDelay,
           visibilityTimeoutMs,
@@ -1015,7 +1016,6 @@ class Worker<TCatalog extends WorkerCatalog> {
             name: this.options.name,
             id,
             job,
-            item,
             visibilityTimeoutMs,
             error: requeueError,
           }


### PR DESCRIPTION
## Summary

Debug logging around run metadata writes previously included the full,
unfiltered metadata object on every flush, so credentials and other
sensitive customer-controlled data could end up in application logs. It now
logs key/operation counts and byte sizes instead, and skips the log
entirely when there is nothing buffered. The webapp logger's redaction list
also now covers `metadata` and `seedMetadata` as a backstop.

Alert webhook delivery failures no longer log the outgoing request body or
the (useless, non-serializable) HMAC signature; they log the response
status, the webhook URL host, and the relevant ids instead.

The redis-worker's failure, retry, and dead-letter logs no longer include
the raw job item. The item is still retrievable by id when needed, and the
default worker logger now filters the `item` key as a backstop.

## Design

Each call site was already computing everything needed to reproduce or
triage a failure without the raw payload (ids, counts, sizes, statuses), so
this trades verbose-by-default logging for those cheaper, non-sensitive
signals.

## Performance
Improves hot path performance relative to baseline.