### PR TITLE
fix(sdk): resolve undefined name variable in updateEnvVar overload

### DIFF
--- a/.changeset/fix-update-env-var-name-scope.md
+++ b/.changeset/fix-update-env-var-name-scope.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+Fix `updateEnvVar` incorrectly reading from an out-of-scope variable when called with the `(projectRef, slug, name, params)` overload. The `name` parameter was undefined in the implementation body; it now correctly reads from `nameOrRequestOptions`.

--- a/packages/trigger-sdk/src/v3/envvars.ts
+++ b/packages/trigger-sdk/src/v3/envvars.ts
@@ -338,7 +338,7 @@ export function update(
 
     $projectRef = projectRefOrName;
     $slug = slugOrParams;
-    $name = name!;
+    $name = nameOrRequestOptions as string;
     $params = params;
   }
 


### PR DESCRIPTION
Closes #

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

The `update` function in `envvars.ts` has three overloads:

1. `(projectRef, slug, name, params, requestOptions?)`
2. `(projectRef, slug, params, requestOptions?)`
3. `(projectRef, slugOrParams, nameOrRequestOptions?, params?, requestOptions?)`

In the implementation body, when overload 1 is matched (four args where the third is a string), the variable `name` is never declared as a parameter — the implementation signature uses `nameOrRequestOptions` as its third positional. The code then writes:

```ts
$name = name!;  // 'name' is undefined here
```

This resolves to `undefined`, silently sending an undefined env var name to the API.

**Fix:** read `nameOrRequestOptions` (which correctly holds the name in this branch):

```ts
$name = nameOrRequestOptions as string;
```

To verify: call `updateEnvVar(projectRef, slug, "MY_VAR", { value: "x" })` — before this fix, `$name` is `undefined` and the API call targets the wrong endpoint; after, it correctly targets `/${projectRef}/${slug}/MY_VAR`.

---

## Changelog

Fixed `updateEnvVar` silently using `undefined` as the env var name when called with the `(projectRef, slug, name, params)` overload. The implementation was reading from the wrong variable in scope.

---

## Screenshots

N/A