### PR TITLE
fix(webapp): focus the search field when a filter sub-menu opens

### DIFF
--- a/apps/webapp/app/components/primitives/Select.tsx
+++ b/apps/webapp/app/components/primitives/Select.tsx
@@ -694,6 +694,15 @@ export function ComboBox({
   shortcut,
   ...props
 }: ComboBoxProps) {
+  const combobox = Ariakit.useComboboxContext();
+  const open = combobox?.useState("open");
+  const input = combobox?.useState("baseElement");
+
+  React.useEffect(() => {
+    if (!open || !input) return;
+    input.focus();
+  }, [open, input]);
+
   return (
     <div className="flex h-9 w-full flex-none items-center border-b border-grid-dimmed bg-transparent pl-0 pr-3 text-xs text-text-dimmed outline-hidden">
       <Ariakit.Combobox


### PR DESCRIPTION
## Summary

Opening a filter sub-menu that has its own search field left the cursor outside it, so you had to click into the field before you could type. The cursor now lands in the search field every time a sub-menu opens.

`ComboBox` now focuses its input whenever the popover is open and the field is present, so the cursor lands there both when a menu opens normally and when a sub-menu mounts its field late. It is a no-op wherever focus already worked.

Verified in the dashboard against the Tags menu: before, the field mounted with focus still on the popover container; after, it mounts focused and accepts typing straight away.