### PR TITLE
fix(cli): redact environment values from build debug logs

### DIFF
--- a/.changeset/silent-build-logs.md
+++ b/.changeset/silent-build-logs.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Prevent build debug logs from including environment variable values.

--- a/packages/cli-v3/src/build/buildWorker.ts
+++ b/packages/cli-v3/src/build/buildWorker.ts
@@ -15,11 +15,12 @@ import { join, relative, sep } from "node:path";
 import { generateContainerfile } from "../deploy/buildImage.js";
 import { writeFile } from "node:fs/promises";
 import { buildManifestToJSON } from "../utilities/buildManifest.js";
+import { logger } from "../utilities/logger.js";
 import { readPackageJSON } from "pkg-types";
 import { writeJSONFile } from "../utilities/fileSystem.js";
 import { isWindows } from "std-env";
 import { pathToFileURL } from "node:url";
-import { logger } from "../utilities/logger.js";
+import { logBuildWorkerStart } from "./buildWorkerLogging.js";
 import { SdkVersionExtractor } from "./plugins.js";
 import { spinner } from "../utilities/windows.js";
 
@@ -42,9 +43,7 @@ export type BuildWorkerOptions = {
 };
 
 export async function buildWorker(options: BuildWorkerOptions) {
-  logger.debug("Starting buildWorker", {
-    options,
-  });
+  logBuildWorkerStart(options);
 
   const resolvedConfig = options.resolvedConfig;
 

--- a/packages/cli-v3/src/build/buildWorkerLogging.test.ts
+++ b/packages/cli-v3/src/build/buildWorkerLogging.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { logBuildWorkerStart } from "./buildWorkerLogging.js";
+import { logger } from "../utilities/logger.js";
+
+const secret = "build-worker-secret-value";
+
+describe("logBuildWorkerStart", () => {
+  it.each(["deploy", "unmanaged"] as const)(
+    "does not log environment values for %s builds",
+    (target) => {
+      const debug = vi.spyOn(logger, "debug").mockImplementation(() => {});
+
+      logBuildWorkerStart({
+        target,
+        branch: "main",
+        envVars: { BUILD_SECRET: secret },
+        rewritePaths: true,
+        forcedExternals: ["example-package"],
+      });
+
+      expect(debug).toHaveBeenCalledOnce();
+      expect(JSON.stringify(debug.mock.calls)).not.toContain(secret);
+      expect(debug).toHaveBeenCalledWith("Starting buildWorker", {
+        target,
+        hasBranch: true,
+        envVarCount: 1,
+        rewritePaths: true,
+        forcedExternalsCount: 1,
+        plain: false,
+      });
+
+      debug.mockRestore();
+    }
+  );
+});

--- a/packages/cli-v3/src/build/buildWorkerLogging.ts
+++ b/packages/cli-v3/src/build/buildWorkerLogging.ts
@@ -1,0 +1,21 @@
+import { logger } from "../utilities/logger.js";
+
+type BuildWorkerLogOptions = {
+  target: string;
+  branch?: string;
+  envVars?: Record<string, string>;
+  rewritePaths?: boolean;
+  forcedExternals?: string[];
+  plain?: boolean;
+};
+
+export function logBuildWorkerStart(options: BuildWorkerLogOptions) {
+  logger.debug("Starting buildWorker", {
+    target: options.target,
+    hasBranch: options.branch !== undefined,
+    envVarCount: Object.keys(options.envVars ?? {}).length,
+    rewritePaths: options.rewritePaths ?? false,
+    forcedExternalsCount: options.forcedExternals?.length ?? 0,
+    plain: options.plain ?? false,
+  });
+}


### PR DESCRIPTION
## Summary

Prevents CLI build debug logs from including resolved environment variable values. The startup record now emits only a safe summary of build options.