### PR TITLE
fix(cli): redact env vars from attempt debug logs

### DIFF
--- a/.changeset/redact-attempt-debug-env.md
+++ b/.changeset/redact-attempt-debug-env.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Task environment variable values are no longer included in attempt debug logs.

--- a/packages/cli-v3/src/entryPoints/managed/execution.ts
+++ b/packages/cli-v3/src/entryPoints/managed/execution.ts
@@ -25,6 +25,7 @@ import { type SnapshotState, SnapshotManager } from "./snapshot.js";
 import type { SupervisorSocket } from "./controller.js";
 import { RunNotifier } from "./notifier.js";
 import type { TaskRunProcessProvider } from "./taskRunProcessProvider.js";
+import { getWorkloadRunAttemptStartLogData } from "./runAttemptLogData.js";
 
 class ExecutionAbortError extends Error {
   constructor(message: string) {
@@ -447,7 +448,9 @@ export class RunExecution {
       podScheduledAt: this.podScheduledAt?.getTime(),
     });
 
-    this.sendDebugLog("started attempt", { start: start.data });
+    this.sendDebugLog("started attempt", {
+      start: getWorkloadRunAttemptStartLogData(start.data),
+    });
 
     return { ...start.data, metrics };
   }

--- a/packages/cli-v3/src/entryPoints/managed/runAttemptLogData.test.ts
+++ b/packages/cli-v3/src/entryPoints/managed/runAttemptLogData.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { getWorkloadRunAttemptStartLogData } from "./runAttemptLogData.js";
+
+describe("getWorkloadRunAttemptStartLogData", () => {
+  it("omits environment variable values from the debug-log payload", () => {
+    const start = {
+      run: { friendlyId: "run_123" },
+      snapshot: { friendlyId: "snapshot_123" },
+      execution: { id: "execution_123" },
+      envVars: { API_KEY: "secret-value" },
+    };
+
+    expect(getWorkloadRunAttemptStartLogData(start)).toEqual({
+      run: start.run,
+      snapshot: start.snapshot,
+      execution: start.execution,
+    });
+  });
+});

--- a/packages/cli-v3/src/entryPoints/managed/runAttemptLogData.ts
+++ b/packages/cli-v3/src/entryPoints/managed/runAttemptLogData.ts
@@ -1,0 +1,13 @@
+type WorkloadRunAttemptStartData = {
+  run: unknown;
+  snapshot: unknown;
+  execution: unknown;
+  envVars: Record<string, string>;
+};
+
+export function getWorkloadRunAttemptStartLogData<T extends WorkloadRunAttemptStartData>(
+  start: T
+): Pick<T, "run" | "snapshot" | "execution"> {
+  const { run, snapshot, execution } = start;
+  return { run, snapshot, execution };
+}


### PR DESCRIPTION
## Summary

- Exclude task environment variable values from the managed attempt debug-log payload.
- Preserve the full response for execution, including environment variables needed to start the task.
- Add regression coverage and the required `trigger.dev` patch changeset.

## Root cause

The `started attempt` debug log serialized the complete start response, which included the task environment variables.

## Validation

- Targeted redaction test: 1 passed.
- Formatting and lint checks passed.
- Full CLI package build is currently blocked by pre-existing missing generated workspace dependencies and baseline TypeScript errors in this checkout.

This issue is already public. New security vulnerabilities should use the private reporting path in SECURITY.md.

Please keep this PR in draft until vouching and CI review are complete.

fixes #3566