### PR TITLE
fix(webapp): stop pinning run metadata logs to debug

### DIFF
--- a/.server-changes/metadata-service-log-level.md
+++ b/.server-changes/metadata-service-log-level.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Self-hosted instances no longer log run metadata activity at debug level regardless of the log level you configured, so logs are much quieter out of the box. Set `BATCH_METADATA_OPERATIONS_LOG_LEVEL=debug` if you want the detailed output back.

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -908,6 +908,9 @@ const EnvironmentSchema = z
     BATCH_METADATA_OPERATIONS_FLUSH_INTERVAL_MS: z.coerce.number().int().default(1000),
     BATCH_METADATA_OPERATIONS_FLUSH_ENABLED: z.string().default("1"),
     BATCH_METADATA_OPERATIONS_FLUSH_LOGGING_ENABLED: z.string().default("1"),
+    BATCH_METADATA_OPERATIONS_LOG_LEVEL: z
+      .enum(["log", "error", "warn", "info", "debug"])
+      .default("info"),
 
     // Run Engine 2.0
     RUN_ENGINE_WORKER_COUNT: z.coerce.number().int().default(4),

--- a/apps/webapp/app/services/metadata/updateMetadataInstance.server.ts
+++ b/apps/webapp/app/services/metadata/updateMetadataInstance.server.ts
@@ -15,7 +15,7 @@ export const updateMetadataService = singleton(
       flushEnabled: env.BATCH_METADATA_OPERATIONS_FLUSH_ENABLED === "1",
       flushLoggingEnabled: env.BATCH_METADATA_OPERATIONS_FLUSH_LOGGING_ENABLED === "1",
       maximumSize: env.TASK_RUN_METADATA_MAXIMUM_SIZE,
-      logLevel: env.BATCH_METADATA_OPERATIONS_FLUSH_LOGGING_ENABLED === "1" ? "debug" : "info",
+      logLevel: env.BATCH_METADATA_OPERATIONS_LOG_LEVEL,
       // Buffered (parent/root) operations land via the flusher, not the caller's request —
       // publish here so those changes wake live feeds too (no-op when the backend is off).
       onRunFlushed: (run) => {


### PR DESCRIPTION
Closes #3617

Most of this issue has already been fixed since it was filed. The morgan access log now has `HTTP_ACCESS_LOG_DISABLED` (`server.ts:147`), and #4403 stopped the flush log firing on every empty tick and dropped the raw metadata dump. What's left is the part in the title: `UpdateMetadataService` still can't be quieted.

The singleton pins the service's log level to `debug` whenever `BATCH_METADATA_OPERATIONS_FLUSH_LOGGING_ENABLED` is `"1"`, and that flag defaults to `"1"`. So the flag is doing two jobs at once: gating the verbose statements, and forcing the threshold. Out of the box every `logger.debug` in that service prints, and there's no level setting an operator can turn down.

This gives the service its own `BATCH_METADATA_OPERATIONS_LOG_LEVEL`, defaulting to `info`. `flushLoggingEnabled` keeps its existing job of gating the statements.

I did not take the fix suggested in the issue (inherit from `logger.server.ts` / `APP_LOG_LEVEL`), because that isn't how this app is wired. `APP_LOG_LEVEL` isn't in `env.server.ts` at all, and around twenty subsystems already declare their own `*_LOG_LEVEL` there defaulting to `info`: `COMMON_WORKER_LOG_LEVEL`, `ALERTS_WORKER_LOG_LEVEL`, `ADMIN_WORKER_LOG_LEVEL`, `SCHEDULE_ENGINE_LOG_LEVEL` and so on. Following that pattern seemed better than introducing a second one. Happy to switch if you'd rather these inherit a global.

Also worth saying: @Negi2110 said in May they were picking this up. There's been no PR since, so I went ahead, but I'll happily step aside if they're still on it.

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

`pnpm run format`, `pnpm run lint` and `pnpm run typecheck` (root, the same command CI runs after `pnpm install --frozen-lockfile` and `pnpm run generate`).

The whole-repo typecheck reports exactly one error, and it isn't from this change:

```
@internal/clickhouse:typecheck: src/client/client.ts(1092,63): error TS2551:
  Property 'rawMessage' does not exist on type 'ClickHouseError'
```

I stashed my changes and ran `pnpm run typecheck --filter @internal/clickhouse` on a clean `main`. Same error, same exit code, so it's pre-existing on my machine and unrelated. Nothing in the output references either file I touched.

The three tests that use `UpdateMetadataService` construct it directly with an explicit `logLevel: "debug"` and never go through the singleton or the env var, so they're unaffected.

---

## Changelog

Run metadata logging now follows `BATCH_METADATA_OPERATIONS_LOG_LEVEL` instead of always running at debug, so self-hosted logs are quieter by default.

---

## Screenshots

n/a

---

Two other loggers default to `debug` the same way, left alone since they're outside this issue: `mollifierStaleSweepState.server.ts:66` and `runsBackfiller.server.ts:24`. Say the word and I'll do them in a follow-up.
