### PR TITLE
fix(cli): sort bundle output files for deterministic task-to-file attribution

### DIFF
--- a/.changeset/bundle-deterministic-file-order.md
+++ b/.changeset/bundle-deterministic-file-order.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Fix non-deterministic task-to-file attribution when multiple tasks share an output bundle. `Object.entries` iteration order is not guaranteed, so tasks defined in imported files could be attributed to the wrong source file. Files are now sorted by entry path before registration.

--- a/packages/cli-v3/src/build/bundle.ts
+++ b/packages/cli-v3/src/build/bundle.ts
@@ -307,6 +307,8 @@ export async function getBundleResultFromBuild(
     }
   }
 
+  files.sort((a, b) => a.entry.localeCompare(b.entry));
+
   if (!configPath) {
     return undefined;
   }


### PR DESCRIPTION
## Summary

When `getBundleResultFromBuild` iterates `Object.entries(result.metafile.outputs)`, the order is not guaranteed by the spec. On some Node versions and esbuild configurations, task files appear in arbitrary order. When `registerResources` then iterates `files` to attribute tasks to their source, a task defined in `child.ts` (imported by `parent.ts`) can end up attributed to `parent.ts` if its output appears first — breaking per-file grouping in the dashboard.

Fixes #4495.

## Change

Sort `files` by `entry` path (alphabetically) after the loop, before returning, so attribution is deterministic regardless of `Object.entries` order.

```diff
+  files.sort((a, b) => a.entry.localeCompare(b.entry));
+
   if (!configPath) {
     return undefined;
   }
```

## How to test

Deploy a project that has a parent task importing a child task in a separate file. Confirm both tasks appear under their correct source files in the dashboard across multiple deploys.