### PR TITLE
docs: fix Supabase Storage example anchor links

### DIFF
--- a/docs/guides/examples/supabase-storage-upload.mdx
+++ b/docs/guides/examples/supabase-storage-upload.mdx
@@ -11,8 +11,8 @@ import SupabaseAuthInfo from "/snippets/supabase-auth-info.mdx";
 
 This example shows how to upload a video file to Supabase Storage using two different methods.
 
-- [Upload to Supabase Storage using the Supabase client](/guides/examples/supabase-storage-upload#example-1-upload-to-supabase-storage-using-the-supabase-storage-client)
-- [Upload to Supabase Storage using the AWS S3 client](/guides/examples/supabase-storage-upload#example-2-upload-to-supabase-storage-using-the-aws-s3-client)
+- [Upload to Supabase Storage using the Supabase client](#upload-to-supabase-storage-using-the-supabase-client)
+- [Upload to Supabase Storage using the AWS S3 client](#upload-to-supabase-storage-using-the-aws-s3-client)
 
 ## Upload to Supabase Storage using the Supabase client
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works.

---

## Testing

- Ran the documentation site locally.
- Verified that both links in the **Overview** section navigate to the correct sections of the page.
- Ran `npm run lint` (only an existing unrelated warning was reported).

---

## Changelog

Updated the Overview links in the Supabase Storage upload guide to use the current heading anchors instead of outdated fragment identifiers. This fixes navigation to both example sections.

---

## Screenshots

N/A (documentation-only change)