### PR TITLE
perf(webapp,run-engine,database): resolve the newest worker and deployment by createdAt

### DIFF
--- a/.server-changes/worker-deployment-lookup-ordering.md
+++ b/.server-changes/worker-deployment-lookup-ordering.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+Speeds up resolving the latest worker version and deployment for an environment, removing an occasional stall when triggering runs in projects that have accumulated many deployed versions.

--- a/apps/webapp/app/services/runsRepository/clickhouseRunsRepository.server.ts
+++ b/apps/webapp/app/services/runsRepository/clickhouseRunsRepository.server.ts
@@ -271,9 +271,6 @@ export class ClickHouseRunsRepository implements IRunsRepository {
               in: ids,
             },
           },
-          orderBy: {
-            id: "desc",
-          },
           select: {
             id: true,
             friendlyId: true,

--- a/apps/webapp/app/v3/models/workerDeployment.server.ts
+++ b/apps/webapp/app/v3/models/workerDeployment.server.ts
@@ -133,9 +133,7 @@ export async function findCurrentWorkerDeployment({
       environmentId,
       type,
     },
-    orderBy: {
-      id: "desc",
-    },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
     select: {
       id: true,
       imageReference: true,

--- a/apps/webapp/app/v3/models/workerDeployment.server.ts
+++ b/apps/webapp/app/v3/models/workerDeployment.server.ts
@@ -128,7 +128,7 @@ export async function findCurrentWorkerDeployment({
   }
 
   // We need to get the latest deployment of the given type
-  const latestDeployment = await prisma.workerDeployment.findFirst({
+  const latestDeployment = await $prisma.workerDeployment.findFirst({
     where: {
       environmentId,
       type,

--- a/apps/webapp/app/v3/runOpsMigration/controlPlaneResolver.server.ts
+++ b/apps/webapp/app/v3/runOpsMigration/controlPlaneResolver.server.ts
@@ -432,7 +432,7 @@ export class ControlPlaneResolver {
     // MANAGED deployment.
     const latestV2Deployment = await client.workerDeployment.findFirst({
       where: { environmentId, type: "MANAGED" },
-      orderBy: { id: "desc" },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       include: { worker: { include: { tasks: true, queues: true } } },
     });
 
@@ -455,7 +455,6 @@ export class ControlPlaneResolver {
     const worker = await client.backgroundWorker.findFirst({
       where: { id: workerId },
       include: { deployment: true, tasks: true, queues: true },
-      orderBy: { id: "desc" },
     });
 
     if (!worker) {
@@ -472,7 +471,7 @@ export class ControlPlaneResolver {
     const worker = await client.backgroundWorker.findFirst({
       where: { runtimeEnvironmentId: environmentId },
       include: { tasks: true, queues: true },
-      orderBy: { id: "desc" },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
     });
 
     if (!worker) {

--- a/apps/webapp/test/v3/runOpsMigration/controlPlaneResolver.server.test.ts
+++ b/apps/webapp/test/v3/runOpsMigration/controlPlaneResolver.server.test.ts
@@ -62,7 +62,12 @@ async function seedControlPlane(prisma: PrismaClient) {
 async function seedWorker(
   prisma: PrismaClient,
   ctx: { projectId: string; environmentId: string },
-  opts?: { promote?: boolean }
+  opts?: {
+    promote?: boolean;
+    createdAt?: Date;
+    deploymentType?: "MANAGED" | "UNMANAGED" | "V1";
+    deploymentCreatedAt?: Date;
+  }
 ) {
   const n = seedCounter++;
   const worker = await prisma.backgroundWorker.create({
@@ -74,6 +79,7 @@ async function seedWorker(
       version: `2024.1.${n}`,
       metadata: {},
       engine: "V2",
+      ...(opts?.createdAt ? { createdAt: opts.createdAt } : {}),
     },
   });
   const task = await prisma.backgroundWorkerTask.create({
@@ -104,11 +110,12 @@ async function seedWorker(
         contentHash: `hash_${n}`,
         version: worker.version,
         shortCode: `dep_${n}`,
-        type: "MANAGED",
+        type: opts?.deploymentType ?? "MANAGED",
         status: "DEPLOYED",
         projectId: ctx.projectId,
         environmentId: ctx.environmentId,
         workerId: worker.id,
+        ...(opts?.deploymentCreatedAt ? { createdAt: opts.deploymentCreatedAt } : {}),
       },
     });
     await prisma.workerDeploymentPromotion.create({
@@ -746,5 +753,105 @@ heteroPostgresTest(
     const readsAfterFirst = reads();
     await resolver.resolveRunLockedWorker({ lockedById: task.id, lockedToVersionId: worker.id });
     expect(reads()).toBe(readsAfterFirst * 2);
+  }
+);
+
+heteroPostgresTest(
+  "resolveWorkerVersion (DEVELOPMENT) resolves the newest worker by createdAt, not by id",
+  async ({ prisma14 }) => {
+    const { environment, project } = await seedControlPlane(prisma14);
+    const ctx = { projectId: project.id, environmentId: environment.id };
+
+    const newest = await seedWorker(prisma14, ctx, {
+      createdAt: new Date("2026-07-31T12:00:00.000Z"),
+    });
+    const oldest = await seedWorker(prisma14, ctx, {
+      createdAt: new Date("2026-07-30T12:00:00.000Z"),
+    });
+
+    expect(oldest.worker.id > newest.worker.id).toBe(true);
+    expect(oldest.worker.createdAt < newest.worker.createdAt).toBe(true);
+
+    const resolver = new ControlPlaneResolver({
+      controlPlaneReplica: prisma14,
+      controlPlanePrimary: prisma14,
+      cache: new ControlPlaneCache(),
+      splitEnabled: () => true,
+    });
+
+    const resolved = await resolver.resolveWorkerVersion({
+      environmentId: environment.id,
+      type: "DEVELOPMENT",
+    });
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.worker.id).toBe(newest.worker.id);
+  }
+);
+
+heteroPostgresTest(
+  "resolveWorkerVersion latest-MANAGED fallback resolves by createdAt, not by id",
+  async ({ prisma14 }) => {
+    const { environment, project } = await seedControlPlane(prisma14);
+    const ctx = { projectId: project.id, environmentId: environment.id };
+
+    await seedWorker(prisma14, ctx, { promote: true, deploymentType: "V1" });
+
+    const newest = await seedWorker(prisma14, ctx, {
+      promote: false,
+      deploymentCreatedAt: new Date("2026-07-31T12:00:00.000Z"),
+    });
+    const oldest = await seedWorker(prisma14, ctx, {
+      promote: false,
+      deploymentCreatedAt: new Date("2026-07-30T12:00:00.000Z"),
+    });
+
+    const newestDeployment = await prisma14.workerDeployment.create({
+      data: {
+        friendlyId: `deployment_newest_${environment.id}`,
+        contentHash: "hash_newest",
+        version: newest.worker.version,
+        shortCode: "dep_newest",
+        type: "MANAGED",
+        status: "DEPLOYED",
+        projectId: project.id,
+        environmentId: environment.id,
+        workerId: newest.worker.id,
+        createdAt: new Date("2026-07-31T12:00:00.000Z"),
+      },
+    });
+    const oldestDeployment = await prisma14.workerDeployment.create({
+      data: {
+        friendlyId: `deployment_oldest_${environment.id}`,
+        contentHash: "hash_oldest",
+        version: oldest.worker.version,
+        shortCode: "dep_oldest",
+        type: "MANAGED",
+        status: "DEPLOYED",
+        projectId: project.id,
+        environmentId: environment.id,
+        workerId: oldest.worker.id,
+        createdAt: new Date("2026-07-30T12:00:00.000Z"),
+      },
+    });
+
+    expect(oldestDeployment.id > newestDeployment.id).toBe(true);
+    expect(oldestDeployment.createdAt < newestDeployment.createdAt).toBe(true);
+
+    const resolver = new ControlPlaneResolver({
+      controlPlaneReplica: prisma14,
+      controlPlanePrimary: prisma14,
+      cache: new ControlPlaneCache(),
+      splitEnabled: () => true,
+    });
+
+    const resolved = await resolver.resolveWorkerVersion({
+      environmentId: environment.id,
+      type: "PRODUCTION",
+    });
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.deployment!.id).toBe(newestDeployment.id);
+    expect(resolved!.worker.id).toBe(newest.worker.id);
   }
 );

--- a/internal-packages/database/prisma/migrations/20260731160000_add_worker_deployment_environment_id_created_at_index/migration.sql
+++ b/internal-packages/database/prisma/migrations/20260731160000_add_worker_deployment_environment_id_created_at_index/migration.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "WorkerDeployment_environmentId_createdAt_idx" ON "public"."WorkerDeployment"("environmentId", "createdAt");

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -2208,6 +2208,7 @@ model WorkerDeployment {
   @@unique([projectId, shortCode])
   @@unique([environmentId, version])
   @@index([commitSHA])
+  @@index([environmentId, createdAt])
 }
 
 enum WorkerDeploymentStatus {

--- a/internal-packages/run-engine/src/engine/controlPlaneResolver.ts
+++ b/internal-packages/run-engine/src/engine/controlPlaneResolver.ts
@@ -234,9 +234,7 @@ export class PassthroughControlPlaneResolver implements ControlPlaneResolver {
         tasks: true,
         queues: true,
       },
-      orderBy: {
-        id: "desc",
-      },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
     });
 
     if (!worker) {
@@ -255,9 +253,6 @@ export class PassthroughControlPlaneResolver implements ControlPlaneResolver {
         deployment: true,
         tasks: true,
         queues: true,
-      },
-      orderBy: {
-        id: "desc",
       },
     });
 
@@ -315,9 +310,7 @@ export class PassthroughControlPlaneResolver implements ControlPlaneResolver {
         environmentId,
         type: "MANAGED",
       },
-      orderBy: {
-        id: "desc",
-      },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       include: {
         worker: {
           include: {

--- a/internal-packages/run-engine/src/engine/tests/dequeueSystem.controlPlaneResolver.test.ts
+++ b/internal-packages/run-engine/src/engine/tests/dequeueSystem.controlPlaneResolver.test.ts
@@ -538,3 +538,142 @@ describe("DequeueSystem controlPlaneResolver (single-DB passthrough)", () => {
     }
   );
 });
+
+heteroPostgresTest(
+  "resolveWorkerVersion (DEVELOPMENT) resolves the newest worker by createdAt, not by id",
+  async ({ prisma14 }) => {
+    const cp = await seedControlPlane(
+      prisma14 as unknown as PrismaClient,
+      "cpord",
+      "ordering-task"
+    );
+
+    await prisma14.backgroundWorker.update({
+      where: { id: cp.worker.id },
+      data: { createdAt: new Date("2026-07-01T12:00:00.000Z") },
+    });
+
+    const newest = await prisma14.backgroundWorker.create({
+      data: {
+        friendlyId: generateFriendlyId("worker"),
+        contentHash: "hash_newest",
+        projectId: cp.project.id,
+        runtimeEnvironmentId: cp.environment.id,
+        version: "20260731.1",
+        metadata: {},
+        engine: "V2",
+        createdAt: new Date("2026-07-31T12:00:00.000Z"),
+      },
+    });
+    const oldest = await prisma14.backgroundWorker.create({
+      data: {
+        friendlyId: generateFriendlyId("worker"),
+        contentHash: "hash_oldest",
+        projectId: cp.project.id,
+        runtimeEnvironmentId: cp.environment.id,
+        version: "20260730.1",
+        metadata: {},
+        engine: "V2",
+        createdAt: new Date("2026-07-30T12:00:00.000Z"),
+      },
+    });
+
+    expect(oldest.id > newest.id).toBe(true);
+    expect(oldest.createdAt < newest.createdAt).toBe(true);
+
+    const resolver = new PassthroughControlPlaneResolver({
+      prisma: prisma14 as unknown as PrismaClient,
+    });
+
+    const resolved = await resolver.resolveWorkerVersion({
+      environmentId: cp.environment.id,
+      type: "DEVELOPMENT",
+    });
+
+    assertNonNullable(resolved);
+    expect(resolved.worker.id).toBe(newest.id);
+  }
+);
+
+heteroPostgresTest(
+  "resolveWorkerVersion latest-MANAGED fallback resolves by createdAt, not by id",
+  async ({ prisma14 }) => {
+    const cp = await seedControlPlane(
+      prisma14 as unknown as PrismaClient,
+      "cpfall",
+      "fallback-task"
+    );
+
+    await prisma14.workerDeployment.update({
+      where: { id: cp.deployment.id },
+      data: { type: "V1" },
+    });
+
+    const newestWorker = await prisma14.backgroundWorker.create({
+      data: {
+        friendlyId: generateFriendlyId("worker"),
+        contentHash: "hash_newest",
+        projectId: cp.project.id,
+        runtimeEnvironmentId: cp.environment.id,
+        version: "20260731.1",
+        metadata: {},
+        engine: "V2",
+      },
+    });
+    const oldestWorker = await prisma14.backgroundWorker.create({
+      data: {
+        friendlyId: generateFriendlyId("worker"),
+        contentHash: "hash_oldest",
+        projectId: cp.project.id,
+        runtimeEnvironmentId: cp.environment.id,
+        version: "20260730.1",
+        metadata: {},
+        engine: "V2",
+      },
+    });
+
+    const newestDeployment = await prisma14.workerDeployment.create({
+      data: {
+        friendlyId: generateFriendlyId("deployment"),
+        contentHash: "hash_newest",
+        version: "20260731.1",
+        shortCode: "short_code_newest",
+        status: "DEPLOYED",
+        projectId: cp.project.id,
+        environmentId: cp.environment.id,
+        workerId: newestWorker.id,
+        type: "MANAGED",
+        createdAt: new Date("2026-07-31T12:00:00.000Z"),
+      },
+    });
+    const oldestDeployment = await prisma14.workerDeployment.create({
+      data: {
+        friendlyId: generateFriendlyId("deployment"),
+        contentHash: "hash_oldest",
+        version: "20260730.1",
+        shortCode: "short_code_oldest",
+        status: "DEPLOYED",
+        projectId: cp.project.id,
+        environmentId: cp.environment.id,
+        workerId: oldestWorker.id,
+        type: "MANAGED",
+        createdAt: new Date("2026-07-30T12:00:00.000Z"),
+      },
+    });
+
+    expect(oldestDeployment.id > newestDeployment.id).toBe(true);
+    expect(oldestDeployment.createdAt < newestDeployment.createdAt).toBe(true);
+
+    const resolver = new PassthroughControlPlaneResolver({
+      prisma: prisma14 as unknown as PrismaClient,
+    });
+
+    const resolved = await resolver.resolveWorkerVersion({
+      environmentId: cp.environment.id,
+      type: "PRODUCTION",
+    });
+
+    assertNonNullable(resolved);
+    expect(resolved.deployment?.id).toBe(newestDeployment.id);
+  }
+);


### PR DESCRIPTION
## Summary

Resolving "the most recent background worker for this environment" was ordered by `id`, which Postgres serves by scanning the primary key backwards and betting it finds a row for the target environment early. For an environment with many worker versions whose rows are all old, that bet loses and the scan crosses a large part of the index, so a lookup that normally takes about a millisecond takes hundreds. The same shape appeared on the deployments table.

These lookups now order by `createdAt` then `id`. On background workers that lands on the existing `(runtimeEnvironmentId, createdAt)` index with no schema change. Deployments had no matching index, so this adds one:

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS "WorkerDeployment_environmentId_createdAt_idx"
ON "WorkerDeployment" ("environmentId", "createdAt");
```

The `id` tiebreak costs an incremental sort over a single `createdAt` group rather than a sort of the whole match set, so the ordering stays index-served.

Also drops three `orderBy` clauses that were dead: two `findFirst` calls keyed by primary key, and one hydration read whose caller re-sorts the rows itself.

## Behaviour change

This changes which row counts as newest wherever `id` order and `createdAt` order disagree: those lookups now answer with the genuinely newest row. Verified end to end against a live environment by forcing that disagreement and confirming a real run resolves to, and successfully executes, the `createdAt`-newest worker. Tests covering both resolvers were red before the change and green after.

## Rollout

The index build is the long pole and wants to go in on its own, so the migration and the code deploy should not be assumed simultaneous. Rollback is a revert plus `DROP INDEX CONCURRENTLY "WorkerDeployment_environmentId_createdAt_idx"`. No data migration and no coexistence concern, since nothing persists the ordering and old and new code can run side by side.

## Known limitation

The new index is keyed `(environmentId, createdAt)`, so the deployment fallback's `type = 'MANAGED'` predicate is applied as a post-index filter rather than an index condition. For an environment whose newest MANAGED deployment sits behind many non-MANAGED ones, that scan still walks the intervening index entries. Left as-is on purpose: the high-volume query this index targets has no `type` predicate, and the fallback only runs when the promoted deployment is not MANAGED. If that fallback ever becomes hot, a partial index on MANAGED is the better shape than widening the composite.

## Second change in here

`findCurrentWorkerDeployment` resolved the caller-supplied prisma client and used it for the promotion read, but issued the latest-of-type fallback read on the module-level client. Callers passing a replica were silently reading the primary for that one query. The fallback now uses the caller's client too.

This is a behaviour change, not just a tidy-up: the fallback read can now be replica-lagged for callers that pass a replica. That is the intended trade, because the previous mix could return a promotion read from a replica alongside a fallback deployment from the primary that did not correspond to it, and the promotion read (which serves the normal case) was already on the caller's client.
