### PR TITLE
test(observability-map): add an unguarded sensitive canary route

### DIFF
--- a/apps/webapp/app/routes/api.v1.obsmap-canary.tokens.ts
+++ b/apps/webapp/app/routes/api.v1.obsmap-canary.tokens.ts
@@ -1,0 +1,10 @@
+// SCORER TEST FIXTURE. A throwaway route used to verify that the observability-map CI
+// comment reports a regression when an unguarded sensitive route is added. Never merge.
+import { json } from "@remix-run/server-runtime";
+import { prisma } from "~/db.server";
+
+export async function action({ params }: { params: { orgParam: string } }) {
+  const org = await prisma.organization.findFirst({ where: { slug: params.orgParam } });
+  const projects = await prisma.project.findMany({ where: { organizationId: org?.id } });
+  return json({ count: projects.length });
+}


### PR DESCRIPTION
Throwaway. Case 2 of 3 in an end-to-end check of the observability-map CI
comment: adding a sensitive route with no auth guard should be reported as a
regression and should reach the top of FIX FIRST.

Locally verified: new entry, sensitive, score 0, fails auth-boundary,
request-context and audit-trail. Global stays 19, because one route in 412
cannot move the rounded mean; the signal is the row, not the headline.

Do not merge. Will be closed once the CI behaviour is observed.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #4485
- <kbd>&nbsp;3&nbsp;</kbd> #4484 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #4483
- <kbd>&nbsp;1&nbsp;</kbd> #4455
<!-- GitButler Footer Boundary Bottom -->