### PR TITLE
fix(sdk): envvars.update() ReferenceError: name is not defined outside task context

### DIFF
--- a/.changeset/fix-envvars-update-name.md
+++ b/.changeset/fix-envvars-update-name.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+Fix `envvars.update()` throwing `ReferenceError: name is not defined` when called outside a task context. The non-task branch referenced an out-of-scope `name` variable instead of the `nameOrRequestOptions` parameter (#4264).

--- a/packages/trigger-sdk/src/v3/envvars.test.ts
+++ b/packages/trigger-sdk/src/v3/envvars.test.ts
@@ -1,0 +1,67 @@
+import { createServer, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { apiClientManager } from "@trigger.dev/core/v3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as envvars from "./envvars.js";
+
+type ReceivedRequest = {
+  method: string;
+  url: string;
+};
+
+describe("envvars.update outside a task context (GH #4264)", () => {
+  let server: Server;
+  let baseUrl: string;
+  let requests: ReceivedRequest[];
+
+  beforeEach(async () => {
+    requests = [];
+    server = createServer((request, response) => {
+      requests.push({ method: request.method ?? "", url: request.url ?? "" });
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ success: true }));
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("resolves the name argument instead of throwing ReferenceError", async () => {
+    const key = "tr_prod_0123456789abcdefghijklmn";
+
+    // Outside a task context, taskContext.ctx is undefined. Before the fix this
+    // path evaluated `$name = name!`, but the implementation signature has no
+    // `name` parameter, so it threw `ReferenceError: name is not defined`.
+    await apiClientManager.runWithConfig({ baseURL: baseUrl, accessToken: key }, async () => {
+      try {
+        await envvars.update("proj_ref", "prod", "MY_SECRET", { value: "abc" });
+      } catch (err) {
+        // Response-shape concerns are irrelevant here; only assert the
+        // argument-resolution crash is gone.
+        expect((err as Error).message).not.toContain("name is not defined");
+      }
+    });
+
+    const updateRequest = requests.find((request) => request.url.includes("MY_SECRET"));
+    expect(updateRequest).toBeDefined();
+    expect(updateRequest!.url).toContain("/projects/proj_ref/envvars/prod/MY_SECRET");
+  });
+
+  it("throws a clear error when the name is missing", async () => {
+    const key = "tr_prod_0123456789abcdefghijklmn";
+
+    await apiClientManager.runWithConfig({ baseURL: baseUrl, accessToken: key }, async () => {
+      await expect(
+        // @ts-expect-error deliberately omitting the name argument
+        envvars.update("proj_ref", "prod", { value: "abc" })
+      ).rejects.toThrow("name is required");
+    });
+  });
+});

--- a/packages/trigger-sdk/src/v3/envvars.ts
+++ b/packages/trigger-sdk/src/v3/envvars.ts
@@ -336,9 +336,13 @@ export function update(
       throw new Error("params is required");
     }
 
+    if (typeof nameOrRequestOptions !== "string") {
+      throw new Error("name is required");
+    }
+
     $projectRef = projectRefOrName;
     $slug = slugOrParams;
-    $name = name!;
+    $name = nameOrRequestOptions;
     $params = params;
   }
 


### PR DESCRIPTION
## Closes #4264

### Problem
Calling `envvars.update(projectRef, slug, name, params)` from **outside a task run** (a plain Node script / CI deploy step) always throws:

```
ReferenceError: name is not defined
```

`create`, `del`, `retrieve`, and `list` all work from the same context — only `update` is affected.

### Root cause
`update()`'s implementation signature is:

```ts
export function update(
  projectRefOrName: string,
  slugOrParams: string | UpdateEnvironmentVariableParams,
  nameOrRequestOptions?: string | ApiRequestOptions,
  params?: UpdateEnvironmentVariableParams,
  requestOptions?: ApiRequestOptions
)
```

There is **no `name` parameter** (the extra `params` argument shifts the name into `nameOrRequestOptions`). But the non-task-context branch did:

```ts
$name = name!;
```

`retrieve`/`del` legitimately have a `name` parameter, so that line works there — it was carried into `update` without renaming to `nameOrRequestOptions`. When `taskContext.ctx` is undefined (outside a task), this branch runs and dereferences the out-of-scope `name` → `ReferenceError`.

### Fix
Use `nameOrRequestOptions`, guarded like the sibling `slug`/`projectRef`/`params` checks in the same branch:

```ts
if (typeof nameOrRequestOptions !== "string") {
  throw new Error("name is required");
}

$projectRef = projectRefOrName;
$slug = slugOrParams;
$name = nameOrRequestOptions;
$params = params;
```

This removes the `ReferenceError`, correctly routes the env var name, and gives a clear error if `name` is genuinely omitted (instead of a confusing crash).

### Tests
Added `packages/trigger-sdk/src/v3/envvars.test.ts` (modeled on `auth.test.ts` — local HTTP server + `apiClientManager.runWithConfig`):
- `update()` outside a task context no longer throws `ReferenceError` and dispatches to `/projects/{ref}/envvars/{slug}/{name}` with the name resolved.
- omitting the name throws a clear `"name is required"`.

Added a changeset (`@trigger.dev/sdk` patch).

### Verification note
I verified the overload-resolution logic with a standalone Node reproduction (before → `ReferenceError: name is not defined`; after → name resolved correctly; missing name → `"name is required"`). The full monorepo test suite/build is heavy on my Windows machine, so I couldn't run vitest locally end-to-end — CI will exercise the added test.
