### PR TITLE
docs(cli): dev --env-file values reach your tasks

### DIFF
--- a/.changeset/env-file-dev-tasks-help.md
+++ b/.changeset/env-file-dev-tasks-help.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Corrected the `--env-file` help text for `trigger dev`. Values from the file are also passed to your tasks, not just the CLI process.

--- a/docs/snippets/cli-options-env-file.mdx
+++ b/docs/snippets/cli-options-env-file.mdx
@@ -1,4 +1,4 @@
 <ParamField body="Env file" type="--env-file">
-  Load environment variables from a file. This will only hydrate the `process.env` of the CLI
-  process, not the tasks.
+  Load environment variables from a file. In `dev`, these are also passed to your tasks. For every
+  other command they only hydrate the `process.env` of the CLI process.
 </ParamField>

--- a/packages/cli-v3/src/commands/dev.ts
+++ b/packages/cli-v3/src/commands/dev.ts
@@ -87,7 +87,7 @@ export function configureDevCommand(program: Command) {
       )
       .option(
         "--env-file <env file>",
-        "Path to the .env file to use for the dev session. Defaults to .env in the project directory."
+        "Path to the .env file to use for the dev session. Values are also passed to your tasks. Defaults to .env in the project directory."
       )
       .option(
         "--max-concurrent-runs <max concurrent runs>",


### PR DESCRIPTION
Closes #4425

The `--env-file` docs snippet says the file only hydrates the CLI's `process.env` and not the tasks. That's true for `deploy` and `preview archive`, but not for `dev`: `DevSupervisor.#getEnvVars()` passes `args.envFile` into `resolveLocalEnvVars`, so the file ends up in the run environment.

The snippet is shared by four pages, so I reworded it to cover both cases instead of splitting it. I added the same fact to `trigger dev --help`, which was silent on it. `dev archive --help` already said "CLI process" and is correct, so it's untouched.

I fixed the docs rather than changing `dev`, since the behavior has shipped for a long time and people rely on `--env-file` reaching tasks. Happy to flip it the other way if you'd rather `dev` matched the old wording.

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Built the CLI and checked both help outputs:

```
$ node packages/cli-v3/dist/esm/index.js dev start --help
--env-file <env file>    Path to the .env file to use for the dev session. Values are also
                         passed to your tasks. Defaults to .env in the project directory.

$ node packages/cli-v3/dist/esm/index.js dev archive --help
--env-file <env file>    Path to the .env file to load into the CLI process. Defaults to
                         .env in the project directory.
```

Also ran `pnpm run format`, `pnpm run lint` and `pnpm run build --filter trigger.dev`.

---

## Changelog

`trigger dev --help` and the CLI docs now say that `--env-file` values are passed to your tasks, not just the CLI process.

---

## Screenshots

n/a

---

Two things I noticed reading this, left alone since they're separate issues:

- In `resolveLocalEnvVars` the dotenv values are spread last, so `--env-file` overrides the environment variables set in the dashboard. That may be intended, but it isn't documented.
- `docs/cli-switch.mdx` includes this snippet, but `switch.ts` has no `--env-file` option.
