### PR TITLE
docs: improve retry discoverability in Errors & Retrying guide

### DIFF
--- a/docs/errors-retrying.mdx
+++ b/docs/errors-retrying.mdx
@@ -28,6 +28,19 @@ This task will retry 10 times with exponential backoff.
 
 <OpenaiRetry />
 
+<Warning>
+  Retrying re-runs the entire `run()` function from the start — it does not resume from
+  where the error was thrown. In the example above, if `openaiTask` fails for any reason
+  *after* a successful call to `openai.chat.completions.create()`, the next attempt calls
+  OpenAI again, and you're billed for both calls.
+
+  This applies to any side effect inside `run()` that isn't idempotent, such as sending an
+  email, charging a card, or calling a paid API. To avoid repeating it on retry, move it
+  into its own [task](/triggering) and trigger it with an [idempotency key](/idempotency),
+  so a retry reuses the cached result instead of re-running it. See [Durable
+  execution](/how-it-works#durable-execution) for a worked example.
+</Warning>
+
 ## Combining tasks
 
 One way to gain reliability is to break your work into smaller tasks and [trigger](/triggering) them from each other. Each task can have its own retrying behavior:
@@ -60,6 +73,8 @@ export const otherTask = task({
 ```
 
 Another benefit of this approach is that you can view the logs and retry each task independently from the dashboard.
+
+If `otherTask` has a side effect you don't want repeated, give it an [idempotency key](/idempotency) — otherwise, each retry of `myTask` triggers a new run of `otherTask`.
 
 ## Retrying smaller parts of a task
 


### PR DESCRIPTION
## Summary

The **Errors & Retrying** guide demonstrates retry configuration using an OpenAI example, but it doesn't explicitly explain that retries restart the entire `run()` function rather than resuming from the point of failure. This can lead readers to unintentionally repeat non-idempotent operations, such as API calls, emails, or payment requests.

Although this behavior is documented elsewhere, it isn't surfaced from this guide, making it easy to overlook.

## Changes

- Added a warning callout explaining that retries restart the entire `run()` function.
- Linked readers to the idempotency guidance and Durable execution example for preventing repeated side effects.
- Added a note to **Combining tasks** explaining that retrying a parent task also re-triggers child tasks unless an idempotency key is used.

## Testing

- Ran the documentation locally using:
  ```bash
  pnpm --filter "*docs*" dev
  ```
- Verified the **Errors & Retrying** page renders correctly.
- Confirmed the new warning and additional guidance appear as expected.

## Checklist

- [x] I have followed the project's contributing guidelines.
- [x] The change is documentation only.
- [x] I verified the documentation locally before submitting.