### PR TITLE
fix(core): mint the fallback external trace id per run

### DIFF
--- a/.changeset/external-trace-id-per-run.md
+++ b/.changeset/external-trace-id-per-run.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/core": patch
+---
+
+Mint the fallback external trace id per run rather than once per `TracingSDK`. Runs that carry no external trace context fall back to a generated trace id, and with `experimental_processKeepAlive` the `TracingSDK` outlives the run — so every run on a warm process was exported to the external OTLP endpoint under one shared trace id, merging unrelated runs into a single trace.

--- a/.changeset/external-trace-id-per-run.md
+++ b/.changeset/external-trace-id-per-run.md
@@ -2,4 +2,4 @@
 "@trigger.dev/core": patch
 ---
 
-Mint the fallback external trace id per run rather than once per `TracingSDK`. Runs that carry no external trace context fall back to a generated trace id, and with `experimental_processKeepAlive` the `TracingSDK` outlives the run — so every run on a warm process was exported to the external OTLP endpoint under one shared trace id, merging unrelated runs into a single trace.
+Runs that don't continue an incoming trace are no longer merged into one trace when they execute on the same warm worker process. Each run now appears as its own trace in your external observability tool, so per-run cost and latency attribution works again.

--- a/packages/core/src/v3/otel/tracingSDK.ts
+++ b/packages/core/src/v3/otel/tracingSDK.ts
@@ -162,7 +162,8 @@ export class TracingSDK {
       )
     );
 
-    const externalTraceId = idGenerator.generateTraceId();
+    // Shared by every wrapper below so a run's spans and logs agree on the id.
+    const externalTraceId = new FallbackExternalTraceId(idGenerator.generateTraceId());
 
     for (const exporter of config.exporters ?? []) {
       spanProcessors.push(
@@ -394,6 +395,19 @@ function setLogLevel(level: TracingDiagnosticLogLevel) {
 }
 
 /**
+ * Identity of the current run's trace context, or undefined when no run is
+ * active.
+ *
+ * An empty context is not a run: the noop manager returns a fresh `{}` on every
+ * call, so treating it as a run would mint a new id on every export.
+ */
+function currentRunTraceContext(): object | undefined {
+  const current = traceContext.getTraceContext();
+
+  return current && Object.keys(current).length > 0 ? current : undefined;
+}
+
+/**
  * The external trace id used by runs that carry no external trace context,
  * minted once per run.
  *
@@ -402,17 +416,20 @@ function setLogLevel(level: TracingDiagnosticLogLevel) {
  * — outlive the run, so an id captured at construction merges every run on the
  * process into one trace. The manager's trace context object is reassigned per
  * run, which makes its identity the run boundary.
+ *
+ * One instance is shared by every wrapper, so a run's spans and logs still
+ * agree on the id after a remint.
  */
-class FallbackExternalTraceId {
+export class FallbackExternalTraceId {
   private traceId: string;
-  private seenTraceContext: unknown;
+  private seenTraceContext: object | undefined;
 
   constructor(
     private seed: string,
     private traceIdGenerator: Pick<RandomIdGenerator, "generateTraceId"> = idGenerator
   ) {
     this.traceId = seed;
-    this.seenTraceContext = traceContext.getTraceContext();
+    this.seenTraceContext = currentRunTraceContext();
   }
 
   get(): string {
@@ -422,10 +439,10 @@ class FallbackExternalTraceId {
       return this.seed;
     }
 
-    const currentTraceContext = traceContext.getTraceContext();
+    const current = currentRunTraceContext();
 
-    if (currentTraceContext !== this.seenTraceContext) {
-      this.seenTraceContext = currentTraceContext;
+    if (current && current !== this.seenTraceContext) {
+      this.seenTraceContext = current;
       this.traceId = this.traceIdGenerator.generateTraceId();
     }
 
@@ -434,15 +451,10 @@ class FallbackExternalTraceId {
 }
 
 export class ExternalSpanExporterWrapper {
-  private fallback: FallbackExternalTraceId;
-
   constructor(
     private underlyingExporter: SpanExporter,
-    externalTraceId: string,
-    traceIdGenerator?: Pick<RandomIdGenerator, "generateTraceId">
-  ) {
-    this.fallback = new FallbackExternalTraceId(externalTraceId, traceIdGenerator);
-  }
+    private fallback: FallbackExternalTraceId
+  ) {}
 
   private transformSpan(span: ReadableSpan): ReadableSpan | undefined {
     // Read external context live, so per-run reassignment of
@@ -463,9 +475,7 @@ export class ExternalSpanExporterWrapper {
       return;
     }
 
-    const externalTraceId = externalTraceContext
-      ? externalTraceContext.traceId
-      : fallbackTraceId;
+    const externalTraceId = externalTraceContext ? externalTraceContext.traceId : fallbackTraceId;
 
     const isAttemptSpan = span.attributes[SemanticInternalAttributes.SPAN_ATTEMPT];
 
@@ -524,15 +534,10 @@ export class ExternalSpanExporterWrapper {
 }
 
 class ExternalLogRecordExporterWrapper {
-  private fallback: FallbackExternalTraceId;
-
   constructor(
     private underlyingExporter: LogRecordExporter,
-    externalTraceId: string,
-    traceIdGenerator?: Pick<RandomIdGenerator, "generateTraceId">
-  ) {
-    this.fallback = new FallbackExternalTraceId(externalTraceId, traceIdGenerator);
-  }
+    private fallback: FallbackExternalTraceId
+  ) {}
 
   export(logs: any[], resultCallback: (result: any) => void): void {
     const externalTraceContext = traceContext.getExternalTraceContext();

--- a/packages/core/src/v3/otel/tracingSDK.ts
+++ b/packages/core/src/v3/otel/tracingSDK.ts
@@ -393,21 +393,67 @@ function setLogLevel(level: TracingDiagnosticLogLevel) {
   diag.setLogger(new DiagConsoleLogger(), diagLogLevel);
 }
 
+/**
+ * The external trace id used by runs that carry no external trace context,
+ * minted once per run.
+ *
+ * It has to change per run for the same reason the wrappers read the external
+ * context live: with `processKeepAlive` the `TracingSDK` — and so the wrappers
+ * — outlive the run, so an id captured at construction merges every run on the
+ * process into one trace. The manager's trace context object is reassigned per
+ * run, which makes its identity the run boundary.
+ */
+class FallbackExternalTraceId {
+  private traceId: string;
+  private seenTraceContext: unknown;
+
+  constructor(
+    private seed: string,
+    private traceIdGenerator: Pick<RandomIdGenerator, "generateTraceId"> = idGenerator
+  ) {
+    this.traceId = seed;
+    this.seenTraceContext = traceContext.getTraceContext();
+  }
+
+  get(): string {
+    // An empty seed means external export is disabled — leave it that way
+    // rather than minting an id and switching the feature on.
+    if (!this.seed) {
+      return this.seed;
+    }
+
+    const currentTraceContext = traceContext.getTraceContext();
+
+    if (currentTraceContext !== this.seenTraceContext) {
+      this.seenTraceContext = currentTraceContext;
+      this.traceId = this.traceIdGenerator.generateTraceId();
+    }
+
+    return this.traceId;
+  }
+}
+
 export class ExternalSpanExporterWrapper {
+  private fallback: FallbackExternalTraceId;
+
   constructor(
     private underlyingExporter: SpanExporter,
-    private externalTraceId: string
-  ) {}
+    externalTraceId: string,
+    traceIdGenerator?: Pick<RandomIdGenerator, "generateTraceId">
+  ) {
+    this.fallback = new FallbackExternalTraceId(externalTraceId, traceIdGenerator);
+  }
 
   private transformSpan(span: ReadableSpan): ReadableSpan | undefined {
     // Read external context live, so per-run reassignment of
     // standardTraceContextManager.traceContext is honoured on warm-started
     // workers that reuse a single TracingSDK across runs.
     const externalTraceContext = traceContext.getExternalTraceContext();
+    const fallbackTraceId = this.fallback.get();
 
     const isExternallySampled = externalTraceContext
       ? isTraceFlagSampled(externalTraceContext.traceFlags)
-      : !!this.externalTraceId;
+      : !!fallbackTraceId;
 
     if (!isExternallySampled) {
       return;
@@ -419,7 +465,7 @@ export class ExternalSpanExporterWrapper {
 
     const externalTraceId = externalTraceContext
       ? externalTraceContext.traceId
-      : this.externalTraceId;
+      : fallbackTraceId;
 
     const isAttemptSpan = span.attributes[SemanticInternalAttributes.SPAN_ATTEMPT];
 
@@ -478,17 +524,23 @@ export class ExternalSpanExporterWrapper {
 }
 
 class ExternalLogRecordExporterWrapper {
+  private fallback: FallbackExternalTraceId;
+
   constructor(
     private underlyingExporter: LogRecordExporter,
-    private externalTraceId: string
-  ) {}
+    externalTraceId: string,
+    traceIdGenerator?: Pick<RandomIdGenerator, "generateTraceId">
+  ) {
+    this.fallback = new FallbackExternalTraceId(externalTraceId, traceIdGenerator);
+  }
 
   export(logs: any[], resultCallback: (result: any) => void): void {
     const externalTraceContext = traceContext.getExternalTraceContext();
+    const fallbackTraceId = this.fallback.get();
 
     const isExternallySampled = externalTraceContext
       ? isTraceFlagSampled(externalTraceContext.traceFlags)
-      : !!this.externalTraceId;
+      : !!fallbackTraceId;
 
     if (!isExternallySampled) {
       this.underlyingExporter.export([], resultCallback);
@@ -496,7 +548,9 @@ class ExternalLogRecordExporterWrapper {
       return;
     }
 
-    const modifiedLogs = logs.map((log) => this.transformLogRecord(log, externalTraceContext));
+    const modifiedLogs = logs.map((log) =>
+      this.transformLogRecord(log, externalTraceContext, fallbackTraceId)
+    );
 
     this.underlyingExporter.export(modifiedLogs, resultCallback);
   }
@@ -517,13 +571,13 @@ class ExternalLogRecordExporterWrapper {
     logRecord: ReadableLogRecord,
     externalTraceContext:
       | { traceId: string; spanId: string; tracestate?: string; traceFlags: number }
-      | undefined
+      | undefined,
+    fallbackTraceId: string
   ): ReadableLogRecord {
     // Capture externalTraceId for use within the proxy's scope.
-    // Use externalTraceContext.traceId if available, otherwise fall back to generated externalTraceId
-    const externalTraceId = externalTraceContext
-      ? externalTraceContext.traceId
-      : this.externalTraceId;
+    // Use externalTraceContext.traceId if available, otherwise fall back to the
+    // per-run generated id.
+    const externalTraceId = externalTraceContext ? externalTraceContext.traceId : fallbackTraceId;
 
     // If there's no spanContext, or if the externalTraceId is not set, return the original logRecord.
     if (!logRecord.spanContext || !externalTraceId) {

--- a/packages/core/src/v3/otel/tracingSDK.ts
+++ b/packages/core/src/v3/otel/tracingSDK.ts
@@ -163,12 +163,12 @@ export class TracingSDK {
     );
 
     // Shared by every wrapper below so a run's spans and logs agree on the id.
-    const externalTraceId = new FallbackExternalTraceId(idGenerator.generateTraceId());
+    const fallbackTraceId = new FallbackExternalTraceId(idGenerator.generateTraceId());
 
     for (const exporter of config.exporters ?? []) {
       spanProcessors.push(
         getEnvVar("TRIGGER_OTEL_BATCH_PROCESSING_ENABLED") === "1"
-          ? new BatchSpanProcessor(new ExternalSpanExporterWrapper(exporter, externalTraceId), {
+          ? new BatchSpanProcessor(new ExternalSpanExporterWrapper(exporter, fallbackTraceId), {
               maxExportBatchSize: parseInt(
                 getEnvVar("TRIGGER_OTEL_SPAN_MAX_EXPORT_BATCH_SIZE") ?? "64"
               ),
@@ -180,7 +180,7 @@ export class TracingSDK {
               ),
               maxQueueSize: parseInt(getEnvVar("TRIGGER_OTEL_SPAN_MAX_QUEUE_SIZE") ?? "512"),
             })
-          : new SimpleSpanProcessor(new ExternalSpanExporterWrapper(exporter, externalTraceId))
+          : new SimpleSpanProcessor(new ExternalSpanExporterWrapper(exporter, fallbackTraceId))
       );
     }
 
@@ -232,7 +232,7 @@ export class TracingSDK {
       logProcessors.push(
         getEnvVar("TRIGGER_OTEL_BATCH_PROCESSING_ENABLED") === "1"
           ? new BatchLogRecordProcessor(
-              new ExternalLogRecordExporterWrapper(externalLogExporter, externalTraceId),
+              new ExternalLogRecordExporterWrapper(externalLogExporter, fallbackTraceId),
               {
                 maxExportBatchSize: parseInt(
                   getEnvVar("TRIGGER_OTEL_LOG_MAX_EXPORT_BATCH_SIZE") ?? "64"
@@ -247,7 +247,7 @@ export class TracingSDK {
               }
             )
           : new SimpleLogRecordProcessor(
-              new ExternalLogRecordExporterWrapper(externalLogExporter, externalTraceId)
+              new ExternalLogRecordExporterWrapper(externalLogExporter, fallbackTraceId)
             )
       );
     }
@@ -395,54 +395,40 @@ function setLogLevel(level: TracingDiagnosticLogLevel) {
 }
 
 /**
- * Identity of the current run's trace context, or undefined when no run is
- * active.
- *
- * An empty context is not a run: the noop manager returns a fresh `{}` on every
- * call, so treating it as a run would mint a new id on every export.
- */
-function currentRunTraceContext(): object | undefined {
-  const current = traceContext.getTraceContext();
-
-  return current && Object.keys(current).length > 0 ? current : undefined;
-}
-
-/**
  * The external trace id used by runs that carry no external trace context,
  * minted once per run.
  *
  * It has to change per run for the same reason the wrappers read the external
  * context live: with `processKeepAlive` the `TracingSDK` — and so the wrappers
  * — outlive the run, so an id captured at construction merges every run on the
- * process into one trace. The manager's trace context object is reassigned per
- * run, which makes its identity the run boundary.
+ * process into one trace.
  *
  * One instance is shared by every wrapper, so a run's spans and logs still
  * agree on the id after a remint.
  */
 export class FallbackExternalTraceId {
   private traceId: string;
-  private seenTraceContext: object | undefined;
+  private seenEpoch: number;
 
   constructor(
     private seed: string,
     private traceIdGenerator: Pick<RandomIdGenerator, "generateTraceId"> = idGenerator
   ) {
     this.traceId = seed;
-    this.seenTraceContext = currentRunTraceContext();
+    this.seenEpoch = traceContext.getTraceContextEpoch();
   }
 
-  get(): string {
+  forCurrentRun(): string {
     // An empty seed means external export is disabled — leave it that way
     // rather than minting an id and switching the feature on.
     if (!this.seed) {
       return this.seed;
     }
 
-    const current = currentRunTraceContext();
+    const epoch = traceContext.getTraceContextEpoch();
 
-    if (current && current !== this.seenTraceContext) {
-      this.seenTraceContext = current;
+    if (epoch !== this.seenEpoch) {
+      this.seenEpoch = epoch;
       this.traceId = this.traceIdGenerator.generateTraceId();
     }
 
@@ -461,7 +447,7 @@ export class ExternalSpanExporterWrapper {
     // standardTraceContextManager.traceContext is honoured on warm-started
     // workers that reuse a single TracingSDK across runs.
     const externalTraceContext = traceContext.getExternalTraceContext();
-    const fallbackTraceId = this.fallback.get();
+    const fallbackTraceId = this.fallback.forCurrentRun();
 
     const isExternallySampled = externalTraceContext
       ? isTraceFlagSampled(externalTraceContext.traceFlags)
@@ -533,7 +519,7 @@ export class ExternalSpanExporterWrapper {
   }
 }
 
-class ExternalLogRecordExporterWrapper {
+export class ExternalLogRecordExporterWrapper {
   constructor(
     private underlyingExporter: LogRecordExporter,
     private fallback: FallbackExternalTraceId
@@ -541,7 +527,7 @@ class ExternalLogRecordExporterWrapper {
 
   export(logs: any[], resultCallback: (result: any) => void): void {
     const externalTraceContext = traceContext.getExternalTraceContext();
-    const fallbackTraceId = this.fallback.get();
+    const fallbackTraceId = this.fallback.forCurrentRun();
 
     const isExternallySampled = externalTraceContext
       ? isTraceFlagSampled(externalTraceContext.traceFlags)

--- a/packages/core/src/v3/traceContext/api.ts
+++ b/packages/core/src/v3/traceContext/api.ts
@@ -10,6 +10,11 @@ class NoopTraceContextManager implements TraceContextManager {
     return {};
   }
 
+  // Never advances: with no manager registered there are no runs to separate.
+  getTraceContextEpoch() {
+    return 0;
+  }
+
   reset() {}
 
   getExternalTraceContext() {
@@ -55,6 +60,10 @@ export class TraceContextAPI implements TraceContextManager {
 
   public getTraceContext() {
     return this.#getManager().getTraceContext();
+  }
+
+  public getTraceContextEpoch() {
+    return this.#getManager().getTraceContextEpoch();
   }
 
   public getExternalTraceContext() {

--- a/packages/core/src/v3/traceContext/manager.ts
+++ b/packages/core/src/v3/traceContext/manager.ts
@@ -4,10 +4,27 @@ import { parseTraceParent } from "@opentelemetry/core";
 import type { TraceContextManager } from "./types.js";
 
 export class StandardTraceContextManager implements TraceContextManager {
-  public traceContext: Record<string, unknown> = {};
+  #traceContext: Record<string, unknown> = {};
+  #epoch = 0;
+
+  // An accessor rather than a plain field so that replacing the context, which
+  // is what starting a run does, is what advances the epoch. Call sites are
+  // unchanged.
+  get traceContext(): Record<string, unknown> {
+    return this.#traceContext;
+  }
+
+  set traceContext(value: Record<string, unknown>) {
+    this.#traceContext = value;
+    this.#epoch++;
+  }
 
   getTraceContext() {
     return this.traceContext;
+  }
+
+  getTraceContextEpoch() {
+    return this.#epoch;
   }
 
   reset() {

--- a/packages/core/src/v3/traceContext/types.ts
+++ b/packages/core/src/v3/traceContext/types.ts
@@ -2,6 +2,12 @@ import type { Context } from "@opentelemetry/api";
 
 export interface TraceContextManager {
   getTraceContext(): Record<string, unknown>;
+  /**
+   * Increments every time the trace context is replaced, which on a worker that
+   * reuses one process across runs is the run boundary. Long-lived consumers
+   * compare it to tell "still the same run" from "a new run started".
+   */
+  getTraceContextEpoch(): number;
   extractContext(): Context;
   reset(): void;
   getExternalTraceContext():

--- a/packages/core/test/externalSpanExporterWrapper.test.ts
+++ b/packages/core/test/externalSpanExporterWrapper.test.ts
@@ -1,7 +1,7 @@
 import { SpanKind, SpanStatusCode, TraceFlags } from "@opentelemetry/api";
 import type { ReadableSpan, SpanExporter } from "@opentelemetry/sdk-trace-node";
 import { beforeEach, describe, expect, it } from "vitest";
-import { ExternalSpanExporterWrapper } from "../src/v3/otel/tracingSDK.js";
+import { ExternalSpanExporterWrapper, FallbackExternalTraceId } from "../src/v3/otel/tracingSDK.js";
 import { SemanticInternalAttributes } from "../src/v3/semanticInternalAttributes.js";
 import { traceContext } from "../src/v3/trace-context-api.js";
 import { StandardTraceContextManager } from "../src/v3/traceContext/manager.js";
@@ -66,7 +66,10 @@ describe("ExternalSpanExporterWrapper warm-start regression", () => {
 
     manager.traceContext = { external: { traceparent: TRACEPARENT_RUN_A } };
 
-    const wrapper = new ExternalSpanExporterWrapper(exporter, "ffffffffffffffffffffffffffffffff");
+    const wrapper = new ExternalSpanExporterWrapper(
+      exporter,
+      new FallbackExternalTraceId("ffffffffffffffffffffffffffffffff")
+    );
 
     manager.traceContext = { external: { traceparent: TRACEPARENT_RUN_B } };
 
@@ -98,8 +101,7 @@ describe("ExternalSpanExporterWrapper warm-start regression", () => {
 
     const wrapper = new ExternalSpanExporterWrapper(
       exporter,
-      "ffffffffffffffffffffffffffffffff",
-      idGenerator
+      new FallbackExternalTraceId("ffffffffffffffffffffffffffffffff", idGenerator)
     );
 
     wrapper.export([createAttemptSpan()], () => {});
@@ -130,8 +132,7 @@ describe("ExternalSpanExporterWrapper warm-start regression", () => {
 
     const wrapper = new ExternalSpanExporterWrapper(
       exporter,
-      "ffffffffffffffffffffffffffffffff",
-      idGenerator
+      new FallbackExternalTraceId("ffffffffffffffffffffffffffffffff", idGenerator)
     );
 
     wrapper.export([createAttemptSpan()], () => {});
@@ -150,12 +151,70 @@ describe("ExternalSpanExporterWrapper warm-start regression", () => {
 
     manager.traceContext = { traceparent: TRACEPARENT_RUN_A };
 
-    const wrapper = new ExternalSpanExporterWrapper(exporter, "", idGenerator);
+    const wrapper = new ExternalSpanExporterWrapper(
+      exporter,
+      new FallbackExternalTraceId("", idGenerator)
+    );
 
     wrapper.export([createAttemptSpan()], () => {});
 
     // Minting an id here would switch external export on for a deployment that
     // never asked for it.
     expect(captured[0]).toHaveLength(0);
+  });
+
+  // The TracingSDK shares one FallbackExternalTraceId across every span and log
+  // wrapper. Giving each wrapper its own would remint them independently, so
+  // from the second run on, a run's logs would carry a different trace id than
+  // its spans and stop correlating in the external backend.
+  it("gives every wrapper sharing one fallback the same id after a remint", () => {
+    const first = makeCapturingExporter();
+    const second = makeCapturingExporter();
+
+    let generated = 0;
+    const idGenerator = {
+      generateTraceId: () => `${++generated}`.padStart(32, "0"),
+    };
+
+    manager.traceContext = { traceparent: TRACEPARENT_RUN_A };
+
+    const fallback = new FallbackExternalTraceId("ffffffffffffffffffffffffffffffff", idGenerator);
+    const spanWrapper = new ExternalSpanExporterWrapper(first.exporter, fallback);
+    const otherWrapper = new ExternalSpanExporterWrapper(second.exporter, fallback);
+
+    manager.traceContext = { traceparent: TRACEPARENT_RUN_B };
+
+    spanWrapper.export([createAttemptSpan()], () => {});
+    otherWrapper.export([createAttemptSpan()], () => {});
+
+    expect(second.captured[0]![0]!.spanContext().traceId).toBe(
+      first.captured[0]![0]!.spanContext().traceId
+    );
+    expect(generated).toBe(1);
+  });
+
+  // The noop manager returns a fresh `{}` on every call, so using its identity
+  // as the run boundary would remint on every export and shatter one run's
+  // trace into many.
+  it("holds the id when no trace context manager is registered", () => {
+    const { exporter, captured } = makeCapturingExporter();
+
+    let generated = 0;
+    const idGenerator = {
+      generateTraceId: () => `${++generated}`.padStart(32, "0"),
+    };
+
+    traceContext.disable();
+
+    const wrapper = new ExternalSpanExporterWrapper(
+      exporter,
+      new FallbackExternalTraceId("ffffffffffffffffffffffffffffffff", idGenerator)
+    );
+
+    wrapper.export([createAttemptSpan()], () => {});
+    wrapper.export([createAttemptSpan()], () => {});
+
+    expect(captured[1]![0]!.spanContext().traceId).toBe(captured[0]![0]!.spanContext().traceId);
+    expect(generated).toBe(0);
   });
 });

--- a/packages/core/test/externalSpanExporterWrapper.test.ts
+++ b/packages/core/test/externalSpanExporterWrapper.test.ts
@@ -53,6 +53,10 @@ describe("ExternalSpanExporterWrapper warm-start regression", () => {
   let manager: StandardTraceContextManager;
 
   beforeEach(() => {
+    // `setGlobalManager` delegates to `registerGlobal`, which ignores a second
+    // registration — without disabling first, every test after the first would
+    // keep mutating the first test's manager.
+    traceContext.disable();
     manager = new StandardTraceContextManager();
     traceContext.setGlobalManager(manager);
   });
@@ -76,5 +80,82 @@ describe("ExternalSpanExporterWrapper warm-start regression", () => {
     expect(span.parentSpanContext?.spanId).not.toBe("1111111111111111");
     expect(span.parentSpanContext?.traceId).toBe("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     expect(span.spanContext().traceId).toBe("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+  });
+
+  // Runs triggered internally — a schedule, or one task triggering another —
+  // carry no external trace context and so take the generated fallback. That id
+  // was captured at construction, which on a warm-started worker meant every run
+  // on the process shared a single trace id.
+  it("mints a new fallback trace id per run when there is no external context", () => {
+    const { exporter, captured } = makeCapturingExporter();
+
+    let generated = 0;
+    const idGenerator = {
+      generateTraceId: () => `${++generated}`.padStart(32, "0"),
+    };
+
+    manager.traceContext = { traceparent: TRACEPARENT_RUN_A };
+
+    const wrapper = new ExternalSpanExporterWrapper(
+      exporter,
+      "ffffffffffffffffffffffffffffffff",
+      idGenerator
+    );
+
+    wrapper.export([createAttemptSpan()], () => {});
+
+    // A second run on the same warm process: the manager is reassigned, so the
+    // fallback has to be reminted.
+    manager.traceContext = { traceparent: TRACEPARENT_RUN_B };
+
+    wrapper.export([createAttemptSpan()], () => {});
+
+    const runATraceId = captured[0]![0]!.spanContext().traceId;
+    const runBTraceId = captured[1]![0]!.spanContext().traceId;
+
+    expect(runATraceId).toBe("ffffffffffffffffffffffffffffffff");
+    expect(runBTraceId).not.toBe(runATraceId);
+    expect(runBTraceId).toBe("00000000000000000000000000000001");
+  });
+
+  it("keeps one fallback trace id across every export within a run", () => {
+    const { exporter, captured } = makeCapturingExporter();
+
+    let generated = 0;
+    const idGenerator = {
+      generateTraceId: () => `${++generated}`.padStart(32, "0"),
+    };
+
+    manager.traceContext = { traceparent: TRACEPARENT_RUN_A };
+
+    const wrapper = new ExternalSpanExporterWrapper(
+      exporter,
+      "ffffffffffffffffffffffffffffffff",
+      idGenerator
+    );
+
+    wrapper.export([createAttemptSpan()], () => {});
+    wrapper.export([createAttemptSpan()], () => {});
+
+    expect(captured[1]![0]!.spanContext().traceId).toBe(captured[0]![0]!.spanContext().traceId);
+    expect(generated).toBe(0);
+  });
+
+  it("leaves external export off when no external trace id was configured", () => {
+    const { exporter, captured } = makeCapturingExporter();
+
+    const idGenerator = {
+      generateTraceId: () => "00000000000000000000000000000001",
+    };
+
+    manager.traceContext = { traceparent: TRACEPARENT_RUN_A };
+
+    const wrapper = new ExternalSpanExporterWrapper(exporter, "", idGenerator);
+
+    wrapper.export([createAttemptSpan()], () => {});
+
+    // Minting an id here would switch external export on for a deployment that
+    // never asked for it.
+    expect(captured[0]).toHaveLength(0);
   });
 });

--- a/packages/core/test/externalSpanExporterWrapper.test.ts
+++ b/packages/core/test/externalSpanExporterWrapper.test.ts
@@ -1,13 +1,19 @@
 import { SpanKind, SpanStatusCode, TraceFlags } from "@opentelemetry/api";
+import type { LogRecordExporter, ReadableLogRecord } from "@opentelemetry/sdk-logs";
 import type { ReadableSpan, SpanExporter } from "@opentelemetry/sdk-trace-node";
 import { beforeEach, describe, expect, it } from "vitest";
-import { ExternalSpanExporterWrapper, FallbackExternalTraceId } from "../src/v3/otel/tracingSDK.js";
+import {
+  ExternalLogRecordExporterWrapper,
+  ExternalSpanExporterWrapper,
+  FallbackExternalTraceId,
+} from "../src/v3/otel/tracingSDK.js";
 import { SemanticInternalAttributes } from "../src/v3/semanticInternalAttributes.js";
 import { traceContext } from "../src/v3/trace-context-api.js";
 import { StandardTraceContextManager } from "../src/v3/traceContext/manager.js";
 
 const TRACEPARENT_RUN_A = "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1111111111111111-01";
 const TRACEPARENT_RUN_B = "00-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-2222222222222222-01";
+const SEED = "ffffffffffffffffffffffffffffffff";
 
 function createAttemptSpan(): ReadableSpan {
   const spanCtx = {
@@ -36,6 +42,18 @@ function createAttemptSpan(): ReadableSpan {
   } as unknown as ReadableSpan;
 }
 
+function createLogRecord(): ReadableLogRecord {
+  return {
+    body: "hello",
+    attributes: {},
+    spanContext: {
+      traceId: "cccccccccccccccccccccccccccccccc",
+      spanId: "3333333333333333",
+      traceFlags: TraceFlags.SAMPLED,
+    },
+  } as unknown as ReadableLogRecord;
+}
+
 function makeCapturingExporter(): { exporter: SpanExporter; captured: ReadableSpan[][] } {
   const captured: ReadableSpan[][] = [];
   const exporter: SpanExporter = {
@@ -47,6 +65,32 @@ function makeCapturingExporter(): { exporter: SpanExporter; captured: ReadableSp
     forceFlush: () => Promise.resolve(),
   };
   return { exporter, captured };
+}
+
+function makeCapturingLogExporter(): {
+  exporter: LogRecordExporter;
+  captured: ReadableLogRecord[][];
+} {
+  const captured: ReadableLogRecord[][] = [];
+  const exporter: LogRecordExporter = {
+    export: (records, cb) => {
+      captured.push(records);
+      cb({ code: 0 } as any);
+    },
+    shutdown: () => Promise.resolve(),
+  };
+  return { exporter, captured };
+}
+
+/** Yields 000…001, 000…002, … so a reminted id is identifiable by its ordinal. */
+function makeIdGenerator() {
+  let generated = 0;
+  return {
+    generateTraceId: () => `${++generated}`.padStart(32, "0"),
+    get count() {
+      return generated;
+    },
+  };
 }
 
 describe("ExternalSpanExporterWrapper warm-start regression", () => {
@@ -66,10 +110,7 @@ describe("ExternalSpanExporterWrapper warm-start regression", () => {
 
     manager.traceContext = { external: { traceparent: TRACEPARENT_RUN_A } };
 
-    const wrapper = new ExternalSpanExporterWrapper(
-      exporter,
-      new FallbackExternalTraceId("ffffffffffffffffffffffffffffffff")
-    );
+    const wrapper = new ExternalSpanExporterWrapper(exporter, new FallbackExternalTraceId(SEED));
 
     manager.traceContext = { external: { traceparent: TRACEPARENT_RUN_B } };
 
@@ -91,23 +132,18 @@ describe("ExternalSpanExporterWrapper warm-start regression", () => {
   // on the process shared a single trace id.
   it("mints a new fallback trace id per run when there is no external context", () => {
     const { exporter, captured } = makeCapturingExporter();
-
-    let generated = 0;
-    const idGenerator = {
-      generateTraceId: () => `${++generated}`.padStart(32, "0"),
-    };
+    const idGenerator = makeIdGenerator();
 
     manager.traceContext = { traceparent: TRACEPARENT_RUN_A };
 
     const wrapper = new ExternalSpanExporterWrapper(
       exporter,
-      new FallbackExternalTraceId("ffffffffffffffffffffffffffffffff", idGenerator)
+      new FallbackExternalTraceId(SEED, idGenerator)
     );
 
     wrapper.export([createAttemptSpan()], () => {});
 
-    // A second run on the same warm process: the manager is reassigned, so the
-    // fallback has to be reminted.
+    // A second run on the same warm process.
     manager.traceContext = { traceparent: TRACEPARENT_RUN_B };
 
     wrapper.export([createAttemptSpan()], () => {});
@@ -115,39 +151,55 @@ describe("ExternalSpanExporterWrapper warm-start regression", () => {
     const runATraceId = captured[0]![0]!.spanContext().traceId;
     const runBTraceId = captured[1]![0]!.spanContext().traceId;
 
-    expect(runATraceId).toBe("ffffffffffffffffffffffffffffffff");
+    expect(runATraceId).toBe(SEED);
     expect(runBTraceId).not.toBe(runATraceId);
     expect(runBTraceId).toBe("00000000000000000000000000000001");
   });
 
-  it("keeps one fallback trace id across every export within a run", () => {
+  // The run boundary is the manager being handed a new context, not that
+  // context having any particular content. A run whose trace context is empty
+  // is still a different run.
+  it("mints a new fallback trace id for a run whose trace context is empty", () => {
     const { exporter, captured } = makeCapturingExporter();
-
-    let generated = 0;
-    const idGenerator = {
-      generateTraceId: () => `${++generated}`.padStart(32, "0"),
-    };
+    const idGenerator = makeIdGenerator();
 
     manager.traceContext = { traceparent: TRACEPARENT_RUN_A };
 
     const wrapper = new ExternalSpanExporterWrapper(
       exporter,
-      new FallbackExternalTraceId("ffffffffffffffffffffffffffffffff", idGenerator)
+      new FallbackExternalTraceId(SEED, idGenerator)
+    );
+
+    wrapper.export([createAttemptSpan()], () => {});
+
+    manager.traceContext = {};
+
+    wrapper.export([createAttemptSpan()], () => {});
+
+    expect(captured[1]![0]!.spanContext().traceId).not.toBe(captured[0]![0]!.spanContext().traceId);
+  });
+
+  it("keeps one fallback trace id across every export within a run", () => {
+    const { exporter, captured } = makeCapturingExporter();
+    const idGenerator = makeIdGenerator();
+
+    manager.traceContext = { traceparent: TRACEPARENT_RUN_A };
+
+    const wrapper = new ExternalSpanExporterWrapper(
+      exporter,
+      new FallbackExternalTraceId(SEED, idGenerator)
     );
 
     wrapper.export([createAttemptSpan()], () => {});
     wrapper.export([createAttemptSpan()], () => {});
 
     expect(captured[1]![0]!.spanContext().traceId).toBe(captured[0]![0]!.spanContext().traceId);
-    expect(generated).toBe(0);
+    expect(idGenerator.count).toBe(0);
   });
 
   it("leaves external export off when no external trace id was configured", () => {
     const { exporter, captured } = makeCapturingExporter();
-
-    const idGenerator = {
-      generateTraceId: () => "00000000000000000000000000000001",
-    };
+    const idGenerator = makeIdGenerator();
 
     manager.traceContext = { traceparent: TRACEPARENT_RUN_A };
 
@@ -163,58 +215,49 @@ describe("ExternalSpanExporterWrapper warm-start regression", () => {
     expect(captured[0]).toHaveLength(0);
   });
 
-  // The TracingSDK shares one FallbackExternalTraceId across every span and log
-  // wrapper. Giving each wrapper its own would remint them independently, so
-  // from the second run on, a run's logs would carry a different trace id than
-  // its spans and stop correlating in the external backend.
-  it("gives every wrapper sharing one fallback the same id after a remint", () => {
-    const first = makeCapturingExporter();
-    const second = makeCapturingExporter();
-
-    let generated = 0;
-    const idGenerator = {
-      generateTraceId: () => `${++generated}`.padStart(32, "0"),
-    };
+  // The TracingSDK shares one FallbackExternalTraceId across its span and log
+  // wrappers. Giving each its own would remint them independently, so from the
+  // second run on, a run's logs would carry a different trace id than its spans
+  // and stop correlating in the external backend.
+  it("keeps a run's spans and logs on the same id after a remint", () => {
+    const spans = makeCapturingExporter();
+    const logs = makeCapturingLogExporter();
+    const idGenerator = makeIdGenerator();
 
     manager.traceContext = { traceparent: TRACEPARENT_RUN_A };
 
-    const fallback = new FallbackExternalTraceId("ffffffffffffffffffffffffffffffff", idGenerator);
-    const spanWrapper = new ExternalSpanExporterWrapper(first.exporter, fallback);
-    const otherWrapper = new ExternalSpanExporterWrapper(second.exporter, fallback);
+    const fallback = new FallbackExternalTraceId(SEED, idGenerator);
+    const spanWrapper = new ExternalSpanExporterWrapper(spans.exporter, fallback);
+    const logWrapper = new ExternalLogRecordExporterWrapper(logs.exporter, fallback);
 
     manager.traceContext = { traceparent: TRACEPARENT_RUN_B };
 
     spanWrapper.export([createAttemptSpan()], () => {});
-    otherWrapper.export([createAttemptSpan()], () => {});
+    logWrapper.export([createLogRecord()], () => {});
 
-    expect(second.captured[0]![0]!.spanContext().traceId).toBe(
-      first.captured[0]![0]!.spanContext().traceId
+    expect(logs.captured[0]![0]!.spanContext!.traceId).toBe(
+      spans.captured[0]![0]!.spanContext().traceId
     );
-    expect(generated).toBe(1);
+    expect(idGenerator.count).toBe(1);
   });
 
-  // The noop manager returns a fresh `{}` on every call, so using its identity
-  // as the run boundary would remint on every export and shatter one run's
-  // trace into many.
+  // With no manager registered the epoch is a constant, so there are no run
+  // boundaries to react to and the id must hold rather than churn per export.
   it("holds the id when no trace context manager is registered", () => {
     const { exporter, captured } = makeCapturingExporter();
-
-    let generated = 0;
-    const idGenerator = {
-      generateTraceId: () => `${++generated}`.padStart(32, "0"),
-    };
+    const idGenerator = makeIdGenerator();
 
     traceContext.disable();
 
     const wrapper = new ExternalSpanExporterWrapper(
       exporter,
-      new FallbackExternalTraceId("ffffffffffffffffffffffffffffffff", idGenerator)
+      new FallbackExternalTraceId(SEED, idGenerator)
     );
 
     wrapper.export([createAttemptSpan()], () => {});
     wrapper.export([createAttemptSpan()], () => {});
 
     expect(captured[1]![0]!.spanContext().traceId).toBe(captured[0]![0]!.spanContext().traceId);
-    expect(generated).toBe(0);
+    expect(idGenerator.count).toBe(0);
   });
 });


### PR DESCRIPTION
## Problem

Runs that carry no external trace context (schedules, task-to-task triggers, anything not started from an incoming `traceparent`) fall back to a generated external trace id. That id is generated once, in the `TracingSDK` constructor:

https://github.com/triggerdotdev/trigger.dev/blob/main/packages/core/src/v3/otel/tracingSDK.ts#L165

With `experimental_processKeepAlive` enabled, the `TracingSDK` outlives the run, so every run that executes on a warm process is exported to the external OTLP endpoint under that same trace id and unrelated runs get merged into one trace on the receiving backend.

This is the same warm-start hazard that c043c4a6a fixed for the external-context path. That commit made the wrappers read `traceContext.getExternalTraceContext()` live instead of capturing it at construction, but deliberately left the fallback captured, so the bug survives for exactly the runs that have no external context.

### What it looks like in production

We export to a self-hosted Langfuse via `telemetry.exporters`. Measured over our production traces:

- 80.3% of traces contain spans from more than one Trigger run
- worst case: 25 distinct runs collapsed into a single trace

Per-trace cost and latency attribution is meaningless as a result: a trace shows an unrelated mix of workloads, and drilling into one run is impossible.

Disabling `experimental_processKeepAlive` avoids it, but that is a significant throughput regression and not a real option for us.

## Fix

`FallbackExternalTraceId` holds the generated id and remints it when the run changes. The `TracingSDK` constructs one instance and passes it to every `ExternalSpanExporterWrapper` and `ExternalLogRecordExporterWrapper`, so a run's spans and logs agree on the id after a remint. That matches the old behaviour, where all wrappers received one identical string.

The run boundary comes from the manager rather than being inferred. `StandardTraceContextManager.traceContext` becomes an accessor pair that advances an epoch whenever the context is replaced, which is exactly what starting a run does, so no call site changes. `getTraceContextEpoch()` is added to `TraceContextManager`, and the noop manager reports a constant, so with no manager registered there are no boundaries to react to.

I did first try inferring the boundary from reference-identity of `getTraceContext()`. It works, but guarding it against the noop manager's freshly allocated `{}` requires testing the context for emptiness, and since `traceContext` is `z.record(z.unknown())` that silently stops reminting for a run whose context is legitimately empty, merging it back into the previous run's trace. The epoch avoids the heuristic entirely.

One behaviour held deliberately: an empty configured id still means external export is off, so the empty seed short-circuits rather than minting an id and switching the feature on for a deployment that never asked for it.

## Tests

`packages/core/test/externalSpanExporterWrapper.test.ts` gains six cases:

- mints a new fallback trace id per run when there is no external context
- mints a new fallback trace id for a run whose trace context is empty
- keeps one fallback trace id across every export within a run
- leaves external export off when no external trace id was configured
- keeps a run's spans and logs on the same id after a remint
- holds the id when no trace context manager is registered

Mutation-checked. Removing the epoch bump fails three of them, and reinstating the emptiness heuristic fails the empty-context case with the exact symptom it describes. Full `packages/core` suite passes (674 tests).

The harness needed one fix to make these meaningful. `traceContext.setGlobalManager()` delegates to `registerGlobal`, which ignores a second registration, so the `beforeEach` only ever installed the first test's manager and every later test was mutating an object that was no longer global. Calling `traceContext.disable()` first makes each test's manager actually take effect.

Happy to split the `traceContext` epoch into its own commit or PR if you'd rather review it separately, or to take a different approach to the boundary entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_Supersedes #4526, which the vouching bot auto-closed before I was on the list and which GitHub will no longer let me reopen (its head is stuck at the first commit). Devin's three findings on that PR are addressed here; see the notes on the closed PR and the `Fix` section above._
