### PR TITLE
feat(llm-model-catalog): add MiniMax provider (MiniMax-M3, MiniMax-M2.7)

### DIFF
--- a/internal-packages/llm-model-catalog/src/default-model-prices.json
+++ b/internal-packages/llm-model-catalog/src/default-model-prices.json
@@ -3987,5 +3987,48 @@
         }
       }
     ]
+  },
+  {
+    "id": "minimax-m3",
+    "modelName": "MiniMax-M3",
+    "matchPattern": "(?i)^(minimax/)?(MiniMax-M3)$",
+    "createdAt": "2026-07-29T00:00:00.000Z",
+    "updatedAt": "2026-07-29T00:00:00.000Z",
+    "pricingTiers": [
+      {
+        "id": "minimax-m3_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 0.0000006,
+          "output": 0.0000024,
+          "input_cache_read": 0.00000012
+        }
+      }
+    ]
+  },
+  {
+    "id": "minimax-m2-7",
+    "modelName": "MiniMax-M2.7",
+    "matchPattern": "(?i)^(minimax/)?(MiniMax-M2.7)$",
+    "createdAt": "2026-07-29T00:00:00.000Z",
+    "updatedAt": "2026-07-29T00:00:00.000Z",
+    "pricingTiers": [
+      {
+        "id": "minimax-m2-7_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 0.0000003,
+          "output": 0.0000012,
+          "input_cache_read": 0.00000006,
+          "input_cache_creation": 0.000000375
+        }
+      }
+    ]
   }
 ]

--- a/internal-packages/llm-model-catalog/src/defaultPrices.ts
+++ b/internal-packages/llm-model-catalog/src/defaultPrices.ts
@@ -3108,4 +3108,41 @@ export const defaultModelPrices: DefaultModelDefinition[] = [
       },
     ],
   },
+  {
+    modelName: "MiniMax-M3",
+    matchPattern: "(?i)^(minimax/)?(MiniMax-M3)$",
+    startDate: "2026-07-29T00:00:00.000Z",
+    pricingTiers: [
+      {
+        name: "Standard",
+        isDefault: true,
+        priority: 0,
+        conditions: [],
+        prices: {
+          input: 6e-7,
+          output: 0.0000024,
+          input_cache_read: 1.2e-7,
+        },
+      },
+    ],
+  },
+  {
+    modelName: "MiniMax-M2.7",
+    matchPattern: "(?i)^(minimax/)?(MiniMax-M2.7)$",
+    startDate: "2026-07-29T00:00:00.000Z",
+    pricingTiers: [
+      {
+        name: "Standard",
+        isDefault: true,
+        priority: 0,
+        conditions: [],
+        prices: {
+          input: 3e-7,
+          output: 0.0000012,
+          input_cache_read: 6e-8,
+          input_cache_creation: 3.75e-7,
+        },
+      },
+    ],
+  },
 ];

--- a/internal-packages/llm-model-catalog/src/model-catalog.json
+++ b/internal-packages/llm-model-catalog/src/model-catalog.json
@@ -1,4 +1,34 @@
 {
+  "MiniMax-M2.7": {
+    "provider": "minimax",
+    "description": "MiniMax's text-only large language model with a 204,800-token context window and always-on thinking for step-by-step reasoning.",
+    "contextWindow": 204800,
+    "maxOutputTokens": null,
+    "capabilities": ["extended_thinking"],
+    "releaseDate": null,
+    "isHidden": false,
+    "supportsStructuredOutput": false,
+    "supportsParallelToolCalls": false,
+    "supportsStreamingToolCalls": false,
+    "deprecationDate": null,
+    "knowledgeCutoff": null,
+    "resolvedAt": "2026-07-29T00:00:00.000Z"
+  },
+  "MiniMax-M3": {
+    "provider": "minimax",
+    "description": "MiniMax's large language model with a 1,000,000-token context window that accepts text, image, and video input and supports adaptive thinking that can be switched on or off.",
+    "contextWindow": 1000000,
+    "maxOutputTokens": null,
+    "capabilities": ["vision", "extended_thinking"],
+    "releaseDate": null,
+    "isHidden": false,
+    "supportsStructuredOutput": false,
+    "supportsParallelToolCalls": false,
+    "supportsStreamingToolCalls": false,
+    "deprecationDate": null,
+    "knowledgeCutoff": null,
+    "resolvedAt": "2026-07-29T00:00:00.000Z"
+  },
   "chatgpt-4o-latest": {
     "provider": "openai",
     "description": "OpenAI's flagship multimodal model optimized for speed and cost, capable of processing text, images, and audio with strong performance across reasoning, coding, and creative tasks.",

--- a/internal-packages/llm-model-catalog/src/modelCatalog.ts
+++ b/internal-packages/llm-model-catalog/src/modelCatalog.ts
@@ -4,6 +4,40 @@ import type { ModelCatalogEntry } from "./types.js";
 // Run `pnpm run generate-catalog` to update the JSON, then `pnpm run generate` to regenerate.
 
 export const modelCatalog: Record<string, ModelCatalogEntry> = {
+  "MiniMax-M2.7": {
+    provider: "minimax",
+    description:
+      "MiniMax's text-only large language model with a 204,800-token context window and always-on thinking for step-by-step reasoning.",
+    contextWindow: 204800,
+    maxOutputTokens: null,
+    capabilities: ["extended_thinking"],
+    releaseDate: null,
+    isHidden: false,
+    supportsStructuredOutput: false,
+    supportsParallelToolCalls: false,
+    supportsStreamingToolCalls: false,
+    deprecationDate: null,
+    knowledgeCutoff: null,
+    resolvedAt: "2026-07-29T00:00:00.000Z",
+    baseModelName: null,
+  },
+  "MiniMax-M3": {
+    provider: "minimax",
+    description:
+      "MiniMax's large language model with a 1,000,000-token context window that accepts text, image, and video input and supports adaptive thinking that can be switched on or off.",
+    contextWindow: 1000000,
+    maxOutputTokens: null,
+    capabilities: ["vision", "extended_thinking"],
+    releaseDate: null,
+    isHidden: false,
+    supportsStructuredOutput: false,
+    supportsParallelToolCalls: false,
+    supportsStreamingToolCalls: false,
+    deprecationDate: null,
+    knowledgeCutoff: null,
+    resolvedAt: "2026-07-29T00:00:00.000Z",
+    baseModelName: null,
+  },
   "chatgpt-4o-latest": {
     provider: "openai",
     description:


### PR DESCRIPTION
Reason: The maintained LLM model catalog and pricing inputs had no MiniMax entries, so runs on MiniMax-M3 and MiniMax-M2.7 could not be matched for model observability or cost attribution.

## What changed

Adds the MiniMax provider and its two current text models to `@internal/llm-model-catalog`, then regenerates the runtime catalog modules from the JSON sources.

**Catalog metadata** (`src/model-catalog.json`):

| Model | Context window | Input | Thinking |
| --- | --- | --- | --- |
| `MiniMax-M3` | 1,000,000 | text, image, video (`vision`) | adaptive / off (`extended_thinking`) |
| `MiniMax-M2.7` | 204,800 | text | always-on (`extended_thinking`) |

**Token pricing** (`src/default-model-prices.json`, USD per 1M tokens):

| Model | Input | Output | Cache read | Cache write |
| --- | --- | --- | --- | --- |
| `MiniMax-M3` | 0.60 | 2.40 | 0.12 | — |
| `MiniMax-M2.7` | 0.30 | 1.20 | 0.06 | 0.375 |

Match patterns follow the existing convention and also accept a provider-prefixed id (e.g. `minimax/MiniMax-M3`).

**Regenerated modules**: `src/defaultPrices.ts` and `src/modelCatalog.ts` were regenerated with `node scripts/generate.mjs` (no manual edits).

## Checks

- `node scripts/generate.mjs` — regenerated the two modules; the diff contains only the new entries.
- `oxfmt --check` on both edited JSON source files — clean.
- `tsc --noEmit` over `types.ts`, `defaultPrices.ts`, `modelCatalog.ts` — passes (generated data conforms to `DefaultModelDefinition` / `ModelCatalogEntry`).
- Verified the new match patterns resolve the model ids (and their provider-prefixed forms) and produce the expected per-token cost.
