### PR TITLE
chore: vouch Leafgard

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -25,3 +25,4 @@ ThullyoCunha
 ConProgramming
 saasjesus
 brentshulman-silkline
+Leafgard


### PR DESCRIPTION
Adds `Leafgard` to the list of vouched outside contributors so their PRs aren't auto-closed by the vouch check.

Closes #4487