### PR TITLE
fix: Safari magic link redirect on MacOS

### DIFF
--- a/apps/webapp/app/services/sessionStorage.server.ts
+++ b/apps/webapp/app/services/sessionStorage.server.ts
@@ -11,7 +11,7 @@ export const DEFAULT_SESSION_DURATION_SECONDS = 31_556_952;
 export const sessionStorage = createCookieSessionStorage({
   cookie: {
     name: "__session",
-    sameSite: "lax",
+    sameSite: env.NODE_ENV === "production" ? "none" : "lax",
     path: "/",
     httpOnly: true,
     secrets: [env.SESSION_SECRET],


### PR DESCRIPTION
Fixes #1384 - Safari magic link redirect on MacOS.