### PR TITLE
docs(cli): clarify dev env-file propagation

### DIFF
--- a/.changeset/clarify-dev-env-file.md
+++ b/.changeset/clarify-dev-env-file.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Clarify that `dev --env-file` values are also available to local task processes.

--- a/docs/snippets/cli-options-env-file.mdx
+++ b/docs/snippets/cli-options-env-file.mdx
@@ -1,4 +1,4 @@
 <ParamField body="Env file" type="--env-file">
-  Load environment variables from a file. This will only hydrate the `process.env` of the CLI
-  process, not the tasks.
+  Load environment variables from a file into the CLI process. When running `dev`, those values
+  are also included in the environment of your local task processes.
 </ParamField>

--- a/packages/cli-v3/src/commands/dev.ts
+++ b/packages/cli-v3/src/commands/dev.ts
@@ -87,7 +87,7 @@ export function configureDevCommand(program: Command) {
       )
       .option(
         "--env-file <env file>",
-        "Path to the .env file to use for the dev session. Defaults to .env in the project directory."
+        "Path to the .env file to use for the dev session and local task processes. Defaults to .env in the project directory."
       )
       .option(
         "--max-concurrent-runs <max concurrent runs>",


### PR DESCRIPTION
## Summary

- Clarify the shared `--env-file` documentation for local task processes.
- Update `trigger dev --help` to describe the same behavior.
- Add the required `trigger.dev` patch changeset.

## Root cause

The implementation already passes local `dev --env-file` values into task processes, but the docs and CLI help incorrectly said they only affected the CLI process.

## Validation

- Formatting and lint checks passed.
- Full CLI package build is currently blocked by pre-existing missing generated workspace dependencies and baseline TypeScript errors in this checkout.

Please keep this PR in draft until vouching and CI review are complete.

fixes #4425