### PR TITLE
fix(webapp): make the Queues hero charts environment-wide

### DIFF
--- a/.server-changes/queues-page-environment-wide-charts.md
+++ b/.server-changes/queues-page-environment-wide-charts.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+The four charts at the top of the Queues page now always cover the whole environment, so paging through or re-sorting your queues no longer changes them. The scheduling delay chart also leaves a gap where no runs started, instead of dropping to zero.

--- a/apps/webapp/app/components/queues/QueueMetricCards.tsx
+++ b/apps/webapp/app/components/queues/QueueMetricCards.tsx
@@ -54,6 +54,8 @@ export function useQueueMetric(
     defaultPeriod?: string;
     /** Poll ClickHouse on this cadence (ms). Omit to use the query's default interval. */
     refreshIntervalMs?: number;
+    /** Floor for the bucket width, for series too sparse to read at the range's natural width. */
+    minBucketSeconds?: number;
   }
 ) {
   return useMetricResourceQuery(query, {
@@ -62,6 +64,7 @@ export function useQueueMetric(
     defaultPeriod: opts.defaultPeriod ?? QUEUE_METRICS_DEFAULT_PERIOD,
     queues: [opts.queueName],
     fillGaps: opts.fillGaps,
+    minBucketSeconds: opts.minBucketSeconds,
     refreshIntervalMs: opts.refreshIntervalMs,
   });
 }
@@ -120,6 +123,14 @@ type QueueMetricChartProps = {
   /** Reports whether the chart has data to plot (false once it settles on the "no activity" state),
    * so a wrapping card can hide the legend to match. */
   onHasDataChange?: (hasData: boolean) => void;
+  /** Floor for the bucket width, for series too sparse to read at the range's natural width. */
+  minBucketSeconds?: number;
+  /**
+   * Column whose value counts the samples behind the plotted series. Where it is zero the metric
+   * has nothing to report, so every series breaks there instead of reading as a real zero. Keep it
+   * out of `series` — it is read for this test only, never drawn.
+   */
+  sampleCountColumn?: string;
 };
 
 // Bare chart (no card chrome) so it can live inside a shared card, e.g. a tabbed panel.
@@ -136,6 +147,8 @@ export function QueueMetricChart({
   carryBackfill,
   thresholdStroke,
   onHasDataChange,
+  minBucketSeconds,
+  sampleCountColumn,
 }: QueueMetricChartProps) {
   const { rows, showLoading, failed } = useQueueMetric(query, {
     ids,
@@ -143,15 +156,17 @@ export function QueueMetricChart({
     queueName,
     fillGaps,
     defaultPeriod,
+    minBucketSeconds,
   });
 
   const data = useMemo(() => {
     const points = rows
       .map((r) => {
-        const point: { bucket: number } & Record<string, number> = {
+        const point: { bucket: number } & Record<string, number | null> = {
           bucket: clickhouseTimeToMs(r.t),
         };
-        for (const s of series) point[s.key] = toNumber(r[s.key]);
+        const hasSamples = sampleCountColumn ? toNumber(r[sampleCountColumn]) > 0 : true;
+        for (const s of series) point[s.key] = hasSamples ? toNumber(r[s.key]) : null;
         return point;
       })
       .filter((p) => Number.isFinite(p.bucket));
@@ -160,7 +175,7 @@ export function QueueMetricChart({
     // value and carry it back over the earlier buckets so the line doesn't start at a false 0.
     if (carryBackfill?.length) {
       for (const key of carryBackfill) {
-        const first = points.findIndex((p) => p[key] > 0);
+        const first = points.findIndex((p) => toNumber(p[key]) > 0);
         if (first > 0) {
           const value = points[first]![key]!;
           for (let i = 0; i < first; i++) points[i]![key] = value;
@@ -168,7 +183,7 @@ export function QueueMetricChart({
       }
     }
     return points;
-  }, [rows, series, carryBackfill]);
+  }, [rows, series, carryBackfill, sampleCountColumn]);
 
   const chartConfig = useMemo(() => {
     const cfg: ChartConfig = {};

--- a/apps/webapp/app/components/queues/QueueMetricCards.tsx
+++ b/apps/webapp/app/components/queues/QueueMetricCards.tsx
@@ -220,9 +220,14 @@ export function QueueMetricChart({
 
   // Report data presence so a wrapping card can hide its legend when the chart settles on the
   // "no activity" state. Only report once loaded, so the legend stays put while loading.
+  const hasPlottedData = useMemo(
+    () => data.some((point) => series.some((s) => point[s.key] != null)),
+    [data, series]
+  );
+
   useEffect(() => {
-    if (!showLoading) onHasDataChange?.(!failed && data.length > 0);
-  }, [showLoading, failed, data.length, onHasDataChange]);
+    if (!showLoading) onHasDataChange?.(!failed && hasPlottedData);
+  }, [showLoading, failed, hasPlottedData, onHasDataChange]);
 
   return (
     <Chart.Root

--- a/apps/webapp/app/hooks/useMetricResourceQuery.ts
+++ b/apps/webapp/app/hooks/useMetricResourceQuery.ts
@@ -51,7 +51,11 @@ function cacheSet(key: string, rows: MetricResourceRow[]) {
  * back-navigation to the queues list) shows its last data immediately and revalidates in the
  * background rather than flashing a loading skeleton.
  */
-/** An empty query means the caller has nothing to ask for, so no request is made. */
+/**
+ * An empty query means the caller has nothing to ask for, so no request is made and any rows or
+ * failure left by a previous query are dropped — a caller that stops asking must not keep reading
+ * the last answer, or a stale failure would outlive the query that caused it.
+ */
 export function useMetricResourceQuery(query: string, opts: MetricResourceQueryOptions) {
   const {
     organizationId,
@@ -103,6 +107,10 @@ export function useMetricResourceQuery(query: string, opts: MetricResourceQueryO
 
   const load = useCallback(() => {
     if (!query) {
+      abortRef.current?.abort();
+      loadedKeyRef.current = cacheKey;
+      setRows(null);
+      setFailed(false);
       setIsLoading(false);
       return;
     }

--- a/apps/webapp/app/hooks/useMetricResourceQuery.ts
+++ b/apps/webapp/app/hooks/useMetricResourceQuery.ts
@@ -51,6 +51,7 @@ function cacheSet(key: string, rows: MetricResourceRow[]) {
  * back-navigation to the queues list) shows its last data immediately and revalidates in the
  * background rather than flashing a loading skeleton.
  */
+/** An empty query means the caller has nothing to ask for, so no request is made. */
 export function useMetricResourceQuery(query: string, opts: MetricResourceQueryOptions) {
   const {
     organizationId,
@@ -101,6 +102,10 @@ export function useMetricResourceQuery(query: string, opts: MetricResourceQueryO
   const loadedKeyRef = useRef<string | null>(null);
 
   const load = useCallback(() => {
+    if (!query) {
+      setIsLoading(false);
+      return;
+    }
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;

--- a/apps/webapp/app/hooks/useMetricResourceQuery.ts
+++ b/apps/webapp/app/hooks/useMetricResourceQuery.ts
@@ -21,6 +21,8 @@ export type MetricResourceQueryOptions = {
   defaultPeriod: string;
   queues?: string[];
   fillGaps?: boolean;
+  /** Floor for the query's bucket width, for series too sparse to read at the range's width. */
+  minBucketSeconds?: number;
   refreshIntervalMs?: number;
 };
 
@@ -56,6 +58,7 @@ export function useMetricResourceQuery(query: string, opts: MetricResourceQueryO
     environmentId,
     defaultPeriod,
     fillGaps,
+    minBucketSeconds,
     refreshIntervalMs = 60_000,
   } = opts;
   const { period, from, to } = opts.timeRange;
@@ -71,10 +74,22 @@ export function useMetricResourceQuery(query: string, opts: MetricResourceQueryO
         from ?? "",
         to ?? "",
         fillGaps ? 1 : 0,
+        minBucketSeconds ?? "",
         queuesKey ?? "",
         query,
       ].join("|"),
-    [organizationId, projectId, environmentId, resolvedPeriod, from, to, fillGaps, queuesKey, query]
+    [
+      organizationId,
+      projectId,
+      environmentId,
+      resolvedPeriod,
+      from,
+      to,
+      fillGaps,
+      minBucketSeconds,
+      queuesKey,
+      query,
+    ]
   );
 
   const [rows, setRows] = useState<MetricResourceRow[] | null>(
@@ -112,6 +127,7 @@ export function useMetricResourceQuery(query: string, opts: MetricResourceQueryO
         organizationId,
         projectId,
         environmentId,
+        ...(minBucketSeconds !== undefined ? { minBucketSeconds } : {}),
         ...(queuesKey !== undefined ? { queues: queuesKey.split(",") } : {}),
       }),
       signal: controller.signal,
@@ -142,6 +158,7 @@ export function useMetricResourceQuery(query: string, opts: MetricResourceQueryO
     from,
     to,
     fillGaps,
+    minBucketSeconds,
     organizationId,
     projectId,
     environmentId,

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -1258,6 +1258,8 @@ function peakOf(points: TilePoint[]): number {
   return points.reduce((max, p) => (p.value === null ? max : Math.max(max, p.value)), 0);
 }
 
+const SCHEDULING_DELAY_QUERY = `SELECT timeBucket() AS t,\n  round(quantilesTDigestMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[3]) AS p95,\n  sum(wait_ms_count) AS samples\nFROM env_metrics\nGROUP BY t\nORDER BY t`;
+
 const THROTTLED_QUERY = `SELECT timeBucket() AS t,\n  sum(throttled_count) AS throttled\nFROM env_metrics\nGROUP BY t\nORDER BY t`;
 
 const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
@@ -1318,7 +1320,7 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
       { color: "var(--color-queues)", label: "p95" },
       { color: "var(--color-warning)", label: "Over 1 min" },
     ],
-    query: `SELECT timeBucket() AS t,\n  round(quantilesTDigestMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[3]) AS p95,\n  sum(wait_ms_count) AS samples\nFROM env_metrics\nGROUP BY t\nORDER BY t`,
+    query: SCHEDULING_DELAY_QUERY,
     formatValue: formatWaitMs,
     formatAxis: formatWaitMs,
     derive: (rows) => {
@@ -1326,13 +1328,27 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
         bucket: tileTimeToMs(r.t),
         value: tileNumber(r.samples) > 0 ? tileNumber(r.p95) : null,
       }));
-      const worst = peakOf(points);
-      return {
-        points,
-        total: worst,
-        formatTotal: (v) => (v > 0 ? formatWaitMs(v) : "–"),
-        totalClassName: worst >= 60_000 ? "text-warning" : undefined,
-      };
+      return { points, total: peakOf(points) };
+    },
+    readout: {
+      query: SCHEDULING_DELAY_QUERY,
+      /**
+       * Merging quantile states over a wider bucket yields a p95 between the sub-buckets' own, so
+       * the worst p95 has to be read at the range's natural width or a burst of slow starts shorter
+       * than the plotted bucket is averaged away. Unlike the gauges, whose max of maxes is the same
+       * at any width.
+       */
+      derive: (rows) => {
+        const worst = rows.reduce(
+          (max, r) => (tileNumber(r.samples) > 0 ? Math.max(max, tileNumber(r.p95)) : max),
+          0
+        );
+        return {
+          total: worst,
+          formatTotal: (v) => (v > 0 ? formatWaitMs(v) : "–"),
+          totalClassName: worst >= 60_000 ? "text-warning" : undefined,
+        };
+      },
     },
   },
   {

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -391,13 +391,6 @@ function QueuesWithMetricsView() {
 
   const metricsByQueue = metrics?.byQueue ?? {};
 
-  // The four header charts mirror exactly the queue set the table is showing (post-search,
-  // post-pagination). These are the `task/`-prefixed queue_name values the queue_metrics table
-  // stores, so the client-side tile queries scope to the same rows the loader listed.
-  const chartQueueNames = success
-    ? queues.map((q) => (q.type === "task" ? `task/${q.name}` : q.name))
-    : [];
-
   const organization = useOrganization();
   const project = useProject();
   const env = useEnvironment();
@@ -635,13 +628,7 @@ function QueuesWithMetricsView() {
           </MetricsLayout.Grid>
         ) : null}
 
-        {/* Env saturation, Backlog, Scheduling delay p95, Throttled viz — full-size, synced,
-            drag-to-zoom line charts (Agent page pattern). Four chart tiles: 2x2 below lg, 4-up
-            from lg, derived from the tile count. `kind="charts"` bakes the fixed row height.
-            Only when there are queues to chart: not-success states (engine-version, no tasks) and a
-            filtered-to-empty list leave chartQueueNames empty, where the tiles would just render
-            four "No activity" cards above the blank state. */}
-        {chartQueueNames.length > 0 ? (
+        {success && (hasFilters || totalQueues !== 0) ? (
           <ChartSyncProvider onZoom={zoomToTimeFilter}>
             <MetricsLayout.Grid kind="charts">
               {QUEUE_HEADER_TILES.map((tile) => (
@@ -649,7 +636,6 @@ function QueuesWithMetricsView() {
                   key={tile.id}
                   tile={tile}
                   timeRange={timeRange}
-                  queueNames={chartQueueNames}
                   referenceLines={
                     tile.id === "saturation"
                       ? [
@@ -1202,8 +1188,7 @@ export function QueueFilters() {
 
 type MetricTileRow = Record<string, number | string | null>;
 
-/** One charted point per time bucket, already aggregated across the visible queue set. */
-type TilePoint = { bucket: number; value: number };
+type TilePoint = { bucket: number; value: number | null };
 
 // Inline colour swatch matching the chart's warning ("yellow") line — used in tooltip copy that
 // refers to that colour instead of naming it, so the swatch always matches the chart.
@@ -1235,10 +1220,8 @@ type QueueHeaderTile = {
   /** Hover tooltip explaining the headline readout next to the title (e.g. what "9% of current
    * period" means). Without it the readout has no tooltip. */
   totalTooltip?: string;
-  // Rows can be one-per-bucket (p95, throttled: aggregated across the set in ClickHouse) or
-  // one-per-(bucket, queue) (saturation, backlog: summed across the set here, since summing a
-  // gauge across queues can't be a flat aggregate without double-counting sub-buckets). Either
-  // way derive returns the per-bucket points the chart draws.
+  /** Turns one row per bucket into the per-bucket points the chart draws. A null value is a
+   * bucket the metric has nothing to say about, and the line breaks there rather than reading 0. */
   derive: (rows: MetricTileRow[]) => {
     points: TilePoint[];
     total: number;
@@ -1257,39 +1240,19 @@ function tileTimeToMs(value: number | string | null): number {
   return Date.parse(s.endsWith("Z") ? s : `${s}Z`);
 }
 
-// Sums a per-(bucket, queue) row set into one value per bucket. `read` pulls the queue's
-// contribution; `envColumn`, when set, carries an env-wide column (identical across the set's
-// rows in a bucket) through as the max, so saturation can divide by the env limit.
-function sumByBucket(
-  rows: MetricTileRow[],
-  read: (row: MetricTileRow) => number,
-  envColumn?: string
-): Array<{ bucket: number; sum: number; env: number }> {
-  const byBucket = new Map<number, { sum: number; env: number }>();
-  for (const row of rows) {
-    const bucket = tileTimeToMs(row.t);
-    if (!Number.isFinite(bucket)) continue;
-    const entry = byBucket.get(bucket) ?? { sum: 0, env: 0 };
-    entry.sum += read(row);
-    if (envColumn) entry.env = Math.max(entry.env, tileNumber(row[envColumn]));
-    byBucket.set(bucket, entry);
-  }
-  return [...byBucket.entries()]
-    .map(([bucket, { sum, env }]) => ({ bucket, sum, env }))
-    .sort((a, b) => a.bucket - b.bucket);
+/** Peak of a series, ignoring the buckets it has nothing to say about. */
+function peakOf(points: TilePoint[]): number {
+  return points.reduce((max, p) => (p.value === null ? max : Math.max(max, p.value)), 0);
 }
 
-// Header tiles fetch their own TRQL query client-side (resources.metric) with fillGaps, scoped to
-// the visible queue set (queue_metrics WHERE queue IN <set>). Saturation and backlog GROUP BY the
-// queue too and sum here; p95 merges quantile states and throttled sums counters in ClickHouse.
 const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
   {
     id: "saturation",
     label: "Env saturation",
     description: (
       <>
-        How much of the environment's concurrency these queues are using. Turns <WarningSwatch />{" "}
-        above 100%, when they're into burst capacity.
+        How much of the environment's concurrency is in use. Turns <WarningSwatch /> above 100%,
+        when it's into burst capacity.
       </>
     ),
     color: "var(--color-queues)",
@@ -1297,35 +1260,32 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
       { color: "var(--color-queues)", label: "Saturation" },
       { color: "var(--color-warning)", label: "Over limit" },
     ],
-    // Numerator: running summed across the visible set. Denominator: the env-wide limit (same for
-    // every queue in a bucket), so the line reads as the set's share of the environment capacity.
-    query: `SELECT timeBucket() AS t,\n  queue,\n  max(max_running) AS running,\n  max(max_env_limit) AS env_limit\nFROM queue_metrics\nGROUP BY t, queue\nORDER BY t`,
+    query: `SELECT timeBucket() AS t,\n  max(max_env_running) AS running,\n  max(max_env_limit) AS env_limit\nFROM env_metrics\nGROUP BY t\nORDER BY t`,
     formatValue: (v) => (v > 100 ? `${v}% — over the environment limit` : `${v}%`),
     formatAxis: (v) => `${v}%`,
     derive: (rows) => {
-      const points = sumByBucket(rows, (r) => tileNumber(r.running), "env_limit").map(
-        ({ bucket, sum, env }) => ({
-          bucket,
-          value: env > 0 ? Math.round((sum / env) * 100) : 0,
-        })
-      );
-      const peak = points.reduce((max, p) => Math.max(max, p.value), 0);
-      return { points, total: peak, formatTotal: (v) => `${v}% peak` };
+      const points = rows.map((r) => {
+        const limit = tileNumber(r.env_limit);
+        return {
+          bucket: tileTimeToMs(r.t),
+          value: limit > 0 ? Math.round((tileNumber(r.running) / limit) * 100) : 0,
+        };
+      });
+      return { points, total: peakOf(points), formatTotal: (v) => `${v}% peak` };
     },
   },
   {
     id: "backlog",
     label: "Backlog",
-    description: "How many runs are waiting across these queues, over time.",
+    description: "How many runs are waiting across the environment, over time.",
     color: "var(--color-queues)",
-    query: `SELECT timeBucket() AS t,\n  queue,\n  max(max_queued) AS queued\nFROM queue_metrics\nGROUP BY t, queue\nORDER BY t`,
+    query: `SELECT timeBucket() AS t,\n  max(max_env_queued) AS queued\nFROM env_metrics\nGROUP BY t\nORDER BY t`,
     derive: (rows) => {
-      const points = sumByBucket(rows, (r) => tileNumber(r.queued)).map(({ bucket, sum }) => ({
-        bucket,
-        value: sum,
+      const points = rows.map((r) => ({
+        bucket: tileTimeToMs(r.t),
+        value: tileNumber(r.queued),
       }));
-      const peak = points.reduce((max, p) => Math.max(max, p.value), 0);
-      return { points, total: peak, formatTotal: (v) => `${v.toLocaleString()} peak` };
+      return { points, total: peakOf(points), formatTotal: (v) => `${v.toLocaleString()} peak` };
     },
   },
   {
@@ -1343,14 +1303,15 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
       { color: "var(--color-queues)", label: "p95" },
       { color: "var(--color-warning)", label: "Over 1 min" },
     ],
-    // quantilesMerge over the set's rows in a bucket is the true p95 across the union of samples
-    // (merging quantile states is valid; averaging per-queue percentiles would not be).
-    query: `SELECT timeBucket() AS t,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[3]) AS p95\nFROM queue_metrics\nGROUP BY t\nORDER BY t`,
+    query: `SELECT timeBucket() AS t,\n  round(quantilesTDigestMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[3]) AS p95,\n  sum(wait_ms_count) AS samples\nFROM env_metrics\nGROUP BY t\nORDER BY t`,
     formatValue: formatWaitMs,
     formatAxis: formatWaitMs,
     derive: (rows) => {
-      const points = rows.map((r) => ({ bucket: tileTimeToMs(r.t), value: tileNumber(r.p95) }));
-      const worst = points.reduce((max, p) => Math.max(max, p.value), 0);
+      const points = rows.map((r) => ({
+        bucket: tileTimeToMs(r.t),
+        value: tileNumber(r.samples) > 0 ? tileNumber(r.p95) : null,
+      }));
+      const worst = peakOf(points);
       return {
         points,
         total: worst,
@@ -1366,7 +1327,7 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
     totalTooltip: "The share of the selected window with at least one blocked dequeue.",
     color: "var(--color-queues)",
     legend: [{ color: "var(--color-warning)", label: "Throttled" }],
-    query: `SELECT timeBucket() AS t,\n  sum(throttled_count) AS throttled\nFROM queue_metrics\nGROUP BY t\nORDER BY t`,
+    query: `SELECT timeBucket() AS t,\n  sum(throttled_count) AS throttled\nFROM env_metrics\nGROUP BY t\nORDER BY t`,
     derive: (rows) => {
       const points = rows.map((r) => ({
         bucket: tileTimeToMs(r.t),
@@ -1376,7 +1337,7 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
       // scales with poll rate and window length); the fraction of buckets with a throttle is.
       // The data path fills gaps (zero-fill for this counter), so every bucket in the window is
       // present and `points.length` is the honest denominator.
-      const nonzero = points.filter((p) => p.value > 0).length;
+      const nonzero = points.filter((p) => p.value !== null && p.value > 0).length;
       const pct = points.length > 0 ? Math.round((nonzero / points.length) * 100) : 0;
       return {
         points,
@@ -1388,10 +1349,12 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
   },
 ];
 
-// When a search matches no queues the set is empty. We still fetch (hooks can't be conditional),
-// but with a queue name that can't exist so the IN filter returns nothing and the tile falls
-// through to its "No activity" empty state instead of silently widening to the whole environment.
-const NO_QUEUES_SENTINEL = "__no_queues__";
+/**
+ * Bucket floor shared by every hero tile. Scheduling delay and throttling are event-driven, so at
+ * the 10-second width a short range would otherwise pick, most buckets hold no samples at all. One
+ * floor for all four keeps their x-axes identical, which the shared hover crosshair relies on.
+ */
+const HERO_CHART_MIN_BUCKET_SECONDS = 60;
 
 type TileTimeRange = MetricResourceTimeRange;
 
@@ -1401,7 +1364,6 @@ type TileTimeRange = MetricResourceTimeRange;
 function QueueEnvMetricChart({
   tile,
   timeRange,
-  queueNames,
   referenceLines,
   thresholdStroke,
   warningOverlay,
@@ -1409,8 +1371,6 @@ function QueueEnvMetricChart({
 }: {
   tile: QueueHeaderTile;
   timeRange: TileTimeRange;
-  /** The visible queue set (post-search, post-pagination) the chart scopes to. */
-  queueNames: string[];
   referenceLines?: Array<{
     y: number;
     label?: string;
@@ -1427,9 +1387,6 @@ function QueueEnvMetricChart({
   const project = useProject();
   const environment = useEnvironment();
 
-  // Scope to exactly the queues the table is showing. Empty set => sentinel that matches nothing,
-  // so the tile shows "No activity" rather than the whole environment. The hook re-fetches when
-  // this list changes (it keys on the joined names), so search/pagination reflow the charts.
   const { rows, showLoading, failed } = useMetricResourceQuery(tile.query, {
     organizationId: organization.id,
     projectId: project.id,
@@ -1437,7 +1394,7 @@ function QueueEnvMetricChart({
     timeRange,
     defaultPeriod: QUEUE_METRICS_DEFAULT_PERIOD,
     fillGaps: true,
-    queues: queueNames.length > 0 ? queueNames : [NO_QUEUES_SENTINEL],
+    minBucketSeconds: HERO_CHART_MIN_BUCKET_SECONDS,
   });
 
   const { points, total, formatTotal, totalClassName } = tile.derive(rows);
@@ -1461,7 +1418,7 @@ function QueueEnvMetricChart({
     () => buildActivityTimeAxis(data),
     [data]
   );
-  const hasData = data.length > 0 && data.some((p) => (p[tile.id] as number) > 0);
+  const hasData = data.length > 0 && data.some((p) => Number(p[tile.id] ?? 0) > 0);
 
   // Peak readout lives in the card title (ChartCard has no dedicated value slot). A zero/empty
   // total renders no readout at all (skipping "0% peak", "0 peak", "0" and the p95 "–" placeholder)

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -1228,6 +1228,19 @@ type QueueHeaderTile = {
     formatTotal?: (total: number) => string;
     totalClassName?: string;
   };
+  /**
+   * Optional second query, run at the range's natural bucket width, that owns the headline readout.
+   * A readout measured in buckets rather than in values (a share of buckets, not a peak) would
+   * otherwise move whenever this tile's bucket floor widens the plotted buckets.
+   */
+  readout?: {
+    query: string;
+    derive: (rows: MetricTileRow[]) => {
+      total: number;
+      formatTotal?: (total: number) => string;
+      totalClassName?: string;
+    };
+  };
 };
 
 function tileNumber(value: number | string | null): number {
@@ -1244,6 +1257,8 @@ function tileTimeToMs(value: number | string | null): number {
 function peakOf(points: TilePoint[]): number {
   return points.reduce((max, p) => (p.value === null ? max : Math.max(max, p.value)), 0);
 }
+
+const THROTTLED_QUERY = `SELECT timeBucket() AS t,\n  sum(throttled_count) AS throttled\nFROM env_metrics\nGROUP BY t\nORDER BY t`;
 
 const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
   {
@@ -1327,24 +1342,31 @@ const QUEUE_HEADER_TILES: QueueHeaderTile[] = [
     totalTooltip: "The share of the selected window with at least one blocked dequeue.",
     color: "var(--color-queues)",
     legend: [{ color: "var(--color-warning)", label: "Throttled" }],
-    query: `SELECT timeBucket() AS t,\n  sum(throttled_count) AS throttled\nFROM env_metrics\nGROUP BY t\nORDER BY t`,
+    query: THROTTLED_QUERY,
     derive: (rows) => {
       const points = rows.map((r) => ({
         bucket: tileTimeToMs(r.t),
         value: tileNumber(r.throttled),
       }));
-      // Share of the window that saw any throttling. A raw event sum isn't interpretable (it
-      // scales with poll rate and window length); the fraction of buckets with a throttle is.
-      // The data path fills gaps (zero-fill for this counter), so every bucket in the window is
-      // present and `points.length` is the honest denominator.
-      const nonzero = points.filter((p) => p.value !== null && p.value > 0).length;
-      const pct = points.length > 0 ? Math.round((nonzero / points.length) * 100) : 0;
-      return {
-        points,
-        total: pct,
-        formatTotal: (v) => `${v}% of current period`,
-        totalClassName: pct > 0 ? "text-warning" : undefined,
-      };
+      return { points, total: peakOf(points) };
+    },
+    readout: {
+      query: THROTTLED_QUERY,
+      /**
+       * Share of the window that saw any throttling. A raw event sum isn't interpretable (it
+       * scales with poll rate and window length); the fraction of buckets with a throttle is.
+       * Gap fill zero-fills this counter, so every bucket in the window is present and the row
+       * count is the honest denominator.
+       */
+      derive: (rows) => {
+        const nonzero = rows.filter((r) => tileNumber(r.throttled) > 0).length;
+        const pct = rows.length > 0 ? Math.round((nonzero / rows.length) * 100) : 0;
+        return {
+          total: pct,
+          formatTotal: (v) => `${v}% of current period`,
+          totalClassName: pct > 0 ? "text-warning" : undefined,
+        };
+      },
     },
   },
 ];
@@ -1387,17 +1409,27 @@ function QueueEnvMetricChart({
   const project = useProject();
   const environment = useEnvironment();
 
-  const { rows, showLoading, failed } = useMetricResourceQuery(tile.query, {
+  const sharedOptions = {
     organizationId: organization.id,
     projectId: project.id,
     environmentId: environment.id,
     timeRange,
     defaultPeriod: QUEUE_METRICS_DEFAULT_PERIOD,
     fillGaps: true,
+  };
+
+  const { rows, showLoading, failed } = useMetricResourceQuery(tile.query, {
+    ...sharedOptions,
     minBucketSeconds: HERO_CHART_MIN_BUCKET_SECONDS,
   });
 
-  const { points, total, formatTotal, totalClassName } = tile.derive(rows);
+  const readoutResult = useMetricResourceQuery(tile.readout?.query ?? "", sharedOptions);
+
+  const derived = tile.derive(rows);
+  const points = derived.points;
+  const { total, formatTotal, totalClassName } = tile.readout
+    ? tile.readout.derive(readoutResult.rows)
+    : derived;
 
   // Same point shape the shared axis/tooltip helpers expect.
   const data = points
@@ -1423,9 +1455,11 @@ function QueueEnvMetricChart({
   // Peak readout lives in the card title (ChartCard has no dedicated value slot). A zero/empty
   // total renders no readout at all (skipping "0% peak", "0 peak", "0" and the p95 "–" placeholder)
   // so the card title stands alone until there's a non-zero value to show.
-  const peak = showLoading ? (
+  const readoutLoading = tile.readout ? readoutResult.showLoading : showLoading;
+  const readoutFailed = tile.readout ? readoutResult.failed : failed;
+  const peak = readoutLoading ? (
     <span className="inline-block h-3 w-12 animate-pulse rounded bg-grid-bright" />
-  ) : failed || total === 0 ? null : formatTotal ? (
+  ) : readoutFailed || total === 0 ? null : formatTotal ? (
     formatTotal(total)
   ) : (
     total.toLocaleString()
@@ -1445,7 +1479,7 @@ function QueueEnvMetricChart({
               />
             </span>
             {peak != null ? (
-              tile.totalTooltip && !showLoading ? (
+              tile.totalTooltip && !readoutLoading ? (
                 <SimpleTooltip
                   button={
                     <span

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues/route.tsx
@@ -1230,8 +1230,11 @@ type QueueHeaderTile = {
   };
   /**
    * Optional second query, run at the range's natural bucket width, that owns the headline readout.
-   * A readout measured in buckets rather than in values (a share of buckets, not a peak) would
-   * otherwise move whenever this tile's bucket floor widens the plotted buckets.
+   * For a headline that is not invariant to bucket width — a share of buckets, or a percentile,
+   * as opposed to a max over gauges — deriving it from the plotted rows would move the number
+   * whenever this tile's floor widens them. Only requested while the floor is actually widening
+   * anything; on ranges whose natural width is already at or above the floor the chart's own rows
+   * are identical and are reused.
    */
   readout?: {
     query: string;
@@ -1439,12 +1442,17 @@ function QueueEnvMetricChart({
     minBucketSeconds: HERO_CHART_MIN_BUCKET_SECONDS,
   });
 
-  const readoutResult = useMetricResourceQuery(tile.readout?.query ?? "", sharedOptions);
-
   const derived = tile.derive(rows);
   const points = derived.points;
+
+  const plottedBucketMs = points.length > 1 ? points[1]!.bucket - points[0]!.bucket : 0;
+  const floorWidenedBuckets =
+    plottedBucketMs > 0 && plottedBucketMs <= HERO_CHART_MIN_BUCKET_SECONDS * 1000;
+  const readoutQuery = tile.readout && floorWidenedBuckets ? tile.readout.query : "";
+  const readoutResult = useMetricResourceQuery(readoutQuery, sharedOptions);
+
   const { total, formatTotal, totalClassName } = tile.readout
-    ? tile.readout.derive(readoutResult.rows)
+    ? tile.readout.derive(readoutQuery ? readoutResult.rows : rows)
     : derived;
 
   // Same point shape the shared axis/tooltip helpers expect.

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -191,6 +191,14 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
 
 const CK_LIVE_LIMIT = 50;
 
+/**
+ * Bucket floor for this page's event-driven charts (scheduling delay, throttling). Their samples
+ * only exist when something started or was held back, so at the 10-second width a short range
+ * picks, most buckets hold nothing and the line reads as a run of zeros. Gauge charts on this page
+ * (concurrency, queue depth, backlogged keys) carry forward and are left at the natural width.
+ */
+const SPARSE_CHART_MIN_BUCKET_SECONDS = 60;
+
 // Whole-queue oldest wait right now: for keyed queues the per-key breakdown carries the oldest
 // enqueue time per key, so the queue's oldest is the max wait across keys; otherwise fall back to
 // the queue's oldest message directly. Returns null when nothing is waiting.
@@ -470,8 +478,10 @@ function OverviewCharts({
           info="How long runs wait before they start."
           showLegend
           className="aspect-[2/1]"
-          query={`SELECT timeBucket() AS t,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[1]) AS p50,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[3]) AS p95,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[4]) AS p99\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
+          query={`SELECT timeBucket() AS t,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[1]) AS p50,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[3]) AS p95,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[4]) AS p99,\n  sum(wait_ms_count) AS samples\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps
+          minBucketSeconds={SPARSE_CHART_MIN_BUCKET_SECONDS}
+          sampleCountColumn="samples"
           ids={ids}
           timeRange={timeRange}
           queueName={queueName}
@@ -493,6 +503,7 @@ function OverviewCharts({
           className="aspect-[2/1] sm:col-span-2 sm:aspect-[4/1]"
           query={`SELECT timeBucket() AS t, sum(throttled_count) AS throttled\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps
+          minBucketSeconds={SPARSE_CHART_MIN_BUCKET_SECONDS}
           ids={ids}
           timeRange={timeRange}
           queueName={queueName}
@@ -1003,7 +1014,10 @@ function KeyDrilldown({
         <QueueDetailChartCard
           title={`Key ${keyName}: mean scheduling delay`}
           className="aspect-[2/1]"
-          query={`SELECT timeBucket() AS t, if(sum(wait_ms_count) > 0, round(sum(wait_ms_sum) / sum(wait_ms_count)), 0) AS wait\nFROM queue_metrics_by_key\nWHERE ${pin}\nGROUP BY t\nORDER BY t`}
+          query={`SELECT timeBucket() AS t, if(sum(wait_ms_count) > 0, round(sum(wait_ms_sum) / sum(wait_ms_count)), 0) AS wait, sum(wait_ms_count) AS samples\nFROM queue_metrics_by_key\nWHERE ${pin}\nGROUP BY t\nORDER BY t`}
+          fillGaps
+          minBucketSeconds={SPARSE_CHART_MIN_BUCKET_SECONDS}
+          sampleCountColumn="samples"
           ids={ids}
           timeRange={timeRange}
           queueName={queueName}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.queues_.$queueParam/route.tsx
@@ -192,12 +192,14 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
 const CK_LIVE_LIMIT = 50;
 
 /**
- * Bucket floor for this page's event-driven charts (scheduling delay, throttling). Their samples
- * only exist when something started or was held back, so at the 10-second width a short range
- * picks, most buckets hold nothing and the line reads as a run of zeros. Gauge charts on this page
- * (concurrency, queue depth, backlogged keys) carry forward and are left at the natural width.
+ * Bucket floor for the charts in a synced group. The event-driven series (scheduling delay,
+ * throttling) need it: their samples only exist when something started or was held back, so at the
+ * 10-second width a short range picks, most buckets hold nothing and the line reads as a run of
+ * zeros. The gauges beside them take the same floor because the shared hover crosshair is a
+ * recharts ReferenceLine on a category x-axis, so it only draws where the hovered bucket
+ * timestamp exists in the other chart's own data — mixing widths in one group silently drops it.
  */
-const SPARSE_CHART_MIN_BUCKET_SECONDS = 60;
+const SYNCED_CHART_MIN_BUCKET_SECONDS = 60;
 
 // Whole-queue oldest wait right now: for keyed queues the per-key breakdown carries the oldest
 // enqueue time per key, so the queue's oldest is the max wait across keys; otherwise fall back to
@@ -417,6 +419,7 @@ function OverviewCharts({
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t, max(max_running) AS running, max(max_limit) AS limit\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps
+          minBucketSeconds={SYNCED_CHART_MIN_BUCKET_SECONDS}
           ids={ids}
           timeRange={timeRange}
           queueName={queueName}
@@ -443,6 +446,7 @@ function OverviewCharts({
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t, max(max_queued) AS queued\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps
+          minBucketSeconds={SYNCED_CHART_MIN_BUCKET_SECONDS}
           ids={ids}
           timeRange={timeRange}
           queueName={queueName}
@@ -462,6 +466,7 @@ function OverviewCharts({
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t,\n  deltaSumTimestampMerge(enqueue_delta) AS enqueued,\n  deltaSumTimestampMerge(started_delta) AS started\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps
+          minBucketSeconds={SYNCED_CHART_MIN_BUCKET_SECONDS}
           ids={ids}
           timeRange={timeRange}
           queueName={queueName}
@@ -480,7 +485,7 @@ function OverviewCharts({
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[1]) AS p50,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[3]) AS p95,\n  round(quantilesMerge(0.5, 0.9, 0.95, 0.99)(wait_quantiles)[4]) AS p99,\n  sum(wait_ms_count) AS samples\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps
-          minBucketSeconds={SPARSE_CHART_MIN_BUCKET_SECONDS}
+          minBucketSeconds={SYNCED_CHART_MIN_BUCKET_SECONDS}
           sampleCountColumn="samples"
           ids={ids}
           timeRange={timeRange}
@@ -503,7 +508,7 @@ function OverviewCharts({
           className="aspect-[2/1] sm:col-span-2 sm:aspect-[4/1]"
           query={`SELECT timeBucket() AS t, sum(throttled_count) AS throttled\nFROM queue_metrics\nGROUP BY t\nORDER BY t`}
           fillGaps
-          minBucketSeconds={SPARSE_CHART_MIN_BUCKET_SECONDS}
+          minBucketSeconds={SYNCED_CHART_MIN_BUCKET_SECONDS}
           ids={ids}
           timeRange={timeRange}
           queueName={queueName}
@@ -993,6 +998,7 @@ function KeyDrilldown({
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t, max(max_queued) AS queued, max(max_running) AS running\nFROM queue_metrics_by_key\nWHERE ${pin}\nGROUP BY t\nORDER BY t`}
           fillGaps
+          minBucketSeconds={SYNCED_CHART_MIN_BUCKET_SECONDS}
           ids={ids}
           timeRange={timeRange}
           queueName={queueName}
@@ -1006,6 +1012,8 @@ function KeyDrilldown({
           title={`Key ${keyName}: throughput`}
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t, deltaSumTimestampMerge(started_delta) AS started\nFROM queue_metrics_by_key\nWHERE ${pin}\nGROUP BY t\nORDER BY t`}
+          fillGaps
+          minBucketSeconds={SYNCED_CHART_MIN_BUCKET_SECONDS}
           ids={ids}
           timeRange={timeRange}
           queueName={queueName}
@@ -1016,7 +1024,7 @@ function KeyDrilldown({
           className="aspect-[2/1]"
           query={`SELECT timeBucket() AS t, if(sum(wait_ms_count) > 0, round(sum(wait_ms_sum) / sum(wait_ms_count)), 0) AS wait, sum(wait_ms_count) AS samples\nFROM queue_metrics_by_key\nWHERE ${pin}\nGROUP BY t\nORDER BY t`}
           fillGaps
-          minBucketSeconds={SPARSE_CHART_MIN_BUCKET_SECONDS}
+          minBucketSeconds={SYNCED_CHART_MIN_BUCKET_SECONDS}
           sampleCountColumn="samples"
           ids={ids}
           timeRange={timeRange}

--- a/apps/webapp/app/routes/resources.metric.tsx
+++ b/apps/webapp/app/routes/resources.metric.tsx
@@ -52,6 +52,7 @@ const MetricWidgetQuery = z.object({
   tags: z.array(z.string()).optional(),
   // Opt into server-side gap fill (carry-forward for gauges, zero-fill for counters).
   fillGaps: z.boolean().optional(),
+  minBucketSeconds: z.number().int().positive().max(86_400).optional(),
   userAuthoredQuery: z.boolean().optional(),
 });
 
@@ -89,6 +90,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     providers,
     tags: _tags,
     fillGaps,
+    minBucketSeconds,
     userAuthoredQuery,
   } = submission.data;
 
@@ -128,6 +130,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     operations,
     providers,
     fillGaps,
+    minBucketSeconds,
     userAuthoredQuery,
     // Set higher concurrency if many widgets are on screen at once
     customOrgConcurrencyLimit: env.METRIC_WIDGET_DEFAULT_ORG_CONCURRENCY_LIMIT,

--- a/apps/webapp/app/services/queryService.server.ts
+++ b/apps/webapp/app/services/queryService.server.ts
@@ -9,8 +9,8 @@ import {
 import type { CustomerQuerySource } from "@trigger.dev/database";
 import {
   calculateTimeBucketInterval,
+  intervalToSeconds,
   type TableSchema,
-  type TimeBucketInterval,
   type WhereClauseCondition,
 } from "@internal/tsql";
 import { z } from "zod";
@@ -135,15 +135,6 @@ export function isQueryConcurrencyRejection(error: unknown): boolean {
   );
 }
 
-const INTERVAL_UNIT_SECONDS: Record<TimeBucketInterval["unit"], number> = {
-  SECOND: 1,
-  MINUTE: 60,
-  HOUR: 3_600,
-  DAY: 86_400,
-  WEEK: 604_800,
-  MONTH: 2_592_000,
-};
-
 function floorToSeconds(date: Date, alignSeconds: number): Date {
   const ms = alignSeconds * 1000;
   return new Date(Math.floor(date.getTime() / ms) * ms);
@@ -167,16 +158,21 @@ function resolveQueryClientType(schema: TableSchema | undefined): ClientType {
  * rollup's granularity. The rollup has identical logical columns, so only the physical
  * table (and therefore rows read) changes.
  */
-function resolveRollup(schema: TableSchema, timeRange: { from: Date; to: Date }): TableSchema {
+function resolveRollup(
+  schema: TableSchema,
+  timeRange: { from: Date; to: Date },
+  minBucketSeconds?: number
+): TableSchema {
   if (!schema.rollups || schema.rollups.length === 0) {
     return schema;
   }
   const interval = calculateTimeBucketInterval(
     timeRange.from,
     timeRange.to,
-    schema.timeBucketThresholds
+    schema.timeBucketThresholds,
+    minBucketSeconds
   );
-  const intervalSeconds = interval.value * INTERVAL_UNIT_SECONDS[interval.unit];
+  const intervalSeconds = intervalToSeconds(interval);
   const best = [...schema.rollups]
     .sort((a, b) => b.minIntervalSeconds - a.minIntervalSeconds)
     .find((r) => r.minIntervalSeconds <= intervalSeconds);
@@ -374,7 +370,9 @@ export async function executeQuery<TOut extends z.ZodSchema>(
     );
     // Serve coarse-bucket queries from the table's rollup when one qualifies.
     const effectiveSchemas = matchedSchema?.rollups
-      ? querySchemas.map((s) => (s === matchedSchema ? resolveRollup(s, timeRange) : s))
+      ? querySchemas.map((s) =>
+          s === matchedSchema ? resolveRollup(s, timeRange, baseOptions.minBucketSeconds) : s
+        )
       : querySchemas;
 
     const queryCacheSettings: ClickHouseSettings = matchedSchema?.queryCache

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -59,6 +59,8 @@ export default defineConfig({
       "@kapaai/react-sdk",
       "@fingerprintjs/fingerprintjs-pro",
       "@fingerprintjs/fingerprintjs-pro-spa",
+      "recharts",
+      /^victory-vendor/,
     ],
     optimizeDeps: {
       include: ["cron-parser"],

--- a/internal-packages/clickhouse/src/client/tsql.ts
+++ b/internal-packages/clickhouse/src/client/tsql.ts
@@ -115,6 +115,11 @@ export interface ExecuteTSQLOptions<TOut extends z.ZodSchema> {
    */
   fillGaps?: boolean;
   /**
+   * Floor for the `timeBucket()` interval, in seconds. Widens buckets past what the range
+   * would pick, for series whose samples are too sparse to read at that width.
+   */
+  minBucketSeconds?: number;
+  /**
    * Set when `query` was written by whoever made the request rather than by us.
    * A rejection of their SQL is then their mistake, not a bug on our side.
    */
@@ -204,6 +209,7 @@ export async function executeTSQL<TOut extends z.ZodSchema>(
       whereClauseFallback: options.whereClauseFallback,
       timeRange: options.timeRange,
       fillGaps: options.fillGaps,
+      minBucketSeconds: options.minBucketSeconds,
     });
 
     generatedSql = sql;

--- a/internal-packages/tsql/src/index.ts
+++ b/internal-packages/tsql/src/index.ts
@@ -134,7 +134,9 @@ export {
 // Re-export time bucket utilities
 export {
   BUCKET_THRESHOLDS,
+  INTERVAL_UNIT_SECONDS,
   calculateTimeBucketInterval,
+  intervalToSeconds,
   type BucketThreshold,
   type TimeBucketInterval,
 } from "./query/time_buckets.js";
@@ -565,6 +567,12 @@ export interface CompileTSQLOptions {
    * Off by default; output is unchanged when not set.
    */
   fillGaps?: boolean;
+  /**
+   * Floor for the `timeBucket()` interval, in seconds. Widens buckets past what the range
+   * would pick, for series whose samples are too sparse to read at that width (e.g. a
+   * percentile over buckets that often contain no samples at all).
+   */
+  minBucketSeconds?: number;
 }
 
 /**
@@ -624,6 +632,7 @@ export function compileTSQL(query: string, options: CompileTSQLOptions): PrintRe
     enforcedWhereClause,
     timeRange: options.timeRange,
     fillGaps: options.fillGaps,
+    minBucketSeconds: options.minBucketSeconds,
   });
 
   // 6. Print the AST to ClickHouse SQL (enforced conditions applied at printer level)

--- a/internal-packages/tsql/src/query/printer.ts
+++ b/internal-packages/tsql/src/query/printer.ts
@@ -624,7 +624,8 @@ export class ClickHousePrinter {
     const interval = calculateTimeBucketInterval(
       timeRange.from,
       timeRange.to,
-      tableSchema.timeBucketThresholds
+      tableSchema.timeBucketThresholds,
+      this.context.minBucketSeconds
     );
     const bucketSql = `toStartOfInterval(${escapeClickHouseIdentifier(clickhouseColumnName)}, INTERVAL ${interval.value} ${interval.unit})`;
 
@@ -3551,7 +3552,8 @@ export class ClickHousePrinter {
     const interval = calculateTimeBucketInterval(
       timeRange.from,
       timeRange.to,
-      tableSchema.timeBucketThresholds
+      tableSchema.timeBucketThresholds,
+      this.context.minBucketSeconds
     );
 
     // Emit toStartOfInterval(column, INTERVAL N UNIT)

--- a/internal-packages/tsql/src/query/printer_context.ts
+++ b/internal-packages/tsql/src/query/printer_context.ts
@@ -128,6 +128,12 @@ export class PrinterContext {
   /** When true, time-bucketed queries emit rows for empty buckets (opt-in). */
   readonly fillGaps?: boolean;
 
+  /**
+   * Floor for the `timeBucket()` interval, in seconds. Widens buckets past what the range
+   * would pick, for series whose samples are too sparse to read at that width.
+   */
+  readonly minBucketSeconds?: number;
+
   constructor(
     /** Schema registry containing allowed tables and columns */
     public readonly schema: SchemaRegistry,
@@ -143,7 +149,9 @@ export class PrinterContext {
     /** Time range for timeBucket() interval calculation */
     timeRange?: TimeRange,
     /** Opt-in gap-fill for time-bucketed queries */
-    fillGaps?: boolean
+    fillGaps?: boolean,
+    /** Floor for the timeBucket() interval, in seconds */
+    minBucketSeconds?: number
   ) {
     // Initialize with default settings
     this.settings = { ...DEFAULT_QUERY_SETTINGS, ...settings };
@@ -151,6 +159,7 @@ export class PrinterContext {
     this.enforcedWhereClause = enforcedWhereClause;
     this.timeRange = timeRange;
     this.fillGaps = fillGaps;
+    this.minBucketSeconds = minBucketSeconds;
   }
 
   /**
@@ -286,6 +295,11 @@ export interface PrinterContextOptions {
   timeRange?: TimeRange;
   /** When true, time-bucketed queries emit rows for empty buckets (opt-in). */
   fillGaps?: boolean;
+  /**
+   * Floor for the `timeBucket()` interval, in seconds. Widens buckets past what the range
+   * would pick, for series whose samples are too sparse to read at that width.
+   */
+  minBucketSeconds?: number;
 }
 
 /**
@@ -298,6 +312,7 @@ export function createPrinterContext(options: PrinterContextOptions): PrinterCon
     options.fieldMappings,
     options.enforcedWhereClause,
     options.timeRange,
-    options.fillGaps
+    options.fillGaps,
+    options.minBucketSeconds
   );
 }

--- a/internal-packages/tsql/src/query/printer_context.ts
+++ b/internal-packages/tsql/src/query/printer_context.ts
@@ -241,7 +241,8 @@ export class PrinterContext {
       this.fieldMappings,
       this.enforcedWhereClause,
       this.timeRange,
-      this.fillGaps
+      this.fillGaps,
+      this.minBucketSeconds
     );
     // Share the same values map so parameters are unified
     child.values = this.values;

--- a/internal-packages/tsql/src/query/time_buckets.test.ts
+++ b/internal-packages/tsql/src/query/time_buckets.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { calculateTimeBucketInterval, type TimeBucketInterval } from "./time_buckets.js";
+import {
+  calculateTimeBucketInterval,
+  type BucketThreshold,
+  type TimeBucketInterval,
+} from "./time_buckets.js";
 
 /**
  * Helper to create a Date range from a start date and a duration
@@ -176,6 +180,48 @@ describe("calculateTimeBucketInterval", () => {
         value: 5,
         unit: "SECOND",
       });
+    });
+  });
+
+  describe("minBucketSeconds floor", () => {
+    const tenSecondThresholds: BucketThreshold[] = [
+      { maxRangeSeconds: 3 * 60 * 60, interval: { value: 10, unit: "SECOND" } },
+    ];
+
+    it("should widen an interval below the floor", () => {
+      const { from, to } = makeRange(new Date("2024-01-01T00:00:00Z"), 1 * HOUR);
+      expect(
+        calculateTimeBucketInterval(from, to, tenSecondThresholds, 60)
+      ).toEqual<TimeBucketInterval>({ value: 1, unit: "MINUTE" });
+    });
+
+    it("should leave an interval already above the floor alone", () => {
+      const { from, to } = makeRange(new Date("2024-01-01T00:00:00Z"), 5 * DAY);
+      expect(calculateTimeBucketInterval(from, to, undefined, 60)).toEqual<TimeBucketInterval>({
+        value: 6,
+        unit: "HOUR",
+      });
+    });
+
+    it("should be a no-op when no floor is given", () => {
+      const { from, to } = makeRange(new Date("2024-01-01T00:00:00Z"), 1 * HOUR);
+      expect(
+        calculateTimeBucketInterval(from, to, tenSecondThresholds)
+      ).toEqual<TimeBucketInterval>({ value: 10, unit: "SECOND" });
+    });
+
+    it("should express the floor in the largest unit it divides evenly into", () => {
+      const { from, to } = makeRange(new Date("2024-01-01T00:00:00Z"), 1 * HOUR);
+      expect(
+        calculateTimeBucketInterval(from, to, tenSecondThresholds, 300)
+      ).toEqual<TimeBucketInterval>({ value: 5, unit: "MINUTE" });
+    });
+
+    it("should fall back to seconds for a floor that is not a whole number of minutes", () => {
+      const { from, to } = makeRange(new Date("2024-01-01T00:00:00Z"), 1 * HOUR);
+      expect(
+        calculateTimeBucketInterval(from, to, tenSecondThresholds, 90)
+      ).toEqual<TimeBucketInterval>({ value: 90, unit: "SECOND" });
     });
   });
 });

--- a/internal-packages/tsql/src/query/time_buckets.ts
+++ b/internal-packages/tsql/src/query/time_buckets.ts
@@ -57,6 +57,36 @@ export const BUCKET_THRESHOLDS: BucketThreshold[] = [
 /** Default interval for very large ranges (365+ days) */
 const DEFAULT_LARGE_INTERVAL: TimeBucketInterval = { value: 1, unit: "MONTH" };
 
+/** Seconds in each bucket unit. MONTH is nominal (30 days) and only used for comparisons. */
+export const INTERVAL_UNIT_SECONDS: Record<TimeBucketInterval["unit"], number> = {
+  SECOND: 1,
+  MINUTE: 60,
+  HOUR: 3600,
+  DAY: 86400,
+  WEEK: 604800,
+  MONTH: 2592000,
+};
+
+/** Duration of a bucket interval, in seconds. */
+export function intervalToSeconds(interval: TimeBucketInterval): number {
+  return interval.value * INTERVAL_UNIT_SECONDS[interval.unit];
+}
+
+/**
+ * Express a duration in seconds as a bucket interval, preferring the largest unit it divides
+ * evenly into so the emitted `INTERVAL N UNIT` reads naturally (120 -> 2 MINUTE, not 120 SECOND).
+ */
+function secondsToInterval(seconds: number): TimeBucketInterval {
+  const units: Array<TimeBucketInterval["unit"]> = ["WEEK", "DAY", "HOUR", "MINUTE"];
+  for (const unit of units) {
+    const unitSeconds = INTERVAL_UNIT_SECONDS[unit];
+    if (seconds >= unitSeconds && seconds % unitSeconds === 0) {
+      return { value: seconds / unitSeconds, unit };
+    }
+  }
+  return { value: Math.max(1, Math.round(seconds)), unit: "SECOND" };
+}
+
 /**
  * Calculate the most appropriate time bucket interval for a given time range.
  *
@@ -66,6 +96,9 @@ const DEFAULT_LARGE_INTERVAL: TimeBucketInterval = { value: 1, unit: "MONTH" };
  *
  * @param from - Start of the time range
  * @param to - End of the time range
+ * @param thresholds - Table-specific thresholds, defaulting to `BUCKET_THRESHOLDS`
+ * @param minBucketSeconds - Floor for the returned interval, for series whose samples are too
+ *   sparse to be meaningful at the range's natural bucket width
  * @returns The recommended bucket interval
  *
  * @example
@@ -86,10 +119,21 @@ const DEFAULT_LARGE_INTERVAL: TimeBucketInterval = { value: 1, unit: "MONTH" };
 export function calculateTimeBucketInterval(
   from: Date,
   to: Date,
-  thresholds?: BucketThreshold[]
+  thresholds?: BucketThreshold[],
+  minBucketSeconds?: number
 ): TimeBucketInterval {
   const rangeSeconds = Math.abs(to.getTime() - from.getTime()) / 1000;
 
+  const interval = pickInterval(rangeSeconds, thresholds);
+
+  if (minBucketSeconds !== undefined && intervalToSeconds(interval) < minBucketSeconds) {
+    return secondsToInterval(minBucketSeconds);
+  }
+
+  return interval;
+}
+
+function pickInterval(rangeSeconds: number, thresholds?: BucketThreshold[]): TimeBucketInterval {
   for (const threshold of thresholds ?? BUCKET_THRESHOLDS) {
     if (rangeSeconds < threshold.maxRangeSeconds) {
       return threshold.interval;


### PR DESCRIPTION
## Summary

The four charts above the queues table aggregated over **at most the 25 queues on the current page**. They reused the loader's already-paginated queue array as a ClickHouse `queue IN (...)` filter, so paging or re-sorting changed the values, and a name search matching nothing blanked the whole chart row. The stat tiles above them were already environment-wide, so the two rows disagreed.

They now read `env_metrics`, the environment-level rollup that already exists for exactly this (the built-in Queues dashboard and the health report read it). That is both correct and queue-count-independent: no `GROUP BY queue` across an entire environment, and no client-side summing.

Note this is not only a paging artifact: page 1 under-reported too. On the seeded environment below, page 1 read 82% saturation against a true 87%, because the environment's running total is not the sum of one page of per-queue gauges.

Three related fixes ride along.

**Scheduling delay and throttling sawed to zero.** Both are event-driven, so at the 10-second bucket a short range picks, most buckets hold no samples at all and were drawn as `0ms`. Measured over a 1-hour window: **232 of 349 buckets had no scheduling-delay samples**. A bucket where nothing started is not a bucket where nothing waited, so the line was both ugly and wrong. TRQL grows a `minBucketSeconds` floor, plumbed through the metric resource route, and the hero tiles set 60s. Buckets that still have no samples render as a gap instead of a dive to zero.

**The floor must not feed a width-dependent headline.** Two of the four headlines are not peaks, so widening the plotted buckets moved them:

- **Throttled** is a share of buckets that saw any throttling, so a single brief throttle came to mark a whole minute instead of ten seconds: the same seeded events read 17% at 10s and 85% at 60s.
- **Scheduling delay p95** is a percentile, and merging quantile states over a wider bucket yields a p95 between the sub-buckets' own. Two 240s samples among twenty in one 10-second sub-bucket give a worst-of-six p95 of 240,000ms against a merged 60-second p95 of 5,000ms — a 48x understatement of a headline whose tooltip claims it is the worst in the window.

Both charts keep the floor, since a readable line was the point of it. Their headlines now come from a second query at the range's natural bucket width, via an optional `readout` on the tile, so each means what its tooltip says regardless of how the plotted buckets are sized. Saturation and backlog are genuinely width-invariant (a max of maxes is the same at any width), so they are unchanged and issue no extra query. Both caught by Devin in review; I had wrongly lumped p95 in with the peaks.

**Charts reported a hydration mismatch on every render.** Recharts resolved victory-vendor's CJS entry on the server and its ESM entry in the browser. Those bundle different d3-shape builds, and the CJS one predates d3-path's digit rounding, so every server-rendered curve carried full-precision coordinates while the client rounded to 3 decimals:

```
Server: M0,3C0.9305555555555555,3,1.8611111111111112,3,...
Client: M0,3C0.931,3,1.861,3,...
```

Bundling recharts for SSR makes both sides resolve the same ESM build. Verified: 45 of 45 server-rendered chart curves now match the client, and the page loads with an empty console.

## Verification

An isolated stack with 40 seeded queues (20 heavily loaded, 20 idle) and 90 minutes of 10-second buckets written into `queue_metrics_raw_v1`, so the real materialized views built `queue_metrics_v1`, `env_metrics_v1` and the 5m rollup. Ground truth for the environment: 260 running against a limit of 300 (**87% saturation**), 800 queued.

| | before | after |
| -- | -- | -- |
| Saturation, page 1 | 82% peak | **87% peak** |
| Saturation, page 2 | 5% peak | **87% peak** |
| Backlog / delay, page 2 | "No activity" | **800 peak / 59.5s** |
| Name search matching nothing | all four charts blank | charts stay environment-wide |
| Metric refetches on a page change | 4, each painting a skeleton | **0, no skeleton** |
| Buckets drawn as 0ms with no samples | 232 of 349 | **0** |
| Throttled readout | 17% | **17%**, unchanged by the wider buckets |
| Worst-p95 readout source | plotted buckets | **natural width**, so a sub-minute spike is not averaged away |
| Crosshair reach, hovering one detail-page chart | 2 of 4 others | **4 of 4** |
| SSR chart curves mismatching the client | 45 | **0** |

The bucket floor was measured across ranges: it widens 10s to 60s at 30m and 1h, and is correctly a no-op at 12h (300s) and 7d (3600s). One extra request per page load, for the throttled readout.

The built-in Queues dashboard, which reads `env_metrics` independently, agrees at 86.7% and 260 of 300.

`internal-packages/tsql` suite green (612 tests), including 5 new ones for the floor that fail without it. Webapp typecheck, oxfmt and oxlint clean. Spot-checked the Run metrics dashboard and the per-queue detail page for SSR regressions from bundling recharts: both render, console clean.

The queue detail page carries the same event-driven series, so its scheduling delay, throttling and per-key mean delay take the same treatment.

## Screenshots

<img width="2540" height="580" alt="after-page1-charts" src="https://github.com/user-attachments/assets/6cd23f9c-e7fd-4918-bcfa-b1d3340b16d1" />

## Rollout

Already behind the per-organization `queueMetricsUiEnabled` flag, so only gated orgs see any of it. Blast radius is chart values on one page plus the SSR bundling of recharts; rollback is a revert with no data migration.

## Stated limitations

- `wait_ms_count` and the quantile state both only count `wait_ms > 0`, so "nothing started in this bucket" and "everything started instantly" are indistinguishable in storage. Both render as a gap. Distinguishing them needs a schema change, which is not in this PR.
- The queue name search deliberately no longer narrows the charts. It only did so incidentally and incorrectly before (first 25 matches, and blanked on zero matches). Search-scoped charts would need the full unpaginated matching set and a server-side aggregate; worth its own ticket if we want it.
- Bundling recharts for SSR grows the server bundle slightly. That is the cost of both sides resolving one d3-shape build.
- The plotted delay line is a smoothed 60-second view, so a sub-minute spike above the one-minute warning threshold can fail to colour the line even though the headline reports it and colours itself.
- Every chart inside one synced group shares the floor, because the hover crosshair is a reference line on a category x-axis and only draws where the hovered bucket exists in the other chart's own data. That costs the queue detail page's gauges some resolution (1 minute instead of 10 seconds) in exchange for the crosshair working across the row.

Separately, while taking the screenshots I found a pre-existing rendering bug unrelated to this change: a **perfectly flat** saturation series draws no line at all (the readout still shows the right percentage), which looks like the threshold gradient's offset degenerating when the series min equals its max. It reproduces on `main`, so it is not a regression here and I have left it alone; filed as its own issue.

Refs TRI-12784
