### PR TITLE
docs: fix Supabase Storage example anchor links

### DIFF
--- a/docs/guides/examples/supabase-storage-upload.mdx
+++ b/docs/guides/examples/supabase-storage-upload.mdx
@@ -11,8 +11,8 @@ import SupabaseAuthInfo from "/snippets/supabase-auth-info.mdx";
 
 This example shows how to upload a video file to Supabase Storage using two different methods.
 
-- [Upload to Supabase Storage using the Supabase client](/guides/examples/supabase-storage-upload#example-1-upload-to-supabase-storage-using-the-supabase-storage-client)
-- [Upload to Supabase Storage using the AWS S3 client](/guides/examples/supabase-storage-upload#example-2-upload-to-supabase-storage-using-the-aws-s3-client)
+- [Upload to Supabase Storage using the Supabase client](#upload-to-supabase-storage-using-the-supabase-client)
+- [Upload to Supabase Storage using the AWS S3 client](#upload-to-supabase-storage-using-the-aws-s3-client)
 
 ## Upload to Supabase Storage using the Supabase client
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the contributing guide.
- [x] The PR title follows the convention.
- [x] I ran and tested the code works.

---

## Testing

- Ran the documentation site locally.
- Verified both links in the Overview section navigate to the correct sections.
- Ran `npm run lint` (existing unrelated warning only).

---

## Changelog

Updated the overview links in the Supabase Storage upload guide to use the current heading anchors, fixing navigation to both examples.

---

## Screenshots

N/A (documentation link fix)