### PR TITLE
fix(webapp): add hasAdminDisplayAccess to the env param test mock

### DIFF
--- a/apps/webapp/test/envParamRoute.ownership.test.ts
+++ b/apps/webapp/test/envParamRoute.ownership.test.ts
@@ -17,6 +17,11 @@ vi.mock("~/db.server", () => ({
 
 vi.mock("~/services/session.server", () => ({
   requireUser: async () => mocks.user,
+  hasAdminDisplayAccess: (user: {
+    admin: boolean;
+    isImpersonating: boolean;
+    isViewingAsUser?: boolean;
+  }) => (user.admin || user.isImpersonating) && !user.isViewingAsUser,
 }));
 
 vi.mock("~/services/dashboardPreferences.server", () => ({


### PR DESCRIPTION
`test/envParamRoute.ownership.test.ts` fails on main: 3 of its 4 tests throw

```
Error: [vitest] No "hasAdminDisplayAccess" export is defined on the
"~/services/session.server" mock. Did you forget to return it from "vi.mock"?
```

#4421 added a `hasAdminDisplayAccess(user)` call to the `env.$envParam` loader, and the test's `vi.mock` of `session.server` only returns `requireUser`, so the call blows up. Both changes were green in their own PR and only conflict once merged together, which is why nobody caught it.

The mock now mirrors the real implementation rather than returning a constant, so it stays correct if the test's user fixture is ever varied. No assertions were changed: the tests were right, the mock was stale.

Worth flagging separately: no workflow runs on push to main, so this has been red since #4421 landed without showing up anywhere. Every PR opened since has inherited the failure.