### PR TITLE
chore: vouch Rohan170603

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -26,3 +26,4 @@ ConProgramming
 saasjesus
 brentshulman-silkline
 Leafgard
+Rohan170603


### PR DESCRIPTION
Adds `Rohan170603` to the list of vouched outside contributors so their PRs aren't auto-closed by the vouch check.

Closes #4498