### PR TITLE
fix(webapp): report message catalogs survive the production bundle

### DIFF
--- a/.server-changes/report-messages-not-treeshaken.md
+++ b/.server-changes/report-messages-not-treeshaken.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Fix the health report failing with an internal error when requested through the API.

--- a/apps/webapp/app/presenters/v3/reports/health/health-messages.ts
+++ b/apps/webapp/app/presenters/v3/reports/health/health-messages.ts
@@ -8,7 +8,7 @@
  * metrics / evidence — meaning lives here, numbers stay facts.
  */
 
-import { registerReportMessages, type ReportMessages } from "../report-messages";
+import { type ReportMessages } from "../report-messages";
 import { type ReasonCode, type Severity } from "../report-view-model";
 
 /** Metric id -> expanded display label. */
@@ -166,5 +166,3 @@ export const healthMessages: ReportMessages = {
   statementMessage,
   actionMessage: (code) => ACTIONS[code] ?? code,
 };
-
-registerReportMessages("health", healthMessages);

--- a/apps/webapp/app/presenters/v3/reports/health/health.ts
+++ b/apps/webapp/app/presenters/v3/reports/health/health.ts
@@ -26,7 +26,6 @@ import { applyFlowPolicy, buildFlowRead, interpretFlow } from "./flow";
 import { interpretLiveness } from "./liveness";
 // Registers the "health" message catalog (side effect) so the renderer resolves this report's
 // codes. Kept here — the health report's entry module — so loading it always registers its prose.
-import "./health-messages";
 
 // Re-exported so the data layer + tests keep a single import path (`./health`).
 export { HEALTH_THRESHOLDS, isPendingIncreasing, type HealthInput } from "./health-core";

--- a/apps/webapp/app/presenters/v3/reports/report-message-catalogs.ts
+++ b/apps/webapp/app/presenters/v3/reports/report-message-catalogs.ts
@@ -1,0 +1,11 @@
+/**
+ * Catalogs by value, in a module that imports ONLY the per-report `*-messages`
+ * files — no loaders, no IO. Presentation stays decoupled from the data layer,
+ * and a value import can't be tree-shaken away.
+ */
+import { healthMessages } from "./health/health-messages";
+import { type ReportMessages } from "./report-messages";
+
+export const REPORT_MESSAGE_CATALOGS: Record<string, ReportMessages> = {
+  health: healthMessages,
+};

--- a/apps/webapp/app/presenters/v3/reports/report-messages.ts
+++ b/apps/webapp/app/presenters/v3/reports/report-messages.ts
@@ -5,7 +5,7 @@
  * No report vocabulary here — that would re-couple the renderer to a specific report.
  */
 
-import { REPORT_REGISTRY } from "./report-registry";
+import { REPORT_MESSAGE_CATALOGS } from "./report-message-catalogs";
 import { type ReasonCode, type Severity } from "./report-view-model";
 
 /**
@@ -23,14 +23,11 @@ export type ReportMessages = {
   actionMessage(code: ReasonCode): string;
 };
 
-/**
- * Look up a report's catalog by `vm.title`. Catalogs live as values on the
- * report registry entries — there is deliberately no register-at-import-time
- * step: a side-effect registration is exactly what the production bundle
- * tree-shakes away under `"sideEffects": false`.
- */
+/** Look up a report's catalog by `vm.title`. Catalogs are values, never
+ * registered at import time — side-effect registration is what the production
+ * bundle tree-shakes away. */
 export function reportMessages(title: string): ReportMessages {
-  const messages = REPORT_REGISTRY[title]?.messages;
+  const messages = REPORT_MESSAGE_CATALOGS[title];
   if (!messages) {
     throw new Error(`report-messages: no catalog registered for report "${title}"`);
   }

--- a/apps/webapp/app/presenters/v3/reports/report-messages.ts
+++ b/apps/webapp/app/presenters/v3/reports/report-messages.ts
@@ -5,6 +5,7 @@
  * No report vocabulary here — that would re-couple the renderer to a specific report.
  */
 
+import { REPORT_REGISTRY } from "./report-registry";
 import { type ReasonCode, type Severity } from "./report-view-model";
 
 /**
@@ -22,16 +23,14 @@ export type ReportMessages = {
   actionMessage(code: ReasonCode): string;
 };
 
-const catalogs = new Map<string, ReportMessages>();
-
-/** Register a report's catalog under its title (e.g. "health"). Called for its side effect. */
-export function registerReportMessages(title: string, messages: ReportMessages): void {
-  catalogs.set(title, messages);
-}
-
-/** Look up a report's catalog by `vm.title`. Throws if the report never registered one. */
+/**
+ * Look up a report's catalog by `vm.title`. Catalogs live as values on the
+ * report registry entries — there is deliberately no register-at-import-time
+ * step: a side-effect registration is exactly what the production bundle
+ * tree-shakes away under `"sideEffects": false`.
+ */
 export function reportMessages(title: string): ReportMessages {
-  const messages = catalogs.get(title);
+  const messages = REPORT_REGISTRY[title]?.messages;
   if (!messages) {
     throw new Error(`report-messages: no catalog registered for report "${title}"`);
   }

--- a/apps/webapp/app/presenters/v3/reports/report-registry.ts
+++ b/apps/webapp/app/presenters/v3/reports/report-registry.ts
@@ -10,21 +10,11 @@
 import { type AuthenticatedEnvironment } from "~/services/apiAuth.server";
 import { interpret as interpretHealth } from "./health/health";
 import { loadHealthInput } from "./health/health-data";
-import { healthMessages } from "./health/health-messages";
-import { type ReportMessages } from "./report-messages";
 import { type ReportViewModel } from "./report-view-model";
 
 export type ReportLoader<TInput> = {
   load: (env: AuthenticatedEnvironment, period: string) => Promise<TInput>;
   interpret: (input: TInput) => ReportViewModel;
-  /**
-   * The report's message catalog, carried BY VALUE on the registry entry. It
-   * used to be registered as a side effect of importing the catalog module —
-   * which the production SSR bundle tree-shook away (`"sideEffects": false`),
-   * leaving `GET /api/v1/reports/health` throwing "no catalog registered".
-   * A value on the entry cannot be dropped.
-   */
-  messages: ReportMessages;
 };
 
 function defineReport<TInput>(loader: ReportLoader<TInput>): ReportLoader<unknown> {
@@ -35,7 +25,6 @@ export const REPORT_REGISTRY: Record<string, ReportLoader<unknown>> = {
   health: defineReport({
     load: (env, period) => loadHealthInput(env, period),
     interpret: interpretHealth,
-    messages: healthMessages,
   }),
 };
 

--- a/apps/webapp/app/presenters/v3/reports/report-registry.ts
+++ b/apps/webapp/app/presenters/v3/reports/report-registry.ts
@@ -10,11 +10,21 @@
 import { type AuthenticatedEnvironment } from "~/services/apiAuth.server";
 import { interpret as interpretHealth } from "./health/health";
 import { loadHealthInput } from "./health/health-data";
+import { healthMessages } from "./health/health-messages";
+import { type ReportMessages } from "./report-messages";
 import { type ReportViewModel } from "./report-view-model";
 
 export type ReportLoader<TInput> = {
   load: (env: AuthenticatedEnvironment, period: string) => Promise<TInput>;
   interpret: (input: TInput) => ReportViewModel;
+  /**
+   * The report's message catalog, carried BY VALUE on the registry entry. It
+   * used to be registered as a side effect of importing the catalog module —
+   * which the production SSR bundle tree-shook away (`"sideEffects": false`),
+   * leaving `GET /api/v1/reports/health` throwing "no catalog registered".
+   * A value on the entry cannot be dropped.
+   */
+  messages: ReportMessages;
 };
 
 function defineReport<TInput>(loader: ReportLoader<TInput>): ReportLoader<unknown> {
@@ -25,6 +35,7 @@ export const REPORT_REGISTRY: Record<string, ReportLoader<unknown>> = {
   health: defineReport({
     load: (env, period) => loadHealthInput(env, period),
     interpret: interpretHealth,
+    messages: healthMessages,
   }),
 };
 


### PR DESCRIPTION
GET /api/v1/reports/health threw `no catalog registered for report "health"` in production (fine in dev): the catalog registered itself as a side effect of a bare import, which the SSR build tree-shakes under `"sideEffects": false`. Verified on the built server bundle — main's is missing the catalog, this branch's carries it.

Fix: catalogs are values on the report registry entries; the resolver reads them from there and the mutable register-at-import step is gone.
