### PR TITLE
perf(supervisor): inspect Docker resources concurrently

### DIFF
--- a/.server-changes/docker-resource-monitor-parallel-inspect.md
+++ b/.server-changes/docker-resource-monitor-parallel-inspect.md
@@ -1,0 +1,6 @@
+---
+area: supervisor
+type: improvement
+---
+
+Resource availability checks now update faster when many task containers are running.

--- a/apps/supervisor/src/resourceMonitor.ts
+++ b/apps/supervisor/src/resourceMonitor.ts
@@ -132,17 +132,21 @@ export class DockerResourceMonitor extends ResourceMonitor {
     let cpuUsed = 0;
     let memoryUsed = 0;
 
-    for (const container of stats) {
-      if (container.State === "running") {
-        const c = this.docker.getContainer(container.Id);
-        const { HostConfig } = await c.inspect();
+    const runningContainers = stats.filter((container) => container.State === "running");
+    const inspectedResources = await Promise.all(
+      runningContainers.map(async (container) => {
+        const { HostConfig } = await this.docker.getContainer(container.Id).inspect();
 
-        const cpu = this.resourceParser.cpu(HostConfig.NanoCpus ?? 0);
-        const memory = this.resourceParser.memory(HostConfig.Memory ?? 0);
+        return {
+          cpu: this.resourceParser.cpu(HostConfig.NanoCpus ?? 0),
+          memory: this.resourceParser.memory(HostConfig.Memory ?? 0),
+        };
+      })
+    );
 
-        cpuUsed += cpu;
-        memoryUsed += memory;
-      }
+    for (const resources of inspectedResources) {
+      cpuUsed += resources.cpu;
+      memoryUsed += resources.memory;
     }
 
     this.cachedResources = this.applyOverrides({


### PR DESCRIPTION
## Summary

- Inspect all running task containers concurrently when calculating node resources.
- Preserve the existing CPU and memory aggregation behavior.
- Add the required supervisor server-change release note.

## Root cause

The supervisor awaited each Docker container inspection inside a sequential loop, delaying resource availability updates as the number of running containers increased.

## Validation

- Formatting and lint checks passed.
- Supervisor typecheck was attempted but is blocked by pre-existing missing generated database artifacts and workspace package outputs in this checkout.
- A deterministic concurrency test was not added because this repository's local guidance prohibits mocks.

Please keep this PR in draft until vouching and CI review are complete.

fixes #3727