### PR TITLE
fix(build): support Playwright 1.58+ browser metadata

### DIFF
--- a/.changeset/playwright-158-dry-run-parser.md
+++ b/.changeset/playwright-158-dry-run-parser.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/build": patch
+---
+
+Playwright 1.58+ deployments can now install browser binaries correctly.

--- a/packages/build/src/extensions/playwright.test.ts
+++ b/packages/build/src/extensions/playwright.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { BuildContext, BuildLayer } from "@trigger.dev/core/v3/build";
+import type { BuildManifest } from "@trigger.dev/core/v3";
+import { playwright } from "./playwright.js";
+
+function runExtension(browsers: ("chromium" | "firefox" | "webkit")[]): BuildLayer | undefined {
+  let captured: BuildLayer | undefined;
+
+  const context = {
+    target: "deploy",
+    config: { project: "proj_test" },
+    logger: {
+      debug() {},
+    },
+    addLayer: (layer: BuildLayer) => {
+      captured = layer;
+    },
+  } as unknown as BuildContext;
+
+  const manifest = {
+    externals: [{ name: "playwright", version: "1.58.0" }],
+  } as unknown as BuildManifest;
+
+  playwright({ browsers }).onBuildComplete!(context, manifest);
+
+  return captured;
+}
+
+describe("playwright extension browser metadata parsing", () => {
+  it("matches the legacy and Playwright 1.58 dry-run headers", () => {
+    const instructions = runExtension(["chromium"])?.image?.instructions ?? [];
+
+    expect(instructions).toContain(
+      "RUN grep -A5 -m1 -E '^(browser: chromium-headless-shell( |$)|.*\\(playwright chromium-headless-shell v)' /tmp/browser-info.txt > /tmp/chromium-headless-shell-info.txt"
+    );
+  });
+
+  it("uses a browser-specific selector for each requested browser", () => {
+    const instructions = runExtension(["chromium", "firefox"])?.image?.instructions ?? [];
+
+    expect(instructions).toContain(
+      "RUN grep -A5 -m1 -E '^(browser: chromium-headless-shell( |$)|.*\\(playwright chromium-headless-shell v)' /tmp/browser-info.txt > /tmp/chromium-headless-shell-info.txt"
+    );
+    expect(instructions).toContain(
+      "RUN grep -A5 -m1 -E '^(browser: firefox( |$)|.*\\(playwright firefox v)' /tmp/browser-info.txt > /tmp/firefox-info.txt"
+    );
+  });
+});

--- a/packages/build/src/extensions/playwright.ts
+++ b/packages/build/src/extensions/playwright.ts
@@ -317,7 +317,7 @@ class PlaywrightExtension implements BuildExtension {
 
     Array.from(browsersToInstall).forEach((browser) => {
       instructions.push(
-        `RUN grep -A5 -m1 "browser: ${browser}" /tmp/browser-info.txt > /tmp/${browser}-info.txt`,
+        `RUN grep -A5 -m1 -E '^(browser: ${browser}( |$)|.*\\(playwright ${browser} v)' /tmp/browser-info.txt > /tmp/${browser}-info.txt`,
 
         `RUN INSTALL_DIR=$(grep "Install location:" /tmp/${browser}-info.txt | cut -d':' -f2- | xargs) && \
           DIR_NAME=$(basename "$INSTALL_DIR") && \


### PR DESCRIPTION
## Summary

- Update the Playwright build extension to parse both legacy `browser:` headers and the Playwright 1.58+ `(playwright <browser> v...)` format.
- Add regression coverage for Chromium and Firefox selectors.
- Add the required `@trigger.dev/build` changeset.

## Root cause

Playwright 1.58 changed the output of `playwright install --dry-run`, so the previous grep no longer found browser metadata and download URLs.

## Validation

- Targeted Playwright extension tests: 2 passed.
- Formatting and lint checks passed.
- Full package build is currently blocked by pre-existing missing generated workspace dependencies in this checkout.

Please keep this PR in draft until vouching and CI review are complete.

refs #3924