### PR TITLE
Pin @types/react and @types/react-dom to 18.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,8 @@
     "overrides": {
       "typescript": "5.5.4",
       "@types/node": "22.20.0",
+      "@types/react": "18.2.69",
+      "@types/react-dom": "18.2.7",
       "react@^18": "18.3.1",
       "react-dom@^18": "18.3.1",
       "ai@^6": "6.0.116",


### PR DESCRIPTION
Fixes TS errors from mixed react versions. See original #3267.