### PR TITLE
fix(sdk,react-hooks): forward debounce when batch triggering with an array

### DIFF
--- a/.changeset/batch-trigger-debounce.md
+++ b/.changeset/batch-trigger-debounce.md
@@ -1,0 +1,14 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+`debounce` now works when you pass an array of items to `batchTrigger` or `batchTriggerAndWait`. Previously the option was accepted by the types and dropped before the request was sent, so every item created its own run instead of collapsing onto the debounce key.
+
+```ts
+await myTask.batchTrigger([
+  { payload: { id: "a" }, options: { debounce: { key: "same-key", delay: "30s" } } },
+  { payload: { id: "b" }, options: { debounce: { key: "same-key", delay: "30s" } } },
+]);
+```
+
+The streaming (async iterable) forms of these calls were already forwarding `debounce` correctly.

--- a/.changeset/batch-trigger-debounce.md
+++ b/.changeset/batch-trigger-debounce.md
@@ -1,8 +1,9 @@
 ---
 "@trigger.dev/sdk": patch
+"@trigger.dev/react-hooks": patch
 ---
 
-`debounce` now works when you pass an array of items to `batchTrigger` or `batchTriggerAndWait`. Previously the option was accepted by the types and dropped before the request was sent, so every item created its own run instead of collapsing onto the debounce key.
+`debounce` now works when you pass an array of items to `batchTrigger` or `batchTriggerAndWait`, and when you trigger from `useTaskTrigger`. Previously the option was accepted by the types and dropped before the request was sent, so every trigger created its own run instead of collapsing onto the debounce key.
 
 ```ts
 await myTask.batchTrigger([
@@ -11,4 +12,4 @@ await myTask.batchTrigger([
 ]);
 ```
 
-The streaming (async iterable) forms of these calls were already forwarding `debounce` correctly.
+The streaming (async iterable) forms of the batch calls were already forwarding `debounce` correctly.

--- a/packages/react-hooks/src/hooks/useTaskTrigger.ts
+++ b/packages/react-hooks/src/hooks/useTaskTrigger.ts
@@ -87,6 +87,7 @@ export function useTaskTrigger<TTask extends AnyTask>(
         metadata: options?.metadata,
         maxDuration: options?.maxDuration,
         lockToVersion: options?.version,
+        debounce: options?.debounce,
       },
     });
 

--- a/packages/trigger-sdk/src/v3/batchDebounce.test.ts
+++ b/packages/trigger-sdk/src/v3/batchDebounce.test.ts
@@ -5,7 +5,14 @@ import { batch } from "./batch.js";
 import { createTask } from "./shared.js";
 import { tasks } from "./tasks.js";
 
-const DEBOUNCE = { key: "warm-conn-notify", delay: "12h", mode: "trailing" as const };
+const debounceFor = (i: number) => ({
+  key: `warm-conn-notify:${i}`,
+  delay: "12h",
+  maxDelay: "24h",
+  mode: "trailing" as const,
+});
+
+const EXPECTED = [debounceFor(0), debounceFor(1)];
 
 type Payload = { i: number };
 
@@ -55,11 +62,12 @@ function installBatchCapture() {
       });
     }
 
-    return Response.json({});
+    throw new Error(`Unexpected request during batch trigger: ${url}`);
   }) as typeof fetch;
 
   return {
-    debounceOptions: () => sent.sort((a, b) => a.index - b.index).map((i) => i.options?.debounce),
+    debounceOptions: () =>
+      [...sent].sort((a, b) => a.index - b.index).map((item) => item.options?.debounce),
     restore: () => {
       globalThis.fetch = originalFetch;
     },
@@ -93,8 +101,8 @@ describe("batch trigger debounce forwarding", () => {
       name: "task.batchTrigger(array)",
       call: () =>
         taskA.batchTrigger([
-          { payload: { i: 0 }, options: { debounce: DEBOUNCE } },
-          { payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+          { payload: { i: 0 }, options: { debounce: debounceFor(0) } },
+          { payload: { i: 1 }, options: { debounce: debounceFor(1) } },
         ]),
     },
     {
@@ -102,8 +110,8 @@ describe("batch trigger debounce forwarding", () => {
       call: () =>
         taskA.batchTrigger(
           asAsyncIterable([
-            { payload: { i: 0 }, options: { debounce: DEBOUNCE } },
-            { payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+            { payload: { i: 0 }, options: { debounce: debounceFor(0) } },
+            { payload: { i: 1 }, options: { debounce: debounceFor(1) } },
           ])
         ),
     },
@@ -111,16 +119,16 @@ describe("batch trigger debounce forwarding", () => {
       name: "tasks.batchTrigger(array)",
       call: () =>
         tasks.batchTrigger<typeof taskA>("task-a", [
-          { payload: { i: 0 }, options: { debounce: DEBOUNCE } },
-          { payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+          { payload: { i: 0 }, options: { debounce: debounceFor(0) } },
+          { payload: { i: 1 }, options: { debounce: debounceFor(1) } },
         ]),
     },
     {
       name: "batch.trigger(array)",
       call: () =>
         batch.trigger<typeof taskA | typeof taskB>([
-          { id: "task-a", payload: { i: 0 }, options: { debounce: DEBOUNCE } },
-          { id: "task-b", payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+          { id: "task-a", payload: { i: 0 }, options: { debounce: debounceFor(0) } },
+          { id: "task-b", payload: { i: 1 }, options: { debounce: debounceFor(1) } },
         ]),
     },
     {
@@ -128,8 +136,8 @@ describe("batch trigger debounce forwarding", () => {
       call: () =>
         batch.trigger<typeof taskA | typeof taskB>(
           asAsyncIterable([
-            { id: "task-a" as const, payload: { i: 0 }, options: { debounce: DEBOUNCE } },
-            { id: "task-b" as const, payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+            { id: "task-a" as const, payload: { i: 0 }, options: { debounce: debounceFor(0) } },
+            { id: "task-b" as const, payload: { i: 1 }, options: { debounce: debounceFor(1) } },
           ])
         ),
     },
@@ -137,8 +145,8 @@ describe("batch trigger debounce forwarding", () => {
       name: "batch.triggerByTask(array)",
       call: () =>
         batch.triggerByTask([
-          { task: taskA, payload: { i: 0 }, options: { debounce: DEBOUNCE } },
-          { task: taskB, payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+          { task: taskA, payload: { i: 0 }, options: { debounce: debounceFor(0) } },
+          { task: taskB, payload: { i: 1 }, options: { debounce: debounceFor(1) } },
         ]),
     },
     {
@@ -146,8 +154,8 @@ describe("batch trigger debounce forwarding", () => {
       call: () =>
         batch.triggerByTask(
           asAsyncIterable([
-            { task: taskA, payload: { i: 0 }, options: { debounce: DEBOUNCE } },
-            { task: taskB, payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+            { task: taskA, payload: { i: 0 }, options: { debounce: debounceFor(0) } },
+            { task: taskB, payload: { i: 1 }, options: { debounce: debounceFor(1) } },
           ])
         ),
     },
@@ -156,7 +164,7 @@ describe("batch trigger debounce forwarding", () => {
   it.each(surfaces)("$name forwards debounce for every item", async ({ call }) => {
     await call();
 
-    expect(capture.debounceOptions()).toEqual([DEBOUNCE, DEBOUNCE]);
+    expect(capture.debounceOptions()).toEqual(EXPECTED);
   });
 
   const waitSurfaces: Array<{ name: string; call: () => Promise<unknown> }> = [
@@ -164,8 +172,8 @@ describe("batch trigger debounce forwarding", () => {
       name: "task.batchTriggerAndWait(array)",
       call: () =>
         taskA.batchTriggerAndWait([
-          { payload: { i: 0 }, options: { debounce: DEBOUNCE } },
-          { payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+          { payload: { i: 0 }, options: { debounce: debounceFor(0) } },
+          { payload: { i: 1 }, options: { debounce: debounceFor(1) } },
         ]),
     },
     {
@@ -173,8 +181,8 @@ describe("batch trigger debounce forwarding", () => {
       call: () =>
         taskA.batchTriggerAndWait(
           asAsyncIterable([
-            { payload: { i: 0 }, options: { debounce: DEBOUNCE } },
-            { payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+            { payload: { i: 0 }, options: { debounce: debounceFor(0) } },
+            { payload: { i: 1 }, options: { debounce: debounceFor(1) } },
           ])
         ),
     },
@@ -182,16 +190,16 @@ describe("batch trigger debounce forwarding", () => {
       name: "tasks.batchTriggerAndWait(array)",
       call: () =>
         tasks.batchTriggerAndWait<typeof taskA>("task-a", [
-          { payload: { i: 0 }, options: { debounce: DEBOUNCE } },
-          { payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+          { payload: { i: 0 }, options: { debounce: debounceFor(0) } },
+          { payload: { i: 1 }, options: { debounce: debounceFor(1) } },
         ]),
     },
     {
       name: "batch.triggerAndWait(array)",
       call: () =>
         batch.triggerAndWait<typeof taskA | typeof taskB>([
-          { id: "task-a", payload: { i: 0 }, options: { debounce: DEBOUNCE } },
-          { id: "task-b", payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+          { id: "task-a", payload: { i: 0 }, options: { debounce: debounceFor(0) } },
+          { id: "task-b", payload: { i: 1 }, options: { debounce: debounceFor(1) } },
         ]),
     },
     {
@@ -199,8 +207,8 @@ describe("batch trigger debounce forwarding", () => {
       call: () =>
         batch.triggerAndWait<typeof taskA | typeof taskB>(
           asAsyncIterable([
-            { id: "task-a" as const, payload: { i: 0 }, options: { debounce: DEBOUNCE } },
-            { id: "task-b" as const, payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+            { id: "task-a" as const, payload: { i: 0 }, options: { debounce: debounceFor(0) } },
+            { id: "task-b" as const, payload: { i: 1 }, options: { debounce: debounceFor(1) } },
           ])
         ),
     },
@@ -208,8 +216,8 @@ describe("batch trigger debounce forwarding", () => {
       name: "batch.triggerByTaskAndWait(array)",
       call: () =>
         batch.triggerByTaskAndWait([
-          { task: taskA, payload: { i: 0 }, options: { debounce: DEBOUNCE } },
-          { task: taskB, payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+          { task: taskA, payload: { i: 0 }, options: { debounce: debounceFor(0) } },
+          { task: taskB, payload: { i: 1 }, options: { debounce: debounceFor(1) } },
         ]),
     },
     {
@@ -217,8 +225,8 @@ describe("batch trigger debounce forwarding", () => {
       call: () =>
         batch.triggerByTaskAndWait(
           asAsyncIterable([
-            { task: taskA, payload: { i: 0 }, options: { debounce: DEBOUNCE } },
-            { task: taskB, payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+            { task: taskA, payload: { i: 0 }, options: { debounce: debounceFor(0) } },
+            { task: taskB, payload: { i: 1 }, options: { debounce: debounceFor(1) } },
           ])
         ),
     },
@@ -229,6 +237,6 @@ describe("batch trigger debounce forwarding", () => {
       await call();
     });
 
-    expect(capture.debounceOptions()).toEqual([DEBOUNCE, DEBOUNCE]);
+    expect(capture.debounceOptions()).toEqual(EXPECTED);
   });
 });

--- a/packages/trigger-sdk/src/v3/batchDebounce.test.ts
+++ b/packages/trigger-sdk/src/v3/batchDebounce.test.ts
@@ -1,0 +1,234 @@
+import { apiClientManager } from "@trigger.dev/core/v3";
+import { runInMockTaskContext } from "@trigger.dev/core/v3/test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { batch } from "./batch.js";
+import { createTask } from "./shared.js";
+import { tasks } from "./tasks.js";
+
+const DEBOUNCE = { key: "warm-conn-notify", delay: "12h", mode: "trailing" as const };
+
+type Payload = { i: number };
+
+const taskA = createTask({
+  id: "task-a",
+  run: async (_payload: Payload) => ({ ok: true }),
+});
+
+const taskB = createTask({
+  id: "task-b",
+  run: async (_payload: Payload) => ({ ok: true }),
+});
+
+type SentItem = {
+  index: number;
+  task: string;
+  options?: { debounce?: { key: string; delay: string; mode?: string; maxDelay?: string } };
+};
+
+/**
+ * Captures the NDJSON item stream the SDK sends in phase 2 of a batch trigger,
+ * answering the only question these tests care about: what actually reached the
+ * wire. Phase 1 (create) and the item stream get canned success responses.
+ */
+function installBatchCapture() {
+  const sent: SentItem[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: any, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : (input?.url ?? String(input));
+
+    if (url.endsWith("/api/v3/batches")) {
+      const body = JSON.parse(String(init?.body));
+      return Response.json({ id: "batch_test", runCount: body.runCount, isCached: false });
+    }
+
+    if (url.includes("/api/v3/batches/") && url.endsWith("/items")) {
+      const ndjson = await new Response(init?.body as any).text();
+      const lines = ndjson.split("\n").filter((line) => line.trim().length > 0);
+      sent.push(...lines.map((line) => JSON.parse(line) as SentItem));
+
+      return Response.json({
+        id: "batch_test",
+        itemsAccepted: lines.length,
+        itemsDeduplicated: 0,
+        sealed: true,
+      });
+    }
+
+    return Response.json({});
+  }) as typeof fetch;
+
+  return {
+    debounceOptions: () => sent.sort((a, b) => a.index - b.index).map((i) => i.options?.debounce),
+    restore: () => {
+      globalThis.fetch = originalFetch;
+    },
+  };
+}
+
+async function* asAsyncIterable<T>(items: T[]): AsyncIterable<T> {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+describe("batch trigger debounce forwarding", () => {
+  let capture: ReturnType<typeof installBatchCapture>;
+
+  beforeEach(() => {
+    apiClientManager.setGlobalAPIClientConfiguration({
+      baseURL: "http://localhost:3030",
+      accessToken: "tr_dev_test",
+    });
+    capture = installBatchCapture();
+  });
+
+  afterEach(() => {
+    capture.restore();
+    apiClientManager.disable();
+  });
+
+  const surfaces: Array<{ name: string; call: () => Promise<unknown> }> = [
+    {
+      name: "task.batchTrigger(array)",
+      call: () =>
+        taskA.batchTrigger([
+          { payload: { i: 0 }, options: { debounce: DEBOUNCE } },
+          { payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+        ]),
+    },
+    {
+      name: "task.batchTrigger(asyncIterable)",
+      call: () =>
+        taskA.batchTrigger(
+          asAsyncIterable([
+            { payload: { i: 0 }, options: { debounce: DEBOUNCE } },
+            { payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+          ])
+        ),
+    },
+    {
+      name: "tasks.batchTrigger(array)",
+      call: () =>
+        tasks.batchTrigger<typeof taskA>("task-a", [
+          { payload: { i: 0 }, options: { debounce: DEBOUNCE } },
+          { payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+        ]),
+    },
+    {
+      name: "batch.trigger(array)",
+      call: () =>
+        batch.trigger<typeof taskA | typeof taskB>([
+          { id: "task-a", payload: { i: 0 }, options: { debounce: DEBOUNCE } },
+          { id: "task-b", payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+        ]),
+    },
+    {
+      name: "batch.trigger(asyncIterable)",
+      call: () =>
+        batch.trigger<typeof taskA | typeof taskB>(
+          asAsyncIterable([
+            { id: "task-a" as const, payload: { i: 0 }, options: { debounce: DEBOUNCE } },
+            { id: "task-b" as const, payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+          ])
+        ),
+    },
+    {
+      name: "batch.triggerByTask(array)",
+      call: () =>
+        batch.triggerByTask([
+          { task: taskA, payload: { i: 0 }, options: { debounce: DEBOUNCE } },
+          { task: taskB, payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+        ]),
+    },
+    {
+      name: "batch.triggerByTask(asyncIterable)",
+      call: () =>
+        batch.triggerByTask(
+          asAsyncIterable([
+            { task: taskA, payload: { i: 0 }, options: { debounce: DEBOUNCE } },
+            { task: taskB, payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+          ])
+        ),
+    },
+  ];
+
+  it.each(surfaces)("$name forwards debounce for every item", async ({ call }) => {
+    await call();
+
+    expect(capture.debounceOptions()).toEqual([DEBOUNCE, DEBOUNCE]);
+  });
+
+  const waitSurfaces: Array<{ name: string; call: () => Promise<unknown> }> = [
+    {
+      name: "task.batchTriggerAndWait(array)",
+      call: () =>
+        taskA.batchTriggerAndWait([
+          { payload: { i: 0 }, options: { debounce: DEBOUNCE } },
+          { payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+        ]),
+    },
+    {
+      name: "task.batchTriggerAndWait(asyncIterable)",
+      call: () =>
+        taskA.batchTriggerAndWait(
+          asAsyncIterable([
+            { payload: { i: 0 }, options: { debounce: DEBOUNCE } },
+            { payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+          ])
+        ),
+    },
+    {
+      name: "tasks.batchTriggerAndWait(array)",
+      call: () =>
+        tasks.batchTriggerAndWait<typeof taskA>("task-a", [
+          { payload: { i: 0 }, options: { debounce: DEBOUNCE } },
+          { payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+        ]),
+    },
+    {
+      name: "batch.triggerAndWait(array)",
+      call: () =>
+        batch.triggerAndWait<typeof taskA | typeof taskB>([
+          { id: "task-a", payload: { i: 0 }, options: { debounce: DEBOUNCE } },
+          { id: "task-b", payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+        ]),
+    },
+    {
+      name: "batch.triggerAndWait(asyncIterable)",
+      call: () =>
+        batch.triggerAndWait<typeof taskA | typeof taskB>(
+          asAsyncIterable([
+            { id: "task-a" as const, payload: { i: 0 }, options: { debounce: DEBOUNCE } },
+            { id: "task-b" as const, payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+          ])
+        ),
+    },
+    {
+      name: "batch.triggerByTaskAndWait(array)",
+      call: () =>
+        batch.triggerByTaskAndWait([
+          { task: taskA, payload: { i: 0 }, options: { debounce: DEBOUNCE } },
+          { task: taskB, payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+        ]),
+    },
+    {
+      name: "batch.triggerByTaskAndWait(asyncIterable)",
+      call: () =>
+        batch.triggerByTaskAndWait(
+          asAsyncIterable([
+            { task: taskA, payload: { i: 0 }, options: { debounce: DEBOUNCE } },
+            { task: taskB, payload: { i: 1 }, options: { debounce: DEBOUNCE } },
+          ])
+        ),
+    },
+  ];
+
+  it.each(waitSurfaces)("$name forwards debounce for every item", async ({ call }) => {
+    await runInMockTaskContext(async () => {
+      await call();
+    });
+
+    expect(capture.debounceOptions()).toEqual([DEBOUNCE, DEBOUNCE]);
+  });
+});

--- a/packages/trigger-sdk/src/v3/shared.ts
+++ b/packages/trigger-sdk/src/v3/shared.ts
@@ -2423,6 +2423,7 @@ async function batchTrigger_internal<TRunTypes extends AnyRunTypes>(
             priority: item.options?.priority,
             region: item.options?.region,
             lockToVersion: item.options?.version ?? scopedEnvVar("TRIGGER_VERSION"),
+            debounce: item.options?.debounce,
           },
         };
       })
@@ -2854,6 +2855,7 @@ async function batchTriggerAndWait_internal<TIdentifier extends string, TPayload
             machine: item.options?.machine,
             priority: item.options?.priority,
             region: item.options?.region,
+            debounce: item.options?.debounce,
           },
         };
       })

--- a/packages/trigger-sdk/src/v3/shared.ts
+++ b/packages/trigger-sdk/src/v3/shared.ts
@@ -749,7 +749,7 @@ export async function batchTriggerById<TTask extends AnyTask>(
             lockToVersion: item.options?.version ?? scopedEnvVar("TRIGGER_VERSION"),
             debounce: item.options?.debounce,
           },
-        };
+        } satisfies BatchItemNDJSON;
       })
     );
 
@@ -1005,7 +1005,7 @@ export async function batchTriggerByIdAndWait<TTask extends AnyTask>(
             region: item.options?.region,
             debounce: item.options?.debounce,
           },
-        };
+        } satisfies BatchItemNDJSON;
       })
     );
 
@@ -1271,7 +1271,7 @@ export async function batchTriggerTasks<TTasks extends readonly AnyTask[]>(
             lockToVersion: item.options?.version ?? scopedEnvVar("TRIGGER_VERSION"),
             debounce: item.options?.debounce,
           },
-        };
+        } satisfies BatchItemNDJSON;
       })
     );
 
@@ -1532,7 +1532,7 @@ export async function batchTriggerAndWaitTasks<TTasks extends readonly AnyTask[]
             region: item.options?.region,
             debounce: item.options?.debounce,
           },
-        };
+        } satisfies BatchItemNDJSON;
       })
     );
 
@@ -2019,7 +2019,7 @@ async function* transformBatchItemsStream<TTask extends AnyTask>(
         lockToVersion: item.options?.version ?? scopedEnvVar("TRIGGER_VERSION"),
         debounce: item.options?.debounce,
       },
-    };
+    } satisfies BatchItemNDJSON;
   }
 }
 
@@ -2071,7 +2071,7 @@ async function* transformBatchItemsStreamForWait<TTask extends AnyTask>(
         region: item.options?.region,
         debounce: item.options?.debounce,
       },
-    };
+    } satisfies BatchItemNDJSON;
   }
 }
 
@@ -2122,7 +2122,7 @@ async function* transformBatchByTaskItemsStream<TTasks extends readonly AnyTask[
         lockToVersion: item.options?.version ?? scopedEnvVar("TRIGGER_VERSION"),
         debounce: item.options?.debounce,
       },
-    };
+    } satisfies BatchItemNDJSON;
   }
 }
 
@@ -2173,7 +2173,7 @@ async function* transformBatchByTaskItemsStreamForWait<TTasks extends readonly A
         region: item.options?.region,
         debounce: item.options?.debounce,
       },
-    };
+    } satisfies BatchItemNDJSON;
   }
 }
 
@@ -2226,7 +2226,7 @@ async function* transformSingleTaskBatchItemsStream<TPayload>(
         lockToVersion: item.options?.version ?? scopedEnvVar("TRIGGER_VERSION"),
         debounce: item.options?.debounce,
       },
-    };
+    } satisfies BatchItemNDJSON;
   }
 }
 
@@ -2286,7 +2286,7 @@ async function* transformSingleTaskBatchItemsStreamForWait<TPayload>(
         region: item.options?.region,
         debounce: item.options?.debounce,
       },
-    };
+    } satisfies BatchItemNDJSON;
   }
 }
 
@@ -2425,7 +2425,7 @@ async function batchTrigger_internal<TRunTypes extends AnyRunTypes>(
             lockToVersion: item.options?.version ?? scopedEnvVar("TRIGGER_VERSION"),
             debounce: item.options?.debounce,
           },
-        };
+        } satisfies BatchItemNDJSON;
       })
     );
 
@@ -2857,7 +2857,7 @@ async function batchTriggerAndWait_internal<TIdentifier extends string, TPayload
             region: item.options?.region,
             debounce: item.options?.debounce,
           },
-        };
+        } satisfies BatchItemNDJSON;
       })
     );
 


### PR DESCRIPTION
Passing `debounce` in the per-item options of a batch trigger did nothing when the items were an array. The option was accepted by the types and by the API, then dropped before the request went out, so every item created its own run instead of collapsing onto the debounce key.

Four public entry points were affected: `task.batchTrigger`, `task.batchTriggerAndWait`, `tasks.batchTrigger`, and `tasks.batchTriggerAndWait`. The streaming (async iterable) forms of the same calls were already correct, as were `batch.trigger`, `batch.triggerAndWait`, `batch.triggerByTask`, and `batch.triggerByTaskAndWait`.

`useTaskTrigger` in `@trigger.dev/react-hooks` had the same silent drop on the single-trigger path, so that is fixed here too. It also drops `machine`, `priority`, `region`, `idempotencyKeyTTL`, and `idempotencyKeyOptions`; those are left alone, since forwarding them is a behaviour change beyond this bug.

Each batch item builder constructs its options field by field, which is why one of them could fall behind without anything catching it. TypeScript did not help: the literal is returned from a `.map` callback inside `Promise.all`, so excess-property checking never fired against the `BatchItemNDJSON[]` annotation, and the server's schema silently strips unknown keys. A misspelled option name therefore reproduced this bug with no compile error and no server error. Every builder now ends in `satisfies BatchItemNDJSON`, which does catch it:

```
error TS2561: Object literal may only specify known properties, but 'debounceTYPO'
does not exist in type '{ ... debounce?: {...} | undefined; }'.
Did you mean to write 'debounce'?
```

The new test drives all six public batch surfaces in both array and async-iterable form and asserts on the NDJSON that actually reaches the wire. Each item carries a distinct debounce key so the test catches a wrong item-to-option pairing, not just a wholesale drop.

Fixes #3304
