### PR TITLE
feat(sdk,slack): route webhooks into agents with chat.event, channels, and human-in-the-loop

### DIFF
--- a/.changeset/hosted-webhook-channels.md
+++ b/.changeset/hosted-webhook-channels.md
@@ -1,0 +1,13 @@
+---
+"@trigger.dev/sdk": minor
+"@trigger.dev/slack": minor
+"trigger.dev": minor
+---
+
+Route hosted webhooks into agents, and turn chat surfaces into agent frontends.
+
+- `chat.event({ source, key, type })` routes deliveries that share a `key` to one durable session (per customer, installation, or issue) and delivers them to an agent's `onAction` as a typed envelope.
+- Channels turn a chat surface into an agent frontend: `chat.channels.custom({ source, key, inbound, send })`, or the new `@trigger.dev/slack` package's `slack()` (Slack Events API verification, per-thread sessions, `chat.postMessage`/`chat.update` egress, `mentions()`, `startOn`, lifecycle reactions). Inbound messages run as turns and the reply posts back.
+- Human-in-the-loop is built in: a tool with no `execute` pauses the turn, the connector posts controls (Slack ships Approve / Deny buttons), and a verified click resolves the tool and resumes the run.
+- `chat.createWatchToken(externalId)` mints a read-only token to watch a session from another surface.
+- The CLI warns about a `chat.event` no agent lists.

--- a/.changeset/hosted-webhook-ingress.md
+++ b/.changeset/hosted-webhook-ingress.md
@@ -1,0 +1,14 @@
+---
+"@trigger.dev/core": minor
+"@trigger.dev/sdk": minor
+"@trigger.dev/slack": minor
+"trigger.dev": minor
+---
+
+Add hosted webhooks: receive and verify provider webhooks as a task, with no ingress or verification code of your own.
+
+- `webhook()` declares an endpoint that routes a verified, typed event to an `onEvent` handler. Choose a source with a preset (`webhooks.stripe()`, `webhooks.github()`, and others) or `webhooks.custom<T>(config)`. Declared webhooks are discovered like tasks and synced to a hosted URL on deploy.
+- `filter` gates which deliveries run, using a type-safe expression checked against the event at author time (`event.`/`header.`/`webhook.` paths, `&&`/`||`, comparison and `in`/`contains` operators, field-to-field comparison, and array quantifiers). A non-matching delivery is still recorded, not routed.
+- `chat.event({ source, key, type })` routes deliveries that share a `key` to one durable session (per customer, installation, or issue) and delivers them to an agent's `onAction` as a typed envelope.
+- Channels turn a chat surface into an agent frontend: `chat.channels.custom({ source, key, inbound, send })`, or the new `@trigger.dev/slack` package's `slack()` (Slack Events API verification, per-thread sessions, `chat.postMessage`/`chat.update` egress, `mentions()`, `startOn`, lifecycle reactions). Inbound messages run as turns and the reply posts back. Human-in-the-loop is built in: a tool with no `execute` pauses the turn, the connector posts controls (Slack ships Approve / Deny buttons), and a verified click resolves the tool and resumes the run.
+- HTTP API for listing webhook endpoints and deliveries, plus rotate-secret, enable/disable, and replay.

--- a/.changeset/hosted-webhook-ingress.md
+++ b/.changeset/hosted-webhook-ingress.md
@@ -1,0 +1,11 @@
+---
+"@trigger.dev/core": minor
+"@trigger.dev/sdk": minor
+"trigger.dev": minor
+---
+
+Add hosted webhooks: receive and verify provider webhooks as a task, with no ingress or verification code of your own.
+
+- `webhook()` declares an endpoint that routes a verified, typed event to an `onEvent` handler. Choose a source with a preset (`webhooks.stripe()`, `webhooks.github()`, and others) or `webhooks.custom<T>(config)`. Declared webhooks are discovered like tasks and synced to a hosted URL on deploy.
+- `filter` gates which deliveries run, using a type-safe expression checked against the event at author time (`event.`/`header.`/`webhook.` paths, `&&`/`||`, comparison and `in`/`contains` operators, field-to-field comparison, and array quantifiers). A non-matching delivery is still recorded, not routed.
+- HTTP API for listing webhook endpoints and deliveries, plus rotate-secret, enable/disable, and replay.

--- a/docs/ai-chat/backend.mdx
+++ b/docs/ai-chat/backend.mdx
@@ -470,6 +470,37 @@ Custom actions let the frontend send structured commands (undo, rollback, edit, 
 
 See [Actions](/ai-chat/actions).
 
+### Webhook events and channels
+
+Two `chat.agent()` options wire an agent to verified inbound webhooks. `events` claims [`chat.event(...)`](/webhooks/session-routing) descriptors: each verified delivery is routed to this agent's session and arrives at `onAction` as an action (not a turn), so [session routing](/webhooks/session-routing) decides which conversation it lands on. `channels` claims channel connectors that turn an external chat surface into a frontend for the agent: an inbound message runs as a turn through `run()` and the reply is posted back. `slack()` ships in `@trigger.dev/slack`, and `chat.channels.custom(...)` builds a connector for any source without a preset.
+
+```ts
+import { webhooks } from "@trigger.dev/sdk";
+import { chat } from "@trigger.dev/sdk/ai";
+import { slack } from "@trigger.dev/slack";
+
+export const orderEvents = chat.event({
+  id: "order-events",
+  source: webhooks.stripe(),
+  key: "{body.data.object.customer}",
+  type: "order.event",
+});
+
+export const myChat = chat.agent({
+  id: "my-chat",
+  events: [orderEvents],
+  channels: [slack({ id: "support-slack", token: process.env.SLACK_BOT_TOKEN! })],
+  onAction: async ({ action }) => {
+    // A verified order-events delivery arrives here as an action.
+  },
+  run: async (payload) => {
+    // Inbound Slack messages run here as normal turns.
+  },
+});
+```
+
+See [session routing](/webhooks/session-routing) and [channels](/webhooks/channels). For the interactive approvals layer, where a turn pauses on a human decision (buttons in the thread) and resumes on the click, see [human-in-the-loop](/webhooks/human-in-the-loop).
+
 ### Chat history
 
 Imperative API for reading and modifying the accumulated message history. Works from any hook (`onAction`, `onTurnStart`, `onBeforeTurnComplete`, `onTurnComplete`, `hydrateMessages`) or from `run()` and AI SDK tools.

--- a/docs/ai-chat/backend.mdx
+++ b/docs/ai-chat/backend.mdx
@@ -497,6 +497,37 @@ Custom actions let the frontend send structured commands (undo, rollback, edit, 
 
 See [Actions](/ai-chat/actions).
 
+### Webhook events and channels
+
+Two `chat.agent()` options wire an agent to verified inbound webhooks. `events` claims [`chat.event(...)`](/webhooks/session-routing) descriptors: each verified delivery is routed to this agent's session and arrives at `onAction` as an action (not a turn), so [session routing](/webhooks/session-routing) decides which conversation it lands on. `channels` claims channel connectors that turn an external chat surface into a frontend for the agent: an inbound message runs as a turn through `run()` and the reply is posted back. `slack()` ships in `@trigger.dev/slack`, and `chat.channels.custom(...)` builds a connector for any source without a preset.
+
+```ts
+import { webhooks } from "@trigger.dev/sdk";
+import { chat } from "@trigger.dev/sdk/ai";
+import { slack } from "@trigger.dev/slack";
+
+export const orderEvents = chat.event({
+  id: "order-events",
+  source: webhooks.stripe(),
+  key: "{body.data.object.customer}",
+  type: "order.event",
+});
+
+export const myChat = chat.agent({
+  id: "my-chat",
+  events: [orderEvents],
+  channels: [slack({ id: "support-slack", token: process.env.SLACK_BOT_TOKEN! })],
+  onAction: async ({ action }) => {
+    // A verified order-events delivery arrives here as an action.
+  },
+  run: async (payload) => {
+    // Inbound Slack messages run here as normal turns.
+  },
+});
+```
+
+See [session routing](/webhooks/session-routing) and [channels](/webhooks/channels). For the interactive approvals layer, where a turn pauses on a human decision (buttons in the thread) and resumes on the click, see [human-in-the-loop](/webhooks/human-in-the-loop).
+
 ### Chat history
 
 Imperative API for reading and modifying the accumulated message history. Works from any hook (`onAction`, `onTurnStart`, `onBeforeTurnComplete`, `onTurnComplete`, `hydrateMessages`) or from `run()` and AI SDK tools.

--- a/docs/ai-chat/reference.mdx
+++ b/docs/ai-chat/reference.mdx
@@ -47,6 +47,8 @@ Options for `chat.agent()`.
 | `hydrateMessages`             | `(event: HydrateMessagesEvent) => UIMessage[] \| Promise<UIMessage[]>` | —                 | Load message history from backend, replacing the linear accumulator. See [hydrateMessages](/ai-chat/lifecycle-hooks#hydratemessages) |
 | `actionSchema`                | `TaskSchema`                                                | —                              | Schema for validating custom actions sent via `transport.sendAction()`. See [Actions](/ai-chat/actions) |
 | `onAction`                    | `(event: ActionEvent) => Promise<unknown> \| unknown`       | —                              | Handle custom actions. Actions are not turns — only `hydrateMessages` + `onAction` fire. Return a `StreamTextResult` (or `string` / `UIMessage`) for a model response; return `void` for side-effect-only. See [Actions](/ai-chat/actions) |
+| `events`                      | `ChatEvent[]`                                               | —                              | Webhook event descriptors (from `chat.event()`) whose verified deliveries are routed to this agent as actions and handled in `onAction`. See [session routing](/webhooks/session-routing). |
+| `channels`                    | `ChannelConnector[]`                                        | —                              | Channel connectors (for example `slack()`) that turn an external chat surface into a frontend for the agent: inbound messages run as turns and the reply posts back. See [channels](/webhooks/channels). |
 | `onTurnStart`                 | `(event: TurnStartEvent) => Promise<void> \| void`          | —                              | Fires every turn before `run()`                                                                     |
 | `onBeforeTurnComplete`        | `(event: BeforeTurnCompleteEvent) => Promise<void> \| void` | —                              | Fires after response but before stream closes. Includes `writer`.                                   |
 | `onTurnComplete`              | `(event: TurnCompleteEvent) => Promise<void> \| void`       | —                              | Fires after each turn completes (stream closed)                                                     |
@@ -501,6 +503,8 @@ All methods available on the `chat` object from `@trigger.dev/sdk/ai`.
 | Method                                      | Description                                                                                                                  |
 | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `chat.agent(options)`                       | Create a chat agent                                                                                                          |
+| `chat.event(options)`                       | Declare an inbound webhook event descriptor an agent claims via `chat.agent({ events })`. See [session routing](/webhooks/session-routing). |
+| `chat.channels.custom(options)`             | Create a generic chat-frontend channel over any verified webhook source (you supply the egress). The `slack()` preset ships in `@trigger.dev/slack`. See [channels](/webhooks/channels). |
 | `chat.createSession(payload, options)`      | Create an async iterator for chat turns                                                                                      |
 | `chat.pipe(source, options?)`               | Pipe a stream to the frontend (from anywhere inside a task)                                                                  |
 | `chat.pipeAndCapture(source, options?)`     | Pipe and capture the response; returns `{ message, status, error }`                                                         |
@@ -529,6 +533,42 @@ All methods available on the `chat` object from `@trigger.dev/sdk/ai`.
 | `chat.MessageAccumulator`                   | Class that accumulates conversation messages across turns                                                                    |
 | `chat.withUIMessage(config?)`               | Returns a [ChatBuilder](/ai-chat/types#chatbuilder) with a fixed `UIMessage` subtype. See [Types](/ai-chat/types)            |
 | `chat.withClientData({ schema })`           | Returns a [ChatBuilder](/ai-chat/types#chatbuilder) with a fixed client data schema. See [Types](/ai-chat/types#typed-client-data-with-chatwithclientdata) |
+
+## `chat.event`
+
+Declare an inbound webhook event that an agent claims via [`events`](#chatagentoptions) on `chat.agent()`. It is a descriptor only, with no handler: it names a [source](/webhooks/sources) to verify, a `key` template that resolves each delivery to a durable [session](/ai-chat/sessions), and an optional `type` label (defaults to the descriptor `id`). Verified deliveries are routed to that session and arrive at `onAction` as a `{ type, event, source, headers, deliveryId }` envelope, not as a chat turn. See [session routing](/webhooks/session-routing).
+
+```ts
+import { webhooks } from "@trigger.dev/sdk";
+import { chat } from "@trigger.dev/sdk/ai";
+
+export const orderEvents = chat.event({
+  id: "order-events",
+  source: webhooks.stripe(),
+  key: "{body.data.object.customer}",
+  type: "order.event",
+});
+```
+
+## `chat.channels.custom`
+
+Create a generic chat-frontend channel over any verified [source](/webhooks/sources), claimed via [`channels`](#chatagentoptions) on `chat.agent()`. You supply the session `key`, the `inbound` map from event to turn message, and your own `send` egress that posts the reply back, so the whole round-trip is under your control. Inbound messages run as normal turns and the reply is posted back. The `slack()` preset ships in `@trigger.dev/slack` and wires the egress for you. See [channels](/webhooks/channels), and the interactive approvals layer at [human-in-the-loop](/webhooks/human-in-the-loop).
+
+```ts
+import { webhooks } from "@trigger.dev/sdk";
+import { chat } from "@trigger.dev/sdk/ai";
+
+export const mySurface = chat.channels.custom({
+  id: "my-surface",
+  source: webhooks.custom<MyEvent>({ /* verifier config */ }),
+  key: "{body.conversationId}",
+  inbound: (event) => event.text,
+  send: async (message, ctx) => {
+    const ref = await postToMySurface(ctx.event, message.text, ctx.previousRef);
+    return { ref };
+  },
+});
+```
 
 ## `chat.withUIMessage`
 

--- a/docs/ai-chat/reference.mdx
+++ b/docs/ai-chat/reference.mdx
@@ -48,6 +48,8 @@ Options for `chat.agent()`.
 | `hydrateMessages`             | `(event: HydrateMessagesEvent) => UIMessage[] \| Promise<UIMessage[]>` | —                 | **Deprecated.** Load message history from backend, replacing the linear accumulator. Use `loadContext` on a `storage` instead; cannot be combined with `storage`. See [hydrateMessages](/ai-chat/lifecycle-hooks#hydratemessages) |
 | `actionSchema`                | `TaskSchema`                                                | —                              | Schema for validating custom actions sent via `transport.sendAction()`. See [Actions](/ai-chat/actions) |
 | `onAction`                    | `(event: ActionEvent) => Promise<void \| ActionTurn> \| void \| ActionTurn` | —                              | Handle custom actions. Actions are state edits: only `hydrateMessages` (or a storage's `loadContext`) + `onAction` fire. Return `chat.turn()` to run a turn on the edited history, or nothing for an edit only. See [Actions](/ai-chat/actions) |
+| `events`                      | `ChatEvent[]`                                               | —                              | Webhook event descriptors (from `chat.event()`) whose verified deliveries are routed to this agent as actions and handled in `onAction`. See [session routing](/webhooks/session-routing). |
+| `channels`                    | `ChannelConnector[]`                                        | —                              | Channel connectors (for example `slack()`) that turn an external chat surface into a frontend for the agent: inbound messages run as turns and the reply posts back. See [channels](/webhooks/channels). |
 | `onTurnStart`                 | `(event: TurnStartEvent) => Promise<void> \| void`          | —                              | Fires every turn before `run()`                                                                     |
 | `onBeforeTurnComplete`        | `(event: BeforeTurnCompleteEvent) => Promise<void> \| void` | —                              | Fires after response but before stream closes. Includes `writer`.                                   |
 | `onTurnComplete`              | `(event: TurnCompleteEvent) => Promise<void> \| void`       | —                              | Fires after each turn completes (stream closed)                                                     |
@@ -536,6 +538,8 @@ All methods available on the `chat` object from `@trigger.dev/sdk/ai`.
 | Method                                      | Description                                                                                                                  |
 | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `chat.agent(options)`                       | Create a chat agent                                                                                                          |
+| `chat.event(options)`                       | Declare an inbound webhook event descriptor an agent claims via `chat.agent({ events })`. See [session routing](/webhooks/session-routing). |
+| `chat.channels.custom(options)`             | Create a generic chat-frontend channel over any verified webhook source (you supply the egress). The `slack()` preset ships in `@trigger.dev/slack`. See [channels](/webhooks/channels). |
 | `chat.createSession(payload, options)`      | Create an async iterator for chat turns                                                                                      |
 | `chat.pipe(source, options?)`               | Pipe a stream to the frontend (from anywhere inside a task)                                                                  |
 | `chat.pipeAndCapture(source, options?)`     | Pipe and capture the response; returns `{ message, status, error }`                                                         |
@@ -567,6 +571,42 @@ All methods available on the `chat` object from `@trigger.dev/sdk/ai`.
 | `chat.MessageAccumulator`                   | Class that accumulates conversation messages across turns                                                                    |
 | `chat.withUIMessage(config?)`               | Returns a [ChatBuilder](/ai-chat/types#chatbuilder) with a fixed `UIMessage` subtype. See [Types](/ai-chat/types)            |
 | `chat.withClientData({ schema })`           | Returns a [ChatBuilder](/ai-chat/types#chatbuilder) with a fixed client data schema. See [Types](/ai-chat/types#typed-client-data-with-chatwithclientdata) |
+
+## `chat.event`
+
+Declare an inbound webhook event that an agent claims via [`events`](#chatagentoptions) on `chat.agent()`. It is a descriptor only, with no handler: it names a [source](/webhooks/sources) to verify, a `key` template that resolves each delivery to a durable [session](/ai-chat/sessions), and an optional `type` label (defaults to the descriptor `id`). Verified deliveries are routed to that session and arrive at `onAction` as a `{ type, event, source, headers, deliveryId }` envelope, not as a chat turn. See [session routing](/webhooks/session-routing).
+
+```ts
+import { webhooks } from "@trigger.dev/sdk";
+import { chat } from "@trigger.dev/sdk/ai";
+
+export const orderEvents = chat.event({
+  id: "order-events",
+  source: webhooks.stripe(),
+  key: "{body.data.object.customer}",
+  type: "order.event",
+});
+```
+
+## `chat.channels.custom`
+
+Create a generic chat-frontend channel over any verified [source](/webhooks/sources), claimed via [`channels`](#chatagentoptions) on `chat.agent()`. You supply the session `key`, the `inbound` map from event to turn message, and your own `send` egress that posts the reply back, so the whole round-trip is under your control. Inbound messages run as normal turns and the reply is posted back. The `slack()` preset ships in `@trigger.dev/slack` and wires the egress for you. See [channels](/webhooks/channels), and the interactive approvals layer at [human-in-the-loop](/webhooks/human-in-the-loop).
+
+```ts
+import { webhooks } from "@trigger.dev/sdk";
+import { chat } from "@trigger.dev/sdk/ai";
+
+export const mySurface = chat.channels.custom({
+  id: "my-surface",
+  source: webhooks.custom<MyEvent>({ /* verifier config */ }),
+  key: "{body.conversationId}",
+  inbound: (event) => event.text,
+  send: async (message, ctx) => {
+    const ref = await postToMySurface(ctx.event, message.text, ctx.previousRef);
+    return { ref };
+  },
+});
+```
 
 ## `chat.withUIMessage`
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -149,6 +149,19 @@
             ]
           },
           {
+            "group": "Webhooks",
+            "pages": [
+              "webhooks/overview",
+              "webhooks/sources",
+              "webhooks/connect",
+              "webhooks/deliveries",
+              "webhooks/filters",
+              "webhooks/session-routing",
+              "webhooks/channels",
+              "webhooks/human-in-the-loop"
+            ]
+          },
+          {
             "group": "Configuration",
             "pages": [
               "config/config-file",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -153,6 +153,16 @@
             ]
           },
           {
+            "group": "Webhooks",
+            "pages": [
+              "webhooks/overview",
+              "webhooks/sources",
+              "webhooks/connect",
+              "webhooks/deliveries",
+              "webhooks/filters"
+            ]
+          },
+          {
             "group": "Configuration",
             "pages": [
               "config/config-file",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -159,7 +159,10 @@
               "webhooks/sources",
               "webhooks/connect",
               "webhooks/deliveries",
-              "webhooks/filters"
+              "webhooks/filters",
+              "webhooks/session-routing",
+              "webhooks/channels",
+              "webhooks/human-in-the-loop"
             ]
           },
           {

--- a/docs/webhooks/channels.mdx
+++ b/docs/webhooks/channels.mdx
@@ -1,0 +1,135 @@
+---
+title: "Channels (chat frontends)"
+description: "Point Slack (or any chat surface) at an agent: messages become turns and replies post back."
+sidebarTitle: "Channels"
+---
+
+A [session route](/webhooks/session-routing) delivers a verified event to an agent as an [action](/ai-chat/actions): the agent reacts, and the response is a side effect. A **channel** is the other half: the webhook IS the chat surface. Inbound messages become **turns** (the normal `run()` loop), and the agent's reply is posted **back** to the surface. A Slack thread becomes a real conversation with the agent, exactly like the browser chat, just a different frontend.
+
+List channels on a [`chat.agent`](/ai-chat/overview) alongside (or instead of) `events`:
+
+```ts
+import { chat } from "@trigger.dev/sdk/ai";
+import { slack } from "@trigger.dev/slack";
+import { streamText } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+
+export const supportAgent = chat.agent({
+  id: "support-agent",
+  channels: [slack({ id: "support-slack", token: process.env.SLACK_BOT_TOKEN! })],
+  run: async ({ messages }) => streamText({ model: anthropic("claude-sonnet-4-5"), messages }),
+});
+```
+
+The `run()` loop is unchanged: the agent does not know or care that it is talking to Slack. One verified Slack message in a thread is routed to a durable [session](/ai-chat/sessions) keyed to that thread, run as a turn, and the reply is posted into the thread.
+
+## Slack
+
+`slack()` (from `@trigger.dev/slack`) is a channel connector: it verifies inbound Slack events, maps a message to the turn, and posts the reply back with `chat.postMessage` / `chat.update`.
+
+<Steps>
+  <Step title="Create a Slack app">
+    Create an app at [api.slack.com/apps](https://api.slack.com/apps). Add the `chat:write` and `channels:history` bot scopes (`chat:write` posts replies; `channels:history` receives the `message.channels` events), then install it to your workspace to get a bot token (`xoxb-...`). If you add scopes after installing, reinstall the app to apply them.
+  </Step>
+  <Step title="Deploy the agent + connect the endpoint">
+    Deploying registers a hosted [endpoint](/webhooks/connect) for the channel. Set its signing secret to your Slack app's **Signing Secret**, and pass the bot token as `token`.
+  </Step>
+  <Step title="Subscribe to events">
+    In the app's **Event Subscriptions**, set the request URL to the endpoint's webhook URL. Slack sends a one-time `url_verification` handshake, which the endpoint answers automatically. Subscribe the bot to `message.channels`, then invite the bot to the channel (`/invite @yourapp`).
+  </Step>
+</Steps>
+
+By default `slack()` keys one session per thread, strips the leading bot mention from the message, posts an "on it..." placeholder while the agent works, and edits it to the answer. Override any of that:
+
+```ts
+slack({
+  id: "support-slack",
+  token: process.env.SLACK_BOT_TOKEN!,
+  // ignore anything but questions (composed with the built-in self-message guard)
+  filter: "event.event.text contains '?'",
+  inbound: (e) => e.event?.text ?? "",
+  outbound: (reply) => ({ text: reply.text }),
+  ack: (e) => ({ text: "thinking..." }), // pass `null` to post only the final answer
+});
+```
+
+<Note>
+  `slack()` always drops the bot's own messages (and their edits) before they reach the agent, so the
+  agent never replies to itself. A multi-workspace app can pass a `token` resolver keyed on the event's
+  team instead of a single string.
+</Note>
+
+### Summoning with a mention
+
+By default `slack()` starts (or resumes) a session for every non-bot message in a subscribed channel. To make the agent respond only when it is @mentioned, pass `startOn` with the `mentions` helper. The first mention in a thread starts the session, and the agent then follows the rest of the thread without needing to be mentioned again.
+
+```ts
+import { slack, mentions } from "@trigger.dev/slack";
+
+slack({
+  id: "support-slack",
+  token: process.env.SLACK_BOT_TOKEN!,
+  startOn: mentions("U012BOT"), // your bot's user id (pass several for multiple bots)
+});
+```
+
+### Reacting to messages
+
+`slack()` can add an emoji reaction to the triggering message to signal progress. Set `reactions` with any of `working`, `done`, and `error`: the connector adds `working` when the turn starts, swaps it to `done` when the turn finishes, and reacts with `error` if it fails. This needs the `reactions:write` scope.
+
+```ts
+slack({
+  id: "support-slack",
+  token: process.env.SLACK_BOT_TOKEN!,
+  reactions: { working: "eyes", done: "white_check_mark", error: "warning" },
+});
+```
+
+### Options
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | Connector id, unique per agent. |
+| `token` | `string` or resolver | Bot token (`xoxb-...`), or a function of the event's team for multi-workspace apps. |
+| `key` | `string` | Session [key](/webhooks/session-routing) template. Defaults to one session per thread. |
+| `filter` | `string` | Extra [filter](/webhooks/filters), composed with the built-in self-message guard. |
+| `startOn` | `string` | Only start a session when the event matches (see `mentions`). Existing sessions always resume. |
+| `ack` | message, `null`, or function | Placeholder posted while the agent works. Pass `null` to post only the final answer. |
+| `reactions` | `{ working?, done?, error? }` | Lifecycle emoji reactions on the triggering message. |
+| `inbound` / `outbound` | functions | Map the Slack event to the turn, and the reply to a Slack message. |
+| `delivery` | `"final"` or `"stream"` | `"final"` (default) posts a placeholder and edits it to the answer. `"stream"` edits live as the reply streams. |
+| `apiBaseUrl` | `string` | Override the Slack Web API base, for testing against a mock. |
+
+## Approvals and interactive controls
+
+An agent on a channel can pause a turn to get a human decision, approving a refund or confirming a deletion, and resume once someone clicks a button in the thread. `slack()` renders Approve / Deny buttons for you and collapses them to the decision once clicked. See [human-in-the-loop](/webhooks/human-in-the-loop).
+
+## Any surface: `chat.channels.custom`
+
+For a surface without a preset, `chat.channels.custom` is the generic connector. You supply the [source](/webhooks/sources) to verify, the session `key`, the `inbound` map, and the egress `send`:
+
+```ts
+import { chat } from "@trigger.dev/sdk/ai";
+import { webhooks } from "@trigger.dev/sdk";
+
+const mySurface = chat.channels.custom({
+  id: "my-surface",
+  source: webhooks.custom<MyEvent>({ /* verifier config */ }),
+  key: "{body.conversationId}",
+  inbound: (e) => e.text,
+  outbound: (reply) => (reply.text ? { text: reply.text } : null), // null posts nothing
+  send: async (message, ctx) => {
+    const ref = await postToMySurface(ctx.event, message.text, ctx.previousRef);
+    return { ref }; // an existing ref means edit-in-place on the next turn
+  },
+});
+```
+
+`send` is called to post the reply. `ctx.previousRef` is the ref you returned last time, so streaming or a follow-up edits the same message instead of posting a new one. Return `null` from `outbound` to stay silent (a tool-only turn, say).
+
+## Channels vs events
+
+Both are inbound surfaces on a `chat.agent`, and an agent can list both:
+
+- [`events`](/webhooks/session-routing) (`chat.event`): the webhook is a signal. Delivered to `onAction`; the agent acts, no reply is sent back.
+- `channels` (`slack`, `chat.channels.custom`): the webhook is a chat frontend. Delivered as a turn to `run()`; the reply is posted back.

--- a/docs/webhooks/channels.mdx
+++ b/docs/webhooks/channels.mdx
@@ -11,6 +11,8 @@ List channels on a [`chat.agent`](/ai-chat/overview) alongside (or instead of) `
 ```ts
 import { chat } from "@trigger.dev/sdk/ai";
 import { slack } from "@trigger.dev/slack";
+import { streamText } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
 
 export const supportAgent = chat.agent({
   id: "support-agent",

--- a/docs/webhooks/channels.mdx
+++ b/docs/webhooks/channels.mdx
@@ -27,7 +27,7 @@ The `run()` loop is unchanged: the agent does not know or care that it is talkin
 
 <Steps>
   <Step title="Create a Slack app">
-    Create an app at [api.slack.com/apps](https://api.slack.com/apps). Add the `chat:write` bot scope and install it to your workspace to get a bot token (`xoxb-...`).
+    Create an app at [api.slack.com/apps](https://api.slack.com/apps). Add the `chat:write` and `channels:history` bot scopes (`chat:write` posts replies; `channels:history` receives the `message.channels` events), then install it to your workspace to get a bot token (`xoxb-...`). If you add scopes after installing, reinstall the app to apply them.
   </Step>
   <Step title="Deploy the agent + connect the endpoint">
     Deploying registers a hosted [endpoint](/webhooks/connect) for the channel. Set its signing secret to your Slack app's **Signing Secret**, and pass the bot token as `token`.

--- a/docs/webhooks/channels.mdx
+++ b/docs/webhooks/channels.mdx
@@ -1,0 +1,133 @@
+---
+title: "Channels (chat frontends)"
+description: "Point Slack (or any chat surface) at an agent: messages become turns and replies post back."
+sidebarTitle: "Channels"
+---
+
+A [session route](/webhooks/session-routing) delivers a verified event to an agent as an [action](/ai-chat/actions): the agent reacts, and the response is a side effect. A **channel** is the other half: the webhook IS the chat surface. Inbound messages become **turns** (the normal `run()` loop), and the agent's reply is posted **back** to the surface. A Slack thread becomes a real conversation with the agent, exactly like the browser chat, just a different frontend.
+
+List channels on a [`chat.agent`](/ai-chat/overview) alongside (or instead of) `events`:
+
+```ts
+import { chat } from "@trigger.dev/sdk/ai";
+import { slack } from "@trigger.dev/slack";
+
+export const supportAgent = chat.agent({
+  id: "support-agent",
+  channels: [slack({ id: "support-slack", token: process.env.SLACK_BOT_TOKEN! })],
+  run: async ({ messages }) => streamText({ model: anthropic("claude-sonnet-4-5"), messages }),
+});
+```
+
+The `run()` loop is unchanged: the agent does not know or care that it is talking to Slack. One verified Slack message in a thread is routed to a durable [session](/ai-chat/sessions) keyed to that thread, run as a turn, and the reply is posted into the thread.
+
+## Slack
+
+`slack()` (from `@trigger.dev/slack`) is a channel connector: it verifies inbound Slack events, maps a message to the turn, and posts the reply back with `chat.postMessage` / `chat.update`.
+
+<Steps>
+  <Step title="Create a Slack app">
+    Create an app at [api.slack.com/apps](https://api.slack.com/apps). Add the `chat:write` bot scope and install it to your workspace to get a bot token (`xoxb-...`).
+  </Step>
+  <Step title="Deploy the agent + connect the endpoint">
+    Deploying registers a hosted [endpoint](/webhooks/connect) for the channel. Set its signing secret to your Slack app's **Signing Secret**, and pass the bot token as `token`.
+  </Step>
+  <Step title="Subscribe to events">
+    In the app's **Event Subscriptions**, set the request URL to the endpoint's webhook URL. Slack sends a one-time `url_verification` handshake, which the endpoint answers automatically. Subscribe the bot to `message.channels`, then invite the bot to the channel (`/invite @yourapp`).
+  </Step>
+</Steps>
+
+By default `slack()` keys one session per thread, strips the leading bot mention from the message, posts an "on it..." placeholder while the agent works, and edits it to the answer. Override any of that:
+
+```ts
+slack({
+  id: "support-slack",
+  token: process.env.SLACK_BOT_TOKEN!,
+  // ignore anything but questions (composed with the built-in self-message guard)
+  filter: "event.event.text contains '?'",
+  inbound: (e) => e.event?.text ?? "",
+  outbound: (reply) => ({ text: reply.text }),
+  ack: (e) => ({ text: "thinking..." }), // pass `null` to post only the final answer
+});
+```
+
+<Note>
+  `slack()` always drops the bot's own messages (and their edits) before they reach the agent, so the
+  agent never replies to itself. A multi-workspace app can pass a `token` resolver keyed on the event's
+  team instead of a single string.
+</Note>
+
+### Summoning with a mention
+
+By default `slack()` starts (or resumes) a session for every non-bot message in a subscribed channel. To make the agent respond only when it is @mentioned, pass `startOn` with the `mentions` helper. The first mention in a thread starts the session, and the agent then follows the rest of the thread without needing to be mentioned again.
+
+```ts
+import { slack, mentions } from "@trigger.dev/slack";
+
+slack({
+  id: "support-slack",
+  token: process.env.SLACK_BOT_TOKEN!,
+  startOn: mentions("U012BOT"), // your bot's user id (pass several for multiple bots)
+});
+```
+
+### Reacting to messages
+
+`slack()` can add an emoji reaction to the triggering message to signal progress. Set `reactions` with any of `working`, `done`, and `error`: the connector adds `working` when the turn starts, swaps it to `done` when the turn finishes, and reacts with `error` if it fails. This needs the `reactions:write` scope.
+
+```ts
+slack({
+  id: "support-slack",
+  token: process.env.SLACK_BOT_TOKEN!,
+  reactions: { working: "eyes", done: "white_check_mark", error: "warning" },
+});
+```
+
+### Options
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | Connector id, unique per agent. |
+| `token` | `string` or resolver | Bot token (`xoxb-...`), or a function of the event's team for multi-workspace apps. |
+| `key` | `string` | Session [key](/webhooks/session-routing) template. Defaults to one session per thread. |
+| `filter` | `string` | Extra [filter](/webhooks/filters), composed with the built-in self-message guard. |
+| `startOn` | `string` | Only start a session when the event matches (see `mentions`). Existing sessions always resume. |
+| `ack` | message, `null`, or function | Placeholder posted while the agent works. Pass `null` to post only the final answer. |
+| `reactions` | `{ working?, done?, error? }` | Lifecycle emoji reactions on the triggering message. |
+| `inbound` / `outbound` | functions | Map the Slack event to the turn, and the reply to a Slack message. |
+| `delivery` | `"final"` or `"stream"` | `"final"` (default) posts a placeholder and edits it to the answer. `"stream"` edits live as the reply streams. |
+| `apiBaseUrl` | `string` | Override the Slack Web API base, for testing against a mock. |
+
+## Approvals and interactive controls
+
+An agent on a channel can pause a turn to get a human decision, approving a refund or confirming a deletion, and resume once someone clicks a button in the thread. `slack()` renders Approve / Deny buttons for you and collapses them to the decision once clicked. See [human-in-the-loop](/webhooks/human-in-the-loop).
+
+## Any surface: `chat.channels.custom`
+
+For a surface without a preset, `chat.channels.custom` is the generic connector. You supply the [source](/webhooks/sources) to verify, the session `key`, the `inbound` map, and the egress `send`:
+
+```ts
+import { chat } from "@trigger.dev/sdk/ai";
+import { webhooks } from "@trigger.dev/sdk";
+
+const mySurface = chat.channels.custom({
+  id: "my-surface",
+  source: webhooks.custom<MyEvent>({ /* verifier config */ }),
+  key: "{body.conversationId}",
+  inbound: (e) => e.text,
+  outbound: (reply) => (reply.text ? { text: reply.text } : null), // null posts nothing
+  send: async (message, ctx) => {
+    const ref = await postToMySurface(ctx.event, message.text, ctx.previousRef);
+    return { ref }; // an existing ref means edit-in-place on the next turn
+  },
+});
+```
+
+`send` is called to post the reply. `ctx.previousRef` is the ref you returned last time, so streaming or a follow-up edits the same message instead of posting a new one. Return `null` from `outbound` to stay silent (a tool-only turn, say).
+
+## Channels vs events
+
+Both are inbound surfaces on a `chat.agent`, and an agent can list both:
+
+- [`events`](/webhooks/session-routing) (`chat.event`): the webhook is a signal. Delivered to `onAction`; the agent acts, no reply is sent back.
+- `channels` (`slack`, `chat.channels.custom`): the webhook is a chat frontend. Delivered as a turn to `run()`; the reply is posted back.

--- a/docs/webhooks/connect.mdx
+++ b/docs/webhooks/connect.mdx
@@ -1,0 +1,35 @@
+---
+title: "Connecting a provider"
+description: "Point a provider at the webhook URL and set the signing secret."
+sidebarTitle: "Connecting a provider"
+---
+
+When you deploy (or run `dev`), each webhook task gets an **endpoint** with a unique, unguessable webhook URL. Open the webhook in the dashboard, go to **Endpoints**, and open the endpoint to find its **Connect** panel.
+
+<Steps>
+  <Step title="Copy the webhook URL">
+    Copy it from the endpoint's Connect panel. On Trigger.dev Cloud it looks like
+    `https://webhooks.trigger.dev/webhooks/v1/ingest/<id>`. A self-hosted instance serves it from that
+    instance's own base URL. This is what you give the provider as its webhook destination.
+  </Step>
+  <Step title="Set the signing secret">
+    A webhook can't accept deliveries until its signing secret is set. Until then every request is
+    rejected. There are two flows, and the Connect panel shows the right one for the provider:
+
+    - **The provider generates the secret** (Stripe, Svix): copy it from the provider and paste it
+      into **Set secret**.
+    - **You choose the secret** (GitHub, or a service you control): click **Generate secret** and
+      Trigger.dev mints a strong secret and shows it once. Paste that into the provider's webhook config.
+  </Step>
+  <Step title="Point the provider at the webhook URL">
+    Add the webhook URL as the destination in your provider's dashboard. The Connect panel
+    shows the exact signature scheme (header, algorithm, signing string) the provider should use.
+  </Step>
+</Steps>
+
+<Warning>
+  The signing secret is stored encrypted and is never shown again after it's set. To rotate it,
+  use **Rotate secret** (or **Regenerate**) and update the provider with the new value.
+</Warning>
+
+Once a provider is sending events, watch them arrive on the [Deliveries](/webhooks/deliveries) page, which also explains what an [endpoint](/webhooks/deliveries#endpoints) is.

--- a/docs/webhooks/deliveries.mdx
+++ b/docs/webhooks/deliveries.mdx
@@ -1,0 +1,48 @@
+---
+title: "Deliveries and endpoints"
+description: "Observe inbound webhook requests, the runs they trigger, and their payloads in the dashboard."
+sidebarTitle: "Deliveries & endpoints"
+---
+
+The dashboard surfaces two concepts under the **Webhooks** section.
+
+## Deliveries
+
+A delivery is a single inbound request that passed verification. The **Deliveries** page lists every
+delivery across all your webhooks (much like the Runs page), and you can filter by webhook, status,
+delivery id, or run id.
+
+Open a delivery to see:
+
+- Its **status** and the **run** it triggered (linked).
+- The verified **event payload** and the inbound **request headers**, on separate tabs.
+- The external delivery id, idempotency key, and timestamps.
+
+<Note>
+  Duplicate deliveries are deduplicated automatically. The idempotency key is the provider's event id
+  (e.g. the Stripe event id, or GitHub's `X-GitHub-Delivery`), so a provider retry of the same event
+  resolves to the original delivery and won't trigger a second run.
+</Note>
+
+## Endpoints
+
+An endpoint is the connection instance for a webhook: its webhook URL, signing-secret state,
+verification scheme, and delivery history. Each webhook's **Endpoints** tab lists its endpoints (a
+declared webhook has one), and opening an endpoint shows its [Connect panel](/webhooks/connect) and
+its scoped deliveries.
+
+## What happens to a request
+
+<Steps>
+  <Step title="Verify">
+    The signature, timestamp, and idempotency key are checked. A failure returns `400` and records
+    nothing.
+  </Step>
+  <Step title="Record">
+    A verified request becomes a delivery, with its parsed event and headers stored.
+  </Step>
+  <Step title="Route">
+    The delivery is routed to your webhook task, which runs and calls `onEvent`. The delivery's status
+    reflects that run's outcome.
+  </Step>
+</Steps>

--- a/docs/webhooks/filters.mdx
+++ b/docs/webhooks/filters.mdx
@@ -1,0 +1,99 @@
+---
+title: "Filtering deliveries"
+description: "Gate which verified webhook deliveries run, with a type-safe filter checked against the event."
+sidebarTitle: "Filters"
+---
+
+By default every verified delivery runs your `onEvent` (or routes to a [session](/webhooks/session-routing)). A **filter** is a server-side predicate that decides whether a delivery is routed at all. A delivery that does not match is still received and recorded, it just does not run anything.
+
+Filtering happens at the endpoint, before any run is triggered, so a filtered-out event costs you nothing.
+
+## Adding a filter
+
+Pass a `filter` string to `webhook()`. It is a small expression checked, at build time, against the event shape from your [source](/webhooks/sources#typing-the-event):
+
+```ts
+import { webhook, webhooks } from "@trigger.dev/sdk";
+
+export const onOrder = webhook({
+  id: "orders",
+  source: webhooks.stripe(),
+  // only route succeeded payment intents over $100
+  filter: "event.type == 'payment_intent.succeeded' && event.data.object.amount >= 10000",
+  onEvent: async ({ event }) => {
+    // only runs for deliveries that matched
+  },
+});
+```
+
+The filter is type-safe: referencing a field that does not exist, or comparing it to the wrong kind of literal, is a compile error, not a runtime surprise.
+
+## What a non-match does
+
+A delivery that does not match is **not dropped**. It still returns `200` to the provider and is recorded as a [delivery](/webhooks/deliveries) with the status `FILTERED` and a reason naming the clause that failed (and the value it saw). It just never triggers a run. This keeps a filtered delivery auditable: you can see in the dashboard that it arrived and why it was not routed.
+
+<Note>
+  If a filter throws while evaluating (for example, a malformed event), the delivery is routed rather
+  than dropped. Filters fail open so a filter bug never silently swallows real events.
+</Note>
+
+## The expression language
+
+A filter is one or more `path operator value` clauses combined with `&&` and `||` (use parentheses to group).
+
+### Paths
+
+A path reads from one of three namespaces:
+
+- `event.*`: the verified, parsed request body, for example `event.data.object.amount`.
+- `header.*`: an inbound request header, matched case-insensitively, for example `header.x-github-event`.
+- `webhook.*`: endpoint metadata (`webhook.source`, `webhook.id`, `webhook.deliveryId`, and for per-tenant endpoints `webhook.externalRef` / `webhook.tenantId`).
+
+The [session routing](/webhooks/session-routing) key template addresses this same parsed body, but spells it `{body.*}` rather than `event.*`.
+
+### Operators
+
+| Operator | Meaning |
+| --- | --- |
+| `==` `!=` | equality |
+| `>` `<` `>=` `<=` | numeric comparison |
+| `in` `not in` | membership in a list, for example `event.type in ['a','b']` |
+| `startsWith` `endsWith` `contains` | string matching |
+
+Values are strings in single quotes (`'created'`), numbers (`10000`), booleans (`true`), or a list for `in` / `not in`.
+
+### Comparing two fields
+
+The right-hand side can be another path instead of a literal, so you can compare two fields of the same event:
+
+```ts
+filter: "event.billing.country == event.shipping.country";
+```
+
+### Matching inside a list
+
+`any` and `all` quantify over an array, testing a sub-path on each element:
+
+```ts
+// route only if at least one line item has a positive quantity
+filter: "event.items any ( quantity > 0 )";
+```
+
+### Spacing
+
+The type checker reads the filter as a token stream, so a couple of spots are strict about spacing: keep `in` / `not in` lists unspaced (`['a','b']`, not `[ 'a', 'b' ]`) and put spaces around the quantifier parentheses (`any ( ... )`).
+
+To match only certain event types, write a clause against the field that carries the type: `event.type` for Stripe / Svix / Square / Discord, or the `x-github-event` header for GitHub (the filter DSL can read a `header.` namespace too):
+
+```ts
+export const onGithub = webhook({
+  id: "github",
+  source: webhooks.github(),
+  filter: "header.x-github-event in ['issues','pull_request']",
+  onEvent: async ({ event }) => {},
+});
+```
+
+## Filtering a session route
+
+A `filter` works the same way on [`chat.event`](/webhooks/session-routing): a non-matching delivery is recorded `FILTERED` and never reaches the session.

--- a/docs/webhooks/filters.mdx
+++ b/docs/webhooks/filters.mdx
@@ -86,6 +86,8 @@ The type checker reads the filter as a token stream, so a couple of spots are st
 To match only certain event types, write a clause against the field that carries the type: `event.type` for Stripe / Svix / Square / Discord, or the `x-github-event` header for GitHub (the filter DSL can read a `header.` namespace too):
 
 ```ts
+import { webhook, webhooks } from "@trigger.dev/sdk";
+
 export const onGithub = webhook({
   id: "github",
   source: webhooks.github(),

--- a/docs/webhooks/filters.mdx
+++ b/docs/webhooks/filters.mdx
@@ -1,0 +1,95 @@
+---
+title: "Filtering deliveries"
+description: "Gate which verified webhook deliveries run, with a type-safe filter checked against the event."
+sidebarTitle: "Filters"
+---
+
+By default every verified delivery runs your `onEvent`. A **filter** is a server-side predicate that decides whether a delivery is routed at all. A delivery that does not match is still received and recorded, it just does not run anything.
+
+Filtering happens at the endpoint, before any run is triggered, so a filtered-out event costs you nothing.
+
+## Adding a filter
+
+Pass a `filter` string to `webhook()`. It is a small expression checked, at build time, against the event shape from your [source](/webhooks/sources#typing-the-event):
+
+```ts
+import { webhook, webhooks } from "@trigger.dev/sdk";
+
+export const onOrder = webhook({
+  id: "orders",
+  source: webhooks.stripe(),
+  // only route succeeded payment intents over $100
+  filter: "event.type == 'payment_intent.succeeded' && event.data.object.amount >= 10000",
+  onEvent: async ({ event }) => {
+    // only runs for deliveries that matched
+  },
+});
+```
+
+The filter is type-safe: referencing a field that does not exist, or comparing it to the wrong kind of literal, is a compile error, not a runtime surprise.
+
+## What a non-match does
+
+A delivery that does not match is **not dropped**. It still returns `200` to the provider and is recorded as a [delivery](/webhooks/deliveries) with the status `FILTERED` and a reason naming the clause that failed (and the value it saw). It just never triggers a run. This keeps a filtered delivery auditable: you can see in the dashboard that it arrived and why it was not routed.
+
+<Note>
+  If a filter throws while evaluating (for example, a malformed event), the delivery is routed rather
+  than dropped. Filters fail open so a filter bug never silently swallows real events.
+</Note>
+
+## The expression language
+
+A filter is one or more `path operator value` clauses combined with `&&` and `||` (use parentheses to group).
+
+### Paths
+
+A path reads from one of three namespaces:
+
+- `event.*`: the verified, parsed request body, for example `event.data.object.amount`.
+- `header.*`: an inbound request header, matched case-insensitively, for example `header.x-github-event`.
+- `webhook.*`: endpoint metadata (`webhook.source`, `webhook.id`, `webhook.deliveryId`, and for per-tenant endpoints `webhook.externalRef` / `webhook.tenantId`).
+
+### Operators
+
+| Operator | Meaning |
+| --- | --- |
+| `==` `!=` | equality |
+| `>` `<` `>=` `<=` | numeric comparison |
+| `in` `not in` | membership in a list, for example `event.type in ['a','b']` |
+| `startsWith` `endsWith` `contains` | string matching |
+
+Values are strings in single quotes (`'created'`), numbers (`10000`), booleans (`true`), or a list for `in` / `not in`.
+
+### Comparing two fields
+
+The right-hand side can be another path instead of a literal, so you can compare two fields of the same event:
+
+```ts
+filter: "event.billing.country == event.shipping.country";
+```
+
+### Matching inside a list
+
+`any` and `all` quantify over an array, testing a sub-path on each element:
+
+```ts
+// route only if at least one line item has a positive quantity
+filter: "event.items any ( quantity > 0 )";
+```
+
+### Spacing
+
+The type checker reads the filter as a token stream, so a couple of spots are strict about spacing: keep `in` / `not in` lists unspaced (`['a','b']`, not `[ 'a', 'b' ]`) and put spaces around the quantifier parentheses (`any ( ... )`).
+
+To match only certain event types, write a clause against the field that carries the type: `event.type` for Stripe / Svix / Square / Discord, or the `x-github-event` header for GitHub (the filter DSL can read a `header.` namespace too):
+
+```ts
+import { webhook, webhooks } from "@trigger.dev/sdk";
+
+export const onGithub = webhook({
+  id: "github",
+  source: webhooks.github(),
+  filter: "header.x-github-event in ['issues','pull_request']",
+  onEvent: async ({ event }) => {},
+});
+```

--- a/docs/webhooks/filters.mdx
+++ b/docs/webhooks/filters.mdx
@@ -4,7 +4,7 @@ description: "Gate which verified webhook deliveries run, with a type-safe filte
 sidebarTitle: "Filters"
 ---
 
-By default every verified delivery runs your `onEvent`. A **filter** is a server-side predicate that decides whether a delivery is routed at all. A delivery that does not match is still received and recorded, it just does not run anything.
+By default every verified delivery runs your `onEvent` (or routes to a [session](/webhooks/session-routing)). A **filter** is a server-side predicate that decides whether a delivery is routed at all. A delivery that does not match is still received and recorded, it just does not run anything.
 
 Filtering happens at the endpoint, before any run is triggered, so a filtered-out event costs you nothing.
 
@@ -48,6 +48,8 @@ A path reads from one of three namespaces:
 - `event.*`: the verified, parsed request body, for example `event.data.object.amount`.
 - `header.*`: an inbound request header, matched case-insensitively, for example `header.x-github-event`.
 - `webhook.*`: endpoint metadata (`webhook.source`, `webhook.id`, `webhook.deliveryId`, and for per-tenant endpoints `webhook.externalRef` / `webhook.tenantId`).
+
+The [session routing](/webhooks/session-routing) key template addresses this same parsed body, but spells it `{body.*}` rather than `event.*`.
 
 ### Operators
 
@@ -93,3 +95,7 @@ export const onGithub = webhook({
   onEvent: async ({ event }) => {},
 });
 ```
+
+## Filtering a session route
+
+A `filter` works the same way on [`chat.event`](/webhooks/session-routing): a non-matching delivery is recorded `FILTERED` and never reaches the session.

--- a/docs/webhooks/human-in-the-loop.mdx
+++ b/docs/webhooks/human-in-the-loop.mdx
@@ -1,0 +1,143 @@
+---
+title: "Human-in-the-loop"
+sidebarTitle: "Human-in-the-loop"
+description: "Pause an agent mid-turn to get a human decision from the channel (Slack approve/deny), then resume with the answer."
+---
+
+**An agent on a [channel](/webhooks/channels) can pause a turn to get a human decision, then resume once someone answers in the thread.** It posts controls into the conversation and picks up where it left off once someone clicks, with the decision merged into the turn. This is the channel counterpart of browser [human-in-the-loop](/ai-chat/patterns/human-in-the-loop): the same no-`execute` tool, but the controls live in Slack (or your own surface) instead of a React component. The [`slack()`](/webhooks/channels) connector ships Approve / Deny buttons out of the box.
+
+## How it works
+
+The building block is a tool with no `execute` function. When the model calls it, the turn completes with the tool call still pending instead of resolving it. Over a channel the framework then takes over the round-trip:
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant S as Slack
+    participant A as Agent run
+    U->>S: Message in a thread
+    S->>A: Verified delivery starts a turn
+    A->>A: Model calls requestApproval (no execute)
+    A->>S: renderInteraction posts Approve / Deny
+    Note over A: Turn completes, run suspends (no compute while waiting)
+    U->>S: Clicks a button
+    S->>A: Signed block_actions callback to the same webhook URL
+    A->>A: onInteraction resolves the pending tool
+    A->>S: finalizeInteraction collapses the buttons
+    A->>A: Run resumes, model continues
+    A->>S: Reply posts back to the thread
+```
+
+Because it is a no-`execute` pause, the run suspends while it waits rather than holding compute. A human can take minutes or days to decide without burning compute or hitting [`maxDuration`](/runs/max-duration). The mechanics are the same as the browser case, covered in [human-in-the-loop](/ai-chat/patterns/human-in-the-loop#duration-and-cost-while-paused).
+
+## Slack approvals
+
+Out of the box, `slack()` posts Approve / Deny buttons for any pending no-`execute` tool. A click resolves to `{ approved: boolean }` and the buttons collapse to the decision. You define the tool and list the channel on the agent:
+
+```ts trigger/support-agent.ts
+import { chat } from "@trigger.dev/sdk/ai";
+import { slack } from "@trigger.dev/slack";
+import { streamText, tool } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+import { z } from "zod";
+
+// No execute: calling this pauses the turn for a human decision.
+const requestApproval = tool({
+  description:
+    "Request human approval before a sensitive or irreversible action. " +
+    "Call this and stop; you will receive { approved: boolean }, then proceed or decline.",
+  inputSchema: z.object({
+    action: z.string().describe("A short description of the action needing approval"),
+  }),
+});
+
+export const supportAgent = chat.agent({
+  id: "support-agent",
+  channels: [slack({ id: "support-slack", token: process.env.SLACK_BOT_TOKEN! })],
+  tools: { requestApproval },
+  run: async ({ messages, tools }) =>
+    streamText({
+      model: anthropic("claude-sonnet-4-5"),
+      messages,
+      tools,
+      system:
+        "Before any sensitive or irreversible action (refunds, cancellations, deletions), " +
+        "call requestApproval and wait. If approved, confirm it is done; if denied, decline.",
+    }),
+});
+```
+
+Button clicks arrive on a different Slack API than messages, so there is one extra setup step beyond [connecting the channel](/webhooks/channels):
+
+<Steps>
+  <Step title="Turn on Interactivity">
+    In the Slack app's **Interactivity & Shortcuts**, enable interactivity and set the Request URL to the **same** webhook URL you used for events. Slack posts button clicks there as a signed `block_actions` callback, which the endpoint verifies and routes to the paused run.
+  </Step>
+  <Step title="Confirm the bot scope">
+    Posting and editing the controls uses the `chat:write` scope you already added for replies. No extra scope is needed to collapse the buttons after a decision.
+  </Step>
+</Steps>
+
+When the model calls `requestApproval`, the bot posts "Approval needed" with the action and Approve / Deny buttons. Clicking **Approve** resolves the tool to `{ approved: true }`, the buttons collapse to "Approved by @you", and the agent continues and posts the outcome. **Deny** resolves `{ approved: false }`.
+
+## Customizing the controls
+
+For [`chat.channels.custom`](/webhooks/channels), or to override the Slack defaults, three hooks own the interaction round-trip:
+
+<ParamField body="renderInteraction" type="(pending, ctx) => ChannelMessage | null">
+  Map the pending tool call(s) to the controls you post. `pending` is a list of `{ toolCallId, toolName, input }`. Return `null` to skip posting controls.
+</ParamField>
+
+<ParamField body="onInteraction" type="(event) => { toolCallId, output } | null">
+  Map a verified callback event to a resolution. The `output` is stitched onto the pending tool call matched by `toolCallId` and the run resumes. Return `null` to treat the event as a normal message instead (a new turn).
+</ParamField>
+
+<ParamField body="finalizeInteraction" type="(event, resolution) => void">
+  Collapse the controls after a decision so they cannot be clicked again. Best effort: a failure here is logged and the run still resumes.
+</ParamField>
+
+Slack encodes the decision in each button's `value` as `${toolCallId}::approve|deny` so `onInteraction` can resolve the exact call, and `finalizeInteraction` posts to the interaction's `response_url` with `replace_original` to swap the buttons for the outcome. On a custom surface you choose the encoding and how you edit the controls away.
+
+```ts
+chat.channels.custom({
+  id: "my-surface",
+  source: webhooks.custom<MyEvent>({ /* verifier config */ }),
+  key: "{body.conversationId}",
+  inbound: (e) => e.text,
+  send: async (message, ctx) => ({ ref: await postToMySurface(ctx.event, message) }),
+  renderInteraction: (pending) => ({
+    text: `Approve: ${pending[0].input.action}?`,
+    buttons: pending.map((c) => [`${c.toolCallId}:yes`, `${c.toolCallId}:no`]),
+  }),
+  onInteraction: (e) => {
+    const [toolCallId, choice] = e.buttonValue.split(":");
+    return { toolCallId, output: { approved: choice === "yes" } };
+  },
+  finalizeInteraction: async (e) => {
+    await editMySurface(e.messageRef, "Decision recorded");
+  },
+});
+```
+
+The resolved `output` is whatever your tool expects to receive. The Slack default resolves `{ approved: boolean }`; if your tool needs a richer answer, supply your own `onInteraction` that returns the shape your tool reads.
+
+## The reply after a decision
+
+When the turn resumes, the channel reply shows the agent's answer, not the text it produced before pausing. The framework posts the assistant text generated after the tool call, so a preamble like "I'll need approval first" is not concatenated onto the final "done" message. The approval prompt itself already lives in the collapsed controls.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Channels" icon="comments" href="/webhooks/channels">
+    Point Slack or any surface at an agent so messages become turns.
+  </Card>
+  <Card title="Browser human-in-the-loop" icon="hand" href="/ai-chat/patterns/human-in-the-loop">
+    The same no-execute pause, rendered in a React frontend.
+  </Card>
+  <Card title="Sessions" icon="layer-group" href="/ai-chat/sessions">
+    The durable per-conversation state a channel turn runs on.
+  </Card>
+  <Card title="Filters" icon="filter" href="/webhooks/filters">
+    Gate which verified deliveries reach the agent.
+  </Card>
+</CardGroup>

--- a/docs/webhooks/human-in-the-loop.mdx
+++ b/docs/webhooks/human-in-the-loop.mdx
@@ -1,0 +1,146 @@
+---
+title: "Human-in-the-loop"
+sidebarTitle: "Human-in-the-loop"
+description: "Pause an agent mid-turn to get a human decision from the channel (Slack approve/deny), then resume with the answer."
+---
+
+**An agent on a [channel](/webhooks/channels) can pause a turn to get a human decision, then resume once someone answers in the thread.** It posts controls into the conversation and picks up where it left off once someone clicks, with the decision merged into the turn. This is the channel counterpart of browser [human-in-the-loop](/ai-chat/patterns/human-in-the-loop): the same no-`execute` tool, but the controls live in Slack (or your own surface) instead of a React component. The [`slack()`](/webhooks/channels) connector ships Approve / Deny buttons out of the box.
+
+## How it works
+
+The building block is a tool with no `execute` function. When the model calls it, the turn completes with the tool call still pending instead of resolving it. Over a channel the framework then takes over the round-trip:
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant S as Slack
+    participant A as Agent run
+    U->>S: Message in a thread
+    S->>A: Verified delivery starts a turn
+    A->>A: Model calls requestApproval (no execute)
+    A->>S: renderInteraction posts Approve / Deny
+    Note over A: Turn completes, run suspends (no compute while waiting)
+    U->>S: Clicks a button
+    S->>A: Signed block_actions callback to the same webhook URL
+    A->>A: onInteraction resolves the pending tool
+    A->>S: finalizeInteraction collapses the buttons
+    A->>A: Run resumes, model continues
+    A->>S: Reply posts back to the thread
+```
+
+Because it is a no-`execute` pause, the run suspends while it waits rather than holding compute. A human can take minutes or days to decide without burning compute or hitting [`maxDuration`](/runs/max-duration). The mechanics are the same as the browser case, covered in [human-in-the-loop](/ai-chat/patterns/human-in-the-loop#duration-and-cost-while-paused).
+
+## Slack approvals
+
+Out of the box, `slack()` posts Approve / Deny buttons for any pending no-`execute` tool. A click resolves to `{ approved: boolean }` and the buttons collapse to the decision. You define the tool and list the channel on the agent:
+
+```ts trigger/support-agent.ts
+import { chat } from "@trigger.dev/sdk/ai";
+import { slack } from "@trigger.dev/slack";
+import { streamText, tool } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+import { z } from "zod";
+
+// No execute: calling this pauses the turn for a human decision.
+const requestApproval = tool({
+  description:
+    "Request human approval before a sensitive or irreversible action. " +
+    "Call this and stop; you will receive { approved: boolean }, then proceed or decline.",
+  inputSchema: z.object({
+    action: z.string().describe("A short description of the action needing approval"),
+  }),
+});
+
+export const supportAgent = chat.agent({
+  id: "support-agent",
+  channels: [slack({ id: "support-slack", token: process.env.SLACK_BOT_TOKEN! })],
+  tools: { requestApproval },
+  run: async ({ messages, tools }) =>
+    streamText({
+      model: anthropic("claude-sonnet-4-5"),
+      messages,
+      tools,
+      system:
+        "Before any sensitive or irreversible action (refunds, cancellations, deletions), " +
+        "call requestApproval and wait. If approved, confirm it is done; if denied, decline.",
+    }),
+});
+```
+
+Button clicks arrive on a different Slack API than messages, so there is one extra setup step beyond [connecting the channel](/webhooks/channels):
+
+<Steps>
+  <Step title="Turn on Interactivity">
+    In the Slack app's **Interactivity & Shortcuts**, enable interactivity and set the Request URL to the **same** webhook URL you used for events. Slack posts button clicks there as a signed `block_actions` callback, which the endpoint verifies and routes to the paused run.
+  </Step>
+  <Step title="Confirm the bot scope">
+    Posting and editing the controls uses the `chat:write` scope you already added for replies. No extra scope is needed to collapse the buttons after a decision.
+  </Step>
+</Steps>
+
+When the model calls `requestApproval`, the bot posts "Approval needed" with the action and Approve / Deny buttons. Clicking **Approve** resolves the tool to `{ approved: true }`, the buttons collapse to "Approved by @you", and the agent continues and posts the outcome. **Deny** resolves `{ approved: false }`.
+
+## Customizing the controls
+
+For [`chat.channels.custom`](/webhooks/channels), or to override the Slack defaults, three hooks own the interaction round-trip:
+
+<ParamField body="renderInteraction" type="(pending, ctx) => ChannelMessage | null">
+  Map the pending tool call(s) to the controls you post. `pending` is a list of `{ toolCallId, toolName, input }`. Return `null` to skip posting controls.
+</ParamField>
+
+<ParamField body="onInteraction" type="(event) => { toolCallId, output } | null">
+  Map a verified callback event to a resolution. The `output` is stitched onto the pending tool call matched by `toolCallId` and the run resumes. Return `null` to treat the event as a normal message instead (a new turn).
+</ParamField>
+
+<ParamField body="finalizeInteraction" type="(event, resolution) => void">
+  Collapse the controls after a decision so they cannot be clicked again. Best effort: a failure here is logged and the run still resumes.
+</ParamField>
+
+Slack encodes the decision in each button's `value` as `${toolCallId}::approve|deny` so `onInteraction` can resolve the exact call, and `finalizeInteraction` posts to the interaction's `response_url` with `replace_original` to swap the buttons for the outcome. On a custom surface you choose the encoding and how you edit the controls away.
+
+```ts
+import { chat } from "@trigger.dev/sdk/ai";
+import { webhooks } from "@trigger.dev/sdk";
+
+chat.channels.custom({
+  id: "my-surface",
+  source: webhooks.custom<MyEvent>({ /* verifier config */ }),
+  key: "{body.conversationId}",
+  inbound: (e) => e.text,
+  send: async (message, ctx) => ({ ref: await postToMySurface(ctx.event, message) }),
+  renderInteraction: (pending) => ({
+    text: `Approve: ${pending[0].input.action}?`,
+    buttons: pending.map((c) => [`${c.toolCallId}:yes`, `${c.toolCallId}:no`]),
+  }),
+  onInteraction: (e) => {
+    const [toolCallId, choice] = e.buttonValue.split(":");
+    return { toolCallId, output: { approved: choice === "yes" } };
+  },
+  finalizeInteraction: async (e) => {
+    await editMySurface(e.messageRef, "Decision recorded");
+  },
+});
+```
+
+The resolved `output` is whatever your tool expects to receive. The Slack default resolves `{ approved: boolean }`; if your tool needs a richer answer, supply your own `onInteraction` that returns the shape your tool reads.
+
+## The reply after a decision
+
+When the turn resumes, the channel reply shows the agent's answer, not the text it produced before pausing. The framework posts the assistant text generated after the tool call, so a preamble like "I'll need approval first" is not concatenated onto the final "done" message. The approval prompt itself already lives in the collapsed controls.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Channels" icon="comments" href="/webhooks/channels">
+    Point Slack or any surface at an agent so messages become turns.
+  </Card>
+  <Card title="Browser human-in-the-loop" icon="hand" href="/ai-chat/patterns/human-in-the-loop">
+    The same no-execute pause, rendered in a React frontend.
+  </Card>
+  <Card title="Sessions" icon="layer-group" href="/ai-chat/sessions">
+    The durable per-conversation state a channel turn runs on.
+  </Card>
+  <Card title="Filters" icon="filter" href="/webhooks/filters">
+    Gate which verified deliveries reach the agent.
+  </Card>
+</CardGroup>

--- a/docs/webhooks/human-in-the-loop.mdx
+++ b/docs/webhooks/human-in-the-loop.mdx
@@ -99,6 +99,9 @@ For [`chat.channels.custom`](/webhooks/channels), or to override the Slack defau
 Slack encodes the decision in each button's `value` as `${toolCallId}::approve|deny` so `onInteraction` can resolve the exact call, and `finalizeInteraction` posts to the interaction's `response_url` with `replace_original` to swap the buttons for the outcome. On a custom surface you choose the encoding and how you edit the controls away.
 
 ```ts
+import { chat } from "@trigger.dev/sdk/ai";
+import { webhooks } from "@trigger.dev/sdk";
+
 chat.channels.custom({
   id: "my-surface",
   source: webhooks.custom<MyEvent>({ /* verifier config */ }),

--- a/docs/webhooks/overview.mdx
+++ b/docs/webhooks/overview.mdx
@@ -1,0 +1,96 @@
+---
+title: "Webhooks overview"
+description: "Receive and verify webhooks from external providers as a task, with a hosted webhook URL."
+sidebarTitle: "Overview"
+---
+
+A webhook is a task that runs when an external provider (Stripe, GitHub, Svix, your own service, …) sends an HTTP request. Trigger.dev gives each webhook a hosted webhook URL, verifies the incoming request's signature, and routes the verified event to your task's `onEvent` handler.
+
+You don't host an endpoint yourself, and you don't write verification code: you declare which provider the webhook is from, point the provider at the webhook URL, and set the signing secret.
+
+## Defining a webhook task
+
+A webhook is created with `webhook()`. It takes an `id`, a `source` (which provider, and how to verify it), and an `onEvent` handler:
+
+```ts
+import { webhook, webhooks } from "@trigger.dev/sdk";
+
+export const onStripeEvent = webhook({
+  id: "stripe-events",
+  source: webhooks.stripe(),
+  onEvent: async ({ event, headers, ctx }) => {
+    // `event` is the verified, parsed body
+    console.log("Received", event.type, event.id);
+
+    // `headers` is a standard Web Headers object
+    console.log(headers.get("stripe-signature"));
+
+    // `ctx` is the usual run context
+    console.log(ctx.run.id);
+  },
+});
+```
+
+`onEvent` receives:
+
+- **`event`**: the verified request body, parsed from JSON and typed by the source (see [Typing the event](/webhooks/sources#typing-the-event)).
+- **`headers`**: the inbound request headers as a Web [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) object (case-insensitive `.get()` / `.has()`).
+- **`ctx`**: the run context, the same one regular tasks receive.
+
+<Note>
+  A webhook is a first-class task kind. It runs on a real run (with retries, logs, and everything else
+  tasks get), and shows up in the dashboard alongside your other tasks.
+</Note>
+
+## How it works
+
+<Steps>
+  <Step title="Declare the webhook">
+    Define a `webhook()` with a `source`. The source is a provider preset (like `webhooks.stripe()`)
+    or a `webhooks.custom()` config. See [Sources and verification](/webhooks/sources).
+  </Step>
+  <Step title="Connect a provider">
+    Deploying the webhook creates an endpoint with a hosted webhook URL. Set its signing secret and
+    point your provider at the URL. See [Connecting a provider](/webhooks/connect).
+  </Step>
+  <Step title="Receive verified events">
+    Each inbound request is verified, recorded as a delivery, and routed to a run that calls your
+    `onEvent`. See [Deliveries and endpoints](/webhooks/deliveries).
+  </Step>
+</Steps>
+
+## Beyond fan-out
+
+A few things build on the basic model:
+
+- **[Filters](/webhooks/filters)** gate which deliveries run. A non-matching delivery is recorded but never triggers a run.
+- **[Session routing](/webhooks/session-routing)** sends deliveries that share a key to one durable session (per customer, installation, or issue) instead of a fresh run each time.
+- **[Channels](/webhooks/channels)** turn a webhook into a chat frontend: inbound messages become agent turns, and the agent's reply posts back to the surface.
+- **[Human-in-the-loop](/webhooks/human-in-the-loop)** adds approvals and interactive controls over a channel, like Slack approve and deny buttons.
+
+<CardGroup cols={2}>
+  <Card title="Sources and verification" icon="shield-check" href="/webhooks/sources">
+    Provider presets, custom verification, and typing the event.
+  </Card>
+  <Card title="Connecting a provider" icon="plug" href="/webhooks/connect">
+    The webhook URL and signing secret.
+  </Card>
+  <Card title="Deliveries and endpoints" icon="inbox" href="/webhooks/deliveries">
+    Observe inbound requests in the dashboard.
+  </Card>
+  <Card title="Filters" icon="filter" href="/webhooks/filters">
+    Route only the deliveries you care about.
+  </Card>
+  <Card title="Session routing" icon="arrows-to-dot" href="/webhooks/session-routing">
+    Route deliveries to a durable per-key session.
+  </Card>
+  <Card title="Channels" icon="comments" href="/webhooks/channels">
+    Turn a webhook into a chat frontend for an agent.
+  </Card>
+  <Card title="Human-in-the-loop" icon="user-check" href="/webhooks/human-in-the-loop">
+    Approvals and interactive controls over a channel.
+  </Card>
+  <Card title="Scheduled tasks" icon="clock" href="/tasks/scheduled">
+    The other declarative task trigger.
+  </Card>
+</CardGroup>

--- a/docs/webhooks/overview.mdx
+++ b/docs/webhooks/overview.mdx
@@ -64,6 +64,9 @@ export const onStripeEvent = webhook({
 A few things build on the basic model:
 
 - **[Filters](/webhooks/filters)** gate which deliveries run. A non-matching delivery is recorded but never triggers a run.
+- **[Session routing](/webhooks/session-routing)** sends deliveries that share a key to one durable session (per customer, installation, or issue) instead of a fresh run each time.
+- **[Channels](/webhooks/channels)** turn a webhook into a chat frontend: inbound messages become agent turns, and the agent's reply posts back to the surface.
+- **[Human-in-the-loop](/webhooks/human-in-the-loop)** adds approvals and interactive controls over a channel, like Slack approve and deny buttons.
 
 <CardGroup cols={2}>
   <Card title="Sources and verification" icon="shield-check" href="/webhooks/sources">
@@ -77,6 +80,15 @@ A few things build on the basic model:
   </Card>
   <Card title="Filters" icon="filter" href="/webhooks/filters">
     Route only the deliveries you care about.
+  </Card>
+  <Card title="Session routing" icon="arrows-to-dot" href="/webhooks/session-routing">
+    Route deliveries to a durable per-key session.
+  </Card>
+  <Card title="Channels" icon="comments" href="/webhooks/channels">
+    Turn a webhook into a chat frontend for an agent.
+  </Card>
+  <Card title="Human-in-the-loop" icon="user-check" href="/webhooks/human-in-the-loop">
+    Approvals and interactive controls over a channel.
   </Card>
   <Card title="Scheduled tasks" icon="clock" href="/tasks/scheduled">
     The other declarative task trigger.

--- a/docs/webhooks/overview.mdx
+++ b/docs/webhooks/overview.mdx
@@ -1,0 +1,84 @@
+---
+title: "Webhooks overview"
+description: "Receive and verify webhooks from external providers as a task, with a hosted webhook URL."
+sidebarTitle: "Overview"
+---
+
+A webhook is a task that runs when an external provider (Stripe, GitHub, Svix, your own service, …) sends an HTTP request. Trigger.dev gives each webhook a hosted webhook URL, verifies the incoming request's signature, and routes the verified event to your task's `onEvent` handler.
+
+You don't host an endpoint yourself, and you don't write verification code: you declare which provider the webhook is from, point the provider at the webhook URL, and set the signing secret.
+
+## Defining a webhook task
+
+A webhook is created with `webhook()`. It takes an `id`, a `source` (which provider, and how to verify it), and an `onEvent` handler:
+
+```ts
+import { webhook, webhooks } from "@trigger.dev/sdk";
+
+export const onStripeEvent = webhook({
+  id: "stripe-events",
+  source: webhooks.stripe(),
+  onEvent: async ({ event, headers, ctx }) => {
+    // `event` is the verified, parsed body
+    console.log("Received", event.type, event.id);
+
+    // `headers` is a standard Web Headers object
+    console.log(headers.get("stripe-signature"));
+
+    // `ctx` is the usual run context
+    console.log(ctx.run.id);
+  },
+});
+```
+
+`onEvent` receives:
+
+- **`event`**: the verified request body, parsed from JSON and typed by the source (see [Typing the event](/webhooks/sources#typing-the-event)).
+- **`headers`**: the inbound request headers as a Web [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) object (case-insensitive `.get()` / `.has()`).
+- **`ctx`**: the run context, the same one regular tasks receive.
+
+<Note>
+  A webhook is a first-class task kind. It runs on a real run (with retries, logs, and everything else
+  tasks get), and shows up in the dashboard alongside your other tasks.
+</Note>
+
+## How it works
+
+<Steps>
+  <Step title="Declare the webhook">
+    Define a `webhook()` with a `source`. The source is a provider preset (like `webhooks.stripe()`)
+    or a `webhooks.custom()` config. See [Sources and verification](/webhooks/sources).
+  </Step>
+  <Step title="Connect a provider">
+    Deploying the webhook creates an endpoint with a hosted webhook URL. Set its signing secret and
+    point your provider at the URL. See [Connecting a provider](/webhooks/connect).
+  </Step>
+  <Step title="Receive verified events">
+    Each inbound request is verified, recorded as a delivery, and routed to a run that calls your
+    `onEvent`. See [Deliveries and endpoints](/webhooks/deliveries).
+  </Step>
+</Steps>
+
+## Beyond fan-out
+
+A few things build on the basic model:
+
+- **[Filters](/webhooks/filters)** gate which deliveries run. A non-matching delivery is recorded but never triggers a run.
+
+<CardGroup cols={2}>
+  <Card title="Sources and verification" icon="shield-check" href="/webhooks/sources">
+    Provider presets, custom verification, and typing the event.
+  </Card>
+  <Card title="Connecting a provider" icon="plug" href="/webhooks/connect">
+    The webhook URL and signing secret.
+  </Card>
+  <Card title="Deliveries and endpoints" icon="inbox" href="/webhooks/deliveries">
+    Observe inbound requests in the dashboard.
+  </Card>
+  <Card title="Filters" icon="filter" href="/webhooks/filters">
+    Route only the deliveries you care about.
+  </Card>
+  <Card title="Scheduled tasks" icon="clock" href="/tasks/scheduled">
+    The other declarative task trigger.
+  </Card>
+</CardGroup>

--- a/docs/webhooks/session-routing.mdx
+++ b/docs/webhooks/session-routing.mdx
@@ -1,0 +1,96 @@
+---
+title: "Routing to a session"
+description: "Route verified webhook deliveries to a durable per-key session instead of a fresh run."
+sidebarTitle: "Session routing"
+---
+
+A plain [`webhook()`](/webhooks/overview) runs a fresh, stateless run for every delivery. Sometimes you want the opposite: deliveries that share a key (a customer, an installation, an issue) should land on **one durable [session](/ai-chat/sessions)** and be handled in order, with state carried across them. That is what session routing does.
+
+Instead of a handler, you declare a `chat.event` and list it on an agent. The verified delivery is routed to a find-or-created session and arrives as an [action](/ai-chat/actions).
+
+## Declaring a chat event
+
+`chat.event` describes the routing only: the [source](/webhooks/sources) to verify, a `key` that identifies the session, and a `type` label for the delivered action. It has no handler.
+
+```ts
+import { webhooks } from "@trigger.dev/sdk";
+import { chat } from "@trigger.dev/sdk/ai";
+
+export const orderEvents = chat.event({
+  id: "order-events",
+  source: webhooks.stripe(),
+  // one session per customer
+  key: "{body.data.object.customer}",
+  type: "order.event",
+});
+```
+
+### The key
+
+The `key` is what makes routing durable: two deliveries that resolve to the same key reach the same session; a different key gets its own. It is a template string, evaluated server-side at ingest, whose `{...}` placeholders read three namespaces:
+
+- `{body.*}`: the parsed body (a bare `{customer}` defaults to the body namespace).
+- `{webhook.*}`: endpoint metadata (`externalRef`, `tenantId`, `id`, `source`, `deliveryId`).
+- `{header.name}`: an inbound header.
+
+[Filter](/webhooks/filters) expressions read this same parsed body, but spell it `event.*` rather than `{body.*}`.
+
+Compose several placeholders into one key: `"{webhook.externalRef}-{body.issue.id}"`. Each placeholder is checked against the event type at build time, so a bad field is a red squiggle on the `key` line, not a runtime surprise.
+
+### The `type` label
+
+`type` is a name you choose for the delivered action. It flows straight through to `action.type` on the envelope, so your handler can tell webhook actions apart from each other and from browser actions. It is optional and defaults to the descriptor `id`.
+
+## Handling deliveries on an agent
+
+List the descriptor on a [`chat.agent`](/ai-chat/overview) (or a session agent). The delivery arrives at `onAction`, not as a chat message:
+
+```ts
+import { chat } from "@trigger.dev/sdk/ai";
+import { orderEvents } from "./order-events";
+
+export const orderAgent = chat.agent({
+  id: "order-agent",
+  events: [orderEvents],
+  onAction: async ({ action }) => {
+    switch (action.type) {
+      case "order.event":
+        // action.event is the verified Stripe event, fully typed
+        console.log("order for", action.event.data.object.customer);
+        break;
+    }
+  },
+  run: async ({ messages, signal }) => {
+    /* ... */
+  },
+});
+```
+
+`action.type` is a closed union of the `type` labels of the events you listed, and each arm narrows `action.event` to that event's payload type. The full envelope is `{ type, event, source, headers, deliveryId }`.
+
+Because it is an [action](/ai-chat/actions), the handler is not a turn: it can mutate session state and, if you return a `streamText` result, produce a model response. Webhook actions bypass your `actionSchema` (their shape is fixed and already typed).
+
+<Note>
+  The descriptor never names the agent, and the agent references the descriptor, so there is no
+  circular dependency. Whichever agent lists it becomes the routing target.
+</Note>
+
+## One endpoint per agent
+
+Listing a descriptor on an agent creates that agent's own endpoint, with its own [webhook URL and signing secret](/webhooks/connect). If two agents list the same descriptor, you get two endpoints, each routing to its own agent, and you point the provider at both URLs.
+
+An exported `chat.event` that no agent lists routes nothing. `trigger dev` warns about it (it is not an error, since declaring the descriptor before wiring the agent is a normal step), so wire it onto an agent once you are ready.
+
+## Filtering
+
+A [`filter`](/webhooks/filters) works here exactly as on a fan-out webhook: a non-matching delivery is recorded `FILTERED` and never reaches the session.
+
+```ts
+export const orderEvents = chat.event({
+  id: "order-events",
+  source: webhooks.stripe(),
+  key: "{body.data.object.customer}",
+  type: "order.event",
+  filter: "event.type == 'payment_intent.succeeded'",
+});
+```

--- a/docs/webhooks/sources.mdx
+++ b/docs/webhooks/sources.mdx
@@ -1,0 +1,133 @@
+---
+title: "Sources and verification"
+description: "Provider presets, custom verification config, and typing the webhook event."
+sidebarTitle: "Sources & verification"
+---
+
+A webhook's `source` tells Trigger.dev which provider the request is from and how to verify it. Use a built-in preset, or `webhooks.custom()` for a provider without one.
+
+## Presets
+
+Built-in presets know the provider's signature scheme, so you don't configure anything:
+
+<CodeGroup>
+
+```ts Stripe
+import { webhook, webhooks } from "@trigger.dev/sdk";
+
+export const stripeWebhook = webhook({
+  id: "stripe",
+  source: webhooks.stripe(),
+  onEvent: async ({ event }) => {
+    if (event.type === "payment_intent.succeeded") {
+      // ...
+    }
+  },
+});
+```
+
+```ts GitHub
+import { webhook, webhooks } from "@trigger.dev/sdk";
+
+export const githubWebhook = webhook({
+  id: "github",
+  source: webhooks.github(),
+  onEvent: async ({ event, headers }) => {
+    // GitHub puts the event type in a header
+    console.log(headers.get("x-github-event"));
+  },
+});
+```
+
+```ts Svix
+import { webhook, webhooks } from "@trigger.dev/sdk";
+
+// Also covers Clerk, Resend, and other Svix-powered providers
+export const svixWebhook = webhook({
+  id: "svix",
+  source: webhooks.svix(),
+  onEvent: async ({ event }) => {
+    // ...
+  },
+});
+```
+
+</CodeGroup>
+
+The available presets are `stripe()`, `github()`, `svix()`, `square()`, and `discord()`.
+
+## Custom providers
+
+For a provider without a preset, `webhooks.custom()` describes the scheme as data. For example, an HMAC-SHA256 signature over the raw body, in a custom header:
+
+```ts
+import { webhook, webhooks } from "@trigger.dev/sdk";
+
+export const customWebhook = webhook({
+  id: "custom",
+  source: webhooks.custom<{ id: string; message: string }>({
+    scheme: "hmac",
+    algorithm: "sha256",
+    encoding: "hex",
+    signatureHeader: "x-webhook-signature",
+    signingString: "raw",
+    idempotencyField: { from: "body", name: "id" },
+  }),
+  onEvent: async ({ event }) => {
+    console.log(event.message);
+  },
+});
+```
+
+<Tip>
+  Reach for a preset first; drop to `custom()` for the long tail. A custom config can almost always
+  express a provider's scheme without any code.
+</Tip>
+
+## Typing the event
+
+Presets ship a sensible default event type, and they're generic, so you can plug in the provider's official type for full type-safety and autocomplete:
+
+```ts
+import type Stripe from "stripe";
+import { webhook, webhooks } from "@trigger.dev/sdk";
+
+export const stripeEvents = webhook({
+  id: "stripe-events",
+  source: webhooks.stripe<Stripe.Event>(),
+  onEvent: async ({ event }) => {
+    // `event` is now the full, discriminated Stripe.Event union
+  },
+});
+```
+
+For `webhooks.custom<T>()`, pass your own event type as `T`.
+
+<Note>
+  The event is typed but not re-validated against that type at runtime: once the signature is
+  verified, the body is trusted (the same model the official provider SDKs use). If you want runtime
+  validation, validate `event` inside `onEvent`.
+</Note>
+
+## How verification works
+
+Every inbound request is verified before your task runs. Trigger.dev checks the signature, the
+timestamp (for replay protection, where the provider supplies one), and derives an idempotency key.
+When the preset maps a provider event id it uses that; otherwise it falls back to a hash of the raw
+body, timestamp, and signature. A request that fails verification gets a `400` and never creates a run.
+
+Presets handle this for you. Under the hood, every scheme is one of:
+
+- **`hmac`**: HMAC over the raw body or a templated signing string, signature in a header. The header can be a raw value, a prefixed one (like GitHub's `sha256=…`), or a structured one (like Stripe's `t=…,v1=…`).
+- **`shared-secret`**: a static token compared in a header, bearer, basic auth, or the body.
+- **`url-secret`**: a secret in the URL path or query string.
+- **`asymmetric`**: public-key signatures (Ed25519, ECDSA, RSA). You store the provider's public key instead of a shared secret.
+
+<Warning>
+  `url-secret` places the secret in the request URL (path or query string), where it can be captured
+  by access logs, proxies, and tracing systems. Prefer a header-based scheme (`hmac` or
+  `shared-secret`) when the provider supports one.
+</Warning>
+
+Once a request is verified, see [Connecting a provider](/webhooks/connect) for how to point the
+provider at the webhook URL and set the secret.

--- a/docs/webhooks/sources.mdx
+++ b/docs/webhooks/sources.mdx
@@ -90,10 +90,15 @@ Presets ship a sensible default event type, and they're generic, so you can plug
 
 ```ts
 import type Stripe from "stripe";
-import { webhooks } from "@trigger.dev/sdk";
+import { webhook, webhooks } from "@trigger.dev/sdk";
 
-// `event` is now the full, discriminated Stripe.Event union
-webhooks.stripe<Stripe.Event>();
+export const stripeEvents = webhook({
+  id: "stripe-events",
+  source: webhooks.stripe<Stripe.Event>(),
+  onEvent: async ({ event }) => {
+    // `event` is now the full, discriminated Stripe.Event union
+  },
+});
 ```
 
 For `webhooks.custom<T>()`, pass your own event type as `T`.
@@ -107,8 +112,9 @@ For `webhooks.custom<T>()`, pass your own event type as `T`.
 ## How verification works
 
 Every inbound request is verified before your task runs. Trigger.dev checks the signature, the
-timestamp (for replay protection, where the provider supplies one), and derives the idempotency key
-from the provider's event id. A request that fails verification gets a `400` and never creates a run.
+timestamp (for replay protection, where the provider supplies one), and derives an idempotency key.
+When the preset maps a provider event id it uses that; otherwise it falls back to a hash of the raw
+body, timestamp, and signature. A request that fails verification gets a `400` and never creates a run.
 
 Presets handle this for you. Under the hood, every scheme is one of:
 
@@ -116,6 +122,12 @@ Presets handle this for you. Under the hood, every scheme is one of:
 - **`shared-secret`**: a static token compared in a header, bearer, basic auth, or the body.
 - **`url-secret`**: a secret in the URL path or query string.
 - **`asymmetric`**: public-key signatures (Ed25519, ECDSA, RSA). You store the provider's public key instead of a shared secret.
+
+<Warning>
+  `url-secret` places the secret in the request URL (path or query string), where it can be captured
+  by access logs, proxies, and tracing systems. Prefer a header-based scheme (`hmac` or
+  `shared-secret`) when the provider supports one.
+</Warning>
 
 Once a request is verified, see [Connecting a provider](/webhooks/connect) for how to point the
 provider at the webhook URL and set the secret.

--- a/docs/webhooks/sources.mdx
+++ b/docs/webhooks/sources.mdx
@@ -1,0 +1,115 @@
+---
+title: "Sources and verification"
+description: "Provider presets, custom verification config, and typing the webhook event."
+sidebarTitle: "Sources & verification"
+---
+
+A webhook's `source` tells Trigger.dev which provider the request is from and how to verify it. Use a built-in preset, or `webhooks.custom()` for a provider without one.
+
+## Presets
+
+Built-in presets know the provider's signature scheme, so you don't configure anything:
+
+<CodeGroup>
+
+```ts Stripe
+import { webhook, webhooks } from "@trigger.dev/sdk";
+
+export const stripeWebhook = webhook({
+  id: "stripe",
+  source: webhooks.stripe(),
+  onEvent: async ({ event }) => {
+    if (event.type === "payment_intent.succeeded") {
+      // ...
+    }
+  },
+});
+```
+
+```ts GitHub
+export const githubWebhook = webhook({
+  id: "github",
+  source: webhooks.github(),
+  onEvent: async ({ event, headers }) => {
+    // GitHub puts the event type in a header
+    console.log(headers.get("x-github-event"));
+  },
+});
+```
+
+```ts Svix
+// Also covers Clerk, Resend, and other Svix-powered providers
+export const svixWebhook = webhook({
+  id: "svix",
+  source: webhooks.svix(),
+  onEvent: async ({ event }) => {
+    // ...
+  },
+});
+```
+
+</CodeGroup>
+
+The available presets are `stripe()`, `github()`, `svix()`, `square()`, and `discord()`.
+
+## Custom providers
+
+For a provider without a preset, `webhooks.custom()` describes the scheme as data. For example, an HMAC-SHA256 signature over the raw body, in a custom header:
+
+```ts
+export const customWebhook = webhook({
+  id: "custom",
+  source: webhooks.custom<{ id: string; message: string }>({
+    scheme: "hmac",
+    algorithm: "sha256",
+    encoding: "hex",
+    signatureHeader: "x-webhook-signature",
+    signingString: "raw",
+    idempotencyField: { from: "body", name: "id" },
+  }),
+  onEvent: async ({ event }) => {
+    console.log(event.message);
+  },
+});
+```
+
+<Tip>
+  Reach for a preset first; drop to `custom()` for the long tail. A custom config can almost always
+  express a provider's scheme without any code.
+</Tip>
+
+## Typing the event
+
+Presets ship a sensible default event type, and they're generic, so you can plug in the provider's official type for full type-safety and autocomplete:
+
+```ts
+import type Stripe from "stripe";
+import { webhooks } from "@trigger.dev/sdk";
+
+// `event` is now the full, discriminated Stripe.Event union
+webhooks.stripe<Stripe.Event>();
+```
+
+For `webhooks.custom<T>()`, pass your own event type as `T`.
+
+<Note>
+  The event is typed but not re-validated against that type at runtime: once the signature is
+  verified, the body is trusted (the same model the official provider SDKs use). If you want runtime
+  validation, validate `event` inside `onEvent`.
+</Note>
+
+## How verification works
+
+Every inbound request is verified before your task runs. Trigger.dev checks the signature, the
+timestamp (for replay protection, where the provider supplies one), and derives the idempotency key
+from the provider's event id. A request that fails verification gets a `400` and never creates a run.
+
+Presets handle this for you. Under the hood, every scheme is one of:
+
+- **`hmac`**: HMAC over the raw body or a templated signing string, signature in a header. The header can be a raw value, a prefixed one (like GitHub's `sha256=…`), or a structured one (like Stripe's `t=…,v1=…`).
+- **`shared-secret`**: a static token compared in a header, bearer, basic auth, or the body.
+- **`url-secret`**: a secret in the URL path or query string.
+- **`asymmetric`**: public-key signatures (Ed25519, ECDSA, RSA). You store the provider's public key instead of a shared secret.
+
+Once a request is verified, see [Connecting a provider](/webhooks/connect) for how to point the
+provider at the webhook URL and set the secret.

--- a/docs/webhooks/sources.mdx
+++ b/docs/webhooks/sources.mdx
@@ -27,6 +27,8 @@ export const stripeWebhook = webhook({
 ```
 
 ```ts GitHub
+import { webhook, webhooks } from "@trigger.dev/sdk";
+
 export const githubWebhook = webhook({
   id: "github",
   source: webhooks.github(),
@@ -38,6 +40,8 @@ export const githubWebhook = webhook({
 ```
 
 ```ts Svix
+import { webhook, webhooks } from "@trigger.dev/sdk";
+
 // Also covers Clerk, Resend, and other Svix-powered providers
 export const svixWebhook = webhook({
   id: "svix",
@@ -57,6 +61,8 @@ The available presets are `stripe()`, `github()`, `svix()`, `square()`, and `dis
 For a provider without a preset, `webhooks.custom()` describes the scheme as data. For example, an HMAC-SHA256 signature over the raw body, in a custom header:
 
 ```ts
+import { webhook, webhooks } from "@trigger.dev/sdk";
+
 export const customWebhook = webhook({
   id: "custom",
   source: webhooks.custom<{ id: string; message: string }>({

--- a/packages/cli-v3/src/dev/devSupervisor.ts
+++ b/packages/cli-v3/src/dev/devSupervisor.ts
@@ -32,7 +32,7 @@ import type { CliApiClient } from "../apiClient.js";
 import { copySkillFolders } from "../build/bundleSkills.js";
 import type { DevCommandOptions } from "../commands/dev.js";
 import { DevRunController } from "../entryPoints/dev-run-controller.js";
-import { cliLink, prettyError } from "../utilities/cliOutput.js";
+import { cliLink, prettyError, prettyWarning } from "../utilities/cliOutput.js";
 import { devBranchPathSegment } from "../utilities/devBranch.js";
 import { eventBus } from "../utilities/eventBus.js";
 import { resolveLocalEnvVars } from "../utilities/localEnvVars.js";
@@ -382,6 +382,16 @@ class DevSupervisor implements WorkerRuntime {
       return;
     }
 
+    // Non-blocking nudge: a chat.event that no agent lists routes nothing. Common (and fine)
+    // mid-development while you wire up the chat.agent, so warn rather than fail.
+    const unclaimedSessionWebhooks = backgroundWorker.manifest.unclaimedSessionWebhooks ?? [];
+    if (unclaimedSessionWebhooks.length > 0) {
+      prettyWarning(
+        `Unclaimed chat.event: ${unclaimedSessionWebhooks.join(", ")}`,
+        "Not listed on any agent's `events: [...]`, so deliveries won't be routed anywhere. Add each to a chat.agent once you wire it up."
+      );
+    }
+
     const sourceFiles = resolveSourceFiles(manifest.sources, backgroundWorker.manifest.tasks);
 
     const backgroundWorkerBody: CreateBackgroundWorkerRequestBody = {
@@ -391,6 +401,7 @@ class DevSupervisor implements WorkerRuntime {
         cliPackageVersion: manifest.cliPackageVersion,
         tasks: backgroundWorker.manifest.tasks,
         prompts: backgroundWorker.manifest.prompts,
+        webhooks: backgroundWorker.manifest.webhooks,
         queues: backgroundWorker.manifest.queues,
         contentHash: manifest.contentHash,
         sourceFiles,

--- a/packages/cli-v3/src/dev/devSupervisor.ts
+++ b/packages/cli-v3/src/dev/devSupervisor.ts
@@ -32,7 +32,7 @@ import type { CliApiClient } from "../apiClient.js";
 import { copySkillFolders } from "../build/bundleSkills.js";
 import type { DevCommandOptions } from "../commands/dev.js";
 import { DevRunController } from "../entryPoints/dev-run-controller.js";
-import { cliLink, prettyError } from "../utilities/cliOutput.js";
+import { cliLink, prettyError, prettyWarning } from "../utilities/cliOutput.js";
 import { devBranchPathSegment } from "../utilities/devBranch.js";
 import { eventBus } from "../utilities/eventBus.js";
 import { resolveLocalEnvVars } from "../utilities/localEnvVars.js";
@@ -380,6 +380,16 @@ class DevSupervisor implements WorkerRuntime {
       );
       stop();
       return;
+    }
+
+    // Non-blocking nudge: a chat.event that no agent lists routes nothing. Common (and fine)
+    // mid-development while you wire up the chat.agent, so warn rather than fail.
+    const unclaimedSessionWebhooks = backgroundWorker.manifest.unclaimedSessionWebhooks ?? [];
+    if (unclaimedSessionWebhooks.length > 0) {
+      prettyWarning(
+        `Unclaimed chat.event: ${unclaimedSessionWebhooks.join(", ")}`,
+        "Not listed on any agent's `events: [...]`, so deliveries won't be routed anywhere. Add each to a chat.agent once you wire it up."
+      );
     }
 
     const sourceFiles = resolveSourceFiles(manifest.sources, backgroundWorker.manifest.tasks);

--- a/packages/cli-v3/src/dev/devSupervisor.ts
+++ b/packages/cli-v3/src/dev/devSupervisor.ts
@@ -391,6 +391,7 @@ class DevSupervisor implements WorkerRuntime {
         cliPackageVersion: manifest.cliPackageVersion,
         tasks: backgroundWorker.manifest.tasks,
         prompts: backgroundWorker.manifest.prompts,
+        webhooks: backgroundWorker.manifest.webhooks,
         queues: backgroundWorker.manifest.queues,
         contentHash: manifest.contentHash,
         sourceFiles,

--- a/packages/cli-v3/src/entryPoints/dev-index-worker.ts
+++ b/packages/cli-v3/src/entryPoints/dev-index-worker.ts
@@ -195,6 +195,8 @@ await sendMessageInCatalog(
       tasks,
       prompts: convertPromptSchemasToJsonSchemas(resourceCatalog.listPromptManifests()),
       skills: resourceCatalog.listSkillManifests(),
+      webhooks: resourceCatalog.listWebhookManifests(),
+      unclaimedSessionWebhooks: resourceCatalog.listUnclaimedSessionWebhooks(),
       queues: resourceCatalog.listQueueManifests(),
       configPath: buildManifest.configPath,
       runtime: buildManifest.runtime,

--- a/packages/cli-v3/src/entryPoints/dev-index-worker.ts
+++ b/packages/cli-v3/src/entryPoints/dev-index-worker.ts
@@ -17,6 +17,7 @@ import { readFile } from "node:fs/promises";
 import sourceMapSupport from "source-map-support";
 import { registerResources } from "../indexing/registerResources.js";
 import { reportTaskIdCollisions } from "../indexing/reportTaskIdCollisions.js";
+import { reportWebhookIdCollisions } from "../indexing/reportWebhookIdCollisions.js";
 import { env } from "std-env";
 import { normalizeImportPath } from "../utilities/normalizeImportPath.js";
 import { detectRuntimeVersion } from "@trigger.dev/core/v3/build";
@@ -123,6 +124,11 @@ const { buildManifest, importErrors, config, timings } = await bootstrap();
 // would silently overwrite the first.
 if (await reportTaskIdCollisions(safeSend)) {
   // Give the message time to flush before the parent kills the worker.
+  await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  process.exit(0);
+}
+
+if (await reportWebhookIdCollisions(safeSend)) {
   await new Promise<void>((resolve) => setTimeout(resolve, 10));
   process.exit(0);
 }

--- a/packages/cli-v3/src/entryPoints/dev-index-worker.ts
+++ b/packages/cli-v3/src/entryPoints/dev-index-worker.ts
@@ -17,6 +17,7 @@ import { readFile } from "node:fs/promises";
 import sourceMapSupport from "source-map-support";
 import { registerResources } from "../indexing/registerResources.js";
 import { reportTaskIdCollisions } from "../indexing/reportTaskIdCollisions.js";
+import { reportWebhookIdCollisions } from "../indexing/reportWebhookIdCollisions.js";
 import { env } from "std-env";
 import { normalizeImportPath } from "../utilities/normalizeImportPath.js";
 import { detectRuntimeVersion } from "@trigger.dev/core/v3/build";
@@ -127,6 +128,11 @@ if (await reportTaskIdCollisions(safeSend)) {
   process.exit(0);
 }
 
+if (await reportWebhookIdCollisions(safeSend)) {
+  await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  process.exit(0);
+}
+
 let tasks = await convertSchemasToJsonSchemas(resourceCatalog.listTaskManifests());
 
 // If the config has retry defaults, we need to apply them to all tasks that don't have any retry settings
@@ -195,6 +201,7 @@ await sendMessageInCatalog(
       tasks,
       prompts: convertPromptSchemasToJsonSchemas(resourceCatalog.listPromptManifests()),
       skills: resourceCatalog.listSkillManifests(),
+      webhooks: resourceCatalog.listWebhookManifests(),
       queues: resourceCatalog.listQueueManifests(),
       configPath: buildManifest.configPath,
       runtime: buildManifest.runtime,

--- a/packages/cli-v3/src/entryPoints/dev-index-worker.ts
+++ b/packages/cli-v3/src/entryPoints/dev-index-worker.ts
@@ -202,6 +202,7 @@ await sendMessageInCatalog(
       prompts: convertPromptSchemasToJsonSchemas(resourceCatalog.listPromptManifests()),
       skills: resourceCatalog.listSkillManifests(),
       webhooks: resourceCatalog.listWebhookManifests(),
+      unclaimedSessionWebhooks: resourceCatalog.listUnclaimedSessionWebhooks(),
       queues: resourceCatalog.listQueueManifests(),
       configPath: buildManifest.configPath,
       runtime: buildManifest.runtime,

--- a/packages/cli-v3/src/entryPoints/managed-index-controller.ts
+++ b/packages/cli-v3/src/entryPoints/managed-index-controller.ts
@@ -103,6 +103,7 @@ async function indexDeployment({
         tasks: workerManifest.tasks,
         prompts: workerManifest.prompts,
         queues: workerManifest.queues,
+        webhooks: workerManifest.webhooks,
         sourceFiles,
         runtime: workerManifest.runtime,
         runtimeVersion: workerManifest.runtimeVersion,

--- a/packages/cli-v3/src/entryPoints/managed-index-worker.ts
+++ b/packages/cli-v3/src/entryPoints/managed-index-worker.ts
@@ -191,6 +191,8 @@ await sendMessageInCatalog(
       tasks,
       prompts: convertPromptSchemasToJsonSchemas(resourceCatalog.listPromptManifests()),
       skills: resourceCatalog.listSkillManifests(),
+      webhooks: resourceCatalog.listWebhookManifests(),
+      unclaimedSessionWebhooks: resourceCatalog.listUnclaimedSessionWebhooks(),
       queues: resourceCatalog.listQueueManifests(),
       configPath: buildManifest.configPath,
       runtime: buildManifest.runtime,

--- a/packages/cli-v3/src/entryPoints/managed-index-worker.ts
+++ b/packages/cli-v3/src/entryPoints/managed-index-worker.ts
@@ -17,6 +17,7 @@ import { readFile } from "node:fs/promises";
 import sourceMapSupport from "source-map-support";
 import { registerResources } from "../indexing/registerResources.js";
 import { reportTaskIdCollisions } from "../indexing/reportTaskIdCollisions.js";
+import { reportWebhookIdCollisions } from "../indexing/reportWebhookIdCollisions.js";
 import { env } from "std-env";
 import { normalizeImportPath } from "../utilities/normalizeImportPath.js";
 import { detectRuntimeVersion } from "@trigger.dev/core/v3/build";
@@ -117,6 +118,11 @@ const { buildManifest, importErrors, config, timings } = await bootstrap();
 // would silently overwrite the first.
 if (await reportTaskIdCollisions(safeSend)) {
   // Give the message time to flush before the parent kills the worker.
+  await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  process.exit(0);
+}
+
+if (await reportWebhookIdCollisions(safeSend)) {
   await new Promise<void>((resolve) => setTimeout(resolve, 10));
   process.exit(0);
 }

--- a/packages/cli-v3/src/entryPoints/managed-index-worker.ts
+++ b/packages/cli-v3/src/entryPoints/managed-index-worker.ts
@@ -198,6 +198,7 @@ await sendMessageInCatalog(
       prompts: convertPromptSchemasToJsonSchemas(resourceCatalog.listPromptManifests()),
       skills: resourceCatalog.listSkillManifests(),
       webhooks: resourceCatalog.listWebhookManifests(),
+      unclaimedSessionWebhooks: resourceCatalog.listUnclaimedSessionWebhooks(),
       queues: resourceCatalog.listQueueManifests(),
       configPath: buildManifest.configPath,
       runtime: buildManifest.runtime,

--- a/packages/cli-v3/src/entryPoints/managed-index-worker.ts
+++ b/packages/cli-v3/src/entryPoints/managed-index-worker.ts
@@ -17,6 +17,7 @@ import { readFile } from "node:fs/promises";
 import sourceMapSupport from "source-map-support";
 import { registerResources } from "../indexing/registerResources.js";
 import { reportTaskIdCollisions } from "../indexing/reportTaskIdCollisions.js";
+import { reportWebhookIdCollisions } from "../indexing/reportWebhookIdCollisions.js";
 import { env } from "std-env";
 import { normalizeImportPath } from "../utilities/normalizeImportPath.js";
 import { detectRuntimeVersion } from "@trigger.dev/core/v3/build";
@@ -121,6 +122,11 @@ if (await reportTaskIdCollisions(safeSend)) {
   process.exit(0);
 }
 
+if (await reportWebhookIdCollisions(safeSend)) {
+  await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  process.exit(0);
+}
+
 let tasks = await convertSchemasToJsonSchemas(resourceCatalog.listTaskManifests());
 
 // If the config has retry defaults, we need to apply them to all tasks that don't have any retry settings
@@ -191,6 +197,7 @@ await sendMessageInCatalog(
       tasks,
       prompts: convertPromptSchemasToJsonSchemas(resourceCatalog.listPromptManifests()),
       skills: resourceCatalog.listSkillManifests(),
+      webhooks: resourceCatalog.listWebhookManifests(),
       queues: resourceCatalog.listQueueManifests(),
       configPath: buildManifest.configPath,
       runtime: buildManifest.runtime,

--- a/packages/cli-v3/src/indexing/indexWorkerManifest.ts
+++ b/packages/cli-v3/src/indexing/indexWorkerManifest.ts
@@ -1,6 +1,7 @@
 import { execPathForRuntime } from "@trigger.dev/core/v3/build";
 import {
   DuplicateTaskIdsError,
+  DuplicateWebhookIdsError,
   TaskIndexingImportError,
   TaskMetadataParseError,
   UncaughtExceptionError,
@@ -91,6 +92,13 @@ export async function indexWorkerManifest({
           clearTimeout(timeout);
           resolved = true;
           reject(new DuplicateTaskIdsError(message.payload.collisions));
+          child.kill("SIGKILL");
+          break;
+        }
+        case "WEBHOOKS_FAILED_TO_INDEX": {
+          clearTimeout(timeout);
+          resolved = true;
+          reject(new DuplicateWebhookIdsError(message.payload.collisions));
           child.kill("SIGKILL");
           break;
         }

--- a/packages/cli-v3/src/indexing/reportWebhookIdCollisions.ts
+++ b/packages/cli-v3/src/indexing/reportWebhookIdCollisions.ts
@@ -1,0 +1,28 @@
+import { indexerToWorkerMessages, resourceCatalog } from "@trigger.dev/core/v3";
+import { sendMessageInCatalog } from "@trigger.dev/core/v3/zodMessageHandler";
+
+/**
+ * If the indexer registered any duplicate webhook ids (across files), report
+ * them to the parent via WEBHOOKS_FAILED_TO_INDEX and return true. Callers must
+ * stop indexing (skip INDEX_COMPLETE) when this returns true.
+ */
+export async function reportWebhookIdCollisions(
+  send: (message: unknown) => void
+): Promise<boolean> {
+  const collisions = resourceCatalog.listWebhookIdCollisions();
+
+  if (collisions.length === 0) {
+    return false;
+  }
+
+  await sendMessageInCatalog(
+    indexerToWorkerMessages,
+    "WEBHOOKS_FAILED_TO_INDEX",
+    { collisions },
+    async (msg) => {
+      send(msg);
+    }
+  );
+
+  return true;
+}

--- a/packages/core/src/v3/errors.ts
+++ b/packages/core/src/v3/errors.ts
@@ -606,6 +606,37 @@ export class DuplicateTaskIdsError extends Error {
   }
 }
 
+function formatDuplicateWebhookIds(collisions: TaskIdCollision[]): string {
+  const lines = collisions.map(({ id, filePaths }) => {
+    const distinct = Array.from(new Set(filePaths));
+
+    if (distinct.length === 1) {
+      return `  - "${id}" found more than once in ${distinct[0]}`;
+    }
+
+    const last = distinct[distinct.length - 1];
+    const head = distinct.slice(0, -1).join(", ");
+
+    return `  - "${id}" found in ${head} and ${last}`;
+  });
+
+  return [
+    "Duplicate webhook ids detected:",
+    "",
+    ...lines,
+    "",
+    "Webhook ids must be unique across your project. Please rename one of them.",
+  ].join("\n");
+}
+
+export class DuplicateWebhookIdsError extends Error {
+  constructor(public readonly collisions: TaskIdCollision[]) {
+    super(formatDuplicateWebhookIds(collisions));
+
+    this.name = "DuplicateWebhookIdsError";
+  }
+}
+
 export class UnexpectedExitError extends Error {
   constructor(
     public code: number,

--- a/packages/core/src/v3/errors.ts
+++ b/packages/core/src/v3/errors.ts
@@ -607,6 +607,37 @@ export class DuplicateTaskIdsError extends Error {
   }
 }
 
+function formatDuplicateWebhookIds(collisions: TaskIdCollision[]): string {
+  const lines = collisions.map(({ id, filePaths }) => {
+    const distinct = Array.from(new Set(filePaths));
+
+    if (distinct.length === 1) {
+      return `  - "${id}" found more than once in ${distinct[0]}`;
+    }
+
+    const last = distinct[distinct.length - 1];
+    const head = distinct.slice(0, -1).join(", ");
+
+    return `  - "${id}" found in ${head} and ${last}`;
+  });
+
+  return [
+    "Duplicate webhook ids detected:",
+    "",
+    ...lines,
+    "",
+    "Webhook ids must be unique across your project. Please rename one of them.",
+  ].join("\n");
+}
+
+export class DuplicateWebhookIdsError extends Error {
+  constructor(public readonly collisions: TaskIdCollision[]) {
+    super(formatDuplicateWebhookIds(collisions));
+
+    this.name = "DuplicateWebhookIdsError";
+  }
+}
+
 export class UnexpectedExitError extends Error {
   constructor(
     public code: number,

--- a/packages/core/src/v3/schemas/messages.ts
+++ b/packages/core/src/v3/schemas/messages.ts
@@ -43,6 +43,10 @@ export const indexerToWorkerMessages = {
     version: z.literal("v1").default("v1"),
     collisions: z.array(z.object({ id: z.string(), filePaths: z.array(z.string()) })),
   }),
+  WEBHOOKS_FAILED_TO_INDEX: z.object({
+    version: z.literal("v1").default("v1"),
+    collisions: z.array(z.object({ id: z.string(), filePaths: z.array(z.string()) })),
+  }),
   UNCAUGHT_EXCEPTION: UncaughtExceptionMessage,
 };
 

--- a/packages/core/src/v3/schemas/messages.ts
+++ b/packages/core/src/v3/schemas/messages.ts
@@ -44,6 +44,10 @@ export const indexerToWorkerMessages = {
     version: z.literal("v1").default("v1"),
     collisions: z.array(z.object({ id: z.string(), filePaths: z.array(z.string()) })),
   }),
+  WEBHOOKS_FAILED_TO_INDEX: z.object({
+    version: z.literal("v1").default("v1"),
+    collisions: z.array(z.object({ id: z.string(), filePaths: z.array(z.string()) })),
+  }),
   UNCAUGHT_EXCEPTION: UncaughtExceptionMessage,
 };
 

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "@trigger.dev/slack",
+  "version": "4.5.0-rc.7",
+  "description": "Slack chat frontend (channel) for trigger.dev agents",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/triggerdotdev/trigger.dev",
+    "directory": "packages/slack"
+  },
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "tshy": {
+    "selfLink": false,
+    "main": true,
+    "module": true,
+    "project": "./tsconfig.src.json",
+    "exclude": [
+      "./src/**/*.test.ts"
+    ],
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./src/index.ts"
+    },
+    "sourceDialects": [
+      "@triggerdotdev/source"
+    ]
+  },
+  "scripts": {
+    "clean": "rimraf dist .tshy .tshy-build .turbo",
+    "build": "tshy && pnpm run update-version",
+    "dev": "tshy --watch",
+    "typecheck": "tsc --noEmit -p tsconfig.src.json",
+    "test": "vitest",
+    "update-version": "tsx ../../scripts/updateVersion.ts",
+    "check-exports": "attw --pack ."
+  },
+  "dependencies": {
+    "@trigger.dev/core": "workspace:4.5.0-rc.7"
+  },
+  "peerDependencies": {
+    "@trigger.dev/sdk": "workspace:^4.5.0-rc.7"
+  },
+  "devDependencies": {
+    "@arethetypeswrong/cli": "^0.18.5",
+    "@trigger.dev/sdk": "workspace:4.5.0-rc.7",
+    "@types/node": "^24.13.3",
+    "rimraf": "6.0.1",
+    "tshy": "^3.0.2",
+    "tsx": "4.17.0"
+  },
+  "engines": {
+    "node": ">=18.20.0"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "@triggerdotdev/source": "./src/index.ts",
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    }
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js"
+}

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@trigger.dev/slack",
+  "version": "4.5.0-rc.7",
+  "description": "Slack chat frontend (channel) for trigger.dev agents",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/triggerdotdev/trigger.dev",
+    "directory": "packages/slack"
+  },
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "tshy": {
+    "selfLink": false,
+    "main": true,
+    "module": true,
+    "project": "./tsconfig.src.json",
+    "exclude": [
+      "./src/**/*.test.ts"
+    ],
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./src/index.ts"
+    },
+    "sourceDialects": [
+      "@triggerdotdev/source"
+    ]
+  },
+  "scripts": {
+    "clean": "rimraf dist .tshy .tshy-build .turbo",
+    "build": "tshy && pnpm run update-version",
+    "dev": "tshy --watch",
+    "typecheck": "tsc --noEmit -p tsconfig.src.json",
+    "test": "vitest",
+    "update-version": "tsx ../../scripts/updateVersion.ts",
+    "check-exports": "attw --pack ."
+  },
+  "dependencies": {
+    "@trigger.dev/core": "workspace:4.5.0-rc.7"
+  },
+  "peerDependencies": {
+    "@trigger.dev/sdk": "workspace:^4.5.0-rc.7"
+  },
+  "devDependencies": {
+    "@arethetypeswrong/cli": "^0.18.5",
+    "@trigger.dev/sdk": "workspace:4.5.0-rc.7",
+    "rimraf": "6.0.1",
+    "tshy": "^3.0.2",
+    "tsx": "4.17.0"
+  },
+  "engines": {
+    "node": ">=18.20.0"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "@triggerdotdev/source": "./src/index.ts",
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/index.d.ts",
+        "default": "./dist/commonjs/index.js"
+      }
+    }
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js"
+}

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.5",
     "@trigger.dev/sdk": "workspace:4.5.0-rc.7",
+    "@types/node": "^24.13.3",
     "rimraf": "6.0.1",
     "tshy": "^3.0.2",
     "tsx": "4.17.0"

--- a/packages/slack/src/index.test.ts
+++ b/packages/slack/src/index.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it, vi } from "vitest";
+import { mentions, slack, toSlackMrkdwn, type SlackMessageEvent } from "./index.js";
+
+const messageEvent = (
+  over: Partial<NonNullable<SlackMessageEvent["event"]>> = {}
+): SlackMessageEvent => ({
+  type: "event_callback",
+  event: { type: "message", channel: "C9", ts: "1699999999.0001", text: "hi", ...over },
+});
+
+describe("slack channel", () => {
+  it("default inbound strips a leading bot mention", () => {
+    const c = slack({ id: "s1", token: "xoxb-t" });
+    expect(c.inbound(messageEvent({ text: "<@U123> hello there" }))).toBe("hello there");
+    expect(c.inbound(messageEvent({ text: "plain" }))).toBe("plain");
+  });
+
+  it("composes the self-message guard with a user filter, and always admits interactivity", () => {
+    const guardOnly = slack({ id: "s2", token: "t" });
+    expect(guardOnly.filter).toContain("event.event.type == 'message'");
+    expect(guardOnly.filter).toContain("event.event.bot_id == null");
+    expect(guardOnly.filter).toContain(
+      "event.event.subtype in [null, 'file_share', 'thread_broadcast']"
+    );
+    expect(guardOnly.filter).toContain("event.type == 'block_actions'");
+
+    const withUser = slack({ id: "s3", token: "t", filter: "event.event.channel == 'C1'" });
+    expect(withUser.filter).toContain("&& (event.event.channel == 'C1')");
+    expect(withUser.filter).toContain("event.type == 'block_actions'");
+  });
+
+  it("keys one session per thread, converging message events and interactivity", () => {
+    const c = slack({ id: "s4", token: "t" });
+    expect(c.key).toBe(
+      "{body.team_id || body.team.id}:{body.event.channel || body.container.channel_id}:{body.event.thread_ts || body.event.ts || body.container.thread_ts || body.container.message_ts}"
+    );
+  });
+
+  it("renderInteraction produces Block Kit approve/deny buttons carrying the toolCallId", () => {
+    const c = slack({ id: "s-hitl", token: "t" });
+    const msg = c.renderInteraction?.(
+      [{ toolCallId: "call-1", toolName: "requestApproval", input: { amount: 50 } }],
+      {
+        event: messageEvent(),
+        deliveryId: "d1",
+      }
+    );
+    const values = (msg?.blocks as any[]).flatMap((b) => b.elements ?? []).map((e: any) => e.value);
+    expect(values).toContain("call-1::approve");
+    expect(values).toContain("call-1::deny");
+  });
+
+  it("onInteraction resolves a block_actions click to a tool output; ignores messages", () => {
+    const c = slack({ id: "s-hitl2", token: "t" });
+    const approve = c.onInteraction?.({
+      type: "block_actions",
+      actions: [{ value: "call-9::approve" }],
+    } as never);
+    expect(approve).toEqual({ toolCallId: "call-9", output: { approved: true } });
+
+    const deny = c.onInteraction?.({
+      type: "block_actions",
+      actions: [{ value: "call-9::deny" }],
+    } as never);
+    expect(deny).toEqual({ toolCallId: "call-9", output: { approved: false } });
+
+    expect(c.onInteraction?.(messageEvent())).toBeNull();
+  });
+
+  it("finalizeInteraction replaces the controls via response_url, dropping the buttons", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: { body: string }) => {
+        calls.push({ url, body: JSON.parse(init.body) });
+        return { json: async () => ({ ok: true }) };
+      })
+    );
+    const c = slack({ id: "s-fin", token: "t" });
+    await c.finalizeInteraction?.(
+      {
+        type: "block_actions",
+        user: { id: "U42" },
+        response_url: "https://hooks.slack.test/r/1",
+        actions: [{ value: "call-1::approve" }],
+        message: {
+          blocks: [
+            { type: "section", text: { type: "mrkdwn", text: "Approval needed" } },
+            { type: "actions", elements: [{ type: "button", value: "call-1::approve" }] },
+          ],
+        },
+      } as never,
+      { toolCallId: "call-1", output: { approved: true } }
+    );
+    expect(calls[0]?.url).toBe("https://hooks.slack.test/r/1");
+    expect(calls[0]?.body.replace_original).toBe(true);
+    const types = (calls[0]?.body.blocks as Array<{ type: string }>).map((b) => b.type);
+    expect(types).not.toContain("actions");
+    expect(JSON.stringify(calls[0]?.body.blocks)).toContain("Approved");
+    vi.unstubAllGlobals();
+  });
+
+  it("finalizeInteraction is a no-op without a response_url", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const c = slack({ id: "s-fin2", token: "t" });
+    await c.finalizeInteraction?.(
+      { type: "block_actions", actions: [{ value: "x::deny" }] } as never,
+      { toolCallId: "x", output: { approved: false } }
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it("passes startOn through verbatim (not composed with the guard)", () => {
+    const none = slack({ id: "s5", token: "t" });
+    expect(none.startOn).toBeUndefined();
+
+    const summon = slack({ id: "s6", token: "t", startOn: mentions("U012BOT") });
+    expect(summon.startOn).toBe(
+      "(event.event.text contains '<@U012BOT>' || event.event.text contains '<@U012BOT|')"
+    );
+  });
+
+  it("default ack varies text on crash recovery", () => {
+    const c = slack({ id: "s7", token: "t" });
+    expect(c.ack?.(messageEvent(), { recovered: false })).toEqual({ text: "on it..." });
+    expect(c.ack?.(messageEvent(), { recovered: true })).toEqual({
+      text: "picking this back up...",
+    });
+  });
+
+  it("ack: null disables the placeholder", () => {
+    const c = slack({ id: "s8", token: "t", ack: null });
+    expect(c.ack).toBeUndefined();
+  });
+
+  it("a custom ack receives the recovery ctx", () => {
+    const c = slack({
+      id: "s9",
+      token: "t",
+      ack: (_e, ctx) => ({ text: ctx.recovered ? "resuming" : "starting" }),
+    });
+    expect(c.ack?.(messageEvent(), { recovered: false })).toEqual({ text: "starting" });
+    expect(c.ack?.(messageEvent(), { recovered: true })).toEqual({ text: "resuming" });
+  });
+
+  it("toSlackMrkdwn converts common markdown to Slack mrkdwn", () => {
+    expect(toSlackMrkdwn("**bold**")).toBe("*bold*");
+    expect(toSlackMrkdwn("__bold__")).toBe("*bold*");
+    expect(toSlackMrkdwn("## Heading")).toBe("*Heading*");
+    expect(toSlackMrkdwn("- one\n- two")).toBe("• one\n• two");
+    expect(toSlackMrkdwn("[docs](https://trigger.dev)")).toBe("<https://trigger.dev|docs>");
+    expect(toSlackMrkdwn("~~gone~~")).toBe("~gone~");
+    // A real model reply: heading + bold + bullets in one string.
+    expect(toSlackMrkdwn("## Help\n\nI can do **stuff**:\n- a\n- b")).toBe(
+      "*Help*\n\nI can do *stuff*:\n• a\n• b"
+    );
+  });
+
+  it("mentions() builds a mention predicate for one or many bot ids", () => {
+    expect(mentions("U1")).toBe(
+      "(event.event.text contains '<@U1>' || event.event.text contains '<@U1|')"
+    );
+    expect(mentions("U1", "U2")).toContain("<@U1>");
+    expect(mentions("U1", "U2")).toContain("<@U2|");
+    expect(() => mentions()).toThrow(/at least one/);
+  });
+
+  it("send posts then edits, threading the ref and using the bot token", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown>; auth: unknown }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: { body: string; headers: Record<string, string> }) => {
+        calls.push({ url, body: JSON.parse(init.body), auth: init.headers.authorization });
+        return { json: async () => ({ ok: true, ts: "1700000000.0001" }) };
+      })
+    );
+
+    const c = slack({ id: "s5", token: "xoxb-secret", apiBaseUrl: "https://mock.slack" });
+    const event = messageEvent();
+
+    const ackRes = await c.send!(
+      { text: "on it..." },
+      {
+        event,
+        deliveryId: "d1",
+        mode: "final",
+        final: false,
+      }
+    );
+    expect(ackRes.ref).toBe("1700000000.0001");
+    expect(calls[0]?.url).toBe("https://mock.slack/chat.postMessage");
+    expect(calls[0]?.auth).toBe("Bearer xoxb-secret");
+    expect(calls[0]?.body.channel).toBe("C9");
+    expect(calls[0]?.body.thread_ts).toBe("1699999999.0001");
+
+    await c.send!(
+      { text: "done" },
+      {
+        event,
+        deliveryId: "d1",
+        previousRef: ackRes.ref,
+        mode: "final",
+        final: true,
+      }
+    );
+    expect(calls[1]?.url).toBe("https://mock.slack/chat.update");
+    expect(calls[1]?.body.ts).toBe("1700000000.0001");
+    expect(calls[1]?.body.text).toBe("done");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("send targets the thread from a block_actions payload (HITL resume egress)", async () => {
+    const calls: Array<{ body: Record<string, unknown> }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: { body: string }) => {
+        calls.push({ body: JSON.parse(init.body) });
+        return { json: async () => ({ ok: true, ts: "1700000000.9" }) };
+      })
+    );
+    const c = slack({ id: "s-resume", token: "t", apiBaseUrl: "https://mock.slack" });
+    const interaction = {
+      type: "block_actions",
+      team: { id: "T1" },
+      container: {
+        type: "message",
+        channel_id: "C42",
+        thread_ts: "1699999999.0001",
+        message_ts: "1700000000.5",
+      },
+      actions: [{ value: "call-1::approve" }],
+    };
+    await c.send!(
+      { text: "refund approved and processed" },
+      {
+        event: interaction as never,
+        deliveryId: "d-resume",
+        mode: "final",
+        final: true,
+      }
+    );
+    expect(calls[0]?.body.channel).toBe("C42");
+    expect(calls[0]?.body.thread_ts).toBe("1699999999.0001");
+    vi.unstubAllGlobals();
+  });
+
+  it("send throws when the bot is not in the channel", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ json: async () => ({ ok: false, error: "not_in_channel" }) }))
+    );
+    const c = slack({ id: "s6", token: "t", apiBaseUrl: "https://mock.slack" });
+    await expect(
+      c.send!({ text: "x" }, { event: messageEvent(), deliveryId: "d", mode: "final", final: true })
+    ).rejects.toThrow(/not_in_channel/);
+    vi.unstubAllGlobals();
+  });
+
+  it("react adds/removes an emoji on the triggering message (colons stripped)", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: { body: string }) => {
+        calls.push({ url, body: JSON.parse(init.body) });
+        return { json: async () => ({ ok: true }) };
+      })
+    );
+    const c = slack({
+      id: "s7",
+      token: "xoxb-secret",
+      apiBaseUrl: "https://mock.slack",
+      reactions: { working: "eyes", done: "white_check_mark" },
+    });
+    expect(c.reactions).toEqual({ working: "eyes", done: "white_check_mark" });
+
+    await c.react!({ name: "eyes" }, { event: messageEvent(), deliveryId: "d1" });
+    expect(calls[0]?.url).toBe("https://mock.slack/reactions.add");
+    expect(calls[0]?.body).toMatchObject({
+      channel: "C9",
+      timestamp: "1699999999.0001",
+      name: "eyes",
+    });
+
+    await c.react!(
+      { name: ":white_check_mark:", remove: true },
+      { event: messageEvent(), deliveryId: "d1" }
+    );
+    expect(calls[1]?.url).toBe("https://mock.slack/reactions.remove");
+    expect(calls[1]?.body.name).toBe("white_check_mark");
+    vi.unstubAllGlobals();
+  });
+
+  it("react swallows already_reacted (idempotent)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ json: async () => ({ ok: false, error: "already_reacted" }) }))
+    );
+    const c = slack({ id: "s8", token: "t", apiBaseUrl: "https://mock.slack" });
+    await expect(
+      c.react!({ name: "eyes" }, { event: messageEvent(), deliveryId: "d1" })
+    ).resolves.toBeUndefined();
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/slack/src/index.test.ts
+++ b/packages/slack/src/index.test.ts
@@ -45,7 +45,8 @@ describe("slack channel", () => {
         deliveryId: "d1",
       }
     );
-    const values = (msg?.blocks as any[]).flatMap((b) => b.elements ?? []).map((e: any) => e.value);
+    expect(msg).not.toBeNull();
+    const values = (msg!.blocks as any[]).flatMap((b) => b.elements ?? []).map((e: any) => e.value);
     expect(values).toContain("call-1::approve");
     expect(values).toContain("call-1::deny");
   });
@@ -129,7 +130,7 @@ describe("slack channel", () => {
     );
     expect(calls[0]?.url).toBe("https://hooks.slack.test/r/1");
     expect(calls[0]?.body.replace_original).toBe(true);
-    const types = (calls[0]?.body.blocks as Array<{ type: string }>).map((b) => b.type);
+    const types = (calls[0]!.body.blocks as Array<{ type: string }>).map((b) => b.type);
     expect(types).not.toContain("actions");
     expect(JSON.stringify(calls[0]?.body.blocks)).toContain("Approved");
     vi.unstubAllGlobals();

--- a/packages/slack/src/index.test.ts
+++ b/packages/slack/src/index.test.ts
@@ -69,6 +69,22 @@ describe("slack channel", () => {
     expect(text.length).toBeLessThan(3000);
   });
 
+  it("renderInteraction posts controls for every pending tool call, not just the first", () => {
+    const c = slack({ id: "s-hitl-multi", token: "t" });
+    const msg = c.renderInteraction?.(
+      [
+        { toolCallId: "call-a", toolName: "refund", input: { amount: 1 } },
+        { toolCallId: "call-b", toolName: "sendEmail", input: { to: "x" } },
+      ],
+      { event: messageEvent(), deliveryId: "d1" }
+    );
+    expect(msg).not.toBeNull();
+    const values = (msg!.blocks as any[]).flatMap((b) => b.elements ?? []).map((e: any) => e.value);
+    expect(values).toEqual(
+      expect.arrayContaining(["call-a::approve", "call-a::deny", "call-b::approve", "call-b::deny"])
+    );
+  });
+
   it("onInteraction resolves a block_actions click to a tool output; ignores messages", () => {
     const c = slack({ id: "s-hitl2", token: "t" });
     const approve = c.onInteraction?.({

--- a/packages/slack/src/index.test.ts
+++ b/packages/slack/src/index.test.ts
@@ -20,7 +20,7 @@ describe("slack channel", () => {
     expect(guardOnly.filter).toContain("event.event.type == 'message'");
     expect(guardOnly.filter).toContain("event.event.bot_id == null");
     expect(guardOnly.filter).toContain(
-      "event.event.subtype in [null, 'file_share', 'thread_broadcast']"
+      "event.event.subtype in [null,'file_share','thread_broadcast']"
     );
     expect(guardOnly.filter).toContain("event.type == 'block_actions'");
 

--- a/packages/slack/src/index.test.ts
+++ b/packages/slack/src/index.test.ts
@@ -50,6 +50,25 @@ describe("slack channel", () => {
     expect(values).toContain("call-1::deny");
   });
 
+  it("renderInteraction truncates an oversized tool input to stay under the Slack block limit", () => {
+    const c = slack({ id: "s-hitl-big", token: "t" });
+    const msg = c.renderInteraction?.(
+      [
+        {
+          toolCallId: "call-big",
+          toolName: "requestApproval",
+          input: { blob: "x".repeat(10_000) },
+        },
+      ],
+      { event: messageEvent(), deliveryId: "d1" }
+    );
+    expect(msg).not.toBeNull();
+    const section = (msg!.blocks as any[]).find((b) => b.type === "section");
+    const text = section.text.text as string;
+    expect(text).toContain("... (truncated)");
+    expect(text.length).toBeLessThan(3000);
+  });
+
   it("onInteraction resolves a block_actions click to a tool output; ignores messages", () => {
     const c = slack({ id: "s-hitl2", token: "t" });
     const approve = c.onInteraction?.({

--- a/packages/slack/src/index.test.ts
+++ b/packages/slack/src/index.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, it, vi } from "vitest";
+import { mentions, slack, toSlackMrkdwn, type SlackMessageEvent } from "./index.js";
+
+const messageEvent = (
+  over: Partial<NonNullable<SlackMessageEvent["event"]>> = {}
+): SlackMessageEvent => ({
+  type: "event_callback",
+  event: { type: "message", channel: "C9", ts: "1699999999.0001", text: "hi", ...over },
+});
+
+describe("slack channel", () => {
+  it("default inbound strips a leading bot mention", () => {
+    const c = slack({ id: "s1", token: "xoxb-t" });
+    expect(c.inbound(messageEvent({ text: "<@U123> hello there" }))).toBe("hello there");
+    expect(c.inbound(messageEvent({ text: "plain" }))).toBe("plain");
+  });
+
+  it("composes the self-message guard with a user filter, and always admits interactivity", () => {
+    const guardOnly = slack({ id: "s2", token: "t" });
+    expect(guardOnly.filter).toContain("event.event.type == 'message'");
+    expect(guardOnly.filter).toContain("event.event.bot_id == null");
+    expect(guardOnly.filter).toContain(
+      "event.event.subtype in [null,'file_share','thread_broadcast']"
+    );
+    expect(guardOnly.filter).toContain("event.type == 'block_actions'");
+
+    const withUser = slack({ id: "s3", token: "t", filter: "event.event.channel == 'C1'" });
+    expect(withUser.filter).toContain("&& (event.event.channel == 'C1')");
+    expect(withUser.filter).toContain("event.type == 'block_actions'");
+  });
+
+  it("keys one session per thread, converging message events and interactivity", () => {
+    const c = slack({ id: "s4", token: "t" });
+    expect(c.key).toBe(
+      "{body.team_id || body.team.id}:{body.event.channel || body.container.channel_id}:{body.event.thread_ts || body.event.ts || body.container.thread_ts || body.container.message_ts}"
+    );
+  });
+
+  it("renderInteraction produces Block Kit approve/deny buttons carrying the toolCallId", () => {
+    const c = slack({ id: "s-hitl", token: "t" });
+    const msg = c.renderInteraction?.(
+      [{ toolCallId: "call-1", toolName: "requestApproval", input: { amount: 50 } }],
+      {
+        event: messageEvent(),
+        deliveryId: "d1",
+      }
+    );
+    expect(msg).not.toBeNull();
+    const values = (msg!.blocks as any[]).flatMap((b) => b.elements ?? []).map((e: any) => e.value);
+    expect(values).toContain("call-1::approve");
+    expect(values).toContain("call-1::deny");
+  });
+
+  it("renderInteraction truncates an oversized tool input to stay under the Slack block limit", () => {
+    const c = slack({ id: "s-hitl-big", token: "t" });
+    const msg = c.renderInteraction?.(
+      [
+        {
+          toolCallId: "call-big",
+          toolName: "requestApproval",
+          input: { blob: "x".repeat(10_000) },
+        },
+      ],
+      { event: messageEvent(), deliveryId: "d1" }
+    );
+    expect(msg).not.toBeNull();
+    const section = (msg!.blocks as any[]).find((b) => b.type === "section");
+    const text = section.text.text as string;
+    expect(text).toContain("... (truncated)");
+    expect(text.length).toBeLessThan(3000);
+  });
+
+  it("renderInteraction posts controls for every pending tool call, not just the first", () => {
+    const c = slack({ id: "s-hitl-multi", token: "t" });
+    const msg = c.renderInteraction?.(
+      [
+        { toolCallId: "call-a", toolName: "refund", input: { amount: 1 } },
+        { toolCallId: "call-b", toolName: "sendEmail", input: { to: "x" } },
+      ],
+      { event: messageEvent(), deliveryId: "d1" }
+    );
+    expect(msg).not.toBeNull();
+    const values = (msg!.blocks as any[]).flatMap((b) => b.elements ?? []).map((e: any) => e.value);
+    expect(values).toEqual(
+      expect.arrayContaining(["call-a::approve", "call-a::deny", "call-b::approve", "call-b::deny"])
+    );
+  });
+
+  it("onInteraction resolves a block_actions click to a tool output; ignores messages", () => {
+    const c = slack({ id: "s-hitl2", token: "t" });
+    const approve = c.onInteraction?.({
+      type: "block_actions",
+      actions: [{ value: "call-9::approve" }],
+    } as never);
+    expect(approve).toEqual({ toolCallId: "call-9", output: { approved: true } });
+
+    const deny = c.onInteraction?.({
+      type: "block_actions",
+      actions: [{ value: "call-9::deny" }],
+    } as never);
+    expect(deny).toEqual({ toolCallId: "call-9", output: { approved: false } });
+
+    expect(c.onInteraction?.(messageEvent())).toBeNull();
+  });
+
+  it("finalizeInteraction replaces the controls via response_url, dropping the buttons", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: { body: string }) => {
+        calls.push({ url, body: JSON.parse(init.body) });
+        return { json: async () => ({ ok: true }) };
+      })
+    );
+    const c = slack({ id: "s-fin", token: "t" });
+    await c.finalizeInteraction?.(
+      {
+        type: "block_actions",
+        user: { id: "U42" },
+        response_url: "https://hooks.slack.test/r/1",
+        actions: [{ value: "call-1::approve" }],
+        message: {
+          blocks: [
+            { type: "section", text: { type: "mrkdwn", text: "Approval needed" } },
+            { type: "actions", elements: [{ type: "button", value: "call-1::approve" }] },
+          ],
+        },
+      } as never,
+      { toolCallId: "call-1", output: { approved: true } }
+    );
+    expect(calls[0]?.url).toBe("https://hooks.slack.test/r/1");
+    expect(calls[0]?.body.replace_original).toBe(true);
+    const types = (calls[0]!.body.blocks as Array<{ type: string }>).map((b) => b.type);
+    expect(types).not.toContain("actions");
+    expect(JSON.stringify(calls[0]?.body.blocks)).toContain("Approved");
+    vi.unstubAllGlobals();
+  });
+
+  it("finalizeInteraction is a no-op without a response_url", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const c = slack({ id: "s-fin2", token: "t" });
+    await c.finalizeInteraction?.(
+      { type: "block_actions", actions: [{ value: "x::deny" }] } as never,
+      { toolCallId: "x", output: { approved: false } }
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it("passes startOn through verbatim (not composed with the guard)", () => {
+    const none = slack({ id: "s5", token: "t" });
+    expect(none.startOn).toBeUndefined();
+
+    const summon = slack({ id: "s6", token: "t", startOn: mentions("U012BOT") });
+    expect(summon.startOn).toBe(
+      "(event.event.text contains '<@U012BOT>' || event.event.text contains '<@U012BOT|')"
+    );
+  });
+
+  it("default ack varies text on crash recovery", () => {
+    const c = slack({ id: "s7", token: "t" });
+    expect(c.ack?.(messageEvent(), { recovered: false })).toEqual({ text: "on it..." });
+    expect(c.ack?.(messageEvent(), { recovered: true })).toEqual({
+      text: "picking this back up...",
+    });
+  });
+
+  it("ack: null disables the placeholder", () => {
+    const c = slack({ id: "s8", token: "t", ack: null });
+    expect(c.ack).toBeUndefined();
+  });
+
+  it("a custom ack receives the recovery ctx", () => {
+    const c = slack({
+      id: "s9",
+      token: "t",
+      ack: (_e, ctx) => ({ text: ctx.recovered ? "resuming" : "starting" }),
+    });
+    expect(c.ack?.(messageEvent(), { recovered: false })).toEqual({ text: "starting" });
+    expect(c.ack?.(messageEvent(), { recovered: true })).toEqual({ text: "resuming" });
+  });
+
+  it("toSlackMrkdwn converts common markdown to Slack mrkdwn", () => {
+    expect(toSlackMrkdwn("**bold**")).toBe("*bold*");
+    expect(toSlackMrkdwn("__bold__")).toBe("*bold*");
+    expect(toSlackMrkdwn("## Heading")).toBe("*Heading*");
+    expect(toSlackMrkdwn("- one\n- two")).toBe("• one\n• two");
+    expect(toSlackMrkdwn("[docs](https://trigger.dev)")).toBe("<https://trigger.dev|docs>");
+    expect(toSlackMrkdwn("~~gone~~")).toBe("~gone~");
+    // A real model reply: heading + bold + bullets in one string.
+    expect(toSlackMrkdwn("## Help\n\nI can do **stuff**:\n- a\n- b")).toBe(
+      "*Help*\n\nI can do *stuff*:\n• a\n• b"
+    );
+  });
+
+  it("mentions() builds a mention predicate for one or many bot ids", () => {
+    expect(mentions("U1")).toBe(
+      "(event.event.text contains '<@U1>' || event.event.text contains '<@U1|')"
+    );
+    expect(mentions("U1", "U2")).toContain("<@U1>");
+    expect(mentions("U1", "U2")).toContain("<@U2|");
+    expect(() => mentions()).toThrow(/at least one/);
+  });
+
+  it("send posts then edits, threading the ref and using the bot token", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown>; auth: unknown }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: { body: string; headers: Record<string, string> }) => {
+        calls.push({ url, body: JSON.parse(init.body), auth: init.headers.authorization });
+        return { json: async () => ({ ok: true, ts: "1700000000.0001" }) };
+      })
+    );
+
+    const c = slack({ id: "s5", token: "xoxb-secret", apiBaseUrl: "https://mock.slack" });
+    const event = messageEvent();
+
+    const ackRes = await c.send!(
+      { text: "on it..." },
+      {
+        event,
+        deliveryId: "d1",
+        mode: "final",
+        final: false,
+      }
+    );
+    expect(ackRes.ref).toBe("1700000000.0001");
+    expect(calls[0]?.url).toBe("https://mock.slack/chat.postMessage");
+    expect(calls[0]?.auth).toBe("Bearer xoxb-secret");
+    expect(calls[0]?.body.channel).toBe("C9");
+    expect(calls[0]?.body.thread_ts).toBe("1699999999.0001");
+
+    await c.send!(
+      { text: "done" },
+      {
+        event,
+        deliveryId: "d1",
+        previousRef: ackRes.ref,
+        mode: "final",
+        final: true,
+      }
+    );
+    expect(calls[1]?.url).toBe("https://mock.slack/chat.update");
+    expect(calls[1]?.body.ts).toBe("1700000000.0001");
+    expect(calls[1]?.body.text).toBe("done");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("send targets the thread from a block_actions payload (HITL resume egress)", async () => {
+    const calls: Array<{ body: Record<string, unknown> }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: { body: string }) => {
+        calls.push({ body: JSON.parse(init.body) });
+        return { json: async () => ({ ok: true, ts: "1700000000.9" }) };
+      })
+    );
+    const c = slack({ id: "s-resume", token: "t", apiBaseUrl: "https://mock.slack" });
+    const interaction = {
+      type: "block_actions",
+      team: { id: "T1" },
+      container: {
+        type: "message",
+        channel_id: "C42",
+        thread_ts: "1699999999.0001",
+        message_ts: "1700000000.5",
+      },
+      actions: [{ value: "call-1::approve" }],
+    };
+    await c.send!(
+      { text: "refund approved and processed" },
+      {
+        event: interaction as never,
+        deliveryId: "d-resume",
+        mode: "final",
+        final: true,
+      }
+    );
+    expect(calls[0]?.body.channel).toBe("C42");
+    expect(calls[0]?.body.thread_ts).toBe("1699999999.0001");
+    vi.unstubAllGlobals();
+  });
+
+  it("send throws when the bot is not in the channel", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ json: async () => ({ ok: false, error: "not_in_channel" }) }))
+    );
+    const c = slack({ id: "s6", token: "t", apiBaseUrl: "https://mock.slack" });
+    await expect(
+      c.send!({ text: "x" }, { event: messageEvent(), deliveryId: "d", mode: "final", final: true })
+    ).rejects.toThrow(/not_in_channel/);
+    vi.unstubAllGlobals();
+  });
+
+  it("react adds/removes an emoji on the triggering message (colons stripped)", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: { body: string }) => {
+        calls.push({ url, body: JSON.parse(init.body) });
+        return { json: async () => ({ ok: true }) };
+      })
+    );
+    const c = slack({
+      id: "s7",
+      token: "xoxb-secret",
+      apiBaseUrl: "https://mock.slack",
+      reactions: { working: "eyes", done: "white_check_mark" },
+    });
+    expect(c.reactions).toEqual({ working: "eyes", done: "white_check_mark" });
+
+    await c.react!({ name: "eyes" }, { event: messageEvent(), deliveryId: "d1" });
+    expect(calls[0]?.url).toBe("https://mock.slack/reactions.add");
+    expect(calls[0]?.body).toMatchObject({
+      channel: "C9",
+      timestamp: "1699999999.0001",
+      name: "eyes",
+    });
+
+    await c.react!(
+      { name: ":white_check_mark:", remove: true },
+      { event: messageEvent(), deliveryId: "d1" }
+    );
+    expect(calls[1]?.url).toBe("https://mock.slack/reactions.remove");
+    expect(calls[1]?.body.name).toBe("white_check_mark");
+    vi.unstubAllGlobals();
+  });
+
+  it("react swallows already_reacted (idempotent)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ json: async () => ({ ok: false, error: "already_reacted" }) }))
+    );
+    const c = slack({ id: "s8", token: "t", apiBaseUrl: "https://mock.slack" });
+    await expect(
+      c.react!({ name: "eyes" }, { event: messageEvent(), deliveryId: "d1" })
+    ).resolves.toBeUndefined();
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -189,6 +189,13 @@ export function slack<TEvent = SlackMessageEvent>(
 }
 
 /**
+ * Cap for the serialized tool input in an approval block. A Slack section `text` field accepts about
+ * 3000 characters; staying well under keeps a large input from failing chat.postMessage with
+ * `invalid_blocks` and dropping the approval controls.
+ */
+const MAX_INTERACTION_INPUT_CHARS = 2500;
+
+/**
  * Default HITL controls: render each pending human-decision tool as a Block Kit approve/deny pair. The
  * button `value` carries `${toolCallId}::${decision}` so `onInteraction` can resolve the exact tool.
  */
@@ -198,7 +205,15 @@ function defaultSlackRenderInteraction(
 ): ChannelMessage | null {
   const call = pending[0];
   if (!call) return null;
-  const detail = call.input !== undefined ? "\n```" + safeStringify(call.input) + "```" : "";
+  let detail = "";
+  if (call.input !== undefined) {
+    const serialized = safeStringify(call.input);
+    const shown =
+      serialized.length > MAX_INTERACTION_INPUT_CHARS
+        ? serialized.slice(0, MAX_INTERACTION_INPUT_CHARS) + "\n... (truncated)"
+        : serialized;
+    detail = "\n```" + shown + "```";
+  }
   return {
     text: `Approval needed: ${call.toolName}`,
     blocks: [

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -271,8 +271,9 @@ function defaultSlackOnInteraction(event: unknown): ChannelInteractionResolution
 /**
  * After a decision, collapse the controls via the interaction's `response_url` (Slack's documented path:
  * the click gets a bare 200 ack, then `response_url` accepts `replace_original` for up to 30 minutes).
- * Keeps the original context blocks, drops the `actions` block, and appends the outcome, so the buttons
- * can't be clicked again. No-op when the payload carries no `response_url` (e.g. a synthetic test event).
+ * Keeps the original context blocks, drops ONLY the resolved tool call's `actions` block (so approve/deny
+ * controls for any other pending tool calls in the same message survive), and appends the outcome. No-op
+ * when the payload carries no `response_url` (e.g. a synthetic test event).
  */
 async function defaultSlackFinalizeInteraction(
   event: unknown,
@@ -292,7 +293,14 @@ async function defaultSlackFinalizeInteraction(
   const who = payload.user?.id ? ` by <@${payload.user.id}>` : "";
 
   const original = Array.isArray(payload.message?.blocks) ? payload.message!.blocks : [];
-  const kept = original.filter((b) => (b as { type?: string })?.type !== "actions");
+  const resolvedPrefix = `${resolution.toolCallId}::`;
+  const kept = original.filter((block) => {
+    const actionBlock = block as { type?: string; elements?: Array<{ value?: string }> };
+    return (
+      actionBlock.type !== "actions" ||
+      !actionBlock.elements?.some((element) => element.value?.startsWith(resolvedPrefix))
+    );
+  });
   const blocks = [
     ...kept,
     { type: "context", elements: [{ type: "mrkdwn", text: `${icon} *${decision}*${who}` }] },

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -326,7 +326,7 @@ function defaultSlackInbound(event: SlackMessageEvent): string {
  */
 export function toSlackMrkdwn(md: string): string {
   return md
-    .replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g, "<$2|$1>")
+    .replace(/\[([^\]\n]{1,300})\]\((https?:\/\/[^)\s]{1,2000})\)/g, "<$2|$1>")
     .replace(/^[ \t]{0,3}#{1,6}[ \t]+(.+?)[ \t]*#*[ \t]*$/gm, "*$1*")
     .replace(/\*\*([^*\n]+)\*\*/g, "*$1*")
     .replace(/__([^_\n]+)__/g, "*$1*")

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -1,0 +1,449 @@
+import { chat } from "@trigger.dev/sdk/ai";
+import type {
+  ChannelAckCtx,
+  ChannelConnector,
+  ChannelInteractionCtx,
+  ChannelInteractionResolution,
+  ChannelMessage,
+  ChannelMessageInput,
+  ChannelPendingToolCall,
+  ChannelReaction,
+  ChannelReactCtx,
+  ChannelReactions,
+  ChannelReply,
+  ChannelSendCtx,
+} from "@trigger.dev/sdk/ai";
+import type {
+  WebhookHandshakeConfig,
+  WebhookHmacConfig,
+  WebhookSource,
+} from "@trigger.dev/core/v3";
+
+// A minimal Slack Events API envelope; pass your own event type for fuller typing.
+export type SlackMessageEvent = {
+  type: string;
+  event_id?: string;
+  team_id?: string;
+  event?: {
+    type: string;
+    subtype?: string;
+    text?: string;
+    user?: string;
+    channel?: string;
+    ts?: string;
+    thread_ts?: string;
+    bot_id?: string;
+  };
+};
+
+// Slack signs `X-Slack-Signature: v0=<hex>` over `v0:{timestamp}:{body}`; the timestamp rides in
+// `X-Slack-Request-Timestamp`. You paste the Slack signing secret as the endpoint's signing secret.
+const SLACK_VERIFIER: WebhookHmacConfig = {
+  scheme: "hmac",
+  algorithm: "sha256",
+  encoding: "hex",
+  signatureHeader: "x-slack-signature",
+  signature: { fieldSeparator: "=", field: "v0" },
+  timestamp: {
+    source: { from: "header", name: "x-slack-request-timestamp" },
+    toleranceSeconds: 300,
+  },
+  signingString: { template: "v0:{timestamp}:{body}" },
+  idempotencyField: { from: "body", name: "event_id" },
+  formPayload: { field: "payload" },
+};
+
+// Slack's Event Subscriptions url_verification handshake: echo the challenge, do not record/route.
+const SLACK_HANDSHAKE: WebhookHandshakeConfig = {
+  matchPath: "type",
+  matchValue: "url_verification",
+  respondPath: "challenge",
+};
+
+/**
+ * One session per Slack thread, for BOTH message events and block_actions interactivity (a button click
+ * on the in-thread ack). thread_ts is only on replies, so a thread-STARTING message falls back to ts;
+ * interactivity carries the same thread via `container.thread_ts` / `container.message_ts`. The `||`
+ * operator resolves to the first non-empty path, so both surfaces converge on one externalId.
+ */
+const DEFAULT_KEY =
+  "{body.team_id || body.team.id}:{body.event.channel || body.container.channel_id}:{body.event.thread_ts || body.event.ts || body.container.thread_ts || body.container.message_ts}";
+
+/**
+ * Mandatory loop guard for MESSAGE events: `bot_id == null` drops the agent's own posts (no reply loop);
+ * the subtype allowlist keeps real user messages (absent subtype matches `null`) and drops system/edit
+ * events. Interactivity (block_actions) is a separate surface, admitted via INTERACTIVITY_PASS.
+ */
+const SELF_MESSAGE_GUARD =
+  "event.event.type == 'message' && event.event.bot_id == null && event.event.subtype in [null,'file_share','thread_broadcast']";
+
+/** Interactivity callbacks (button clicks) always pass the loop guard; onInteraction resolves them. */
+const INTERACTIVITY_PASS = "event.type == 'block_actions'";
+
+const SLACK_API_BASE_URL = "https://slack.com/api";
+
+export type SlackToken<TEvent> = string | ((event: TEvent) => string | Promise<string>);
+
+export type SlackChannelOptions<TEvent> = {
+  id: string;
+  /** Bot token (xoxb-...). A string for one workspace, or a resolver keyed on the event's team_id. */
+  token: SlackToken<TEvent>;
+  /** Session key template. Defaults to one session per thread. */
+  key?: string;
+  /** Map a Slack event to the turn's message. Defaults to the message text with the bot mention stripped. */
+  inbound?: (event: TEvent) => ChannelMessageInput;
+  /** Map the agent's reply to a Slack message. Defaults to the reply text (null posts nothing). */
+  outbound?: (reply: ChannelReply) => ChannelMessage | null;
+  /** Placeholder posted while the agent works, then edited to the answer. `null` posts only the answer. */
+  ack?: ((event: TEvent, ctx: ChannelAckCtx) => ChannelMessage | null) | null;
+  /** Extra server-side filter, composed AND with the mandatory self-message guard. */
+  filter?: string;
+  /**
+   * Only start a NEW session when an event matches this filter; existing threads always resume. Use it
+   * to summon the bot on mention, then continue the thread silently, e.g.
+   * `startOn: "event.event.text contains '<@U012BOT>'"` (your bot's user id).
+   */
+  startOn?: string;
+  /** "final" (default): ack then one edit. "stream": debounced live edits (fast-follow). */
+  delivery?: "final" | "stream";
+  /**
+   * Lifecycle emoji reactions on the user's message (names without colons, e.g. "eyes"): `working` is
+   * added while the turn runs and swapped to `done`, or `error` on failure. Needs the `reactions:write`
+   * scope. The agent can also react itself via `run({ channel })`.
+   */
+  reactions?: ChannelReactions<TEvent>;
+  /** Override the Slack Web API base URL (for testing against a mock). */
+  apiBaseUrl?: string;
+};
+
+/**
+ * Build a predicate that matches when the bot is @mentioned, for `startOn` (summon-on-mention) or
+ * `filter`. Pass your bot's user id(s) from the Slack app (they start with `U`); matches both the plain
+ * `<@U012BOT>` and labelled `<@U012BOT|name>` mention forms:
+ * `slack({ id, token, startOn: mentions("U012BOT") })`.
+ */
+export function mentions(...botUserIds: string[]): string {
+  const ids = botUserIds.filter(Boolean);
+  if (ids.length === 0) throw new Error("mentions() requires at least one bot user id");
+  const clauses = ids.flatMap((id) => [
+    `event.event.text contains '<@${id}>'`,
+    `event.event.text contains '<@${id}|'`,
+  ]);
+  return `(${clauses.join(" || ")})`;
+}
+
+/**
+ * A Slack webhook source for `webhook({ source })`: HMAC signature verification, the one-time
+ * `url_verification` handshake Slack requires before an Event Subscriptions URL can be saved, and
+ * form-encoded interactivity parsing. Paste your Slack app's Signing Secret as the endpoint secret.
+ * For a full chat-agent frontend (per-thread sessions, replies, HITL) use `slack()` instead.
+ */
+export function webhookSource<TEvent = SlackMessageEvent>(): WebhookSource<TEvent> {
+  return {
+    provider: "slack",
+    verifier: { kind: "config", config: SLACK_VERIFIER, handshake: SLACK_HANDSHAKE },
+    secretProvisioning: "provider",
+  };
+}
+
+/**
+ * Slack as a chat frontend for an agent. List on `chat.agent({ channels: [slack({...})] })`: verified
+ * Slack messages in a thread are routed to a durable per-thread session and run as turns, and the reply
+ * is posted back to the thread. Set the endpoint's signing secret to your Slack signing secret; pass the
+ * bot token as `token`. Subscribe the app to `message.channels` (and invite the bot to the channel).
+ */
+export function slack<TEvent = SlackMessageEvent>(
+  options: SlackChannelOptions<TEvent>
+): ChannelConnector<TEvent> {
+  const apiBaseUrl = options.apiBaseUrl ?? SLACK_API_BASE_URL;
+  const source: WebhookSource<TEvent> = webhookSource<TEvent>();
+  const messageFilter = options.filter
+    ? `${SELF_MESSAGE_GUARD} && (${options.filter})`
+    : SELF_MESSAGE_GUARD;
+  const filter = `${INTERACTIVITY_PASS} || (${messageFilter})`;
+  const ack =
+    options.ack === null
+      ? undefined
+      : (options.ack ??
+        ((_event: TEvent, ctx: ChannelAckCtx) => ({
+          text: ctx.recovered ? "picking this back up..." : "on it...",
+        })));
+
+  return chat.channels.custom<WebhookSource<TEvent>>({
+    id: options.id,
+    source,
+    key: options.key ?? DEFAULT_KEY,
+    inbound: options.inbound ?? (defaultSlackInbound as (event: TEvent) => ChannelMessageInput),
+    outbound: options.outbound ?? defaultSlackOutbound,
+    ack,
+    send: makeSlackSend(options.token, apiBaseUrl),
+    renderInteraction: defaultSlackRenderInteraction as (
+      pending: ChannelPendingToolCall[],
+      ctx: ChannelInteractionCtx<TEvent>
+    ) => ChannelMessage | null,
+    onInteraction: defaultSlackOnInteraction as (
+      event: TEvent
+    ) => ChannelInteractionResolution | null,
+    finalizeInteraction: defaultSlackFinalizeInteraction as (
+      event: TEvent,
+      resolution: ChannelInteractionResolution
+    ) => Promise<void>,
+    // Composed at runtime (guard + optional user filter), so it bypasses the literal-only filter
+    // validator; the user's `filter` arg was already validated on the way in.
+    filter: filter as never,
+    startOn: options.startOn as never,
+    delivery: options.delivery ?? "final",
+    react: makeSlackReact(options.token, apiBaseUrl),
+    reactions: options.reactions,
+  });
+}
+
+/**
+ * Cap for the serialized tool input in an approval block. A Slack section `text` field accepts about
+ * 3000 characters; staying well under keeps a large input from failing chat.postMessage with
+ * `invalid_blocks` and dropping the approval controls.
+ */
+const MAX_INTERACTION_INPUT_CHARS = 2500;
+
+/**
+ * Default HITL controls: render each pending human-decision tool as a Block Kit approve/deny pair. The
+ * button `value` carries `${toolCallId}::${decision}` so `onInteraction` can resolve the exact tool.
+ */
+function defaultSlackRenderInteraction(
+  pending: ChannelPendingToolCall[],
+  _ctx: ChannelInteractionCtx<unknown>
+): ChannelMessage | null {
+  if (pending.length === 0) return null;
+
+  const blocks = pending.flatMap((call) => {
+    let detail = "";
+    if (call.input !== undefined) {
+      const serialized = safeStringify(call.input);
+      const shown =
+        serialized.length > MAX_INTERACTION_INPUT_CHARS
+          ? serialized.slice(0, MAX_INTERACTION_INPUT_CHARS) + "\n... (truncated)"
+          : serialized;
+      detail = "\n```" + shown + "```";
+    }
+    return [
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: `*Approval needed* for \`${call.toolName}\`${detail}` },
+      },
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            action_id: "trigger_hitl_approve",
+            style: "primary",
+            text: { type: "plain_text", text: "Approve" },
+            value: `${call.toolCallId}::approve`,
+          },
+          {
+            type: "button",
+            action_id: "trigger_hitl_deny",
+            style: "danger",
+            text: { type: "plain_text", text: "Deny" },
+            value: `${call.toolCallId}::deny`,
+          },
+        ],
+      },
+    ];
+  });
+
+  return {
+    text:
+      pending.length === 1
+        ? `Approval needed: ${pending[0]!.toolName}`
+        : `Approval needed: ${pending.length} tool calls`,
+    blocks,
+  };
+}
+
+/**
+ * Default interaction resolver: a `block_actions` button click resolves the tool named in its `value`
+ * (`${toolCallId}::approve|deny`) to `{ approved }`. Any non-interactivity event returns null (the
+ * normal message path handles it).
+ */
+function defaultSlackOnInteraction(event: unknown): ChannelInteractionResolution | null {
+  const payload = event as { type?: string; actions?: Array<{ value?: string }> };
+  if (payload?.type !== "block_actions") return null;
+  const action = (payload.actions ?? []).find(
+    (a) => typeof a?.value === "string" && a.value.includes("::")
+  );
+  if (!action?.value) return null;
+  const [toolCallId, decision] = action.value.split("::");
+  if (!toolCallId || (decision !== "approve" && decision !== "deny")) return null;
+  return { toolCallId, output: { approved: decision === "approve" } };
+}
+
+/**
+ * After a decision, collapse the controls via the interaction's `response_url` (Slack's documented path:
+ * the click gets a bare 200 ack, then `response_url` accepts `replace_original` for up to 30 minutes).
+ * Keeps the original context blocks, drops ONLY the resolved tool call's `actions` block (so approve/deny
+ * controls for any other pending tool calls in the same message survive), and appends the outcome. No-op
+ * when the payload carries no `response_url` (e.g. a synthetic test event).
+ */
+async function defaultSlackFinalizeInteraction(
+  event: unknown,
+  resolution: ChannelInteractionResolution
+): Promise<void> {
+  const payload = event as {
+    response_url?: string;
+    user?: { id?: string };
+    message?: { blocks?: unknown[] };
+  };
+  const responseUrl = payload?.response_url;
+  if (!responseUrl) return;
+
+  const approved = (resolution.output as { approved?: boolean } | undefined)?.approved === true;
+  const decision = approved ? "Approved" : "Denied";
+  const icon = approved ? ":white_check_mark:" : ":x:";
+  const who = payload.user?.id ? ` by <@${payload.user.id}>` : "";
+
+  const original = Array.isArray(payload.message?.blocks) ? payload.message!.blocks : [];
+  const resolvedPrefix = `${resolution.toolCallId}::`;
+  const kept = original.filter((block) => {
+    const actionBlock = block as { type?: string; elements?: Array<{ value?: string }> };
+    return (
+      actionBlock.type !== "actions" ||
+      !actionBlock.elements?.some((element) => element.value?.startsWith(resolvedPrefix))
+    );
+  });
+  const blocks = [
+    ...kept,
+    { type: "context", elements: [{ type: "mrkdwn", text: `${icon} *${decision}*${who}` }] },
+  ];
+
+  await fetch(responseUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ replace_original: true, text: `${decision}${who}`, blocks }),
+  });
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+// Strip a leading bot mention (`<@U123> hi` -> `hi`) so the agent sees the plain text.
+function defaultSlackInbound(event: SlackMessageEvent): string {
+  return (event.event?.text ?? "").replace(/^\s*<@[A-Z0-9]+>\s*/i, "");
+}
+
+/**
+ * Convert common GitHub-flavored markdown (what a model emits) to Slack mrkdwn: `**bold**` -> `*bold*`,
+ * `#` headings -> bold, `-`/`*` bullets -> `•`, `[t](url)` -> `<url|t>`, `~~s~~` -> `~s~`. Applied by the
+ * default outbound; a custom `outbound` controls its own formatting (call this from it if you want it).
+ * Note: single-asterisk `*italic*` is left as-is, so it renders bold in Slack (rare in model output).
+ */
+export function toSlackMrkdwn(md: string): string {
+  return md
+    .replace(/\[([^\]\n]{1,300})\]\((https?:\/\/[^)\s]{1,2000})\)/g, "<$2|$1>")
+    .replace(/^[ \t]{0,3}#{1,6}[ \t]+(.+?)[ \t]*#*[ \t]*$/gm, "*$1*")
+    .replace(/\*\*([^*\n]+)\*\*/g, "*$1*")
+    .replace(/__([^_\n]+)__/g, "*$1*")
+    .replace(/~~([^~\n]+)~~/g, "~$1~")
+    .replace(/^([ \t]*)[-*+][ \t]+/gm, "$1• ");
+}
+
+function defaultSlackOutbound(reply: ChannelReply): ChannelMessage | null {
+  return reply.text ? { text: toSlackMrkdwn(reply.text) } : null;
+}
+
+function makeSlackSend<TEvent>(token: SlackToken<TEvent>, apiBaseUrl: string) {
+  return async (
+    message: ChannelMessage,
+    ctx: ChannelSendCtx<TEvent>
+  ): Promise<{ ref?: string }> => {
+    const event = ctx.event as SlackMessageEvent & {
+      container?: { channel_id?: string; thread_ts?: string; message_ts?: string };
+      channel?: { id?: string };
+    };
+    const channel = event.event?.channel ?? event.container?.channel_id ?? event.channel?.id;
+    const threadTs =
+      event.event?.thread_ts ??
+      event.event?.ts ??
+      event.container?.thread_ts ??
+      event.container?.message_ts;
+
+    const resolve = () => (typeof token === "function" ? token(ctx.event) : token);
+    let botToken = await resolve();
+
+    const blocks = (message as { blocks?: unknown }).blocks;
+    const hasBlocks = Array.isArray(blocks) && blocks.length > 0;
+
+    const post = async () =>
+      ctx.previousRef
+        ? slackApi(apiBaseUrl, "chat.update", botToken, {
+            channel,
+            ts: ctx.previousRef,
+            text: message.text,
+            blocks: hasBlocks ? blocks : [],
+          })
+        : slackApi(apiBaseUrl, "chat.postMessage", botToken, {
+            channel,
+            thread_ts: threadTs,
+            text: message.text,
+            ...(hasBlocks ? { blocks } : {}),
+          });
+
+    let result = await post();
+    // Re-resolve once on an auth error (token rotation) when a resolver was supplied.
+    if (!result.ok && typeof token === "function" && isAuthError(result.error)) {
+      botToken = await resolve();
+      result = await post();
+    }
+    if (!result.ok) {
+      // not_in_channel / channel_not_found is the common one: the bot isn't in the channel. Surface it.
+      throw new Error(
+        `slack ${ctx.previousRef ? "chat.update" : "chat.postMessage"} failed: ${result.error}`
+      );
+    }
+    return { ref: ctx.previousRef ?? result.ts };
+  };
+}
+
+function isAuthError(error: string | undefined): boolean {
+  return error === "invalid_auth" || error === "token_revoked" || error === "account_inactive";
+}
+
+// Add/remove an emoji reaction on the triggering Slack message (needs the reactions:write scope).
+function makeSlackReact<TEvent>(token: SlackToken<TEvent>, apiBaseUrl: string) {
+  return async (reaction: ChannelReaction, ctx: ChannelReactCtx<TEvent>): Promise<void> => {
+    const event = ctx.event as SlackMessageEvent;
+    const channel = event.event?.channel;
+    const timestamp = event.event?.ts;
+    const name = reaction.name.replace(/^:|:$/g, "");
+    if (!channel || !timestamp || !name) return;
+    const botToken = typeof token === "function" ? await token(ctx.event) : token;
+    const method = reaction.remove ? "reactions.remove" : "reactions.add";
+    const result = await slackApi(apiBaseUrl, method, botToken, { channel, timestamp, name });
+    // already_reacted / no_reaction are benign idempotent outcomes; surface anything else.
+    if (!result.ok && result.error !== "already_reacted" && result.error !== "no_reaction") {
+      throw new Error(`slack ${method} failed: ${result.error}`);
+    }
+  };
+}
+
+async function slackApi(
+  baseUrl: string,
+  method: string,
+  token: string,
+  body: Record<string, unknown>
+): Promise<{ ok: boolean; ts?: string; error?: string }> {
+  const res = await fetch(`${baseUrl}/${method}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+  return (await res.json()) as { ok: boolean; ts?: string; error?: string };
+}

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -145,7 +145,7 @@ export function slack<TEvent = SlackMessageEvent>(
   const source: WebhookSource<TEvent> = {
     provider: "slack",
     verifier: { kind: "config", config: SLACK_VERIFIER, handshake: SLACK_HANDSHAKE },
-    secretProvisioning: "integrator",
+    secretProvisioning: "provider",
   };
   const messageFilter = options.filter
     ? `${SELF_MESSAGE_GUARD} && (${options.filter})`

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -203,20 +203,19 @@ function defaultSlackRenderInteraction(
   pending: ChannelPendingToolCall[],
   _ctx: ChannelInteractionCtx<unknown>
 ): ChannelMessage | null {
-  const call = pending[0];
-  if (!call) return null;
-  let detail = "";
-  if (call.input !== undefined) {
-    const serialized = safeStringify(call.input);
-    const shown =
-      serialized.length > MAX_INTERACTION_INPUT_CHARS
-        ? serialized.slice(0, MAX_INTERACTION_INPUT_CHARS) + "\n... (truncated)"
-        : serialized;
-    detail = "\n```" + shown + "```";
-  }
-  return {
-    text: `Approval needed: ${call.toolName}`,
-    blocks: [
+  if (pending.length === 0) return null;
+
+  const blocks = pending.flatMap((call) => {
+    let detail = "";
+    if (call.input !== undefined) {
+      const serialized = safeStringify(call.input);
+      const shown =
+        serialized.length > MAX_INTERACTION_INPUT_CHARS
+          ? serialized.slice(0, MAX_INTERACTION_INPUT_CHARS) + "\n... (truncated)"
+          : serialized;
+      detail = "\n```" + shown + "```";
+    }
+    return [
       {
         type: "section",
         text: { type: "mrkdwn", text: `*Approval needed* for \`${call.toolName}\`${detail}` },
@@ -240,7 +239,15 @@ function defaultSlackRenderInteraction(
           },
         ],
       },
-    ],
+    ];
+  });
+
+  return {
+    text:
+      pending.length === 1
+        ? `Approval needed: ${pending[0]!.toolName}`
+        : `Approval needed: ${pending.length} tool calls`,
+    blocks,
   };
 }
 

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -366,7 +366,7 @@ function makeSlackSend<TEvent>(token: SlackToken<TEvent>, apiBaseUrl: string) {
     let botToken = await resolve();
 
     const blocks = (message as { blocks?: unknown }).blocks;
-    const rich = Array.isArray(blocks) && blocks.length > 0 ? { blocks } : {};
+    const hasBlocks = Array.isArray(blocks) && blocks.length > 0;
 
     const post = async () =>
       ctx.previousRef
@@ -374,13 +374,13 @@ function makeSlackSend<TEvent>(token: SlackToken<TEvent>, apiBaseUrl: string) {
             channel,
             ts: ctx.previousRef,
             text: message.text,
-            ...rich,
+            blocks: hasBlocks ? blocks : [],
           })
         : slackApi(apiBaseUrl, "chat.postMessage", botToken, {
             channel,
             thread_ts: threadTs,
             text: message.text,
-            ...rich,
+            ...(hasBlocks ? { blocks } : {}),
           });
 
     let result = await post();

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -133,6 +133,20 @@ export function mentions(...botUserIds: string[]): string {
 }
 
 /**
+ * A Slack webhook source for `webhook({ source })`: HMAC signature verification, the one-time
+ * `url_verification` handshake Slack requires before an Event Subscriptions URL can be saved, and
+ * form-encoded interactivity parsing. Paste your Slack app's Signing Secret as the endpoint secret.
+ * For a full chat-agent frontend (per-thread sessions, replies, HITL) use `slack()` instead.
+ */
+export function webhookSource<TEvent = SlackMessageEvent>(): WebhookSource<TEvent> {
+  return {
+    provider: "slack",
+    verifier: { kind: "config", config: SLACK_VERIFIER, handshake: SLACK_HANDSHAKE },
+    secretProvisioning: "provider",
+  };
+}
+
+/**
  * Slack as a chat frontend for an agent. List on `chat.agent({ channels: [slack({...})] })`: verified
  * Slack messages in a thread are routed to a durable per-thread session and run as turns, and the reply
  * is posted back to the thread. Set the endpoint's signing secret to your Slack signing secret; pass the
@@ -142,11 +156,7 @@ export function slack<TEvent = SlackMessageEvent>(
   options: SlackChannelOptions<TEvent>
 ): ChannelConnector<TEvent> {
   const apiBaseUrl = options.apiBaseUrl ?? SLACK_API_BASE_URL;
-  const source: WebhookSource<TEvent> = {
-    provider: "slack",
-    verifier: { kind: "config", config: SLACK_VERIFIER, handshake: SLACK_HANDSHAKE },
-    secretProvisioning: "provider",
-  };
+  const source: WebhookSource<TEvent> = webhookSource<TEvent>();
   const messageFilter = options.filter
     ? `${SELF_MESSAGE_GUARD} && (${options.filter})`
     : SELF_MESSAGE_GUARD;

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -1,0 +1,409 @@
+import { chat } from "@trigger.dev/sdk/ai";
+import type {
+  ChannelAckCtx,
+  ChannelConnector,
+  ChannelInteractionCtx,
+  ChannelInteractionResolution,
+  ChannelMessage,
+  ChannelMessageInput,
+  ChannelPendingToolCall,
+  ChannelReaction,
+  ChannelReactCtx,
+  ChannelReactions,
+  ChannelReply,
+  ChannelSendCtx,
+} from "@trigger.dev/sdk/ai";
+import type {
+  WebhookHandshakeConfig,
+  WebhookHmacConfig,
+  WebhookSource,
+} from "@trigger.dev/core/v3";
+
+// A minimal Slack Events API envelope; pass your own event type for fuller typing.
+export type SlackMessageEvent = {
+  type: string;
+  event_id?: string;
+  team_id?: string;
+  event?: {
+    type: string;
+    subtype?: string;
+    text?: string;
+    user?: string;
+    channel?: string;
+    ts?: string;
+    thread_ts?: string;
+    bot_id?: string;
+  };
+};
+
+// Slack signs `X-Slack-Signature: v0=<hex>` over `v0:{timestamp}:{body}`; the timestamp rides in
+// `X-Slack-Request-Timestamp`. You paste the Slack signing secret as the endpoint's signing secret.
+const SLACK_VERIFIER: WebhookHmacConfig = {
+  scheme: "hmac",
+  algorithm: "sha256",
+  encoding: "hex",
+  signatureHeader: "x-slack-signature",
+  signature: { fieldSeparator: "=", field: "v0" },
+  timestamp: {
+    source: { from: "header", name: "x-slack-request-timestamp" },
+    toleranceSeconds: 300,
+  },
+  signingString: { template: "v0:{timestamp}:{body}" },
+  idempotencyField: { from: "body", name: "event_id" },
+  formPayload: { field: "payload" },
+};
+
+// Slack's Event Subscriptions url_verification handshake: echo the challenge, do not record/route.
+const SLACK_HANDSHAKE: WebhookHandshakeConfig = {
+  matchPath: "type",
+  matchValue: "url_verification",
+  respondPath: "challenge",
+};
+
+/**
+ * One session per Slack thread, for BOTH message events and block_actions interactivity (a button click
+ * on the in-thread ack). thread_ts is only on replies, so a thread-STARTING message falls back to ts;
+ * interactivity carries the same thread via `container.thread_ts` / `container.message_ts`. The `||`
+ * operator resolves to the first non-empty path, so both surfaces converge on one externalId.
+ */
+const DEFAULT_KEY =
+  "{body.team_id || body.team.id}:{body.event.channel || body.container.channel_id}:{body.event.thread_ts || body.event.ts || body.container.thread_ts || body.container.message_ts}";
+
+/**
+ * Mandatory loop guard for MESSAGE events: `bot_id == null` drops the agent's own posts (no reply loop);
+ * the subtype allowlist keeps real user messages (absent subtype matches `null`) and drops system/edit
+ * events. Interactivity (block_actions) is a separate surface, admitted via INTERACTIVITY_PASS.
+ */
+const SELF_MESSAGE_GUARD =
+  "event.event.type == 'message' && event.event.bot_id == null && event.event.subtype in [null, 'file_share', 'thread_broadcast']";
+
+/** Interactivity callbacks (button clicks) always pass the loop guard; onInteraction resolves them. */
+const INTERACTIVITY_PASS = "event.type == 'block_actions'";
+
+const SLACK_API_BASE_URL = "https://slack.com/api";
+
+export type SlackToken<TEvent> = string | ((event: TEvent) => string | Promise<string>);
+
+export type SlackChannelOptions<TEvent> = {
+  id: string;
+  /** Bot token (xoxb-...). A string for one workspace, or a resolver keyed on the event's team_id. */
+  token: SlackToken<TEvent>;
+  /** Session key template. Defaults to one session per thread. */
+  key?: string;
+  /** Map a Slack event to the turn's message. Defaults to the message text with the bot mention stripped. */
+  inbound?: (event: TEvent) => ChannelMessageInput;
+  /** Map the agent's reply to a Slack message. Defaults to the reply text (null posts nothing). */
+  outbound?: (reply: ChannelReply) => ChannelMessage | null;
+  /** Placeholder posted while the agent works, then edited to the answer. `null` posts only the answer. */
+  ack?: ((event: TEvent, ctx: ChannelAckCtx) => ChannelMessage | null) | null;
+  /** Extra server-side filter, composed AND with the mandatory self-message guard. */
+  filter?: string;
+  /**
+   * Only start a NEW session when an event matches this filter; existing threads always resume. Use it
+   * to summon the bot on mention, then continue the thread silently, e.g.
+   * `startOn: "event.event.text contains '<@U012BOT>'"` (your bot's user id).
+   */
+  startOn?: string;
+  /** "final" (default): ack then one edit. "stream": debounced live edits (fast-follow). */
+  delivery?: "final" | "stream";
+  /**
+   * Lifecycle emoji reactions on the user's message (names without colons, e.g. "eyes"): `working` is
+   * added while the turn runs and swapped to `done`, or `error` on failure. Needs the `reactions:write`
+   * scope. The agent can also react itself via `run({ channel })`.
+   */
+  reactions?: ChannelReactions<TEvent>;
+  /** Override the Slack Web API base URL (for testing against a mock). */
+  apiBaseUrl?: string;
+};
+
+/**
+ * Build a predicate that matches when the bot is @mentioned, for `startOn` (summon-on-mention) or
+ * `filter`. Pass your bot's user id(s) from the Slack app (they start with `U`); matches both the plain
+ * `<@U012BOT>` and labelled `<@U012BOT|name>` mention forms:
+ * `slack({ id, token, startOn: mentions("U012BOT") })`.
+ */
+export function mentions(...botUserIds: string[]): string {
+  const ids = botUserIds.filter(Boolean);
+  if (ids.length === 0) throw new Error("mentions() requires at least one bot user id");
+  const clauses = ids.flatMap((id) => [
+    `event.event.text contains '<@${id}>'`,
+    `event.event.text contains '<@${id}|'`,
+  ]);
+  return `(${clauses.join(" || ")})`;
+}
+
+/**
+ * Slack as a chat frontend for an agent. List on `chat.agent({ channels: [slack({...})] })`: verified
+ * Slack messages in a thread are routed to a durable per-thread session and run as turns, and the reply
+ * is posted back to the thread. Set the endpoint's signing secret to your Slack signing secret; pass the
+ * bot token as `token`. Subscribe the app to `message.channels` (and invite the bot to the channel).
+ */
+export function slack<TEvent = SlackMessageEvent>(
+  options: SlackChannelOptions<TEvent>
+): ChannelConnector<TEvent> {
+  const apiBaseUrl = options.apiBaseUrl ?? SLACK_API_BASE_URL;
+  const source: WebhookSource<TEvent> = {
+    provider: "slack",
+    verifier: { kind: "config", config: SLACK_VERIFIER, handshake: SLACK_HANDSHAKE },
+    secretProvisioning: "integrator",
+  };
+  const messageFilter = options.filter
+    ? `${SELF_MESSAGE_GUARD} && (${options.filter})`
+    : SELF_MESSAGE_GUARD;
+  const filter = `${INTERACTIVITY_PASS} || (${messageFilter})`;
+  const ack =
+    options.ack === null
+      ? undefined
+      : (options.ack ??
+        ((_event: TEvent, ctx: ChannelAckCtx) => ({
+          text: ctx.recovered ? "picking this back up..." : "on it...",
+        })));
+
+  return chat.channels.custom<WebhookSource<TEvent>>({
+    id: options.id,
+    source,
+    key: options.key ?? DEFAULT_KEY,
+    inbound: options.inbound ?? (defaultSlackInbound as (event: TEvent) => ChannelMessageInput),
+    outbound: options.outbound ?? defaultSlackOutbound,
+    ack,
+    send: makeSlackSend(options.token, apiBaseUrl),
+    renderInteraction: defaultSlackRenderInteraction as (
+      pending: ChannelPendingToolCall[],
+      ctx: ChannelInteractionCtx<TEvent>
+    ) => ChannelMessage | null,
+    onInteraction: defaultSlackOnInteraction as (
+      event: TEvent
+    ) => ChannelInteractionResolution | null,
+    finalizeInteraction: defaultSlackFinalizeInteraction as (
+      event: TEvent,
+      resolution: ChannelInteractionResolution
+    ) => Promise<void>,
+    // Composed at runtime (guard + optional user filter), so it bypasses the literal-only filter
+    // validator; the user's `filter` arg was already validated on the way in.
+    filter: filter as never,
+    startOn: options.startOn as never,
+    delivery: options.delivery ?? "final",
+    react: makeSlackReact(options.token, apiBaseUrl),
+    reactions: options.reactions,
+  });
+}
+
+/**
+ * Default HITL controls: render each pending human-decision tool as a Block Kit approve/deny pair. The
+ * button `value` carries `${toolCallId}::${decision}` so `onInteraction` can resolve the exact tool.
+ */
+function defaultSlackRenderInteraction(
+  pending: ChannelPendingToolCall[],
+  _ctx: ChannelInteractionCtx<unknown>
+): ChannelMessage | null {
+  const call = pending[0];
+  if (!call) return null;
+  const detail = call.input !== undefined ? "\n```" + safeStringify(call.input) + "```" : "";
+  return {
+    text: `Approval needed: ${call.toolName}`,
+    blocks: [
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: `*Approval needed* for \`${call.toolName}\`${detail}` },
+      },
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            action_id: "trigger_hitl_approve",
+            style: "primary",
+            text: { type: "plain_text", text: "Approve" },
+            value: `${call.toolCallId}::approve`,
+          },
+          {
+            type: "button",
+            action_id: "trigger_hitl_deny",
+            style: "danger",
+            text: { type: "plain_text", text: "Deny" },
+            value: `${call.toolCallId}::deny`,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+/**
+ * Default interaction resolver: a `block_actions` button click resolves the tool named in its `value`
+ * (`${toolCallId}::approve|deny`) to `{ approved }`. Any non-interactivity event returns null (the
+ * normal message path handles it).
+ */
+function defaultSlackOnInteraction(event: unknown): ChannelInteractionResolution | null {
+  const payload = event as { type?: string; actions?: Array<{ value?: string }> };
+  if (payload?.type !== "block_actions") return null;
+  const action = (payload.actions ?? []).find(
+    (a) => typeof a?.value === "string" && a.value.includes("::")
+  );
+  if (!action?.value) return null;
+  const [toolCallId, decision] = action.value.split("::");
+  if (!toolCallId || (decision !== "approve" && decision !== "deny")) return null;
+  return { toolCallId, output: { approved: decision === "approve" } };
+}
+
+/**
+ * After a decision, collapse the controls via the interaction's `response_url` (Slack's documented path:
+ * the click gets a bare 200 ack, then `response_url` accepts `replace_original` for up to 30 minutes).
+ * Keeps the original context blocks, drops the `actions` block, and appends the outcome, so the buttons
+ * can't be clicked again. No-op when the payload carries no `response_url` (e.g. a synthetic test event).
+ */
+async function defaultSlackFinalizeInteraction(
+  event: unknown,
+  resolution: ChannelInteractionResolution
+): Promise<void> {
+  const payload = event as {
+    response_url?: string;
+    user?: { id?: string };
+    message?: { blocks?: unknown[] };
+  };
+  const responseUrl = payload?.response_url;
+  if (!responseUrl) return;
+
+  const approved = (resolution.output as { approved?: boolean } | undefined)?.approved === true;
+  const decision = approved ? "Approved" : "Denied";
+  const icon = approved ? ":white_check_mark:" : ":x:";
+  const who = payload.user?.id ? ` by <@${payload.user.id}>` : "";
+
+  const original = Array.isArray(payload.message?.blocks) ? payload.message!.blocks : [];
+  const kept = original.filter((b) => (b as { type?: string })?.type !== "actions");
+  const blocks = [
+    ...kept,
+    { type: "context", elements: [{ type: "mrkdwn", text: `${icon} *${decision}*${who}` }] },
+  ];
+
+  await fetch(responseUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ replace_original: true, text: `${decision}${who}`, blocks }),
+  });
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+// Strip a leading bot mention (`<@U123> hi` -> `hi`) so the agent sees the plain text.
+function defaultSlackInbound(event: SlackMessageEvent): string {
+  return (event.event?.text ?? "").replace(/^\s*<@[A-Z0-9]+>\s*/i, "");
+}
+
+/**
+ * Convert common GitHub-flavored markdown (what a model emits) to Slack mrkdwn: `**bold**` -> `*bold*`,
+ * `#` headings -> bold, `-`/`*` bullets -> `•`, `[t](url)` -> `<url|t>`, `~~s~~` -> `~s~`. Applied by the
+ * default outbound; a custom `outbound` controls its own formatting (call this from it if you want it).
+ * Note: single-asterisk `*italic*` is left as-is, so it renders bold in Slack (rare in model output).
+ */
+export function toSlackMrkdwn(md: string): string {
+  return md
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g, "<$2|$1>")
+    .replace(/^[ \t]{0,3}#{1,6}[ \t]+(.+?)[ \t]*#*[ \t]*$/gm, "*$1*")
+    .replace(/\*\*([^*\n]+)\*\*/g, "*$1*")
+    .replace(/__([^_\n]+)__/g, "*$1*")
+    .replace(/~~([^~\n]+)~~/g, "~$1~")
+    .replace(/^([ \t]*)[-*+][ \t]+/gm, "$1• ");
+}
+
+function defaultSlackOutbound(reply: ChannelReply): ChannelMessage | null {
+  return reply.text ? { text: toSlackMrkdwn(reply.text) } : null;
+}
+
+function makeSlackSend<TEvent>(token: SlackToken<TEvent>, apiBaseUrl: string) {
+  return async (
+    message: ChannelMessage,
+    ctx: ChannelSendCtx<TEvent>
+  ): Promise<{ ref?: string }> => {
+    const event = ctx.event as SlackMessageEvent & {
+      container?: { channel_id?: string; thread_ts?: string; message_ts?: string };
+      channel?: { id?: string };
+    };
+    const channel = event.event?.channel ?? event.container?.channel_id ?? event.channel?.id;
+    const threadTs =
+      event.event?.thread_ts ??
+      event.event?.ts ??
+      event.container?.thread_ts ??
+      event.container?.message_ts;
+
+    const resolve = () => (typeof token === "function" ? token(ctx.event) : token);
+    let botToken = await resolve();
+
+    const blocks = (message as { blocks?: unknown }).blocks;
+    const rich = Array.isArray(blocks) && blocks.length > 0 ? { blocks } : {};
+
+    const post = async () =>
+      ctx.previousRef
+        ? slackApi(apiBaseUrl, "chat.update", botToken, {
+            channel,
+            ts: ctx.previousRef,
+            text: message.text,
+            ...rich,
+          })
+        : slackApi(apiBaseUrl, "chat.postMessage", botToken, {
+            channel,
+            thread_ts: threadTs,
+            text: message.text,
+            ...rich,
+          });
+
+    let result = await post();
+    // Re-resolve once on an auth error (token rotation) when a resolver was supplied.
+    if (!result.ok && typeof token === "function" && isAuthError(result.error)) {
+      botToken = await resolve();
+      result = await post();
+    }
+    if (!result.ok) {
+      // not_in_channel / channel_not_found is the common one: the bot isn't in the channel. Surface it.
+      throw new Error(
+        `slack ${ctx.previousRef ? "chat.update" : "chat.postMessage"} failed: ${result.error}`
+      );
+    }
+    return { ref: ctx.previousRef ?? result.ts };
+  };
+}
+
+function isAuthError(error: string | undefined): boolean {
+  return error === "invalid_auth" || error === "token_revoked" || error === "account_inactive";
+}
+
+// Add/remove an emoji reaction on the triggering Slack message (needs the reactions:write scope).
+function makeSlackReact<TEvent>(token: SlackToken<TEvent>, apiBaseUrl: string) {
+  return async (reaction: ChannelReaction, ctx: ChannelReactCtx<TEvent>): Promise<void> => {
+    const event = ctx.event as SlackMessageEvent;
+    const channel = event.event?.channel;
+    const timestamp = event.event?.ts;
+    const name = reaction.name.replace(/^:|:$/g, "");
+    if (!channel || !timestamp || !name) return;
+    const botToken = typeof token === "function" ? await token(ctx.event) : token;
+    const method = reaction.remove ? "reactions.remove" : "reactions.add";
+    const result = await slackApi(apiBaseUrl, method, botToken, { channel, timestamp, name });
+    // already_reacted / no_reaction are benign idempotent outcomes; surface anything else.
+    if (!result.ok && result.error !== "already_reacted" && result.error !== "no_reaction") {
+      throw new Error(`slack ${method} failed: ${result.error}`);
+    }
+  };
+}
+
+async function slackApi(
+  baseUrl: string,
+  method: string,
+  token: string,
+  body: Record<string, unknown>
+): Promise<{ ok: boolean; ts?: string; error?: string }> {
+  const res = await fetch(`${baseUrl}/${method}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+  return (await res.json()) as { ok: boolean; ts?: string; error?: string };
+}

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -75,7 +75,7 @@ const DEFAULT_KEY =
  * events. Interactivity (block_actions) is a separate surface, admitted via INTERACTIVITY_PASS.
  */
 const SELF_MESSAGE_GUARD =
-  "event.event.type == 'message' && event.event.bot_id == null && event.event.subtype in [null, 'file_share', 'thread_broadcast']";
+  "event.event.type == 'message' && event.event.bot_id == null && event.event.subtype in [null,'file_share','thread_broadcast']";
 
 /** Interactivity callbacks (button clicks) always pass the loop guard; onInteraction resolves them. */
 const INTERACTIVITY_PASS = "event.type == 'block_actions'";

--- a/packages/slack/tsconfig.json
+++ b/packages/slack/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../.configs/tsconfig.base.json",
+  "references": [
+    {
+      "path": "./tsconfig.src.json"
+    }
+  ]
+}

--- a/packages/slack/tsconfig.src.json
+++ b/packages/slack/tsconfig.src.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["./src/**/*.ts"],
+  "exclude": ["./src/**/*.test.ts"],
+  "compilerOptions": {
+    "isolatedDeclarations": false,
+    "composite": true,
+    "sourceMap": true,
+    "customConditions": ["@triggerdotdev/source"],
+    "types": ["node"]
+  }
+}

--- a/packages/slack/vitest.config.ts
+++ b/packages/slack/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.test.ts"],
+    globals: true,
+  },
+});

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -7083,13 +7083,19 @@ function chatAgent<
                       }
                     }
                   }
-                  channelWorkingReaction = await resolveReactionChoice(
-                    channelConn.reactions?.working,
-                    wireChannelEvent.event
-                  );
-                  if (channelWorkingReaction) {
-                    await applyChannelReaction(channelConn, wireChannelEvent, {
-                      name: channelWorkingReaction,
+                  try {
+                    channelWorkingReaction = await resolveReactionChoice(
+                      channelConn.reactions?.working,
+                      wireChannelEvent.event
+                    );
+                    if (channelWorkingReaction) {
+                      await applyChannelReaction(channelConn, wireChannelEvent, {
+                        name: channelWorkingReaction,
+                      });
+                    }
+                  } catch (reactionError) {
+                    logger.warn("chat.agent: channel working reaction failed", {
+                      error: reactionError,
                     });
                   }
                 }
@@ -8406,19 +8412,25 @@ function chatAgent<
 
                   // Lifecycle reaction: turn done. Remove "working", mark "done".
                   if (wireChannelEvent && channelConn?.react) {
-                    if (channelWorkingReaction) {
-                      await applyChannelReaction(channelConn, wireChannelEvent, {
-                        name: channelWorkingReaction,
-                        remove: true,
-                      });
-                    }
-                    const doneReaction = await resolveReactionChoice(
-                      channelConn.reactions?.done,
-                      wireChannelEvent.event
-                    );
-                    if (doneReaction) {
-                      await applyChannelReaction(channelConn, wireChannelEvent, {
-                        name: doneReaction,
+                    try {
+                      if (channelWorkingReaction) {
+                        await applyChannelReaction(channelConn, wireChannelEvent, {
+                          name: channelWorkingReaction,
+                          remove: true,
+                        });
+                      }
+                      const doneReaction = await resolveReactionChoice(
+                        channelConn.reactions?.done,
+                        wireChannelEvent.event
+                      );
+                      if (doneReaction) {
+                        await applyChannelReaction(channelConn, wireChannelEvent, {
+                          name: doneReaction,
+                        });
+                      }
+                    } catch (reactionError) {
+                      logger.warn("chat.agent: channel done reaction failed", {
+                        error: reactionError,
                       });
                     }
                   }

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -4942,7 +4942,9 @@ function channelReplyText(message: UIMessage): string {
     parts
       .slice(from)
       .map((p) =>
-        p && typeof p === "object" && "text" in p ? String((p as { text: unknown }).text) : ""
+        p && typeof p === "object" && (p as { type?: unknown }).type === "text"
+          ? String((p as { text: unknown }).text)
+          : ""
       )
       .join("");
   const trailing = textFrom(lastToolIdx + 1);
@@ -6970,6 +6972,7 @@ function chatAgent<
           let channelAckRef: string | undefined;
           let channelStreamEditor: ChannelStreamEditor | undefined;
           let droppedStaleInteraction = false;
+          let channelFinalAnswerPosted = false;
           try {
             // Extract turn-level context before entering the span. Slim
             // wire: at most one delta message per record. `headStartMessages`
@@ -8364,6 +8367,7 @@ function chatAgent<
                           mode: channelConn.delivery,
                           final: true,
                         });
+                        channelFinalAnswerPosted = true;
                       } catch (egressError) {
                         logger.warn("chat.agent: channel egress send failed", {
                           error: egressError,
@@ -8678,7 +8682,8 @@ function chatAgent<
               } catch {
                 channelErrorText = "An unexpected error occurred";
               }
-              const channelErrorMessageId = channelAckRef ?? channelWireEvent.deliveryId;
+              const errorPreviousRef = channelFinalAnswerPosted ? undefined : channelAckRef;
+              const channelErrorMessageId = errorPreviousRef ?? channelWireEvent.deliveryId;
               let errorMessage: ChannelMessage | null = null;
               try {
                 errorMessage = (channelConn.outbound ?? defaultChannelOutbound)({
@@ -8700,7 +8705,7 @@ function chatAgent<
                   await channelConn.send(errorMessage, {
                     event: channelWireEvent.event,
                     deliveryId: channelWireEvent.deliveryId,
-                    previousRef: channelAckRef,
+                    previousRef: errorPreviousRef,
                     mode: channelConn.delivery,
                     final: true,
                   });

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -6925,6 +6925,7 @@ function chatAgent<
           let channelConn: AnyChannelConnector | undefined;
           let channelWorkingReaction: string | undefined;
           let channelWireEvent: { event: unknown; deliveryId: string } | undefined;
+          let droppedStaleInteraction = false;
           try {
             // Extract turn-level context before entering the span. Slim
             // wire: at most one delta message per record. `headStartMessages`
@@ -6962,6 +6963,14 @@ function chatAgent<
                       });
                     }
                   }
+                } else if (interaction) {
+                  droppedStaleInteraction = true;
+                  logger.debug(
+                    "chat.agent: dropping stale channel interaction that matched no pending tool call",
+                    {
+                      deliveryId: wireChannelEvent.deliveryId,
+                    }
+                  );
                 } else {
                   effectiveIncomingMessage = toUserUIMessage(
                     channelConn.inbound(wireChannelEvent.event),
@@ -7244,7 +7253,7 @@ function chatAgent<
                 // snapshot + `session.out` replay (or `hydrateMessages`,
                 // which also fires per-turn below). Per-turn handling is
                 // therefore a delta merge, not a full-history reset.
-                if (currentWirePayload.trigger !== "action") {
+                if (currentWirePayload.trigger !== "action" && !droppedStaleInteraction) {
                   let cleanedUIMessages: TUIMessage[] = cleanedIncomingMessages;
 
                   // Turn-0 head-start with hydrateMessages: the boot seeding from
@@ -7543,7 +7552,7 @@ function chatAgent<
                   turn--;
                 }
 
-                if (!isAction) {
+                if (!isAction && !droppedStaleInteraction) {
                   // Mint a scoped public access token once per turn, reused for
                   // onChatStart, onTurnStart, onTurnComplete, and the turn-complete chunk.
                   const currentRunId = ctx.run.id;

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -6995,7 +6995,14 @@ function chatAgent<
               channelConn = channels?.find((c) => c.id === wireChannelEvent.connectorId);
               if (channelConn) {
                 const interaction = channelConn.onInteraction?.(wireChannelEvent.event) ?? null;
-                if (interaction && hydrateMessages && accumulatedUIMessages.length === 0) {
+                const accumulatorHasInteractionToolCall =
+                  interaction != null &&
+                  accumulatedUIMessages.some((m) =>
+                    ((m.parts ?? []) as { toolCallId?: unknown }[]).some(
+                      (p) => p?.toolCallId === interaction.toolCallId
+                    )
+                  );
+                if (interaction && hydrateMessages && !accumulatorHasInteractionToolCall) {
                   try {
                     const hydratedForInteraction = (await hydrateMessages({
                       chatId: currentWirePayload.chatId,

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -5057,13 +5057,23 @@ function makeChannelStreamEditor<TEvent>(
 ) {
   const outbound = connector.outbound ?? defaultChannelOutbound;
   let latest = "";
+  let lastSent = "";
   let timer: ReturnType<typeof setTimeout> | undefined;
   let inFlight = false;
   let stopped = false;
 
+  const arm = () => {
+    if (stopped || timer) return;
+    timer = setTimeout(() => {
+      timer = undefined;
+      void edit();
+    }, CHANNEL_STREAM_EDIT_INTERVAL_MS);
+  };
+
   const edit = async () => {
     if (stopped || inFlight) return;
     const text = latest;
+    if (text === lastSent) return;
     const message = outbound({
       text,
       message: { id: ackRef, role: "assistant", parts: [{ type: "text", text }] } as UIMessage,
@@ -5080,10 +5090,12 @@ function makeChannelStreamEditor<TEvent>(
         mode: "stream",
         final: false,
       });
+      lastSent = text;
     } catch (error) {
       logger.warn("chat.agent: channel stream edit failed", { error });
     } finally {
       inFlight = false;
+      if (!stopped && latest !== lastSent) arm();
     }
   };
 
@@ -5093,11 +5105,7 @@ function makeChannelStreamEditor<TEvent>(
       const c = chunk as { type?: string; delta?: unknown };
       if (c?.type === "text-delta" && typeof c.delta === "string") {
         latest += c.delta;
-        if (!timer)
-          timer = setTimeout(() => {
-            timer = undefined;
-            void edit();
-          }, CHANNEL_STREAM_EDIT_INTERVAL_MS);
+        arm();
       }
     },
     stop() {
@@ -5109,6 +5117,39 @@ function makeChannelStreamEditor<TEvent>(
     },
   };
 }
+
+type ChannelStreamEditor = { observe(chunk: unknown): void; stop(): void };
+
+/**
+ * Wrap the reply stream so it debounce-edits the channel message as it streams.
+ * Both `flush` (the stream completed) and `cancel` (the stream was aborted or
+ * cancelled downstream) stop the editor, so a pending debounce timer can never
+ * fire an edit after the turn ended, onto a message the next turn already owns.
+ */
+function makeChannelStreamTap(editor: ChannelStreamEditor): TransformStream<unknown, unknown> {
+  const transformer: {
+    transform(chunk: unknown, controller: TransformStreamDefaultController<unknown>): void;
+    flush(): void;
+    cancel?: (reason?: unknown) => void;
+  } = {
+    transform(chunk, controller) {
+      editor.observe(chunk);
+      controller.enqueue(chunk);
+    },
+    flush() {
+      editor.stop();
+    },
+    cancel() {
+      editor.stop();
+    },
+  };
+  return new TransformStream<unknown, unknown>(transformer);
+}
+
+export {
+  makeChannelStreamEditor as __makeChannelStreamEditorForTests,
+  makeChannelStreamTap as __makeChannelStreamTapForTests,
+};
 
 // The `action` type onAction receives: the actionSchema output (when set) unioned with the action
 // envelopes of any listed chat.event descriptors. ChatEventActions<[]> is `never`, so it collapses
@@ -6925,6 +6966,8 @@ function chatAgent<
           let channelConn: AnyChannelConnector | undefined;
           let channelWorkingReaction: string | undefined;
           let channelWireEvent: { event: unknown; deliveryId: string } | undefined;
+          let channelAckRef: string | undefined;
+          let channelStreamEditor: ChannelStreamEditor | undefined;
           let droppedStaleInteraction = false;
           try {
             // Extract turn-level context before entering the span. Slim
@@ -6941,7 +6984,6 @@ function chatAgent<
             void _hsm;
             channelWireEvent = wireChannelEvent;
             let effectiveIncomingMessage = incomingMessage;
-            let channelAckRef: string | undefined;
             if (wireChannelEvent) {
               channelConn = channels?.find((c) => c.id === wireChannelEvent.connectorId);
               if (channelConn) {
@@ -7799,21 +7841,13 @@ function chatAgent<
                         channelAckRef &&
                         uiStream instanceof ReadableStream
                       ) {
-                        const editor = makeChannelStreamEditor(
+                        channelStreamEditor = makeChannelStreamEditor(
                           channelConn,
                           wireChannelEvent,
                           channelAckRef
                         );
                         streamForPipe = uiStream.pipeThrough(
-                          new TransformStream({
-                            transform(chunk, controller) {
-                              editor.observe(chunk);
-                              controller.enqueue(chunk);
-                            },
-                            flush() {
-                              editor.stop();
-                            },
-                          })
+                          makeChannelStreamTap(channelStreamEditor)
                         );
                       }
                       await pipeChat(tapUIMessageChunks(streamForPipe, turnBufferedChunks), {
@@ -7833,6 +7867,7 @@ function chatAgent<
                     }
                   } finally {
                     msgSub.off();
+                    channelStreamEditor?.stop();
                   }
 
                   // Wait for onFinish to fire — on abort this may resolve slightly
@@ -8590,6 +8625,37 @@ function chatAgent<
               );
               if (errorReaction) {
                 await applyChannelReaction(channelConn, channelWireEvent, { name: errorReaction });
+              }
+            }
+
+            if (channelWireEvent && channelConn?.send && channelAckRef) {
+              const channelErrorText =
+                turnError instanceof Error ? turnError.message : "An unexpected error occurred";
+              const errorMessage = (channelConn.outbound ?? defaultChannelOutbound)({
+                text: channelErrorText,
+                message: {
+                  id: channelAckRef,
+                  role: "assistant",
+                  parts: [{ type: "text", text: channelErrorText }],
+                } as UIMessage,
+                final: true,
+                stopped: false,
+                error: turnError,
+              });
+              if (errorMessage) {
+                try {
+                  await channelConn.send(errorMessage, {
+                    event: channelWireEvent.event,
+                    deliveryId: channelWireEvent.deliveryId,
+                    previousRef: channelAckRef,
+                    mode: channelConn.delivery,
+                    final: true,
+                  });
+                } catch (egressError) {
+                  logger.warn("chat.agent: channel error egress send failed", {
+                    error: egressError,
+                  });
+                }
               }
             }
 

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -5062,7 +5062,7 @@ function makeChannelStreamEditor<TEvent>(
   let latest = "";
   let lastSent = "";
   let timer: ReturnType<typeof setTimeout> | undefined;
-  let inFlight = false;
+  let inFlightPromise: Promise<void> | undefined;
   let stopped = false;
 
   const arm = () => {
@@ -5074,7 +5074,7 @@ function makeChannelStreamEditor<TEvent>(
   };
 
   const edit = async () => {
-    if (stopped || inFlight) return;
+    if (stopped || inFlightPromise) return;
     const text = latest;
     if (text === lastSent) return;
     const message = outbound({
@@ -5084,22 +5084,24 @@ function makeChannelStreamEditor<TEvent>(
       stopped: false,
     });
     if (!message) return;
-    inFlight = true;
-    try {
-      await connector.send!(message, {
-        event: channelEvent.event as TEvent,
-        deliveryId: channelEvent.deliveryId,
-        previousRef: ackRef,
-        mode: "stream",
-        final: false,
-      });
-      lastSent = text;
-    } catch (error) {
-      logger.warn("chat.agent: channel stream edit failed", { error });
-    } finally {
-      inFlight = false;
-      if (!stopped && latest !== lastSent) arm();
-    }
+    inFlightPromise = (async () => {
+      try {
+        await connector.send!(message, {
+          event: channelEvent.event as TEvent,
+          deliveryId: channelEvent.deliveryId,
+          previousRef: ackRef,
+          mode: "stream",
+          final: false,
+        });
+        lastSent = text;
+      } catch (error) {
+        logger.warn("chat.agent: channel stream edit failed", { error });
+      } finally {
+        inFlightPromise = undefined;
+        if (!stopped && latest !== lastSent) arm();
+      }
+    })();
+    await inFlightPromise;
   };
 
   return {
@@ -5111,17 +5113,22 @@ function makeChannelStreamEditor<TEvent>(
         arm();
       }
     },
-    stop() {
+    async stop() {
       stopped = true;
       if (timer) {
         clearTimeout(timer);
         timer = undefined;
       }
+      if (inFlightPromise) {
+        try {
+          await inFlightPromise;
+        } catch {}
+      }
     },
   };
 }
 
-type ChannelStreamEditor = { observe(chunk: unknown): void; stop(): void };
+type ChannelStreamEditor = { observe(chunk: unknown): void; stop(): void | Promise<void> };
 
 /**
  * Wrap the reply stream so it debounce-edits the channel message as it streams.
@@ -5132,18 +5139,18 @@ type ChannelStreamEditor = { observe(chunk: unknown): void; stop(): void };
 function makeChannelStreamTap(editor: ChannelStreamEditor): TransformStream<unknown, unknown> {
   const transformer: {
     transform(chunk: unknown, controller: TransformStreamDefaultController<unknown>): void;
-    flush(): void;
-    cancel?: (reason?: unknown) => void;
+    flush(): Promise<void>;
+    cancel?: (reason?: unknown) => Promise<void>;
   } = {
     transform(chunk, controller) {
       editor.observe(chunk);
       controller.enqueue(chunk);
     },
-    flush() {
-      editor.stop();
+    async flush() {
+      await editor.stop();
     },
-    cancel() {
-      editor.stop();
+    async cancel() {
+      await editor.stop();
     },
   };
   return new TransformStream<unknown, unknown>(transformer);
@@ -7938,7 +7945,7 @@ function chatAgent<
                     }
                   } finally {
                     msgSub.off();
-                    channelStreamEditor?.stop();
+                    await channelStreamEditor?.stop();
                   }
 
                   // Wait for onFinish to fire — on abort this may resolve slightly

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -7146,6 +7146,12 @@ function chatAgent<
                   // instead of the wire buffer. The frontend handles re-sending
                   // non-injected messages via sendMessage on turn complete.
                   if (pmConfig) {
+                    if ((msg as { channelEvent?: unknown }).channelEvent != null) {
+                      pendingWireMessages.push(
+                        msg as ChatTaskWirePayload<TUIMessage, inferSchemaIn<TClientDataSchema>>
+                      );
+                      return;
+                    }
                     // Slim wire: at most one delta message per record. The
                     // pendingMessages handler reads `msg.message` directly
                     // instead of slicing an array — a wire record arrives
@@ -8618,35 +8624,44 @@ function chatAgent<
             }
 
             if (channelWireEvent && channelConn?.react) {
-              if (channelWorkingReaction) {
-                await applyChannelReaction(channelConn, channelWireEvent, {
-                  name: channelWorkingReaction,
-                  remove: true,
-                });
-              }
-              const errorReaction = await resolveReactionChoice(
-                channelConn.reactions?.error,
-                channelWireEvent.event
-              );
-              if (errorReaction) {
-                await applyChannelReaction(channelConn, channelWireEvent, { name: errorReaction });
+              try {
+                if (channelWorkingReaction) {
+                  await applyChannelReaction(channelConn, channelWireEvent, {
+                    name: channelWorkingReaction,
+                    remove: true,
+                  });
+                }
+                const errorReaction = await resolveReactionChoice(
+                  channelConn.reactions?.error,
+                  channelWireEvent.event
+                );
+                if (errorReaction) {
+                  await applyChannelReaction(channelConn, channelWireEvent, { name: errorReaction });
+                }
+              } catch (reactionError) {
+                logger.warn("chat.agent: channel error reaction failed", { error: reactionError });
               }
             }
 
             if (channelWireEvent && channelConn?.send && channelAckRef) {
               const channelErrorText =
                 turnError instanceof Error ? turnError.message : "An unexpected error occurred";
-              const errorMessage = (channelConn.outbound ?? defaultChannelOutbound)({
-                text: channelErrorText,
-                message: {
-                  id: channelAckRef,
-                  role: "assistant",
-                  parts: [{ type: "text", text: channelErrorText }],
-                } as UIMessage,
-                final: true,
-                stopped: false,
-                error: turnError,
-              });
+              let errorMessage: ChannelMessage | null = null;
+              try {
+                errorMessage = (channelConn.outbound ?? defaultChannelOutbound)({
+                  text: channelErrorText,
+                  message: {
+                    id: channelAckRef,
+                    role: "assistant",
+                    parts: [{ type: "text", text: channelErrorText }],
+                  } as UIMessage,
+                  final: true,
+                  stopped: false,
+                  error: turnError,
+                });
+              } catch (outboundError) {
+                logger.warn("chat.agent: channel error outbound failed", { error: outboundError });
+              }
               if (errorMessage) {
                 try {
                   await channelConn.send(errorMessage, {

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -6972,6 +6972,7 @@ function chatAgent<
           let channelAckRef: string | undefined;
           let channelStreamEditor: ChannelStreamEditor | undefined;
           let droppedStaleInteraction = false;
+          let droppedUnknownConnector = false;
           let channelFinalAnswerPosted = false;
           try {
             // Extract turn-level context before entering the span. Slim
@@ -7085,6 +7086,15 @@ function chatAgent<
                     });
                   }
                 }
+              } else {
+                droppedUnknownConnector = true;
+                logger.warn(
+                  "chat.agent: no channel connector matches this delivery; skipping turn",
+                  {
+                    connectorId: wireChannelEvent.connectorId,
+                    deliveryId: wireChannelEvent.deliveryId,
+                  }
+                );
               }
             }
             const incomingMessages: TUIMessage[] = effectiveIncomingMessage
@@ -7334,7 +7344,11 @@ function chatAgent<
                 // snapshot + `session.out` replay (or `hydrateMessages`,
                 // which also fires per-turn below). Per-turn handling is
                 // therefore a delta merge, not a full-history reset.
-                if (currentWirePayload.trigger !== "action" && !droppedStaleInteraction) {
+                if (
+                  currentWirePayload.trigger !== "action" &&
+                  !droppedStaleInteraction &&
+                  !droppedUnknownConnector
+                ) {
                   let cleanedUIMessages: TUIMessage[] = cleanedIncomingMessages;
 
                   // Turn-0 head-start with hydrateMessages: the boot seeding from
@@ -7633,12 +7647,12 @@ function chatAgent<
                   turn--;
                 }
 
-                if (droppedStaleInteraction) {
+                if (droppedStaleInteraction || droppedUnknownConnector) {
                   msgSub.off();
                   turn--;
                 }
 
-                if (!isAction && !droppedStaleInteraction) {
+                if (!isAction && !droppedStaleInteraction && !droppedUnknownConnector) {
                   // Mint a scoped public access token once per turn, reused for
                   // onChatStart, onTurnStart, onTurnComplete, and the turn-complete chunk.
                   const currentRunId = ctx.run.id;

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -5523,6 +5523,13 @@ export type ChatAgentOptions<
    *   },
    * });
    * ```
+   *
+   * Note: on a channel HITL resume turn (a button click that lands on a fresh
+   * run whose accumulator doesn't yet hold the pending tool call), this hook is
+   * called twice for the one delivery: once with `incomingMessages: []` to load
+   * the chain and locate the pending tool call, then again with the synthesized
+   * resolution message so it can be persisted. Keep the hook's read path
+   * idempotent.
    */
   hydrateMessages?: (
     event: HydrateMessagesEvent<inferSchemaOut<TClientDataSchema>, TUIMessage>

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -6985,6 +6985,9 @@ function chatAgent<
             void _hsm;
             channelWireEvent = wireChannelEvent;
             let effectiveIncomingMessage = incomingMessage;
+            const clientData = (
+              parseClientData ? await parseClientData(wireMetadata) : wireMetadata
+            ) as inferSchemaOut<TClientDataSchema>;
             if (wireChannelEvent) {
               channelConn = channels?.find((c) => c.id === wireChannelEvent.connectorId);
               if (channelConn) {
@@ -7083,9 +7086,6 @@ function chatAgent<
             const cleanedIncomingMessages: TUIMessage[] = incomingMessages.map((msg) =>
               msg.role === "assistant" ? cleanupAbortedParts(msg) : msg
             );
-            const clientData = (
-              parseClientData ? await parseClientData(wireMetadata) : wireMetadata
-            ) as inferSchemaOut<TClientDataSchema>;
             const lastUserMessage = extractLastUserMessageText(cleanedIncomingMessages);
 
             // Actions are not turns. They use a different span name

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -8691,7 +8691,9 @@ function chatAgent<
                   channelWireEvent.event
                 );
                 if (errorReaction) {
-                  await applyChannelReaction(channelConn, channelWireEvent, { name: errorReaction });
+                  await applyChannelReaction(channelConn, channelWireEvent, {
+                    name: errorReaction,
+                  });
                 }
               } catch (reactionError) {
                 logger.warn("chat.agent: channel error reaction failed", { error: reactionError });

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -4984,6 +4984,7 @@ function buildInteractionResolutionMessage(
       const isTool =
         typeof type === "string" && (type.startsWith("tool-") || type === "dynamic-tool");
       if (!isTool) continue;
+      if (part.state !== "input-available") return undefined;
       const slimPart: Record<string, unknown> = {
         type,
         toolCallId: resolution.toolCallId,
@@ -8665,15 +8666,25 @@ function chatAgent<
               }
             }
 
-            if (channelWireEvent && channelConn?.send && channelAckRef) {
-              const channelErrorText =
-                turnError instanceof Error ? turnError.message : "An unexpected error occurred";
+            if (channelWireEvent && channelConn?.send) {
+              const sanitizeChannelError = resolveUIMessageStreamOptions().onError;
+              let channelErrorText: string;
+              try {
+                channelErrorText = sanitizeChannelError
+                  ? sanitizeChannelError(turnError)
+                  : turnError instanceof Error
+                    ? turnError.message
+                    : "An unexpected error occurred";
+              } catch {
+                channelErrorText = "An unexpected error occurred";
+              }
+              const channelErrorMessageId = channelAckRef ?? channelWireEvent.deliveryId;
               let errorMessage: ChannelMessage | null = null;
               try {
                 errorMessage = (channelConn.outbound ?? defaultChannelOutbound)({
                   text: channelErrorText,
                   message: {
-                    id: channelAckRef,
+                    id: channelErrorMessageId,
                     role: "assistant",
                     parts: [{ type: "text", text: channelErrorText }],
                   } as UIMessage,

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -36,6 +36,14 @@ import {
   type TaskWithSchema,
   TRIGGER_CONTROL_SUBTYPE,
   type StreamWriteResult,
+  type AnyChatEvent,
+  type ChatEventActions,
+  type ValidatedWebhookKey,
+  type ValidateWebhookFilter,
+  type WebhookVerifierArtifact,
+  type WebhookSecretProvisioning,
+  type AnyWebhookSource,
+  type InferWebhookEvent,
 } from "@trigger.dev/core/v3";
 import type {
   FinishReason,
@@ -50,6 +58,7 @@ import type {
   JSONSchema7,
   Schema,
 } from "ai";
+import { chatEvent, normalizeKeyString } from "./webhooks.js";
 // Runtime VALUES go through the ESM/CJS shim so the CJS build can `require`
 // ESM-only `ai@7` (see ../imports/ai-runtime.ts).
 import { type Attributes, trace } from "@opentelemetry/api";
@@ -170,6 +179,17 @@ const chatSessionHandleKey = locals.create<SessionHandle>("chat.sessionHandle");
 // is documented to carry. Custom-agent loops never set per-turn context, so subtask tool
 // metadata reads this directly rather than the Session handle id.
 const chatExternalIdKey = locals.create<string>("chat.externalId");
+
+/**
+ * Set at boot when a continuation run inherited an interrupted turn (a
+ * partial assistant reply on `session.out`). Consumed by the first channel
+ * turn's ack so the re-emitted placeholder reads as a recovery resume rather
+ * than a silent duplicate. Boxed so the ack site can flip it to false.
+ * @internal
+ */
+const chatChannelRecoveryPendingKey = locals.create<{ value: boolean }>(
+  "chat.channelRecoveryPending"
+);
 
 /**
  * S2 seq_num of the most recent `turn-complete` control record written by
@@ -1243,6 +1263,41 @@ function createChatAccessToken<TTask extends AnyTask>(
   return auth.createTriggerPublicToken(taskId as string, { expirationTime: "24h" });
 }
 
+/**
+ * Mint a read-only, session-scoped token for WATCHING a chat session by its `externalId`.
+ *
+ * A session is addressed by `externalId`, so the same session is reachable from any surface that
+ * knows it: a web `useChat` client and a Slack thread converge on one session when they share an
+ * `externalId` (for a channel, the connector's `key` template produces it). This token carries
+ * `read:sessions:{externalId}` only (no write): the holder can subscribe to the session's `.out`
+ * stream (observe the conversation, hydrating history from the snapshot) but cannot append to `.in`.
+ *
+ * Use it for a dashboard viewer or a cross-surface watcher of a Slack-thread session. Run server-side
+ * (needs the secret key). To CONTINUE a session from another surface (drive it, not just watch), mint
+ * a read+write token instead ({@link createChatStartSessionAction}).
+ *
+ * @example
+ * ```ts
+ * // actions.ts
+ * "use server";
+ * import { chat } from "@trigger.dev/sdk/ai";
+ *
+ * export const watchChat = (externalId: string) => chat.createWatchToken(externalId);
+ * ```
+ */
+function createChatWatchToken(
+  externalId: string,
+  options?: { tokenTTL?: string }
+): Promise<string> {
+  if (!externalId) {
+    throw new Error("chat.createWatchToken: externalId is required (the session addressing key).");
+  }
+  return auth.createPublicToken({
+    scopes: { read: { sessions: externalId } },
+    expirationTime: options?.tokenTTL ?? "1h",
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Chat transport helpers — backend side
 // ---------------------------------------------------------------------------
@@ -1532,6 +1587,11 @@ export type ChatTaskRunPayload<
      * `tools` option on `chat.agent`). Empty object when no `tools` were declared.
      */
     tools: TTools;
+    /**
+     * Present only for a channel-delivered turn whose connector supports reactions. Lets the agent
+     * react to the triggering message to signal meaning (e.g. `channel.react("white_check_mark")`).
+     */
+    channel?: ChannelRunSurface;
   };
 
 // Input streams for bidirectional chat communication
@@ -4642,12 +4702,434 @@ export type ChatResumeEvent<TClientData = unknown, TUIM extends UIMessage = UIMe
       clientData?: TClientData;
     };
 
+// ── Channels: a webhook that IS the chat frontend (Slack, etc.), delivered as a TURN not an action ──
+// A connector registers an agent-scoped endpoint that delivers each verified event as a channel
+// message; the run applies inbound() to the raw event to get the turn's message. The loop guard is the
+// server-side `filter` (an ignored event never becomes a delivery), so inbound is a pure mapper.
+// The reply round-trips (egress) in-run: outbound() maps the turn's reply to a channel message, send()
+// posts/edits it. delivery "final" posts an ack at turn start then edits it to the answer at turn end.
+export type ChannelMessageInput = string | UIMessage;
+
+// The channel message a provider posts. Framework requires `text`; providers extend (Slack adds blocks).
+export type ChannelMessage = { text: string; [key: string]: unknown };
+
+// What outbound() receives: enough to decide what (or whether, null) to post. For "stream", `text` is
+// the accumulated text so far.
+export type ChannelReply = {
+  text: string;
+  message: UIMessage;
+  final: boolean;
+  stopped: boolean;
+  error?: unknown;
+};
+
+export type ChannelSendCtx<TEvent = unknown> = {
+  event: TEvent;
+  deliveryId: string;
+  previousRef?: string;
+  mode: "final" | "stream";
+  final: boolean;
+};
+
+export type ChannelAckCtx = {
+  /**
+   * True when this ack is being re-posted because the run is recovering an
+   * interrupted turn after a crash/continuation. The prior run's message ref
+   * is gone, so egress re-emits into the thread as a fresh message; a
+   * connector can vary the placeholder text to read as a deliberate resume
+   * ("picking this back up...") rather than a silent duplicate.
+   */
+  recovered: boolean;
+};
+
+/**
+ * A tool call the turn paused on, awaiting a human decision (HITL). `renderInteraction` maps these to
+ * the controls posted in the thread; the callback resolves one by `toolCallId`.
+ */
+export type ChannelPendingToolCall = { toolCallId: string; toolName: string; input?: unknown };
+
+/**
+ * A verified interaction callback resolved to a tool output. `onInteraction` returns this to resume the
+ * paused run: the framework stitches `output` onto the pending tool part (by `toolCallId`) and continues.
+ */
+export type ChannelInteractionResolution = { toolCallId: string; output: unknown };
+
+export type ChannelInteractionCtx<TEvent = unknown> = { event: TEvent; deliveryId: string };
+
+// A reaction to add (or remove) on the triggering message. `name` is a provider emoji id (e.g. "eyes").
+export type ChannelReaction = { name: string; remove?: boolean };
+export type ChannelReactCtx<TEvent = unknown> = { event: TEvent; deliveryId: string };
+
+// A lifecycle reaction choice: one emoji name, an array (one picked at random per turn), or a resolver
+// of the event returning either (null/undefined to skip). Names are provider emoji ids without colons.
+export type ChannelReactionChoice<TEvent = unknown> =
+  | string
+  | string[]
+  | ((
+      event: TEvent
+    ) => string | string[] | null | undefined | Promise<string | string[] | null | undefined>);
+
+// Lifecycle reactions the run loop applies to the user's message around a turn (add working at start,
+// swap to done at complete, error on failure). Any subset; requires the connector's `react`.
+export type ChannelReactions<TEvent = unknown> = {
+  working?: ChannelReactionChoice<TEvent>;
+  done?: ChannelReactionChoice<TEvent>;
+  error?: ChannelReactionChoice<TEvent>;
+};
+
+// Handed to run() for a channel-delivered turn (when the connector supports reactions), so the agent can
+// react to the triggering message to signal meaning. Best-effort: a failed reaction never throws.
+export type ChannelRunSurface = {
+  react: (name: string) => Promise<void>;
+  unreact: (name: string) => Promise<void>;
+};
+
+// Reserved for 2c: resolve a provider credential keyed by the incoming event's installation (team_id),
+// not the connector (one connector serves many Slack workspaces). The in-run send() calls it at post time.
+export type ResolveChannelToken<TEvent = unknown> = (event: TEvent) => Promise<string>;
+
+declare const channelEventPhantom: unique symbol;
+
+export interface ChannelConnector<TEvent = unknown> {
+  id: string;
+  source: string;
+  key: string; // compiled canonical key template
+  verifierArtifact: WebhookVerifierArtifact;
+  secretProvisioning?: WebhookSecretProvisioning;
+  filter?: string;
+  // Gate session creation: a resolved key with no session is only started when the event matches this
+  // filter (existing sessions always resume). Absent => every routed event can start one.
+  startOn?: string;
+  inbound: (event: TEvent) => ChannelMessageInput;
+  // Egress (optional; a channel can be inbound-only). Fires only when `send` is set.
+  outbound?: (reply: ChannelReply) => ChannelMessage | null;
+  ack?: (event: TEvent, ctx: ChannelAckCtx) => ChannelMessage | null; // placeholder posted at turn start ("final" mode)
+  send?: (message: ChannelMessage, ctx: ChannelSendCtx<TEvent>) => Promise<{ ref?: string }>;
+  /** HITL: controls posted when a turn pauses on a human-decision tool (a tool with no `execute`). */
+  renderInteraction?: (
+    pending: ChannelPendingToolCall[],
+    ctx: ChannelInteractionCtx<TEvent>
+  ) => ChannelMessage | null;
+  /**
+   * HITL: map a verified callback event to a tool resolution. Non-null resumes the paused run; null
+   * means treat the event as a normal inbound message (a new turn).
+   */
+  onInteraction?: (event: TEvent) => ChannelInteractionResolution | null;
+  /**
+   * HITL: finalize the posted controls once a decision is made (edit them away, show the outcome), so
+   * the buttons can't be clicked again. Called with the same verified callback event when
+   * `onInteraction` resolves, before the run resumes. Best-effort: a throw is logged and the run continues.
+   */
+  finalizeInteraction?: (
+    event: TEvent,
+    resolution: ChannelInteractionResolution
+  ) => Promise<void> | void;
+  delivery: "final" | "stream"; // "final" (ack + edit) is v1; "stream" (debounced edits) is a fast-follow
+  // Add/remove a reaction on the triggering message. Powers lifecycle reactions + run()'s channel surface.
+  react?: (reaction: ChannelReaction, ctx: ChannelReactCtx<TEvent>) => Promise<void>;
+  reactions?: ChannelReactions<TEvent>;
+  readonly [channelEventPhantom]?: TEvent;
+}
+export type AnyChannelConnector = ChannelConnector<any>;
+
+/**
+ * A generic chat-frontend channel over any verified source. Unlike `slack()`, you supply the egress
+ * `send` yourself (post/edit the reply back to your surface), so the whole round-trip is under your
+ * control. Use for providers without a preset, or to test the channel round-trip end to end.
+ */
+export function chatChannelCustom<
+  TSource extends AnyWebhookSource,
+  const TKey extends string = string,
+  const TFilter extends string = string,
+  const TStartOn extends string = string,
+>(options: {
+  id: string;
+  source: TSource;
+  key: ValidatedWebhookKey<InferWebhookEvent<TSource>, TKey>;
+  inbound: (event: InferWebhookEvent<TSource>) => ChannelMessageInput;
+  outbound?: (reply: ChannelReply) => ChannelMessage | null;
+  ack?: (event: InferWebhookEvent<TSource>, ctx: ChannelAckCtx) => ChannelMessage | null;
+  send?: (
+    message: ChannelMessage,
+    ctx: ChannelSendCtx<InferWebhookEvent<TSource>>
+  ) => Promise<{ ref?: string }>;
+  renderInteraction?: (
+    pending: ChannelPendingToolCall[],
+    ctx: ChannelInteractionCtx<InferWebhookEvent<TSource>>
+  ) => ChannelMessage | null;
+  onInteraction?: (event: InferWebhookEvent<TSource>) => ChannelInteractionResolution | null;
+  finalizeInteraction?: (
+    event: InferWebhookEvent<TSource>,
+    resolution: ChannelInteractionResolution
+  ) => Promise<void> | void;
+  react?: (
+    reaction: ChannelReaction,
+    ctx: ChannelReactCtx<InferWebhookEvent<TSource>>
+  ) => Promise<void>;
+  reactions?: ChannelReactions<InferWebhookEvent<TSource>>;
+  filter?: TFilter & ValidateWebhookFilter<InferWebhookEvent<TSource>, TFilter>;
+  // Only start a new session when the event matches this filter (existing sessions always resume).
+  startOn?: TStartOn & ValidateWebhookFilter<InferWebhookEvent<TSource>, TStartOn>;
+  delivery?: "final" | "stream";
+}): ChannelConnector<InferWebhookEvent<TSource>> {
+  const {
+    id,
+    source,
+    key,
+    inbound,
+    outbound,
+    ack,
+    send,
+    renderInteraction,
+    onInteraction,
+    finalizeInteraction,
+    react,
+    reactions,
+    filter,
+    startOn,
+    delivery,
+  } = options;
+  resourceCatalog.registerDeclaredSessionWebhook(id);
+  return {
+    id,
+    source: source.provider,
+    key: normalizeKeyString(key as string),
+    verifierArtifact: source.verifier,
+    secretProvisioning: source.secretProvisioning,
+    filter,
+    startOn,
+    inbound,
+    outbound,
+    ack,
+    send,
+    renderInteraction,
+    onInteraction,
+    finalizeInteraction,
+    react,
+    reactions,
+    delivery: delivery ?? "final",
+  } as ChannelConnector<InferWebhookEvent<TSource>>;
+}
+
+const chatChannels = {
+  /** A generic chat-frontend channel over any source, with your own egress. See {@link chatChannelCustom}. */
+  custom: chatChannelCustom,
+};
+
+// Turn a channel connector's inbound() result into a user UIMessage for the turn.
+function toUserUIMessage(input: ChannelMessageInput, messageId: string): UIMessage {
+  if (typeof input !== "string") return input;
+  return { id: messageId, role: "user", parts: [{ type: "text", text: input }] } as UIMessage;
+}
+
+/**
+ * The assistant's closing text for a channel reply: the text after the last tool part in the message,
+ * so a pre-tool preamble (e.g. the HITL "I'll need approval first" line, or a "let me look that up")
+ * is dropped and only the answer is posted. Falls back to all text when there's no trailing text or no
+ * tool parts (an ordinary turn), so a plain reply is unchanged.
+ */
+function channelReplyText(message: UIMessage): string {
+  const parts = (message.parts ?? []) as any[];
+  const isTool = (p: any) => {
+    const t = p?.type;
+    return typeof t === "string" && (t.startsWith("tool-") || t === "dynamic-tool");
+  };
+  let lastToolIdx = -1;
+  parts.forEach((p, i) => {
+    if (isTool(p)) lastToolIdx = i;
+  });
+  const textFrom = (from: number) =>
+    parts
+      .slice(from)
+      .map((p) =>
+        p && typeof p === "object" && "text" in p ? String((p as { text: unknown }).text) : ""
+      )
+      .join("");
+  const trailing = textFrom(lastToolIdx + 1);
+  return trailing.trim().length > 0 ? trailing : textFrom(0);
+}
+
+/** Tool parts of a UIMessage awaiting a human answer (`input-available`), for `renderInteraction`. */
+function pendingToolCallsInMessage(message: UIMessage): ChannelPendingToolCall[] {
+  const out: ChannelPendingToolCall[] = [];
+  for (const part of (message.parts ?? []) as any[]) {
+    if (!part || typeof part !== "object") continue;
+    const type = part.type;
+    const isTool =
+      typeof type === "string" && (type.startsWith("tool-") || type === "dynamic-tool");
+    if (!isTool || part.state !== "input-available") continue;
+    const toolName =
+      type === "dynamic-tool" ? String(part.toolName ?? "") : String(type).slice("tool-".length);
+    if (typeof part.toolCallId === "string")
+      out.push({ toolCallId: part.toolCallId, toolName, input: part.input });
+  }
+  return out;
+}
+
+/**
+ * Build the slim assistant message the HITL resume path expects (mirrors `slimSubmitMessageForWire`):
+ * the pending tool part matched by `toolCallId` across `messages`, advanced to `output-available` with
+ * the interaction's output. Returns undefined when no pending part matches (a stale/duplicate callback).
+ */
+function buildInteractionResolutionMessage(
+  resolution: ChannelInteractionResolution,
+  messages: UIMessage[]
+): UIMessage | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]!;
+    if (message.role !== "assistant") continue;
+    for (const part of (message.parts ?? []) as any[]) {
+      if (!part || typeof part !== "object" || part.toolCallId !== resolution.toolCallId) continue;
+      const type = part.type;
+      const isTool =
+        typeof type === "string" && (type.startsWith("tool-") || type === "dynamic-tool");
+      if (!isTool) continue;
+      const slimPart: Record<string, unknown> = {
+        type,
+        toolCallId: resolution.toolCallId,
+        state: "output-available",
+        output: resolution.output,
+      };
+      if (type === "dynamic-tool" && typeof part.toolName === "string")
+        slimPart.toolName = part.toolName;
+      return { id: message.id, role: "assistant", parts: [slimPart] } as unknown as UIMessage;
+    }
+  }
+  return undefined;
+}
+
+// Default outbound: post the reply text, or nothing when empty (a tool-only / empty turn).
+function defaultChannelOutbound(reply: ChannelReply): ChannelMessage | null {
+  return reply.text ? { text: reply.text } : null;
+}
+
+// Resolve a lifecycle reaction choice to one emoji name for this turn: call a resolver if given, then
+// pick one at random from an array. Returns undefined to skip (no choice / empty).
+export async function resolveReactionChoice(
+  choice: ChannelReactionChoice | undefined,
+  event: unknown
+): Promise<string | undefined> {
+  if (choice == null) return undefined;
+  let value: string | string[] | null | undefined =
+    typeof choice === "function" ? await choice(event) : choice;
+  if (Array.isArray(value)) {
+    if (value.length === 0) return undefined;
+    value = value[Math.floor(Math.random() * value.length)];
+  }
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+// Best-effort reaction on the triggering message; a failure never breaks the turn.
+async function applyChannelReaction(
+  connector: AnyChannelConnector | undefined,
+  wireEvent: { event: unknown; deliveryId: string } | undefined,
+  reaction: ChannelReaction
+): Promise<void> {
+  if (!connector?.react || !wireEvent || !reaction.name) return;
+  try {
+    await connector.react(reaction, { event: wireEvent.event, deliveryId: wireEvent.deliveryId });
+  } catch (error) {
+    logger.warn("chat.agent: channel reaction failed", { error, name: reaction.name });
+  }
+}
+
+// The run()-facing reaction surface for a channel turn (flavor 2). Undefined when the connector has no
+// `react`, so `payload.channel` is only present when reacting is actually possible.
+function buildChannelRunSurface(
+  connector: AnyChannelConnector | undefined,
+  wireEvent: { event: unknown; deliveryId: string } | undefined
+): ChannelRunSurface | undefined {
+  if (!connector?.react || !wireEvent) return undefined;
+  return {
+    react: (name) => applyChannelReaction(connector, wireEvent, { name }),
+    unreact: (name) => applyChannelReaction(connector, wireEvent, { name, remove: true }),
+  };
+}
+
+// "stream" egress: as the reply streams, debounce-edit the ack message (previousRef) with the growing
+// text. Trailing-edge, one edit per interval (Slack chat.update ~1/s); the turn-complete final edit is
+// the authoritative last write. Best-effort: an edit failure is logged, never fatal.
+const CHANNEL_STREAM_EDIT_INTERVAL_MS = 1000;
+function makeChannelStreamEditor<TEvent>(
+  connector: ChannelConnector<TEvent>,
+  channelEvent: { event: unknown; deliveryId: string },
+  ackRef: string
+) {
+  const outbound = connector.outbound ?? defaultChannelOutbound;
+  let latest = "";
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let inFlight = false;
+  let stopped = false;
+
+  const edit = async () => {
+    if (stopped || inFlight) return;
+    const text = latest;
+    const message = outbound({
+      text,
+      message: { id: ackRef, role: "assistant", parts: [{ type: "text", text }] } as UIMessage,
+      final: false,
+      stopped: false,
+    });
+    if (!message) return;
+    inFlight = true;
+    try {
+      await connector.send!(message, {
+        event: channelEvent.event as TEvent,
+        deliveryId: channelEvent.deliveryId,
+        previousRef: ackRef,
+        mode: "stream",
+        final: false,
+      });
+    } catch (error) {
+      logger.warn("chat.agent: channel stream edit failed", { error });
+    } finally {
+      inFlight = false;
+    }
+  };
+
+  return {
+    observe(chunk: unknown) {
+      if (stopped) return;
+      const c = chunk as { type?: string; delta?: unknown };
+      if (c?.type === "text-delta" && typeof c.delta === "string") {
+        latest += c.delta;
+        if (!timer)
+          timer = setTimeout(() => {
+            timer = undefined;
+            void edit();
+          }, CHANNEL_STREAM_EDIT_INTERVAL_MS);
+      }
+    },
+    stop() {
+      stopped = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+    },
+  };
+}
+
+// The `action` type onAction receives: the actionSchema output (when set) unioned with the action
+// envelopes of any listed chat.event descriptors. ChatEventActions<[]> is `never`, so it collapses
+// cleanly when no events are listed; `unknown` is kept only when neither source is present.
+type ChatActionType<
+  TActionSchema extends TaskSchema | undefined,
+  TW extends readonly AnyChatEvent[],
+> = [TActionSchema] extends [TaskSchema]
+  ? inferSchemaOut<TActionSchema> | ChatEventActions<TW>
+  : [TW] extends [readonly []]
+    ? unknown
+    : ChatEventActions<TW>;
+
 export type ChatAgentOptions<
   TIdentifier extends string,
   TClientDataSchema extends TaskSchema | undefined = undefined,
   TUIMessage extends UIMessage = UIMessage,
   TActionSchema extends TaskSchema | undefined = undefined,
   TTools extends ToolSet = ToolSet,
+  TW extends readonly AnyChatEvent[] = [],
+  TChannels extends readonly AnyChannelConnector[] = [],
 > = Omit<
   TaskOptions<
     TIdentifier,
@@ -4750,9 +5232,25 @@ export type ChatAgentOptions<
    * `StreamTextResult` (auto-piped), `string`, or `UIMessage`. Returning
    * `void` or nothing is the side-effect-only default.
    */
+  /**
+   * Inbound `chat.event(...)` descriptors this agent handles. Listing one registers an agent-scoped
+   * webhook endpoint that routes verified deliveries to this agent's session; the delivery arrives at
+   * `onAction` as a `{ type, event, source, headers, deliveryId }` envelope whose `type` is the
+   * descriptor's `type`. The same descriptor listed on another agent gets its own endpoint.
+   */
+  events?: TW;
+
+  /**
+   * Inbound chat frontends (Slack, etc.) via `chat.channels.*`. Listing one registers an agent-scoped
+   * webhook endpoint that routes verified events to a durable per-key session and delivers them as
+   * turns: the connector's `inbound()` maps the raw event to the turn's message, `run()` fires as
+   * normal, and the reply streams back to the channel. Use the connector's `filter` to ignore events.
+   */
+  channels?: TChannels;
+
   onAction?: (
     event: ActionEvent<
-      [TActionSchema] extends [TaskSchema] ? inferSchemaOut<TActionSchema> : unknown,
+      ChatActionType<TActionSchema, TW>,
       inferSchemaOut<TClientDataSchema>,
       TUIMessage
     >
@@ -5395,8 +5893,18 @@ function chatAgent<
   TUIMessage extends UIMessage = UIMessage,
   TActionSchema extends TaskSchema | undefined = undefined,
   TTools extends ToolSet = ToolSet,
+  const TW extends readonly AnyChatEvent[] = [],
+  const TChannels extends readonly AnyChannelConnector[] = [],
 >(
-  options: ChatAgentOptions<TIdentifier, TClientDataSchema, TUIMessage, TActionSchema, TTools>
+  options: ChatAgentOptions<
+    TIdentifier,
+    TClientDataSchema,
+    TUIMessage,
+    TActionSchema,
+    TTools,
+    TW,
+    TChannels
+  >
 ): Task<TIdentifier, ChatTaskWirePayload<TUIMessage, inferSchemaIn<TClientDataSchema>>, unknown> {
   const {
     run: userRun,
@@ -5408,6 +5916,8 @@ function chatAgent<
     onValidateMessages,
     hydrateMessages,
     actionSchema,
+    events,
+    channels,
     onAction,
     onTurnStart,
     onBeforeTurnComplete,
@@ -5780,6 +6290,10 @@ function chatAgent<
         // predecessor chose to end before processing the message;
         // those route through the normal continuation-wait path.
         const hasRecoveredState = partialAssistant !== undefined;
+
+        if (couldHavePriorState && hasRecoveredState) {
+          locals.set(chatChannelRecoveryPendingKey, { value: true });
+        }
 
         let hookChain: TUIMessage[] | undefined;
         let hookRecoveredTurns: TUIMessage[] | undefined;
@@ -6408,6 +6922,9 @@ function chatAgent<
           let capturedPartialResponse: TUIMessage | undefined;
           let responseCommitted = false;
           const turnBufferedChunks: UIMessageChunk[] = [];
+          let channelConn: AnyChannelConnector | undefined;
+          let channelWorkingReaction: string | undefined;
+          let channelWireEvent: { event: unknown; deliveryId: string } | undefined;
           try {
             // Extract turn-level context before entering the span. Slim
             // wire: at most one delta message per record. `headStartMessages`
@@ -6417,11 +6934,74 @@ function chatAgent<
               metadata: wireMetadata,
               message: incomingMessage,
               headStartMessages: _hsm,
+              channelEvent: wireChannelEvent,
               ...restWire
             } = currentWirePayload;
             void _hsm;
-            const incomingMessages: TUIMessage[] = incomingMessage
-              ? [incomingMessage as TUIMessage]
+            channelWireEvent = wireChannelEvent;
+            let effectiveIncomingMessage = incomingMessage;
+            let channelAckRef: string | undefined;
+            if (wireChannelEvent) {
+              channelConn = channels?.find((c) => c.id === wireChannelEvent.connectorId);
+              if (channelConn) {
+                const interaction = channelConn.onInteraction?.(wireChannelEvent.event) ?? null;
+                const resolutionMessage = interaction
+                  ? buildInteractionResolutionMessage(
+                      interaction,
+                      accumulatedUIMessages as UIMessage[]
+                    )
+                  : undefined;
+                if (resolutionMessage) {
+                  effectiveIncomingMessage = resolutionMessage as typeof incomingMessage;
+                  if (interaction && channelConn.finalizeInteraction) {
+                    try {
+                      await channelConn.finalizeInteraction(wireChannelEvent.event, interaction);
+                    } catch (finalizeError) {
+                      logger.warn("chat.agent: channel finalizeInteraction failed; continuing", {
+                        error: finalizeError,
+                      });
+                    }
+                  }
+                } else {
+                  effectiveIncomingMessage = toUserUIMessage(
+                    channelConn.inbound(wireChannelEvent.event),
+                    currentWirePayload.messageId ?? wireChannelEvent.deliveryId
+                  ) as typeof incomingMessage;
+                  if (channelConn.send && channelConn.ack) {
+                    const recoveryPending = locals.get(chatChannelRecoveryPendingKey);
+                    const recovered = recoveryPending?.value === true;
+                    if (recovered) recoveryPending!.value = false;
+                    const ackMessage = channelConn.ack(wireChannelEvent.event, { recovered });
+                    if (ackMessage) {
+                      try {
+                        const ackResult = await channelConn.send(ackMessage, {
+                          event: wireChannelEvent.event,
+                          deliveryId: wireChannelEvent.deliveryId,
+                          mode: channelConn.delivery,
+                          final: false,
+                        });
+                        channelAckRef = ackResult?.ref;
+                      } catch (ackError) {
+                        logger.warn("chat.agent: channel ack post failed; continuing", {
+                          error: ackError,
+                        });
+                      }
+                    }
+                  }
+                  channelWorkingReaction = await resolveReactionChoice(
+                    channelConn.reactions?.working,
+                    wireChannelEvent.event
+                  );
+                  if (channelWorkingReaction) {
+                    await applyChannelReaction(channelConn, wireChannelEvent, {
+                      name: channelWorkingReaction,
+                    });
+                  }
+                }
+              }
+            }
+            const incomingMessages: TUIMessage[] = effectiveIncomingMessage
+              ? [effectiveIncomingMessage as TUIMessage]
               : [];
             // Cleaning happens once here so `extractLastUserMessageText` and
             // every downstream consumer see the same message shape — and
@@ -6580,9 +7160,11 @@ function chatAgent<
                 let actionStreamResult: unknown = undefined;
                 if (isAction) {
                   // Parse and validate the action payload
-                  const parsedAction = parseAction
-                    ? await parseAction(currentWirePayload.action)
-                    : currentWirePayload.action;
+                  const isWebhookAction = currentWirePayload.actionSource === "webhook";
+                  const parsedAction =
+                    parseAction && !isWebhookAction
+                      ? await parseAction(currentWirePayload.action)
+                      : currentWirePayload.action;
 
                   // Hydrate messages from backend if configured
                   if (hydrateMessages) {
@@ -7157,6 +7739,7 @@ function chatAgent<
                         signal: combinedSignal,
                         cancelSignal,
                         stopSignal,
+                        channel: buildChannelRunSurface(channelConn, wireChannelEvent),
                       } as any);
                     }
 
@@ -7199,7 +7782,32 @@ function chatAgent<
                           resolveOnFinish!();
                         },
                       });
-                      await pipeChat(tapUIMessageChunks(uiStream, turnBufferedChunks), {
+                      let streamForPipe: typeof uiStream = uiStream;
+                      if (
+                        wireChannelEvent &&
+                        channelConn?.send &&
+                        channelConn.delivery === "stream" &&
+                        channelAckRef &&
+                        uiStream instanceof ReadableStream
+                      ) {
+                        const editor = makeChannelStreamEditor(
+                          channelConn,
+                          wireChannelEvent,
+                          channelAckRef
+                        );
+                        streamForPipe = uiStream.pipeThrough(
+                          new TransformStream({
+                            transform(chunk, controller) {
+                              editor.observe(chunk);
+                              controller.enqueue(chunk);
+                            },
+                            flush() {
+                              editor.stop();
+                            },
+                          })
+                        );
+                      }
+                      await pipeChat(tapUIMessageChunks(streamForPipe, turnBufferedChunks), {
                         signal: combinedSignal,
                         spanName: "stream response",
                       });
@@ -7650,6 +8258,61 @@ function chatAgent<
                     turnAccessToken
                   );
 
+                  // Channel egress ("final"): map the turn's reply via outbound() and send it, editing
+                  // the ack placeholder posted at turn start (previousRef). Best-effort: an egress failure
+                  // is logged, not fatal. A manual-pipe turn has no responseMessage, so it opts out.
+                  if (wireChannelEvent && channelConn?.send && turnCompleteEvent.responseMessage) {
+                    const pendingToolCalls = pendingToolCallsInMessage(
+                      turnCompleteEvent.responseMessage
+                    );
+                    const channelMessage =
+                      pendingToolCalls.length > 0 && channelConn.renderInteraction
+                        ? channelConn.renderInteraction(pendingToolCalls, {
+                            event: wireChannelEvent.event,
+                            deliveryId: wireChannelEvent.deliveryId,
+                          })
+                        : (channelConn.outbound ?? defaultChannelOutbound)({
+                            text: channelReplyText(turnCompleteEvent.responseMessage),
+                            message: turnCompleteEvent.responseMessage,
+                            final: true,
+                            stopped: turnCompleteEvent.stopped,
+                          });
+                    if (channelMessage) {
+                      try {
+                        await channelConn.send(channelMessage, {
+                          event: wireChannelEvent.event,
+                          deliveryId: wireChannelEvent.deliveryId,
+                          previousRef: channelAckRef,
+                          mode: channelConn.delivery,
+                          final: true,
+                        });
+                      } catch (egressError) {
+                        logger.warn("chat.agent: channel egress send failed", {
+                          error: egressError,
+                        });
+                      }
+                    }
+                  }
+
+                  // Lifecycle reaction: turn done. Remove "working", mark "done".
+                  if (wireChannelEvent && channelConn?.react) {
+                    if (channelWorkingReaction) {
+                      await applyChannelReaction(channelConn, wireChannelEvent, {
+                        name: channelWorkingReaction,
+                        remove: true,
+                      });
+                    }
+                    const doneReaction = await resolveReactionChoice(
+                      channelConn.reactions?.done,
+                      wireChannelEvent.event
+                    );
+                    if (doneReaction) {
+                      await applyChannelReaction(channelConn, wireChannelEvent, {
+                        name: doneReaction,
+                      });
+                    }
+                  }
+
                   // Fire onTurnComplete — stream is closed, use for persistence.
                   if (onTurnComplete) {
                     await tracer.startActiveSpan(
@@ -7905,6 +8568,22 @@ function chatAgent<
               throw turnError;
             }
 
+            if (channelWireEvent && channelConn?.react) {
+              if (channelWorkingReaction) {
+                await applyChannelReaction(channelConn, channelWireEvent, {
+                  name: channelWorkingReaction,
+                  remove: true,
+                });
+              }
+              const errorReaction = await resolveReactionChoice(
+                channelConn.reactions?.error,
+                channelWireEvent.event
+              );
+              if (errorReaction) {
+                await applyChannelReaction(channelConn, channelWireEvent, { name: errorReaction });
+              }
+            }
+
             let errorTurnCompleteResult:
               | Awaited<ReturnType<typeof writeTurnCompleteChunk>>
               | undefined;
@@ -8134,6 +8813,52 @@ function chatAgent<
     resourceCatalog.updateTaskMetadata(options.id, {
       schema: clientDataSchema as any,
     });
+  }
+
+  // Claim each listed chat.event descriptor: register an agent-scoped webhook endpoint that routes
+  // verified deliveries to THIS agent's session. The id is scoped by agent so the same descriptor on
+  // two agents yields two endpoints (no collision), each routing to its own agent.
+  if (events) {
+    for (const wh of events) {
+      resourceCatalog.markSessionWebhookClaimed(wh.id);
+      resourceCatalog.registerWebhookMetadata({
+        id: `${options.id}:${wh.id}`,
+        source: wh.source,
+        verifierArtifact: wh.verifierArtifact,
+        secretProvisioning: wh.secretProvisioning,
+        filter: wh.filter,
+        routingTarget: {
+          type: "session",
+          taskIdentifier: options.id,
+          keyTemplate: wh.key,
+          actionType: wh.type,
+          deliverAs: "action",
+        },
+      });
+    }
+  }
+
+  // Claim each listed channel connector: same agent-scoped endpoint, but deliverAs "message" so a
+  // verified event becomes a turn (the run maps it via the connector's inbound(), resolved by connectorId).
+  if (channels) {
+    for (const ch of channels) {
+      resourceCatalog.markSessionWebhookClaimed(ch.id);
+      resourceCatalog.registerWebhookMetadata({
+        id: `${options.id}:${ch.id}`,
+        source: ch.source,
+        verifierArtifact: ch.verifierArtifact,
+        secretProvisioning: ch.secretProvisioning,
+        filter: ch.filter,
+        routingTarget: {
+          type: "session",
+          taskIdentifier: options.id,
+          keyTemplate: ch.key,
+          connectorId: ch.id,
+          deliverAs: "message",
+          startOn: ch.startOn,
+        },
+      });
+    }
   }
 
   return task;
@@ -10671,6 +11396,10 @@ async function mintPublicTokenWithOverride(args: {
 export const chat = {
   /** Create a chat agent. See {@link chatAgent}. */
   agent: chatAgent,
+  /** Declare an inbound webhook event an agent claims via `chat.agent({ events })`. See {@link chatEvent}. */
+  event: chatEvent,
+  /** Chat frontend connectors (Slack, etc.) an agent claims via `chat.agent({ channels })`. */
+  channels: chatChannels,
   /** Create a custom agent with manual lifecycle control. See {@link chatCustomAgent}. */
   customAgent: chatCustomAgent,
   /** Create a chat task with a fixed {@link UIMessage} subtype and optional default stream options. See {@link withUIMessage}. */
@@ -10685,6 +11414,8 @@ export const chat = {
   local: chatLocal,
   /** Create a public access token for a chat task. See {@link createChatAccessToken}. */
   createAccessToken: createChatAccessToken,
+  /** Mint a read-only token to WATCH a session by externalId (cross-surface). See {@link createChatWatchToken}. */
+  createWatchToken: createChatWatchToken,
   /** Override the turn timeout at runtime (duration string). See {@link setTurnTimeout}. */
   setTurnTimeout,
   /** Override the turn timeout at runtime (seconds). See {@link setTurnTimeoutInSeconds}. */

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -7594,6 +7594,11 @@ function chatAgent<
                   turn--;
                 }
 
+                if (droppedStaleInteraction) {
+                  msgSub.off();
+                  turn--;
+                }
+
                 if (!isAction && !droppedStaleInteraction) {
                   // Mint a scoped public access token once per turn, reused for
                   // onChatStart, onTurnStart, onTurnComplete, and the turn-complete chunk.

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -6988,6 +6988,28 @@ function chatAgent<
               channelConn = channels?.find((c) => c.id === wireChannelEvent.connectorId);
               if (channelConn) {
                 const interaction = channelConn.onInteraction?.(wireChannelEvent.event) ?? null;
+                if (interaction && hydrateMessages && accumulatedUIMessages.length === 0) {
+                  try {
+                    const hydratedForInteraction = (await hydrateMessages({
+                      chatId: currentWirePayload.chatId,
+                      turn,
+                      trigger: "submit-message",
+                      incomingMessages: [],
+                      previousMessages: [...accumulatedUIMessages],
+                      clientData,
+                      continuation,
+                      previousRunId,
+                    })) as TUIMessage[];
+                    accumulatedUIMessages = hydratedForInteraction;
+                    accumulatedMessages = await toModelMessages(hydratedForInteraction);
+                    locals.set(chatCurrentUIMessagesKey, accumulatedUIMessages);
+                  } catch (hydrateError) {
+                    logger.warn(
+                      "chat.agent: hydrateMessages for channel interaction resolution failed",
+                      { error: hydrateError }
+                    );
+                  }
+                }
                 const resolutionMessage = interaction
                   ? buildInteractionResolutionMessage(
                       interaction,

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -46,6 +46,14 @@ import {
   type SessionStreamRecord,
   type AnySessionChannel,
   type SessionChannelName,
+  type AnyChatEvent,
+  type ChatEventActions,
+  type ValidatedWebhookKey,
+  type ValidateWebhookFilter,
+  type WebhookVerifierArtifact,
+  type WebhookSecretProvisioning,
+  type AnyWebhookSource,
+  type InferWebhookEvent,
 } from "@trigger.dev/core/v3";
 import type {
   streamText as aiStreamTextSignature,
@@ -62,6 +70,7 @@ import type {
   JSONSchema7,
   Schema,
 } from "ai";
+import { chatEvent, normalizeKeyString } from "./webhooks.js";
 // Runtime VALUES go through the ESM/CJS shim so the CJS build can `require`
 // ESM-only `ai@7` (see ../imports/ai-runtime.ts).
 import { type Attributes, trace } from "@opentelemetry/api";
@@ -215,6 +224,17 @@ const chatSessionHandleKey = locals.create<SessionHandle>("chat.sessionHandle");
 // is documented to carry. Custom-agent loops never set per-turn context, so subtask tool
 // metadata reads this directly rather than the Session handle id.
 const chatExternalIdKey = locals.create<string>("chat.externalId");
+
+/**
+ * Set at boot when a continuation run inherited an interrupted turn (a
+ * partial assistant reply on `session.out`). Consumed by the first channel
+ * turn's ack so the re-emitted placeholder reads as a recovery resume rather
+ * than a silent duplicate. Boxed so the ack site can flip it to false.
+ * @internal
+ */
+const chatChannelRecoveryPendingKey = locals.create<{ value: boolean }>(
+  "chat.channelRecoveryPending"
+);
 
 /**
  * S2 seq_num of the most recent `turn-complete` control record written by
@@ -1064,6 +1084,41 @@ function createChatAccessToken<TTask extends AnyTask>(
   return auth.createTriggerPublicToken(taskId as string, { expirationTime: "24h" });
 }
 
+/**
+ * Mint a read-only, session-scoped token for WATCHING a chat session by its `externalId`.
+ *
+ * A session is addressed by `externalId`, so the same session is reachable from any surface that
+ * knows it: a web `useChat` client and a Slack thread converge on one session when they share an
+ * `externalId` (for a channel, the connector's `key` template produces it). This token carries
+ * `read:sessions:{externalId}` only (no write): the holder can subscribe to the session's `.out`
+ * stream (observe the conversation, hydrating history from the snapshot) but cannot append to `.in`.
+ *
+ * Use it for a dashboard viewer or a cross-surface watcher of a Slack-thread session. Run server-side
+ * (needs the secret key). To CONTINUE a session from another surface (drive it, not just watch), mint
+ * a read+write token instead ({@link createChatStartSessionAction}).
+ *
+ * @example
+ * ```ts
+ * // actions.ts
+ * "use server";
+ * import { chat } from "@trigger.dev/sdk/ai";
+ *
+ * export const watchChat = (externalId: string) => chat.createWatchToken(externalId);
+ * ```
+ */
+function createChatWatchToken(
+  externalId: string,
+  options?: { tokenTTL?: string }
+): Promise<string> {
+  if (!externalId) {
+    throw new Error("chat.createWatchToken: externalId is required (the session addressing key).");
+  }
+  return auth.createPublicToken({
+    scopes: { read: { sessions: externalId } },
+    expirationTime: options?.tokenTTL ?? "1h",
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Chat transport helpers — backend side
 // ---------------------------------------------------------------------------
@@ -1708,6 +1763,11 @@ export type ChatTaskRunPayload<
      * `tools` option on `chat.agent`). Empty object when no `tools` were declared.
      */
     tools: TTools;
+    /**
+     * Present only for a channel-delivered turn whose connector supports reactions. Lets the agent
+     * react to the triggering message to signal meaning (e.g. `channel.react("white_check_mark")`).
+     */
+    channel?: ChannelRunSurface;
   };
 
 // Input streams for bidirectional chat communication
@@ -6038,12 +6098,485 @@ export type ChatResumeEvent<TClientData = unknown, TUIM extends UIMessage = UIMe
       clientData?: TClientData;
     };
 
+// ── Channels: a webhook that IS the chat frontend (Slack, etc.), delivered as a TURN not an action ──
+// A connector registers an agent-scoped endpoint that delivers each verified event as a channel
+// message; the run applies inbound() to the raw event to get the turn's message. The loop guard is the
+// server-side `filter` (an ignored event never becomes a delivery), so inbound is a pure mapper.
+// The reply round-trips (egress) in-run: outbound() maps the turn's reply to a channel message, send()
+// posts/edits it. delivery "final" posts an ack at turn start then edits it to the answer at turn end.
+export type ChannelMessageInput = string | UIMessage;
+
+// The channel message a provider posts. Framework requires `text`; providers extend (Slack adds blocks).
+export type ChannelMessage = { text: string; [key: string]: unknown };
+
+// What outbound() receives: enough to decide what (or whether, null) to post. For "stream", `text` is
+// the accumulated text so far.
+export type ChannelReply = {
+  text: string;
+  message: UIMessage;
+  final: boolean;
+  stopped: boolean;
+  error?: unknown;
+};
+
+export type ChannelSendCtx<TEvent = unknown> = {
+  event: TEvent;
+  deliveryId: string;
+  previousRef?: string;
+  mode: "final" | "stream";
+  final: boolean;
+};
+
+export type ChannelAckCtx = {
+  /**
+   * True when this ack is being re-posted because the run is recovering an
+   * interrupted turn after a crash/continuation. The prior run's message ref
+   * is gone, so egress re-emits into the thread as a fresh message; a
+   * connector can vary the placeholder text to read as a deliberate resume
+   * ("picking this back up...") rather than a silent duplicate.
+   */
+  recovered: boolean;
+};
+
+/**
+ * A tool call the turn paused on, awaiting a human decision (HITL). `renderInteraction` maps these to
+ * the controls posted in the thread; the callback resolves one by `toolCallId`.
+ */
+export type ChannelPendingToolCall = { toolCallId: string; toolName: string; input?: unknown };
+
+/**
+ * A verified interaction callback resolved to a tool output. `onInteraction` returns this to resume the
+ * paused run: the framework stitches `output` onto the pending tool part (by `toolCallId`) and continues.
+ */
+export type ChannelInteractionResolution = { toolCallId: string; output: unknown };
+
+export type ChannelInteractionCtx<TEvent = unknown> = { event: TEvent; deliveryId: string };
+
+// A reaction to add (or remove) on the triggering message. `name` is a provider emoji id (e.g. "eyes").
+export type ChannelReaction = { name: string; remove?: boolean };
+export type ChannelReactCtx<TEvent = unknown> = { event: TEvent; deliveryId: string };
+
+// A lifecycle reaction choice: one emoji name, an array (one picked at random per turn), or a resolver
+// of the event returning either (null/undefined to skip). Names are provider emoji ids without colons.
+export type ChannelReactionChoice<TEvent = unknown> =
+  | string
+  | string[]
+  | ((
+      event: TEvent
+    ) => string | string[] | null | undefined | Promise<string | string[] | null | undefined>);
+
+// Lifecycle reactions the run loop applies to the user's message around a turn (add working at start,
+// swap to done at complete, error on failure). Any subset; requires the connector's `react`.
+export type ChannelReactions<TEvent = unknown> = {
+  working?: ChannelReactionChoice<TEvent>;
+  done?: ChannelReactionChoice<TEvent>;
+  error?: ChannelReactionChoice<TEvent>;
+};
+
+// Handed to run() for a channel-delivered turn (when the connector supports reactions), so the agent can
+// react to the triggering message to signal meaning. Best-effort: a failed reaction never throws.
+export type ChannelRunSurface = {
+  react: (name: string) => Promise<void>;
+  unreact: (name: string) => Promise<void>;
+};
+
+// Reserved for 2c: resolve a provider credential keyed by the incoming event's installation (team_id),
+// not the connector (one connector serves many Slack workspaces). The in-run send() calls it at post time.
+export type ResolveChannelToken<TEvent = unknown> = (event: TEvent) => Promise<string>;
+
+declare const channelEventPhantom: unique symbol;
+
+export interface ChannelConnector<TEvent = unknown> {
+  id: string;
+  source: string;
+  key: string; // compiled canonical key template
+  verifierArtifact: WebhookVerifierArtifact;
+  secretProvisioning?: WebhookSecretProvisioning;
+  filter?: string;
+  // Gate session creation: a resolved key with no session is only started when the event matches this
+  // filter (existing sessions always resume). Absent => every routed event can start one.
+  startOn?: string;
+  inbound: (event: TEvent) => ChannelMessageInput;
+  // Egress (optional; a channel can be inbound-only). Fires only when `send` is set.
+  outbound?: (reply: ChannelReply) => ChannelMessage | null;
+  ack?: (event: TEvent, ctx: ChannelAckCtx) => ChannelMessage | null; // placeholder posted at turn start ("final" mode)
+  send?: (message: ChannelMessage, ctx: ChannelSendCtx<TEvent>) => Promise<{ ref?: string }>;
+  /** HITL: controls posted when a turn pauses on a human-decision tool (a tool with no `execute`). */
+  renderInteraction?: (
+    pending: ChannelPendingToolCall[],
+    ctx: ChannelInteractionCtx<TEvent>
+  ) => ChannelMessage | null;
+  /**
+   * HITL: map a verified callback event to a tool resolution. Non-null resumes the paused run; null
+   * means treat the event as a normal inbound message (a new turn).
+   */
+  onInteraction?: (event: TEvent) => ChannelInteractionResolution | null;
+  /**
+   * HITL: finalize the posted controls once a decision is made (edit them away, show the outcome), so
+   * the buttons can't be clicked again. Called with the same verified callback event when
+   * `onInteraction` resolves, before the run resumes. Best-effort: a throw is logged and the run continues.
+   */
+  finalizeInteraction?: (
+    event: TEvent,
+    resolution: ChannelInteractionResolution
+  ) => Promise<void> | void;
+  delivery: "final" | "stream"; // "final" (ack + edit) is v1; "stream" (debounced edits) is a fast-follow
+  // Add/remove a reaction on the triggering message. Powers lifecycle reactions + run()'s channel surface.
+  react?: (reaction: ChannelReaction, ctx: ChannelReactCtx<TEvent>) => Promise<void>;
+  reactions?: ChannelReactions<TEvent>;
+  readonly [channelEventPhantom]?: TEvent;
+}
+export type AnyChannelConnector = ChannelConnector<any>;
+
+/**
+ * A generic chat-frontend channel over any verified source. Unlike `slack()`, you supply the egress
+ * `send` yourself (post/edit the reply back to your surface), so the whole round-trip is under your
+ * control. Use for providers without a preset, or to test the channel round-trip end to end.
+ */
+export function chatChannelCustom<
+  TSource extends AnyWebhookSource,
+  const TKey extends string = string,
+  const TFilter extends string = string,
+  const TStartOn extends string = string,
+>(options: {
+  id: string;
+  source: TSource;
+  key: ValidatedWebhookKey<InferWebhookEvent<TSource>, TKey>;
+  inbound: (event: InferWebhookEvent<TSource>) => ChannelMessageInput;
+  outbound?: (reply: ChannelReply) => ChannelMessage | null;
+  ack?: (event: InferWebhookEvent<TSource>, ctx: ChannelAckCtx) => ChannelMessage | null;
+  send?: (
+    message: ChannelMessage,
+    ctx: ChannelSendCtx<InferWebhookEvent<TSource>>
+  ) => Promise<{ ref?: string }>;
+  renderInteraction?: (
+    pending: ChannelPendingToolCall[],
+    ctx: ChannelInteractionCtx<InferWebhookEvent<TSource>>
+  ) => ChannelMessage | null;
+  onInteraction?: (event: InferWebhookEvent<TSource>) => ChannelInteractionResolution | null;
+  finalizeInteraction?: (
+    event: InferWebhookEvent<TSource>,
+    resolution: ChannelInteractionResolution
+  ) => Promise<void> | void;
+  react?: (
+    reaction: ChannelReaction,
+    ctx: ChannelReactCtx<InferWebhookEvent<TSource>>
+  ) => Promise<void>;
+  reactions?: ChannelReactions<InferWebhookEvent<TSource>>;
+  filter?: TFilter & ValidateWebhookFilter<InferWebhookEvent<TSource>, TFilter>;
+  // Only start a new session when the event matches this filter (existing sessions always resume).
+  startOn?: TStartOn & ValidateWebhookFilter<InferWebhookEvent<TSource>, TStartOn>;
+  delivery?: "final" | "stream";
+}): ChannelConnector<InferWebhookEvent<TSource>> {
+  const {
+    id,
+    source,
+    key,
+    inbound,
+    outbound,
+    ack,
+    send,
+    renderInteraction,
+    onInteraction,
+    finalizeInteraction,
+    react,
+    reactions,
+    filter,
+    startOn,
+    delivery,
+  } = options;
+  resourceCatalog.registerDeclaredSessionWebhook(id);
+  return {
+    id,
+    source: source.provider,
+    key: normalizeKeyString(key as string),
+    verifierArtifact: source.verifier,
+    secretProvisioning: source.secretProvisioning,
+    filter,
+    startOn,
+    inbound,
+    outbound,
+    ack,
+    send,
+    renderInteraction,
+    onInteraction,
+    finalizeInteraction,
+    react,
+    reactions,
+    delivery: delivery ?? "final",
+  } as ChannelConnector<InferWebhookEvent<TSource>>;
+}
+
+const chatChannels = {
+  /** A generic chat-frontend channel over any source, with your own egress. See {@link chatChannelCustom}. */
+  custom: chatChannelCustom,
+};
+
+// Turn a channel connector's inbound() result into a user UIMessage for the turn.
+function toUserUIMessage(input: ChannelMessageInput, messageId: string): UIMessage {
+  if (typeof input !== "string") return input;
+  return { id: messageId, role: "user", parts: [{ type: "text", text: input }] } as UIMessage;
+}
+
+/**
+ * The assistant's closing text for a channel reply: the text after the last tool part in the message,
+ * so a pre-tool preamble (e.g. the HITL "I'll need approval first" line, or a "let me look that up")
+ * is dropped and only the answer is posted. Falls back to all text when there's no trailing text or no
+ * tool parts (an ordinary turn), so a plain reply is unchanged.
+ */
+function channelReplyText(message: UIMessage): string {
+  const parts = (message.parts ?? []) as any[];
+  const isTool = (p: any) => {
+    const t = p?.type;
+    return typeof t === "string" && (t.startsWith("tool-") || t === "dynamic-tool");
+  };
+  let lastToolIdx = -1;
+  parts.forEach((p, i) => {
+    if (isTool(p)) lastToolIdx = i;
+  });
+  const textFrom = (from: number) =>
+    parts
+      .slice(from)
+      .map((p) =>
+        p && typeof p === "object" && (p as { type?: unknown }).type === "text"
+          ? String((p as { text: unknown }).text)
+          : ""
+      )
+      .join("");
+  const trailing = textFrom(lastToolIdx + 1);
+  return trailing.trim().length > 0 ? trailing : textFrom(0);
+}
+
+/** Tool parts of a UIMessage awaiting a human answer (`input-available`), for `renderInteraction`. */
+function pendingToolCallsInMessage(message: UIMessage): ChannelPendingToolCall[] {
+  const out: ChannelPendingToolCall[] = [];
+  for (const part of (message.parts ?? []) as any[]) {
+    if (!part || typeof part !== "object") continue;
+    const type = part.type;
+    const isTool =
+      typeof type === "string" && (type.startsWith("tool-") || type === "dynamic-tool");
+    if (!isTool || part.state !== "input-available") continue;
+    const toolName =
+      type === "dynamic-tool" ? String(part.toolName ?? "") : String(type).slice("tool-".length);
+    if (typeof part.toolCallId === "string")
+      out.push({ toolCallId: part.toolCallId, toolName, input: part.input });
+  }
+  return out;
+}
+
+/**
+ * Build the slim assistant message the HITL resume path expects (mirrors `slimSubmitMessageForWire`):
+ * the pending tool part matched by `toolCallId` across `messages`, advanced to `output-available` with
+ * the interaction's output. Returns undefined when no pending part matches (a stale/duplicate callback).
+ */
+function buildInteractionResolutionMessage(
+  resolution: ChannelInteractionResolution,
+  messages: UIMessage[]
+): UIMessage | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]!;
+    if (message.role !== "assistant") continue;
+    for (const part of (message.parts ?? []) as any[]) {
+      if (!part || typeof part !== "object" || part.toolCallId !== resolution.toolCallId) continue;
+      const type = part.type;
+      const isTool =
+        typeof type === "string" && (type.startsWith("tool-") || type === "dynamic-tool");
+      if (!isTool) continue;
+      if (part.state !== "input-available") return undefined;
+      const slimPart: Record<string, unknown> = {
+        type,
+        toolCallId: resolution.toolCallId,
+        state: "output-available",
+        output: resolution.output,
+      };
+      if (type === "dynamic-tool" && typeof part.toolName === "string")
+        slimPart.toolName = part.toolName;
+      return { id: message.id, role: "assistant", parts: [slimPart] } as unknown as UIMessage;
+    }
+  }
+  return undefined;
+}
+
+// Default outbound: post the reply text, or nothing when empty (a tool-only / empty turn).
+function defaultChannelOutbound(reply: ChannelReply): ChannelMessage | null {
+  return reply.text ? { text: reply.text } : null;
+}
+
+// Resolve a lifecycle reaction choice to one emoji name for this turn: call a resolver if given, then
+// pick one at random from an array. Returns undefined to skip (no choice / empty).
+export async function resolveReactionChoice(
+  choice: ChannelReactionChoice | undefined,
+  event: unknown
+): Promise<string | undefined> {
+  if (choice == null) return undefined;
+  let value: string | string[] | null | undefined =
+    typeof choice === "function" ? await choice(event) : choice;
+  if (Array.isArray(value)) {
+    if (value.length === 0) return undefined;
+    value = value[Math.floor(Math.random() * value.length)];
+  }
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+// Best-effort reaction on the triggering message; a failure never breaks the turn.
+async function applyChannelReaction(
+  connector: AnyChannelConnector | undefined,
+  wireEvent: { event: unknown; deliveryId: string } | undefined,
+  reaction: ChannelReaction
+): Promise<void> {
+  if (!connector?.react || !wireEvent || !reaction.name) return;
+  try {
+    await connector.react(reaction, { event: wireEvent.event, deliveryId: wireEvent.deliveryId });
+  } catch (error) {
+    logger.warn("chat.agent: channel reaction failed", { error, name: reaction.name });
+  }
+}
+
+// The run()-facing reaction surface for a channel turn (flavor 2). Undefined when the connector has no
+// `react`, so `payload.channel` is only present when reacting is actually possible.
+function buildChannelRunSurface(
+  connector: AnyChannelConnector | undefined,
+  wireEvent: { event: unknown; deliveryId: string } | undefined
+): ChannelRunSurface | undefined {
+  if (!connector?.react || !wireEvent) return undefined;
+  return {
+    react: (name) => applyChannelReaction(connector, wireEvent, { name }),
+    unreact: (name) => applyChannelReaction(connector, wireEvent, { name, remove: true }),
+  };
+}
+
+// "stream" egress: as the reply streams, debounce-edit the ack message (previousRef) with the growing
+// text. Trailing-edge, one edit per interval (Slack chat.update ~1/s); the turn-complete final edit is
+// the authoritative last write. Best-effort: an edit failure is logged, never fatal.
+const CHANNEL_STREAM_EDIT_INTERVAL_MS = 1000;
+function makeChannelStreamEditor<TEvent>(
+  connector: ChannelConnector<TEvent>,
+  channelEvent: { event: unknown; deliveryId: string },
+  ackRef: string
+) {
+  const outbound = connector.outbound ?? defaultChannelOutbound;
+  let latest = "";
+  let lastSent = "";
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let inFlightPromise: Promise<void> | undefined;
+  let stopped = false;
+
+  const arm = () => {
+    if (stopped || timer) return;
+    timer = setTimeout(() => {
+      timer = undefined;
+      void edit();
+    }, CHANNEL_STREAM_EDIT_INTERVAL_MS);
+  };
+
+  const edit = async () => {
+    if (stopped || inFlightPromise) return;
+    const text = latest;
+    if (text === lastSent) return;
+    const message = outbound({
+      text,
+      message: { id: ackRef, role: "assistant", parts: [{ type: "text", text }] } as UIMessage,
+      final: false,
+      stopped: false,
+    });
+    if (!message) return;
+    inFlightPromise = (async () => {
+      try {
+        await connector.send!(message, {
+          event: channelEvent.event as TEvent,
+          deliveryId: channelEvent.deliveryId,
+          previousRef: ackRef,
+          mode: "stream",
+          final: false,
+        });
+        lastSent = text;
+      } catch (error) {
+        logger.warn("chat.agent: channel stream edit failed", { error });
+      } finally {
+        inFlightPromise = undefined;
+        if (!stopped && latest !== lastSent) arm();
+      }
+    })();
+    await inFlightPromise;
+  };
+
+  return {
+    observe(chunk: unknown) {
+      if (stopped) return;
+      const c = chunk as { type?: string; delta?: unknown };
+      if (c?.type === "text-delta" && typeof c.delta === "string") {
+        latest += c.delta;
+        arm();
+      }
+    },
+    async stop() {
+      stopped = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      if (inFlightPromise) {
+        try {
+          await inFlightPromise;
+        } catch {}
+      }
+    },
+  };
+}
+
+type ChannelStreamEditor = { observe(chunk: unknown): void; stop(): void | Promise<void> };
+
+/**
+ * Wrap the reply stream so it debounce-edits the channel message as it streams.
+ * Both `flush` (the stream completed) and `cancel` (the stream was aborted or
+ * cancelled downstream) stop the editor, so a pending debounce timer can never
+ * fire an edit after the turn ended, onto a message the next turn already owns.
+ */
+function makeChannelStreamTap(editor: ChannelStreamEditor): TransformStream<unknown, unknown> {
+  const transformer: {
+    transform(chunk: unknown, controller: TransformStreamDefaultController<unknown>): void;
+    flush(): Promise<void>;
+    cancel?: (reason?: unknown) => Promise<void>;
+  } = {
+    transform(chunk, controller) {
+      editor.observe(chunk);
+      controller.enqueue(chunk);
+    },
+    async flush() {
+      await editor.stop();
+    },
+    async cancel() {
+      await editor.stop();
+    },
+  };
+  return new TransformStream<unknown, unknown>(transformer);
+}
+
+export {
+  makeChannelStreamEditor as __makeChannelStreamEditorForTests,
+  makeChannelStreamTap as __makeChannelStreamTapForTests,
+};
+
+// The `action` type onAction receives: the actionSchema output (when set) unioned with the action
+// envelopes of any listed chat.event descriptors. ChatEventActions<[]> is `never`, so it collapses
+// cleanly when no events are listed; `unknown` is kept only when neither source is present.
+type ChatActionType<
+  TActionSchema extends TaskSchema | undefined,
+  TW extends readonly AnyChatEvent[],
+> = [TActionSchema] extends [TaskSchema]
+  ? inferSchemaOut<TActionSchema> | ChatEventActions<TW>
+  : [TW] extends [readonly []]
+    ? unknown
+    : ChatEventActions<TW>;
+
 export type ChatAgentOptions<
   TIdentifier extends string,
   TClientDataSchema extends TaskSchema | undefined = undefined,
   TUIMessage extends UIMessage = UIMessage,
   TActionSchema extends TaskSchema | undefined = undefined,
   TTools extends ToolSet = ToolSet,
+  TW extends readonly AnyChatEvent[] = [],
+  TChannels extends readonly AnyChannelConnector[] = [],
 > = Omit<
   TaskOptions<
     TIdentifier,
@@ -6159,9 +6692,25 @@ export type ChatAgentOptions<
    * action that returns nothing is a state edit only. Returning anything else
    * is an error; a response can no longer be returned directly.
    */
+  /**
+   * Inbound `chat.event(...)` descriptors this agent handles. Listing one registers an agent-scoped
+   * webhook endpoint that routes verified deliveries to this agent's session; the delivery arrives at
+   * `onAction` as a `{ type, event, source, headers, deliveryId }` envelope whose `type` is the
+   * descriptor's `type`. The same descriptor listed on another agent gets its own endpoint.
+   */
+  events?: TW;
+
+  /**
+   * Inbound chat frontends (Slack, etc.) via `chat.channels.*`. Listing one registers an agent-scoped
+   * webhook endpoint that routes verified events to a durable per-key session and delivers them as
+   * turns: the connector's `inbound()` maps the raw event to the turn's message, `run()` fires as
+   * normal, and the reply streams back to the channel. Use the connector's `filter` to ignore events.
+   */
+  channels?: TChannels;
+
   onAction?: (
     event: ActionEvent<
-      [TActionSchema] extends [TaskSchema] ? inferSchemaOut<TActionSchema> : unknown,
+      ChatActionType<TActionSchema, TW>,
       inferSchemaOut<TClientDataSchema>,
       TUIMessage
     >
@@ -6395,6 +6944,13 @@ export type ChatAgentOptions<
    *   },
    * });
    * ```
+   *
+   * Note: on a channel HITL resume turn (a button click that lands on a fresh
+   * run whose accumulator doesn't yet hold the pending tool call), this hook is
+   * called twice for the one delivery: once with `incomingMessages: []` to load
+   * the chain and locate the pending tool call, then again with the synthesized
+   * resolution message so it can be persisted. Keep the hook's read path
+   * idempotent.
    */
   hydrateMessages?: (
     event: HydrateMessagesEvent<inferSchemaOut<TClientDataSchema>, TUIMessage>
@@ -7017,8 +7573,18 @@ function chatAgent<
   TUIMessage extends UIMessage = UIMessage,
   TActionSchema extends TaskSchema | undefined = undefined,
   TTools extends ToolSet = ToolSet,
+  const TW extends readonly AnyChatEvent[] = [],
+  const TChannels extends readonly AnyChannelConnector[] = [],
 >(
-  options: ChatAgentOptions<TIdentifier, TClientDataSchema, TUIMessage, TActionSchema, TTools>
+  options: ChatAgentOptions<
+    TIdentifier,
+    TClientDataSchema,
+    TUIMessage,
+    TActionSchema,
+    TTools,
+    TW,
+    TChannels
+  >
 ): Task<TIdentifier, ChatTaskWirePayload<TUIMessage, inferSchemaIn<TClientDataSchema>>, unknown> {
   const {
     run: userRun,
@@ -7031,6 +7597,8 @@ function chatAgent<
     hydrateMessages,
     storage,
     actionSchema,
+    events,
+    channels,
     onAction,
     onTurnStart,
     onBeforeTurnComplete,
@@ -7677,6 +8245,10 @@ function chatAgent<
         // predecessor chose to end before processing the message;
         // those route through the normal continuation-wait path.
         const hasRecoveredState = partialAssistant !== undefined;
+
+        if (couldHavePriorState && hasRecoveredState) {
+          locals.set(chatChannelRecoveryPendingKey, { value: true });
+        }
 
         let hookChain: TUIMessage[] | undefined;
         let hookRecoveredTurns: TUIMessage[] | undefined;
@@ -8348,6 +8920,14 @@ function chatAgent<
           let capturedPartialResponse: TUIMessage | undefined;
           let responseCommitted = false;
           const turnBufferedChunks: UIMessageChunk[] = [];
+          let channelConn: AnyChannelConnector | undefined;
+          let channelWorkingReaction: string | undefined;
+          let channelWireEvent: { event: unknown; deliveryId: string } | undefined;
+          let channelAckRef: string | undefined;
+          let channelStreamEditor: ChannelStreamEditor | undefined;
+          let droppedStaleInteraction = false;
+          let droppedUnknownConnector = false;
+          let channelFinalAnswerPosted = false;
           try {
             // Extract turn-level context before entering the span. Slim
             // wire: at most one delta message per record. `headStartMessages`
@@ -8357,11 +8937,131 @@ function chatAgent<
               metadata: wireMetadata,
               message: incomingMessage,
               headStartMessages: _hsm,
+              channelEvent: wireChannelEvent,
               ...restWire
             } = currentWirePayload;
             void _hsm;
-            const incomingMessages: TUIMessage[] = incomingMessage
-              ? [incomingMessage as TUIMessage]
+            channelWireEvent = wireChannelEvent;
+            let effectiveIncomingMessage = incomingMessage;
+            const clientData = (
+              parseClientData ? await parseClientData(wireMetadata) : wireMetadata
+            ) as inferSchemaOut<TClientDataSchema>;
+            turnClientData = clientData;
+            if (wireChannelEvent) {
+              channelConn = channels?.find((c) => c.id === wireChannelEvent.connectorId);
+              if (channelConn) {
+                const interaction = channelConn.onInteraction?.(wireChannelEvent.event) ?? null;
+                const accumulatorHasInteractionToolCall =
+                  interaction != null &&
+                  accumulatedUIMessages.some((m) =>
+                    ((m.parts ?? []) as { toolCallId?: unknown }[]).some(
+                      (p) => p?.toolCallId === interaction.toolCallId
+                    )
+                  );
+                if (interaction && loadContextHook && !accumulatorHasInteractionToolCall) {
+                  try {
+                    const hydratedForInteraction = (await loadContextHook({
+                      chatId: currentWirePayload.chatId,
+                      turn,
+                      trigger: "submit-message",
+                      incomingMessages: [],
+                      previousMessages: [...accumulatedUIMessages],
+                      clientData,
+                      continuation,
+                      previousRunId,
+                    })) as TUIMessage[];
+                    accumulatedUIMessages = hydratedForInteraction;
+                    accumulatedMessages = await toModelMessages(hydratedForInteraction);
+                    laneCompacted = false;
+                    laneInjections = [];
+                    locals.set(chatCurrentUIMessagesKey, accumulatedUIMessages);
+                  } catch (hydrateError) {
+                    logger.warn(
+                      "chat.agent: hydrateMessages for channel interaction resolution failed",
+                      { error: hydrateError }
+                    );
+                  }
+                }
+                const resolutionMessage = interaction
+                  ? buildInteractionResolutionMessage(
+                      interaction,
+                      accumulatedUIMessages as UIMessage[]
+                    )
+                  : undefined;
+                if (resolutionMessage) {
+                  effectiveIncomingMessage = resolutionMessage as typeof incomingMessage;
+                  if (interaction && channelConn.finalizeInteraction) {
+                    try {
+                      await channelConn.finalizeInteraction(wireChannelEvent.event, interaction);
+                    } catch (finalizeError) {
+                      logger.warn("chat.agent: channel finalizeInteraction failed; continuing", {
+                        error: finalizeError,
+                      });
+                    }
+                  }
+                } else if (interaction) {
+                  droppedStaleInteraction = true;
+                  logger.debug(
+                    "chat.agent: dropping stale channel interaction that matched no pending tool call",
+                    {
+                      deliveryId: wireChannelEvent.deliveryId,
+                    }
+                  );
+                } else {
+                  effectiveIncomingMessage = toUserUIMessage(
+                    channelConn.inbound(wireChannelEvent.event),
+                    currentWirePayload.messageId ?? wireChannelEvent.deliveryId
+                  ) as typeof incomingMessage;
+                  if (channelConn.send && channelConn.ack) {
+                    const recoveryPending = locals.get(chatChannelRecoveryPendingKey);
+                    const recovered = recoveryPending?.value === true;
+                    if (recovered) recoveryPending!.value = false;
+                    const ackMessage = channelConn.ack(wireChannelEvent.event, { recovered });
+                    if (ackMessage) {
+                      try {
+                        const ackResult = await channelConn.send(ackMessage, {
+                          event: wireChannelEvent.event,
+                          deliveryId: wireChannelEvent.deliveryId,
+                          mode: channelConn.delivery,
+                          final: false,
+                        });
+                        channelAckRef = ackResult?.ref;
+                      } catch (ackError) {
+                        logger.warn("chat.agent: channel ack post failed; continuing", {
+                          error: ackError,
+                        });
+                      }
+                    }
+                  }
+                  try {
+                    channelWorkingReaction = await resolveReactionChoice(
+                      channelConn.reactions?.working,
+                      wireChannelEvent.event
+                    );
+                    if (channelWorkingReaction) {
+                      await applyChannelReaction(channelConn, wireChannelEvent, {
+                        name: channelWorkingReaction,
+                      });
+                    }
+                  } catch (reactionError) {
+                    logger.warn("chat.agent: channel working reaction failed", {
+                      error: reactionError,
+                    });
+                  }
+                }
+              } else {
+                droppedUnknownConnector = true;
+                logger.warn(
+                  "chat.agent: no channel connector matches this delivery; skipping turn",
+                  {
+                    connectorId: wireChannelEvent.connectorId,
+                    deliveryId: wireChannelEvent.deliveryId,
+                  }
+                );
+              }
+            }
+            const incomingMessages: TUIMessage[] = effectiveIncomingMessage
+              ? [effectiveIncomingMessage as TUIMessage]
               : [];
             // Cleaning happens once here so `extractLastUserMessageText` and
             // every downstream consumer see the same message shape — and
@@ -8369,10 +9069,6 @@ function chatAgent<
             const cleanedIncomingMessages: TUIMessage[] = incomingMessages.map((msg) =>
               msg.role === "assistant" ? cleanupAbortedParts(msg) : msg
             );
-            const clientData = (
-              parseClientData ? await parseClientData(wireMetadata) : wireMetadata
-            ) as inferSchemaOut<TClientDataSchema>;
-            turnClientData = clientData;
             const lastUserMessage = extractLastUserMessageText(cleanedIncomingMessages);
 
             // Actions are not turns. They use a different span name
@@ -8465,6 +9161,12 @@ function chatAgent<
                   ? chatInputRouter().observe(CHAT_ROUTE_MESSAGES, async (record) => {
                       const msg = (record.data as Extract<ChatInputChunk, { kind: "message" }>)
                         .payload;
+                      // A channel-delivered record (Slack or any `chat.channels.*` connector)
+                      // is never steered mid-turn. Observing does not consume, so leaving
+                      // it here keeps it queued on the router to run as its own turn.
+                      if ((msg as { channelEvent?: unknown }).channelEvent != null) {
+                        return;
+                      }
                       // Slim wire: at most one delta message per record. The
                       // pendingMessages handler reads `msg.message` directly
                       // instead of slicing an array — a wire record arrives
@@ -8538,9 +9240,11 @@ function chatAgent<
                 let actionChangedHistory = false;
                 if (isAction) {
                   // Parse and validate the action payload
-                  const parsedAction = parseAction
-                    ? await parseAction(currentWirePayload.action)
-                    : currentWirePayload.action;
+                  const isWebhookAction = currentWirePayload.actionSource === "webhook";
+                  const parsedAction =
+                    parseAction && !isWebhookAction
+                      ? await parseAction(currentWirePayload.action)
+                      : currentWirePayload.action;
 
                   // Hydrate messages from backend if configured
                   if (loadContextHook) {
@@ -8626,7 +9330,11 @@ function chatAgent<
                 // snapshot + `session.out` replay (or `hydrateMessages`,
                 // which also fires per-turn below). Per-turn handling is
                 // therefore a delta merge, not a full-history reset.
-                if (currentWirePayload.trigger !== "action") {
+                if (
+                  currentWirePayload.trigger !== "action" &&
+                  !droppedStaleInteraction &&
+                  !droppedUnknownConnector
+                ) {
                   let cleanedUIMessages: TUIMessage[] = cleanedIncomingMessages;
 
                   // Turn-0 head-start with hydrateMessages: the boot seeding from
@@ -8907,19 +9615,26 @@ function chatAgent<
                 // calling the model would prefill its own last reply. Keyed on
                 // the model tail, so a `tool`-terminated chain (a merged tool
                 // approval) still runs.
+                // A channel delivery the run decided not to turn into a turn: a stale
+                // interaction callback (no pending tool call matched) or an event for
+                // a connector this agent does not list. Nothing to answer either way.
+                const isDroppedChannelDelivery = droppedStaleInteraction || droppedUnknownConnector;
                 const isNoOpTurn =
-                  !isAction &&
-                  !splicedHandoverPartial &&
-                  currentWirePayload.trigger === "submit-message" &&
-                  turnNewUIMessages.length === 0 &&
-                  accumulatedMessages[accumulatedMessages.length - 1]?.role === "assistant";
+                  isDroppedChannelDelivery ||
+                  (!isAction &&
+                    !splicedHandoverPartial &&
+                    currentWirePayload.trigger === "submit-message" &&
+                    turnNewUIMessages.length === 0 &&
+                    accumulatedMessages[accumulatedMessages.length - 1]?.role === "assistant");
 
                 if (isNoOpTurn) {
                   msgSub?.off();
-                  logger.warn("chat.agent: turn added no new user message; skipping the model", {
-                    chatId: currentWirePayload.chatId,
-                    messageId: currentWirePayload.messageId,
-                  });
+                  if (!isDroppedChannelDelivery) {
+                    logger.warn("chat.agent: turn added no new user message; skipping the model", {
+                      chatId: currentWirePayload.chatId,
+                      messageId: currentWirePayload.messageId,
+                    });
+                  }
                   settleRecoveredTurn(currentWirePayload);
                   await writeTurnCompleteChunk(currentWirePayload.chatId);
                   // Not a turn — don't consume an iteration.
@@ -9201,6 +9916,7 @@ function chatAgent<
                           agentCacheControl,
                           agentSystemProviderOptions
                         ),
+                        channel: buildChannelRunSurface(channelConn, wireChannelEvent),
                       } as any);
                     }
 
@@ -9243,7 +9959,24 @@ function chatAgent<
                           resolveOnFinish!();
                         },
                       });
-                      await pipeChat(tapUIMessageChunks(uiStream, turnBufferedChunks), {
+                      let streamForPipe: typeof uiStream = uiStream;
+                      if (
+                        wireChannelEvent &&
+                        channelConn?.send &&
+                        channelConn.delivery === "stream" &&
+                        channelAckRef &&
+                        uiStream instanceof ReadableStream
+                      ) {
+                        channelStreamEditor = makeChannelStreamEditor(
+                          channelConn,
+                          wireChannelEvent,
+                          channelAckRef
+                        );
+                        streamForPipe = uiStream.pipeThrough(
+                          makeChannelStreamTap(channelStreamEditor)
+                        );
+                      }
+                      await pipeChat(tapUIMessageChunks(streamForPipe, turnBufferedChunks), {
                         signal: combinedSignal,
                         spanName: "stream response",
                       });
@@ -9260,6 +9993,7 @@ function chatAgent<
                     }
                   } finally {
                     msgSub?.off();
+                    await channelStreamEditor?.stop();
                   }
 
                   // Wait for onFinish to fire — on abort this may resolve slightly
@@ -9770,6 +10504,68 @@ function chatAgent<
                     turnAccessToken
                   );
 
+                  // Channel egress ("final"): map the turn's reply via outbound() and send it, editing
+                  // the ack placeholder posted at turn start (previousRef). Best-effort: an egress failure
+                  // is logged, not fatal. A manual-pipe turn has no responseMessage, so it opts out.
+                  if (wireChannelEvent && channelConn?.send && turnCompleteEvent.responseMessage) {
+                    const pendingToolCalls = pendingToolCallsInMessage(
+                      turnCompleteEvent.responseMessage
+                    );
+                    const channelMessage =
+                      pendingToolCalls.length > 0 && channelConn.renderInteraction
+                        ? channelConn.renderInteraction(pendingToolCalls, {
+                            event: wireChannelEvent.event,
+                            deliveryId: wireChannelEvent.deliveryId,
+                          })
+                        : (channelConn.outbound ?? defaultChannelOutbound)({
+                            text: channelReplyText(turnCompleteEvent.responseMessage),
+                            message: turnCompleteEvent.responseMessage,
+                            final: true,
+                            stopped: turnCompleteEvent.stopped,
+                          });
+                    if (channelMessage) {
+                      try {
+                        await channelConn.send(channelMessage, {
+                          event: wireChannelEvent.event,
+                          deliveryId: wireChannelEvent.deliveryId,
+                          previousRef: channelAckRef,
+                          mode: channelConn.delivery,
+                          final: true,
+                        });
+                        channelFinalAnswerPosted = true;
+                      } catch (egressError) {
+                        logger.warn("chat.agent: channel egress send failed", {
+                          error: egressError,
+                        });
+                      }
+                    }
+                  }
+
+                  // Lifecycle reaction: turn done. Remove "working", mark "done".
+                  if (wireChannelEvent && channelConn?.react) {
+                    try {
+                      if (channelWorkingReaction) {
+                        await applyChannelReaction(channelConn, wireChannelEvent, {
+                          name: channelWorkingReaction,
+                          remove: true,
+                        });
+                      }
+                      const doneReaction = await resolveReactionChoice(
+                        channelConn.reactions?.done,
+                        wireChannelEvent.event
+                      );
+                      if (doneReaction) {
+                        await applyChannelReaction(channelConn, wireChannelEvent, {
+                          name: doneReaction,
+                        });
+                      }
+                    } catch (reactionError) {
+                      logger.warn("chat.agent: channel done reaction failed", {
+                        error: reactionError,
+                      });
+                    }
+                  }
+
                   // Fire onTurnComplete — stream is closed, use for persistence.
                   if (onTurnComplete) {
                     await tracer.startActiveSpan(
@@ -10030,6 +10826,75 @@ function chatAgent<
             // (same chatId / Session, accumulator rehydrates).
             if (turnError instanceof OutOfMemoryError) {
               throw turnError;
+            }
+
+            if (channelWireEvent && channelConn?.react) {
+              try {
+                if (channelWorkingReaction) {
+                  await applyChannelReaction(channelConn, channelWireEvent, {
+                    name: channelWorkingReaction,
+                    remove: true,
+                  });
+                }
+                const errorReaction = await resolveReactionChoice(
+                  channelConn.reactions?.error,
+                  channelWireEvent.event
+                );
+                if (errorReaction) {
+                  await applyChannelReaction(channelConn, channelWireEvent, {
+                    name: errorReaction,
+                  });
+                }
+              } catch (reactionError) {
+                logger.warn("chat.agent: channel error reaction failed", { error: reactionError });
+              }
+            }
+
+            if (channelWireEvent && channelConn?.send) {
+              const sanitizeChannelError = resolveUIMessageStreamOptions().onError;
+              let channelErrorText: string;
+              try {
+                channelErrorText = sanitizeChannelError
+                  ? sanitizeChannelError(turnError)
+                  : turnError instanceof Error
+                    ? turnError.message
+                    : "An unexpected error occurred";
+              } catch {
+                channelErrorText = "An unexpected error occurred";
+              }
+              const errorPreviousRef = channelFinalAnswerPosted ? undefined : channelAckRef;
+              const channelErrorMessageId = errorPreviousRef ?? channelWireEvent.deliveryId;
+              let errorMessage: ChannelMessage | null = null;
+              try {
+                errorMessage = (channelConn.outbound ?? defaultChannelOutbound)({
+                  text: channelErrorText,
+                  message: {
+                    id: channelErrorMessageId,
+                    role: "assistant",
+                    parts: [{ type: "text", text: channelErrorText }],
+                  } as UIMessage,
+                  final: true,
+                  stopped: false,
+                  error: turnError,
+                });
+              } catch (outboundError) {
+                logger.warn("chat.agent: channel error outbound failed", { error: outboundError });
+              }
+              if (errorMessage) {
+                try {
+                  await channelConn.send(errorMessage, {
+                    event: channelWireEvent.event,
+                    deliveryId: channelWireEvent.deliveryId,
+                    previousRef: errorPreviousRef,
+                    mode: channelConn.delivery,
+                    final: true,
+                  });
+                } catch (egressError) {
+                  logger.warn("chat.agent: channel error egress send failed", {
+                    error: egressError,
+                  });
+                }
+              }
             }
 
             let errorTurnCompleteResult:
@@ -10329,6 +11194,52 @@ function chatAgent<
     resourceCatalog.updateTaskMetadata(options.id, {
       schema: clientDataSchema as any,
     });
+  }
+
+  // Claim each listed chat.event descriptor: register an agent-scoped webhook endpoint that routes
+  // verified deliveries to THIS agent's session. The id is scoped by agent so the same descriptor on
+  // two agents yields two endpoints (no collision), each routing to its own agent.
+  if (events) {
+    for (const wh of events) {
+      resourceCatalog.markSessionWebhookClaimed(wh.id);
+      resourceCatalog.registerWebhookMetadata({
+        id: `${options.id}:${wh.id}`,
+        source: wh.source,
+        verifierArtifact: wh.verifierArtifact,
+        secretProvisioning: wh.secretProvisioning,
+        filter: wh.filter,
+        routingTarget: {
+          type: "session",
+          taskIdentifier: options.id,
+          keyTemplate: wh.key,
+          actionType: wh.type,
+          deliverAs: "action",
+        },
+      });
+    }
+  }
+
+  // Claim each listed channel connector: same agent-scoped endpoint, but deliverAs "message" so a
+  // verified event becomes a turn (the run maps it via the connector's inbound(), resolved by connectorId).
+  if (channels) {
+    for (const ch of channels) {
+      resourceCatalog.markSessionWebhookClaimed(ch.id);
+      resourceCatalog.registerWebhookMetadata({
+        id: `${options.id}:${ch.id}`,
+        source: ch.source,
+        verifierArtifact: ch.verifierArtifact,
+        secretProvisioning: ch.secretProvisioning,
+        filter: ch.filter,
+        routingTarget: {
+          type: "session",
+          taskIdentifier: options.id,
+          keyTemplate: ch.key,
+          connectorId: ch.id,
+          deliverAs: "message",
+          startOn: ch.startOn,
+        },
+      });
+    }
   }
 
   return task;
@@ -13449,6 +14360,10 @@ function createChatLoadTranscriptAction<TClientData = unknown>(
 export const chat = {
   /** Create a chat agent. See {@link chatAgent}. */
   agent: chatAgent,
+  /** Declare an inbound webhook event an agent claims via `chat.agent({ events })`. See {@link chatEvent}. */
+  event: chatEvent,
+  /** Chat frontend connectors (Slack, etc.) an agent claims via `chat.agent({ channels })`. */
+  channels: chatChannels,
   /** Create a custom agent with manual lifecycle control. See {@link chatCustomAgent}. */
   customAgent: chatCustomAgent,
   /** Create a chat task with a fixed {@link UIMessage} subtype and optional default stream options. See {@link withUIMessage}. */
@@ -13467,6 +14382,8 @@ export const chat = {
   local: chatLocal,
   /** Create a public access token for a chat task. See {@link createChatAccessToken}. */
   createAccessToken: createChatAccessToken,
+  /** Mint a read-only token to WATCH a session by externalId (cross-surface). See {@link createChatWatchToken}. */
+  createWatchToken: createChatWatchToken,
   /** Override the turn timeout at runtime (duration string). See {@link setTurnTimeout}. */
   setTurnTimeout,
   /** Override the turn timeout at runtime (seconds). See {@link setTurnTimeoutInSeconds}. */

--- a/packages/trigger-sdk/src/v3/channelReactions.test.ts
+++ b/packages/trigger-sdk/src/v3/channelReactions.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { resolveReactionChoice } from "./ai.js";
+
+describe("resolveReactionChoice", () => {
+  it("returns a single string as-is", async () => {
+    expect(await resolveReactionChoice("eyes", {})).toBe("eyes");
+  });
+
+  it("skips when absent or empty", async () => {
+    expect(await resolveReactionChoice(undefined, {})).toBeUndefined();
+    expect(await resolveReactionChoice("", {})).toBeUndefined();
+    expect(await resolveReactionChoice([], {})).toBeUndefined();
+    expect(await resolveReactionChoice(() => undefined, {})).toBeUndefined();
+    expect(await resolveReactionChoice(() => null, {})).toBeUndefined();
+  });
+
+  it("picks a member of an array (randomly)", async () => {
+    const options = ["eyes", "hourglass", "thinking_face"];
+    const seen = new Set<string>();
+    for (let i = 0; i < 60; i++) {
+      const picked = await resolveReactionChoice(options, {});
+      expect(options).toContain(picked);
+      seen.add(picked!);
+    }
+    // Over 60 draws from 3 options, seeing only one is astronomically unlikely: proves it varies.
+    expect(seen.size).toBeGreaterThan(1);
+  });
+
+  it("resolves a function of the event, returning a string or an array", async () => {
+    const byKind = (e: unknown) => `emoji-${(e as { kind: string }).kind}`;
+    expect(await resolveReactionChoice(byKind, { kind: "bug" })).toBe("emoji-bug");
+    const picked = await resolveReactionChoice(() => ["a", "b"], {});
+    expect(["a", "b"]).toContain(picked);
+  });
+
+  it("awaits an async resolver", async () => {
+    expect(await resolveReactionChoice(async () => "shipit", {})).toBe("shipit");
+  });
+});

--- a/packages/trigger-sdk/src/v3/chat.ts
+++ b/packages/trigger-sdk/src/v3/chat.ts
@@ -97,6 +97,24 @@ export type ChatTaskWirePayload<TMessage extends UIMessage = UIMessage, TMetadat
   metadata?: TMetadata;
   /** Custom action payload when `trigger` is `"action"`. Validated against `actionSchema` on the backend. */
   action?: unknown;
+  /**
+   * Origin of an `"action"` trigger. `"webhook"` actions (delivered by the hosted webhook ingress)
+   * carry a fixed envelope typed via `ChatEventActions`, so they bypass `actionSchema` validation;
+   * omitted / `"client"` actions (frontend or server) are validated against `actionSchema`.
+   */
+  actionSource?: "client" | "webhook";
+  /**
+   * A channel-delivered turn (hosted webhook ingress -> a chat frontend like Slack). Carries the raw
+   * verified provider event; the run resolves the connector by `connectorId` from `chat.agent({ channels })`
+   * and applies its `inbound()` mapper to produce the turn's message. Present instead of `message`.
+   */
+  channelEvent?: {
+    connectorId: string;
+    event: unknown;
+    source: string;
+    headers: Record<string, string>;
+    deliveryId: string;
+  };
   /** Whether this run is continuing an existing chat whose previous run ended. */
   continuation?: boolean;
   /** The run ID of the previous run (only set when `continuation` is true). */

--- a/packages/trigger-sdk/src/v3/chat.ts
+++ b/packages/trigger-sdk/src/v3/chat.ts
@@ -106,6 +106,24 @@ export type ChatTaskWirePayload<TMessage extends UIMessage = UIMessage, TMetadat
    * this against `actionSchema`; raw custom agents must validate it themselves.
    */
   action?: unknown;
+  /**
+   * Origin of an `"action"` trigger. `"webhook"` actions (delivered by the hosted webhook ingress)
+   * carry a fixed envelope typed via `ChatEventActions`, so they bypass `actionSchema` validation;
+   * omitted / `"client"` actions (frontend or server) are validated against `actionSchema`.
+   */
+  actionSource?: "client" | "webhook";
+  /**
+   * A channel-delivered turn (hosted webhook ingress -> a chat frontend like Slack). Carries the raw
+   * verified provider event; the run resolves the connector by `connectorId` from `chat.agent({ channels })`
+   * and applies its `inbound()` mapper to produce the turn's message. Present instead of `message`.
+   */
+  channelEvent?: {
+    connectorId: string;
+    event: unknown;
+    source: string;
+    headers: Record<string, string>;
+    deliveryId: string;
+  };
   /** Whether this run is continuing an existing chat whose previous run ended. */
   continuation?: boolean;
   /** The run ID of the previous run (only set when `continuation` is true). */

--- a/packages/trigger-sdk/src/v3/test/index.ts
+++ b/packages/trigger-sdk/src/v3/test/index.ts
@@ -8,10 +8,21 @@ import "./setup-catalog.js";
 
 export {
   mockChatAgent,
+  DEFAULT_TEST_CONNECTOR_ID,
   type MockChatAgentOptions,
   type MockChatAgentHarness,
   type MockChatAgentTurn,
 } from "./mock-chat-agent.js";
+
+export {
+  recordingChannelConnector,
+  type RecordingChannelConnector,
+  type RecordingChannelConnectorOptions,
+  type RecordedSend,
+  type RecordedReaction,
+  type RecordedFinalize,
+  type TestChannelEvent,
+} from "./mock-channel-connector.js";
 
 // Re-export the lower-level task context harness so consumers can build
 // their own test helpers without adding a separate `@trigger.dev/core`

--- a/packages/trigger-sdk/src/v3/test/index.ts
+++ b/packages/trigger-sdk/src/v3/test/index.ts
@@ -8,6 +8,7 @@ import "./setup-catalog.js";
 
 export {
   mockChatAgent,
+  DEFAULT_TEST_CONNECTOR_ID,
   type MockChatAgentOptions,
   type MockChatAgentHarness,
   type MockChatAgentTurn,
@@ -17,6 +18,16 @@ export {
   runTranscriptStorageTests,
   type TranscriptStorageTestOptions,
 } from "./transcript-storage-tests.js";
+
+export {
+  recordingChannelConnector,
+  type RecordingChannelConnector,
+  type RecordingChannelConnectorOptions,
+  type RecordedSend,
+  type RecordedReaction,
+  type RecordedFinalize,
+  type TestChannelEvent,
+} from "./mock-channel-connector.js";
 
 // Re-export the lower-level task context harness so consumers can build
 // their own test helpers without adding a separate `@trigger.dev/core`

--- a/packages/trigger-sdk/src/v3/test/mock-channel-connector.ts
+++ b/packages/trigger-sdk/src/v3/test/mock-channel-connector.ts
@@ -1,0 +1,183 @@
+import { chat } from "../ai.js";
+import type {
+  ChannelAckCtx,
+  ChannelConnector,
+  ChannelInteractionCtx,
+  ChannelInteractionResolution,
+  ChannelMessage,
+  ChannelMessageInput,
+  ChannelPendingToolCall,
+  ChannelReaction,
+  ChannelReactions,
+  ChannelSendCtx,
+} from "../ai.js";
+import { webhooks } from "../webhooks.js";
+import { DEFAULT_TEST_CONNECTOR_ID } from "./mock-chat-agent.js";
+
+/** The default event shape {@link recordingChannelConnector} maps when no `inbound` is given. */
+export type TestChannelEvent = { text: string; threadId?: string };
+
+/** A single `send()` call captured by {@link recordingChannelConnector}. */
+export type RecordedSend<TEvent = unknown> = {
+  /** The channel message the connector was asked to post (or edit into place). */
+  message: ChannelMessage;
+  /** The egress context: `final`, `mode`, `previousRef`, the raw `event`, `deliveryId`. */
+  ctx: ChannelSendCtx<TEvent>;
+  /** The ref this send resolved to (echoes `previousRef` on an edit, else a fresh id). */
+  ref: string;
+};
+
+/** A reaction applied to the triggering message, captured by {@link recordingChannelConnector}. */
+export type RecordedReaction<TEvent = unknown> = { reaction: ChannelReaction; event: TEvent };
+
+/** A HITL `finalizeInteraction()` call, captured by {@link recordingChannelConnector}. */
+export type RecordedFinalize<TEvent = unknown> = {
+  event: TEvent;
+  resolution: ChannelInteractionResolution;
+};
+
+/**
+ * A real {@link ChannelConnector} whose egress hooks record what they were
+ * asked to do instead of touching a network, so a test can assert the channel
+ * round-trip a `chat.agent` turn produced. Built through the real
+ * `chat.channels.custom` factory, so it is a genuinely-shaped connector; only
+ * `send` / `ack` / `react` / `finalizeInteraction` are swapped for recorders.
+ */
+export type RecordingChannelConnector<TEvent = unknown> = ChannelConnector<TEvent> & {
+  /** Every `send()` call in order: the ack, any stream edits, and the final reply. */
+  readonly sent: ReadonlyArray<RecordedSend<TEvent>>;
+  /** Turn-start placeholder posts ("final" delivery): `final: false`, no `previousRef`. */
+  readonly acks: ReadonlyArray<RecordedSend<TEvent>>;
+  /** Stream-mode intermediate edits: `mode: "stream"`, `final: false`, with `previousRef`. */
+  readonly edits: ReadonlyArray<RecordedSend<TEvent>>;
+  /** Every reaction applied to the triggering message (lifecycle + `run().channel`). */
+  readonly reactionsApplied: ReadonlyArray<RecordedReaction<TEvent>>;
+  /** Every HITL `finalizeInteraction()` call. */
+  readonly finalized: ReadonlyArray<RecordedFinalize<TEvent>>;
+  /** The ref of the most recent `send()`, i.e. the current edit target. */
+  readonly lastRef: string | undefined;
+  /** Text of the final reply (`final: true`), or `undefined` if none posted yet. */
+  finalText(): string | undefined;
+};
+
+/** Options for {@link recordingChannelConnector}. */
+export type RecordingChannelConnectorOptions<TEvent = TestChannelEvent> = {
+  /** Connector id. Defaults to {@link DEFAULT_TEST_CONNECTOR_ID} so it lines up with `sendChannelEvent`. */
+  id?: string;
+  /** `"final"` (default: ack then edit-to-answer) or `"stream"` (debounced live edits). */
+  delivery?: "final" | "stream";
+  /** Session key template. Unused in-run (server-side routing only); defaults to `"{body.threadId}"`. */
+  key?: string;
+  /** Map the raw event to the turn's message. Defaults to reading `event.text`. */
+  inbound?: (event: TEvent) => ChannelMessageInput;
+  /**
+   * Placeholder posted at turn start ("final" delivery). Defaults to `{ text: "..." }`.
+   * Pass `null` (or a function returning `null`) to post no ack, so the final reply
+   * arrives as a fresh message instead of an edit.
+   */
+  ack?: ChannelMessage | null | ((event: TEvent, ctx: ChannelAckCtx) => ChannelMessage | null);
+  /** HITL: map a verified callback event to a tool resolution (null => treat as a normal message). */
+  onInteraction?: (event: TEvent) => ChannelInteractionResolution | null;
+  /** HITL: map the pending tool call(s) to the controls posted in the thread. */
+  renderInteraction?: (
+    pending: ChannelPendingToolCall[],
+    ctx: ChannelInteractionCtx<TEvent>
+  ) => ChannelMessage | null;
+  /** Lifecycle reaction choices (working/done/error). Requires nothing extra; `react` is always recorded. */
+  reactions?: ChannelReactions<TEvent>;
+};
+
+/**
+ * Create a {@link RecordingChannelConnector} for driving a `chat.agent`
+ * channel turn offline. Pair it with `mockChatAgent(...).sendChannelEvent(...)`:
+ * list the connector on the agent's `channels`, deliver an event, then assert
+ * against `connector.sent` / `.acks` / `.edits` / `.finalText()`.
+ *
+ * @example
+ * ```ts
+ * const channel = recordingChannelConnector();
+ * const agent = chat.agent({ id: "support", channels: [channel], run: ... });
+ * const harness = mockChatAgent(agent);
+ * await harness.sendChannelEvent({ event: { text: "hi", threadId: "t1" } });
+ * expect(channel.finalText()).toBe("hello");
+ * ```
+ */
+export function recordingChannelConnector<TEvent = TestChannelEvent>(
+  options: RecordingChannelConnectorOptions<TEvent> = {}
+): RecordingChannelConnector<TEvent> {
+  const sent: RecordedSend<TEvent>[] = [];
+  const reactionsApplied: RecordedReaction<TEvent>[] = [];
+  const finalized: RecordedFinalize<TEvent>[] = [];
+  let refCounter = 0;
+  let lastRef: string | undefined;
+
+  const inbound = options.inbound ?? ((event: TEvent) => (event as { text?: string })?.text ?? "");
+
+  const ackFn: (event: TEvent, ctx: ChannelAckCtx) => ChannelMessage | null =
+    options.ack === undefined
+      ? () => ({ text: "..." })
+      : typeof options.ack === "function"
+        ? (options.ack as (event: TEvent, ctx: ChannelAckCtx) => ChannelMessage | null)
+        : () => options.ack as ChannelMessage | null;
+
+  const send = async (message: ChannelMessage, ctx: ChannelSendCtx<TEvent>) => {
+    const ref = ctx.previousRef ?? `ref_${++refCounter}`;
+    sent.push({ message, ctx, ref });
+    lastRef = ref;
+    return { ref };
+  };
+
+  const react = async (reaction: ChannelReaction, ctx: { event: TEvent }) => {
+    reactionsApplied.push({ reaction, event: ctx.event });
+  };
+
+  const finalizeInteraction = async (event: TEvent, resolution: ChannelInteractionResolution) => {
+    finalized.push({ event, resolution });
+  };
+
+  const connector = chat.channels.custom({
+    id: options.id ?? DEFAULT_TEST_CONNECTOR_ID,
+    source: webhooks.custom<TEvent>({
+      scheme: "shared-secret",
+      placement: "header",
+      fieldName: "x-test-signature",
+    }),
+    key: (options.key ?? "{body.threadId}") as never,
+    inbound: inbound as (event: TEvent) => ChannelMessageInput,
+    ack: ackFn as never,
+    send: send as never,
+    react: react as never,
+    finalizeInteraction: finalizeInteraction as never,
+    ...(options.onInteraction ? { onInteraction: options.onInteraction as never } : {}),
+    ...(options.renderInteraction ? { renderInteraction: options.renderInteraction as never } : {}),
+    ...(options.reactions ? { reactions: options.reactions as never } : {}),
+    delivery: options.delivery ?? "final",
+  }) as ChannelConnector<TEvent>;
+
+  Object.defineProperties(connector, {
+    sent: { get: () => sent, enumerable: true },
+    reactionsApplied: { get: () => reactionsApplied, enumerable: true },
+    finalized: { get: () => finalized, enumerable: true },
+    lastRef: { get: () => lastRef, enumerable: true },
+    acks: {
+      get: () => sent.filter((s) => s.ctx.final === false && s.ctx.previousRef === undefined),
+      enumerable: true,
+    },
+    edits: {
+      get: () =>
+        sent.filter(
+          (s) => s.ctx.mode === "stream" && s.ctx.final === false && s.ctx.previousRef !== undefined
+        ),
+      enumerable: true,
+    },
+  });
+
+  (connector as RecordingChannelConnector<TEvent>).finalText = () => {
+    for (let i = sent.length - 1; i >= 0; i--) {
+      if (sent[i]!.ctx.final) return sent[i]!.message.text;
+    }
+    return undefined;
+  };
+
+  return connector as RecordingChannelConnector<TEvent>;
+}

--- a/packages/trigger-sdk/src/v3/test/mock-chat-agent.ts
+++ b/packages/trigger-sdk/src/v3/test/mock-chat-agent.ts
@@ -219,6 +219,20 @@ export type MockChatAgentHarness = {
     deliveryId?: string;
   }): Promise<MockChatAgentTurn>;
 
+  /**
+   * Deliver a channel event without waiting for a turn. Mirrors an event that
+   * the run may not turn into a turn: a filtered or deduped delivery, or a
+   * stale interaction callback that is dropped (matches no pending tool call).
+   * Resolves once the run has had a chance to process and possibly drop it.
+   */
+  deliverChannelEvent(args: {
+    event: unknown;
+    connectorId?: string;
+    source?: string;
+    headers?: Record<string, string>;
+    deliveryId?: string;
+  }): Promise<void>;
+
   /** Fire a stop signal. Does not wait for the turn — the task keeps running. */
   sendStop(message?: string): Promise<void>;
 
@@ -689,6 +703,27 @@ export function mockChatAgent(
       });
       await settlePostTurnChannelEgress();
       return turn;
+    },
+
+    async deliverChannelEvent(args) {
+      await harnessReady;
+      const deliveryId = args.deliveryId ?? `dlv_${++channelDeliveryCounter}`;
+      await sendSessionInput(sessionId, {
+        kind: "message",
+        payload: {
+          chatId,
+          trigger: "submit-message",
+          channelEvent: {
+            connectorId: args.connectorId ?? DEFAULT_TEST_CONNECTOR_ID,
+            event: args.event,
+            source: args.source ?? "custom",
+            headers: args.headers ?? {},
+            deliveryId,
+          },
+          metadata: clientData,
+        },
+      });
+      await settlePostTurnChannelEgress();
     },
 
     async sendStop(message) {

--- a/packages/trigger-sdk/src/v3/test/mock-chat-agent.ts
+++ b/packages/trigger-sdk/src/v3/test/mock-chat-agent.ts
@@ -208,8 +208,10 @@ export type MockChatAgentHarness = {
    * connector by `connectorId`, maps the event with its `inbound()`, runs the
    * turn, and posts the reply back through the connector's `send()`.
    *
-   * `connectorId` defaults to the `id` of the connector on the agent when the
-   * agent lists exactly one; pass it explicitly for multi-connector agents.
+   * `connectorId` defaults to `DEFAULT_TEST_CONNECTOR_ID`, which is also the id
+   * `recordingChannelConnector()` uses when you don't set one, so the common
+   * single-connector case lines up. Pass it explicitly for a connector with a
+   * custom id or for multi-connector agents.
    */
   sendChannelEvent(args: {
     event: unknown;

--- a/packages/trigger-sdk/src/v3/test/mock-chat-agent.ts
+++ b/packages/trigger-sdk/src/v3/test/mock-chat-agent.ts
@@ -36,6 +36,19 @@ type ChatWirePayload = {
   messageId?: string;
   metadata?: unknown;
   action?: unknown;
+  /**
+   * A channel-delivered turn (Slack or any `chat.channels.*` connector). Carries
+   * the raw verified provider event; the run resolves the connector by
+   * `connectorId` from `chat.agent({ channels })` and applies its `inbound()`
+   * mapper to produce the turn's message. Present instead of `message`.
+   */
+  channelEvent?: {
+    connectorId: string;
+    event: unknown;
+    source: string;
+    headers: Record<string, string>;
+    deliveryId: string;
+  };
   continuation?: boolean;
   previousRunId?: string;
   idleTimeoutInSeconds?: number;
@@ -187,6 +200,25 @@ export type MockChatAgentHarness = {
   /** Send a custom action and wait for the next turn-complete. */
   sendAction(action: unknown): Promise<MockChatAgentTurn>;
 
+  /**
+   * Deliver a verified channel event (Slack or any `chat.channels.*`
+   * connector) and wait for the next turn-complete. Mirrors what the hosted
+   * webhook ingress appends to `session.in`: a `submit-message` wire payload
+   * carrying `channelEvent` instead of `message`. The run resolves the
+   * connector by `connectorId`, maps the event with its `inbound()`, runs the
+   * turn, and posts the reply back through the connector's `send()`.
+   *
+   * `connectorId` defaults to the `id` of the connector on the agent when the
+   * agent lists exactly one; pass it explicitly for multi-connector agents.
+   */
+  sendChannelEvent(args: {
+    event: unknown;
+    connectorId?: string;
+    source?: string;
+    headers?: Record<string, string>;
+    deliveryId?: string;
+  }): Promise<MockChatAgentTurn>;
+
   /** Fire a stop signal. Does not wait for the turn — the task keeps running. */
   sendStop(message?: string): Promise<void>;
 
@@ -278,6 +310,28 @@ export type MockChatAgentHarness = {
   readonly allRawChunks: unknown[];
 };
 
+/**
+ * Default `connectorId` used by {@link MockChatAgentHarness.sendChannelEvent}
+ * when the caller omits it. Matches the default `id` of
+ * {@link recordingChannelConnector}, so a single-connector agent needs no
+ * explicit id on either side.
+ */
+export const DEFAULT_TEST_CONNECTOR_ID = "test-channel";
+
+/**
+ * Wait for a channel turn's post-completion egress to land. The run loop
+ * writes the `trigger:turn-complete` chunk (which unblocks the harness's
+ * turn-complete latch) BEFORE it awaits the connector's final `send()` and
+ * its done/error reactions. Draining a handful of macrotasks lets those
+ * awaited-but-immediate calls settle so `sendChannelEvent` callers can assert
+ * against the connector's recorded sends/reactions deterministically.
+ */
+async function settlePostTurnChannelEgress(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
 const CONTROL_CHUNK_TYPES = new Set(["trigger:turn-complete", "trigger:upgrade-required"]);
 
 function isControlChunk(chunk: unknown): boolean {
@@ -365,6 +419,8 @@ export function mockChatAgent(
   let sendSessionInput!: (sessionId: string, data: unknown) => Promise<void>;
   let closeSessionInput: ((sessionId: string) => void) | undefined;
   let runSignal!: AbortController;
+
+  let channelDeliveryCounter = 0;
 
   // A latch that resolves every time `trigger:turn-complete` appears on the chat stream.
   // We use a shared pending promise and replace it after each completion.
@@ -615,6 +671,24 @@ export function mockChatAgent(
         action,
         metadata: clientData,
       });
+    },
+
+    async sendChannelEvent(args) {
+      const deliveryId = args.deliveryId ?? `dlv_${++channelDeliveryCounter}`;
+      const turn = await sendPayloadAndWait({
+        chatId,
+        trigger: "submit-message",
+        channelEvent: {
+          connectorId: args.connectorId ?? DEFAULT_TEST_CONNECTOR_ID,
+          event: args.event,
+          source: args.source ?? "custom",
+          headers: args.headers ?? {},
+          deliveryId,
+        },
+        metadata: clientData,
+      });
+      await settlePostTurnChannelEgress();
+      return turn;
     },
 
     async sendStop(message) {

--- a/packages/trigger-sdk/src/v3/test/mock-chat-agent.ts
+++ b/packages/trigger-sdk/src/v3/test/mock-chat-agent.ts
@@ -39,6 +39,19 @@ type ChatWirePayload = {
   messageId?: string;
   metadata?: unknown;
   action?: unknown;
+  /**
+   * A channel-delivered turn (Slack or any `chat.channels.*` connector). Carries
+   * the raw verified provider event; the run resolves the connector by
+   * `connectorId` from `chat.agent({ channels })` and applies its `inbound()`
+   * mapper to produce the turn's message. Present instead of `message`.
+   */
+  channelEvent?: {
+    connectorId: string;
+    event: unknown;
+    source: string;
+    headers: Record<string, string>;
+    deliveryId: string;
+  };
   continuation?: boolean;
   previousRunId?: string;
   idleTimeoutInSeconds?: number;
@@ -201,6 +214,41 @@ export type MockChatAgentHarness = {
    */
   sendPendingMessage(message: UIMessage): Promise<void>;
 
+  /**
+   * Deliver a verified channel event (Slack or any `chat.channels.*`
+   * connector) and wait for the next turn-complete. Mirrors what the hosted
+   * webhook ingress appends to `session.in`: a `submit-message` wire payload
+   * carrying `channelEvent` instead of `message`. The run resolves the
+   * connector by `connectorId`, maps the event with its `inbound()`, runs the
+   * turn, and posts the reply back through the connector's `send()`.
+   *
+   * `connectorId` defaults to `DEFAULT_TEST_CONNECTOR_ID`, which is also the id
+   * `recordingChannelConnector()` uses when you don't set one, so the common
+   * single-connector case lines up. Pass it explicitly for a connector with a
+   * custom id or for multi-connector agents.
+   */
+  sendChannelEvent(args: {
+    event: unknown;
+    connectorId?: string;
+    source?: string;
+    headers?: Record<string, string>;
+    deliveryId?: string;
+  }): Promise<MockChatAgentTurn>;
+
+  /**
+   * Deliver a channel event without waiting for a turn. Mirrors an event that
+   * the run may not turn into a turn: a filtered or deduped delivery, or a
+   * stale interaction callback that is dropped (matches no pending tool call).
+   * Resolves once the run has had a chance to process and possibly drop it.
+   */
+  deliverChannelEvent(args: {
+    event: unknown;
+    connectorId?: string;
+    source?: string;
+    headers?: Record<string, string>;
+    deliveryId?: string;
+  }): Promise<void>;
+
   /** Fire a stop signal. Does not wait for the turn — the task keeps running. */
   sendStop(message?: string): Promise<void>;
 
@@ -327,6 +375,28 @@ export type MockChatAgentHarness = {
   readonly allRawChunks: unknown[];
 };
 
+/**
+ * Default `connectorId` used by {@link MockChatAgentHarness.sendChannelEvent}
+ * when the caller omits it. Matches the default `id` of
+ * {@link recordingChannelConnector}, so a single-connector agent needs no
+ * explicit id on either side.
+ */
+export const DEFAULT_TEST_CONNECTOR_ID = "test-channel";
+
+/**
+ * Wait for a channel turn's post-completion egress to land. The run loop
+ * writes the `trigger:turn-complete` chunk (which unblocks the harness's
+ * turn-complete latch) BEFORE it awaits the connector's final `send()` and
+ * its done/error reactions. Draining a handful of macrotasks lets those
+ * awaited-but-immediate calls settle so `sendChannelEvent` callers can assert
+ * against the connector's recorded sends/reactions deterministically.
+ */
+async function settlePostTurnChannelEgress(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
 const CONTROL_CHUNK_TYPES = new Set(["trigger:turn-complete", "trigger:upgrade-required"]);
 
 function isControlChunk(chunk: unknown): boolean {
@@ -429,6 +499,8 @@ export function mockChatAgent(
   ) => Promise<void>;
   let closeSessionInput: ((sessionId: string) => void) | undefined;
   let runSignal!: AbortController;
+
+  let channelDeliveryCounter = 0;
 
   // A latch that resolves every time `trigger:turn-complete` appears on the chat stream.
   // We use a shared pending promise and replace it after each completion.
@@ -743,6 +815,45 @@ export function mockChatAgent(
         }
         await new Promise((resolve) => setTimeout(resolve, 5));
       }
+    },
+
+    async sendChannelEvent(args) {
+      const deliveryId = args.deliveryId ?? `dlv_${++channelDeliveryCounter}`;
+      const turn = await sendPayloadAndWait({
+        chatId,
+        trigger: "submit-message",
+        channelEvent: {
+          connectorId: args.connectorId ?? DEFAULT_TEST_CONNECTOR_ID,
+          event: args.event,
+          source: args.source ?? "custom",
+          headers: args.headers ?? {},
+          deliveryId,
+        },
+        metadata: clientData,
+      });
+      await settlePostTurnChannelEgress();
+      return turn;
+    },
+
+    async deliverChannelEvent(args) {
+      await harnessReady;
+      const deliveryId = args.deliveryId ?? `dlv_${++channelDeliveryCounter}`;
+      await sendSessionInput(sessionId, {
+        kind: "message",
+        payload: {
+          chatId,
+          trigger: "submit-message",
+          channelEvent: {
+            connectorId: args.connectorId ?? DEFAULT_TEST_CONNECTOR_ID,
+            event: args.event,
+            source: args.source ?? "custom",
+            headers: args.headers ?? {},
+            deliveryId,
+          },
+          metadata: clientData,
+        },
+      });
+      await settlePostTurnChannelEgress();
     },
 
     async sendStop(message) {

--- a/packages/trigger-sdk/src/v3/webhooks.ts
+++ b/packages/trigger-sdk/src/v3/webhooks.ts
@@ -1,5 +1,28 @@
-import { Webhook } from "@trigger.dev/core/v3";
+import { Webhook, resourceCatalog } from "@trigger.dev/core/v3";
+import type {
+  WebhookSource,
+  InferWebhookEvent,
+  AnyWebhookSource,
+  WebhookRunPayload,
+  ValidateWebhookFilter,
+  ChatEvent,
+  ValidatedWebhookKey,
+  WebhookVerifierConfig,
+  StripeWebhookEvent,
+  GitHubWebhookEvent,
+  TaskRunContext,
+} from "@trigger.dev/core/v3";
 import { subtle } from "../imports/uncrypto.js";
+import { createTask, type Task } from "./shared.js";
+import {
+  discordVerifierConfig,
+  githubVerifierConfig,
+  squareVerifierConfig,
+  stripeVerifierConfig,
+  svixVerifierConfig,
+  webhookProviderConfigs,
+  type WebhookProviderId,
+} from "@trigger.dev/core/webhooks";
 
 /**
  * The type of error thrown when a webhook fails to parse or verify
@@ -23,6 +46,275 @@ type ConstructEventOptions = {
   /** Signature header as string, Buffer, or string array */
   header: string | Buffer | Array<string>;
 };
+
+// ── Source producers (presets carry the event type) ──
+export const webhookSources = {
+  custom<T = unknown>(config: WebhookVerifierConfig): WebhookSource<T> {
+    // Roll-your-own webhooks: you control both ends, so offer paste AND generate.
+    return {
+      provider: "custom",
+      verifier: { kind: "config", config },
+      secretProvisioning: "either",
+    };
+  },
+
+  // Stripe: `Stripe-Signature: t=…,v1=…` (comma-kv), signed `{t}.{body}`, hex.
+  // Defaults to a minimal event shape; pass the official type for full typing: stripe<Stripe.Event>().
+  stripe<TEvent = StripeWebhookEvent>(opts?: { toleranceSeconds?: number }): WebhookSource<TEvent> {
+    return {
+      provider: "stripe",
+      verifier: { kind: "preset", preset: "stripe", config: stripeVerifierConfig(opts) },
+      secretProvisioning: "provider",
+    };
+  },
+
+  // GitHub: `X-Hub-Signature-256: sha256=<hex>` (prefixed), signed raw body.
+  // Defaults to an open shape; pass your event type for full typing: github<MyPushEvent>().
+  github<TEvent = GitHubWebhookEvent>(): WebhookSource<TEvent> {
+    return {
+      provider: "github",
+      verifier: { kind: "preset", preset: "github", config: githubVerifierConfig() },
+      secretProvisioning: "integrator",
+    };
+  },
+
+  // Svix family (Svix, Clerk, Resend): `svix-signature: v1,<b64> v1,<b64>` (space-list),
+  // signed `{id}.{timestamp}.{body}`, base64; the `whsec_` secret is base64-decoded.
+  svix<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "svix",
+      verifier: { kind: "preset", preset: "svix", config: svixVerifierConfig() },
+      secretProvisioning: "provider",
+    };
+  },
+
+  // Square: bare base64 signature over `{notificationURL}{body}` (URL template var, no separator).
+  square<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "square",
+      verifier: { kind: "preset", preset: "square", config: squareVerifierConfig() },
+      secretProvisioning: "provider",
+    };
+  },
+
+  // Discord: asymmetric Ed25519 over `{timestamp}{body}`. The "secret" stored on the endpoint is
+  // the application PUBLIC KEY (hex by default). No shared secret.
+  discord<T = unknown>(opts: { publicKeyEncoding?: "raw-hex" | "pem" } = {}): WebhookSource<T> {
+    return {
+      provider: "discord",
+      verifier: { kind: "preset", preset: "discord", config: discordVerifierConfig(opts) },
+      secretProvisioning: "provider",
+    };
+  },
+
+  /**
+   * Per-provider producers over shared presets. Each is a thin wrapper: same verifier config as the
+   * preset it references, differing only in `provider` (routing + picker identity) and who provisions
+   * the secret. Pass the provider's own published type for full typing, e.g. clerk<WebhookEvent>().
+   */
+  clerk<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "clerk",
+      verifier: { kind: "preset", preset: "svix", config: svixVerifierConfig() },
+      secretProvisioning: "provider",
+    };
+  },
+
+  resend<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "resend",
+      verifier: { kind: "preset", preset: "svix", config: svixVerifierConfig() },
+      secretProvisioning: "provider",
+    };
+  },
+
+  openai<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "openai",
+      verifier: { kind: "preset", preset: "svix", config: svixVerifierConfig() },
+      secretProvisioning: "provider",
+    };
+  },
+
+  replicate<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "replicate",
+      verifier: { kind: "preset", preset: "svix", config: svixVerifierConfig() },
+      secretProvisioning: "provider",
+    };
+  },
+
+  recallai<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "recall-ai",
+      verifier: { kind: "preset", preset: "svix", config: svixVerifierConfig() },
+      secretProvisioning: "provider",
+    };
+  },
+
+  brex<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "brex",
+      verifier: { kind: "preset", preset: "svix", config: svixVerifierConfig() },
+      secretProvisioning: "provider",
+    };
+  },
+
+  gitlab<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "gitlab",
+      verifier: { kind: "preset", preset: "svix", config: svixVerifierConfig() },
+      secretProvisioning: "integrator",
+    };
+  },
+
+  whatsapp<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "whatsapp",
+      verifier: { kind: "preset", preset: "github", config: githubVerifierConfig() },
+      secretProvisioning: "integrator",
+    };
+  },
+} as const;
+
+/**
+ * Per-provider producers generated from the core config table (kind "config"). Each carries the
+ * provider's own HMAC verifier config and stays in lockstep with the round-trip-tested configs.
+ */
+export type ProviderProducers = {
+  [K in WebhookProviderId]: <TEvent = unknown>() => WebhookSource<TEvent>;
+};
+
+export const providerProducers = Object.fromEntries(
+  Object.entries(webhookProviderConfigs).map(([provider, entry]) => [
+    provider,
+    () => ({
+      provider,
+      verifier: { kind: "config" as const, config: entry.config() },
+      secretProvisioning: entry.secretProvisioning,
+    }),
+  ])
+) as ProviderProducers;
+
+// ── webhook() entry: single-callback IoC, infers event from source ──
+export type WebhookOnEventParams<TEvent> = {
+  /** The verified event body, typed by the source (a preset type, or the `<T>` you supply). */
+  event: TEvent;
+  /** The inbound request headers (case-insensitive, Web `Headers`). e.g. headers.get("x-github-event"). */
+  headers: Headers;
+  ctx: TaskRunContext;
+};
+
+export type WebhookOptions<TIdentifier extends string, TSource extends AnyWebhookSource> = {
+  id: TIdentifier;
+  source: TSource;
+  /**
+   * Optional server-side filter (a type-safe string DSL checked against the event shape). A delivery
+   * that doesn't match is received and recorded but not routed (no run). e.g.
+   * `"event.action == 'created' && event.repository.private == false"`.
+   */
+  filter?: string;
+  onEvent: (params: WebhookOnEventParams<InferWebhookEvent<TSource>>) => Promise<void> | void;
+};
+
+export type WebhookHandle<TIdentifier extends string, TEvent> = Task<TIdentifier, TEvent, void>;
+
+export function webhook<
+  TIdentifier extends string,
+  TSource extends AnyWebhookSource,
+  const TFilter extends string = string,
+>(
+  options: WebhookOptions<TIdentifier, TSource> & {
+    filter?: TFilter & ValidateWebhookFilter<InferWebhookEvent<TSource>, TFilter>;
+  }
+): WebhookHandle<TIdentifier, InferWebhookEvent<TSource>> {
+  const { id, source, onEvent, filter } = options;
+
+  // 1. The task half: webhook IS a first-class task kind (triggerSource "webhook").
+  // The platform delivers a { event, headers } envelope; unwrap it for onEvent. The handle's
+  // payload type stays the event (webhook tasks are triggered by the ingress, not tasks.trigger).
+  const task = createTask<TIdentifier, InferWebhookEvent<TSource>, void>({
+    id,
+    triggerSource: "webhook",
+    run: async (payload, runOptions) => {
+      const envelope = payload as unknown as WebhookRunPayload<InferWebhookEvent<TSource>>;
+      await onEvent({
+        event: envelope.event,
+        headers: new Headers(envelope.headers ?? {}),
+        ctx: runOptions.ctx,
+      });
+    },
+  });
+
+  // 2. The endpoint half: register the verifier + default routing target (this task) + filter.
+  resourceCatalog.registerWebhookMetadata({
+    id,
+    source: source.provider,
+    verifierArtifact: source.verifier,
+    routingTarget: { type: "task", taskId: id },
+    secretProvisioning: source.secretProvisioning,
+    filter,
+  });
+
+  return task;
+}
+
+// ── chat.event(): declarative descriptor an agent claims via chat.agent({ events }). No handler. ──
+// Carries the verifier (source), a validated string `key`, and a `type` discriminant. The `key`
+// validates against the event/webhook/header namespaces and mirrors the stored {body.x} wire template.
+export function chatEvent<
+  TSource extends AnyWebhookSource,
+  const TId extends string = string,
+  const TKey extends string = string,
+  const TType extends string = TId,
+  const TFilter extends string = string,
+>(options: {
+  id: TId;
+  source: TSource;
+  key: ValidatedWebhookKey<InferWebhookEvent<TSource>, TKey>;
+  /** The `action.type` the handler reads. Optional; defaults to `id`. */
+  type?: TType;
+  /** Optional server-side filter (same type-safe DSL as `webhook()`); a non-match is recorded FILTERED and not routed. */
+  filter?: TFilter & ValidateWebhookFilter<InferWebhookEvent<TSource>, TFilter>;
+}): ChatEvent<TType, InferWebhookEvent<TSource>> {
+  const { id, source, key, type, filter } = options;
+  const keyTemplate = normalizeKeyString(key as string);
+
+  // Record the descriptor as declared so the indexer can flag it if no agent ever claims it.
+  resourceCatalog.registerDeclaredSessionWebhook(id);
+
+  return {
+    id,
+    type: type ?? id,
+    key: keyTemplate,
+    source: source.provider,
+    verifierArtifact: source.verifier,
+    secretProvisioning: source.secretProvisioning,
+    filter,
+  } as ChatEvent<TType, InferWebhookEvent<TSource>>;
+}
+
+// Public chat-event types (descriptor, the shared action union, and the key namespaces).
+export type {
+  ChatEvent,
+  AnyChatEvent,
+  ChatEventAction,
+  ChatEventActions,
+  WebhookKeyMeta,
+} from "@trigger.dev/core/v3";
+
+// Brace placeholders without a recognized namespace default to the event body. webhook./header./body.
+// pass through unchanged.
+export function normalizeKeyString(key: string): string {
+  return key.replace(/\{([^}]+)\}/g, (_match, path: string) =>
+    path.startsWith("webhook.") || path.startsWith("header.") || path.startsWith("body.")
+      ? `{${path}}`
+      : `{body.${path}}`
+  );
+}
+
+// P2 seam (TYPE only):
+export type { CreateWebhookEndpointParams } from "@trigger.dev/core/v3";
 
 /**
  * Interface describing the webhook utilities
@@ -50,14 +342,43 @@ interface Webhooks {
 
   /** Header name used for webhook signatures */
   SIGNATURE_HEADER_NAME: string;
+  custom: typeof webhookSources.custom;
+  stripe: typeof webhookSources.stripe;
+  github: typeof webhookSources.github;
+  svix: typeof webhookSources.svix;
+  square: typeof webhookSources.square;
+  discord: typeof webhookSources.discord;
+  clerk: typeof webhookSources.clerk;
+  resend: typeof webhookSources.resend;
+  openai: typeof webhookSources.openai;
+  replicate: typeof webhookSources.replicate;
+  recallai: typeof webhookSources.recallai;
+  brex: typeof webhookSources.brex;
+  gitlab: typeof webhookSources.gitlab;
+  whatsapp: typeof webhookSources.whatsapp;
 }
 
 /**
  * Webhook utilities for handling incoming webhook requests
  */
-export const webhooks: Webhooks = {
+export const webhooks: Webhooks & ProviderProducers = {
+  ...providerProducers,
   constructEvent,
   SIGNATURE_HEADER_NAME,
+  custom: webhookSources.custom,
+  stripe: webhookSources.stripe,
+  github: webhookSources.github,
+  svix: webhookSources.svix,
+  square: webhookSources.square,
+  discord: webhookSources.discord,
+  clerk: webhookSources.clerk,
+  resend: webhookSources.resend,
+  openai: webhookSources.openai,
+  replicate: webhookSources.replicate,
+  recallai: webhookSources.recallai,
+  brex: webhookSources.brex,
+  gitlab: webhookSources.gitlab,
+  whatsapp: webhookSources.whatsapp,
 };
 
 async function constructEvent(

--- a/packages/trigger-sdk/src/v3/webhooks.ts
+++ b/packages/trigger-sdk/src/v3/webhooks.ts
@@ -163,7 +163,10 @@ export const webhookSources = {
   gitlab<T = unknown>(): WebhookSource<T> {
     return {
       provider: "gitlab",
-      verifier: { kind: "preset", preset: "svix", config: svixVerifierConfig() },
+      verifier: {
+        kind: "config",
+        config: { scheme: "shared-secret", placement: "header", fieldName: "x-gitlab-token" },
+      },
       secretProvisioning: "integrator",
     };
   },

--- a/packages/trigger-sdk/src/v3/webhooks.ts
+++ b/packages/trigger-sdk/src/v3/webhooks.ts
@@ -189,15 +189,17 @@ export type ProviderProducers = {
 };
 
 export const providerProducers = Object.fromEntries(
-  Object.entries(webhookProviderConfigs).map(([provider, entry]) => [
-    provider,
-    () => ({
+  Object.entries(webhookProviderConfigs)
+    .filter(([provider]) => provider !== "slack")
+    .map(([provider, entry]) => [
       provider,
-      verifier: { kind: "config" as const, config: entry.config() },
-      secretProvisioning: entry.secretProvisioning,
-    }),
-  ])
-) as ProviderProducers;
+      () => ({
+        provider,
+        verifier: { kind: "config" as const, config: entry.config() },
+        secretProvisioning: entry.secretProvisioning,
+      }),
+    ])
+) as Omit<ProviderProducers, "slack">;
 
 // ── webhook() entry: single-callback IoC, infers event from source ──
 export type WebhookOnEventParams<TEvent> = {
@@ -371,7 +373,7 @@ interface Webhooks {
 /**
  * Webhook utilities for handling incoming webhook requests
  */
-export const webhooks: Webhooks & ProviderProducers = {
+export const webhooks: Webhooks & Omit<ProviderProducers, "slack"> = {
   ...providerProducers,
   constructEvent,
   SIGNATURE_HEADER_NAME,

--- a/packages/trigger-sdk/src/v3/webhooks.ts
+++ b/packages/trigger-sdk/src/v3/webhooks.ts
@@ -306,7 +306,7 @@ export type {
 // Brace placeholders without a recognized namespace default to the event body. webhook./header./body.
 // pass through unchanged.
 export function normalizeKeyString(key: string): string {
-  return key.replace(/\{([^}]+)\}/g, (_match, path: string) =>
+  return key.replace(/\{([^{}]+)\}/g, (_match, path: string) =>
     path.startsWith("webhook.") || path.startsWith("header.") || path.startsWith("body.")
       ? `{${path}}`
       : `{body.${path}}`

--- a/packages/trigger-sdk/src/v3/webhooks.ts
+++ b/packages/trigger-sdk/src/v3/webhooks.ts
@@ -306,10 +306,17 @@ export type {
 // Brace placeholders without a recognized namespace default to the event body. webhook./header./body.
 // pass through unchanged.
 export function normalizeKeyString(key: string): string {
-  return key.replace(/\{([^{}]+)\}/g, (_match, path: string) =>
-    path.startsWith("webhook.") || path.startsWith("header.") || path.startsWith("body.")
-      ? `{${path}}`
-      : `{body.${path}}`
+  const namespaceAlternative = (alternative: string): string => {
+    const trimmed = alternative.trim();
+    return trimmed.startsWith("webhook.") ||
+      trimmed.startsWith("header.") ||
+      trimmed.startsWith("body.")
+      ? trimmed
+      : `body.${trimmed}`;
+  };
+  return key.replace(
+    /\{([^{}]+)\}/g,
+    (_match, path: string) => `{${path.split("||").map(namespaceAlternative).join(" || ")}}`
   );
 }
 

--- a/packages/trigger-sdk/src/v3/webhooks.ts
+++ b/packages/trigger-sdk/src/v3/webhooks.ts
@@ -5,6 +5,8 @@ import type {
   AnyWebhookSource,
   WebhookRunPayload,
   ValidateWebhookFilter,
+  ChatEvent,
+  ValidatedWebhookKey,
   WebhookVerifierConfig,
   StripeWebhookEvent,
   GitHubWebhookEvent,
@@ -260,6 +262,67 @@ export function webhook<
   });
 
   return task;
+}
+
+// ── chat.event(): declarative descriptor an agent claims via chat.agent({ events }). No handler. ──
+// Carries the verifier (source), a validated string `key`, and a `type` discriminant. The `key`
+// validates against the event/webhook/header namespaces and mirrors the stored {body.x} wire template.
+export function chatEvent<
+  TSource extends AnyWebhookSource,
+  const TId extends string = string,
+  const TKey extends string = string,
+  const TType extends string = TId,
+  const TFilter extends string = string,
+>(options: {
+  id: TId;
+  source: TSource;
+  key: ValidatedWebhookKey<InferWebhookEvent<TSource>, TKey>;
+  /** The `action.type` the handler reads. Optional; defaults to `id`. */
+  type?: TType;
+  /** Optional server-side filter (same type-safe DSL as `webhook()`); a non-match is recorded FILTERED and not routed. */
+  filter?: TFilter & ValidateWebhookFilter<InferWebhookEvent<TSource>, TFilter>;
+}): ChatEvent<TType, InferWebhookEvent<TSource>> {
+  const { id, source, key, type, filter } = options;
+  const keyTemplate = normalizeKeyString(key as string);
+
+  // Record the descriptor as declared so the indexer can flag it if no agent ever claims it.
+  resourceCatalog.registerDeclaredSessionWebhook(id);
+
+  return {
+    id,
+    type: type ?? id,
+    key: keyTemplate,
+    source: source.provider,
+    verifierArtifact: source.verifier,
+    secretProvisioning: source.secretProvisioning,
+    filter,
+  } as ChatEvent<TType, InferWebhookEvent<TSource>>;
+}
+
+// Public chat-event types (descriptor, the shared action union, and the key namespaces).
+export type {
+  ChatEvent,
+  AnyChatEvent,
+  ChatEventAction,
+  ChatEventActions,
+  WebhookKeyMeta,
+} from "@trigger.dev/core/v3";
+
+// Brace placeholders without a recognized namespace default to the event body. webhook./header./body.
+// pass through unchanged.
+export function normalizeKeyString(key: string): string {
+  const namespaceAlternative = (alternative: string): string => {
+    const trimmed = alternative.trim();
+    return trimmed.startsWith("webhook.") ||
+      trimmed.startsWith("header.") ||
+      trimmed.startsWith("body.")
+      ? trimmed
+      : `body.${trimmed}`;
+  };
+  return key.replace(
+    /\{([^{}]+)\}/g,
+    (_match, path: string) => `{${path.split("||").map(namespaceAlternative).join(" || ")}}`
+  );
 }
 
 // P2 seam (TYPE only):

--- a/packages/trigger-sdk/src/v3/webhooks.ts
+++ b/packages/trigger-sdk/src/v3/webhooks.ts
@@ -1,5 +1,26 @@
-import { Webhook } from "@trigger.dev/core/v3";
+import { Webhook, resourceCatalog } from "@trigger.dev/core/v3";
+import type {
+  WebhookSource,
+  InferWebhookEvent,
+  AnyWebhookSource,
+  WebhookRunPayload,
+  ValidateWebhookFilter,
+  WebhookVerifierConfig,
+  StripeWebhookEvent,
+  GitHubWebhookEvent,
+  TaskRunContext,
+} from "@trigger.dev/core/v3";
 import { subtle } from "../imports/uncrypto.js";
+import { createTask, type Task } from "./shared.js";
+import {
+  discordVerifierConfig,
+  githubVerifierConfig,
+  squareVerifierConfig,
+  stripeVerifierConfig,
+  svixVerifierConfig,
+  webhookProviderConfigs,
+  type WebhookProviderId,
+} from "@trigger.dev/core/webhooks";
 
 /**
  * The type of error thrown when a webhook fails to parse or verify
@@ -23,6 +44,226 @@ type ConstructEventOptions = {
   /** Signature header as string, Buffer, or string array */
   header: string | Buffer | Array<string>;
 };
+
+// ── Source producers (presets carry the event type) ──
+export const webhookSources = {
+  custom<T = unknown>(config: WebhookVerifierConfig): WebhookSource<T> {
+    // Roll-your-own webhooks: you control both ends, so offer paste AND generate.
+    return {
+      provider: "custom",
+      verifier: { kind: "config", config },
+      secretProvisioning: "either",
+    };
+  },
+
+  // Stripe: `Stripe-Signature: t=…,v1=…` (comma-kv), signed `{t}.{body}`, hex.
+  // Defaults to a minimal event shape; pass the official type for full typing: stripe<Stripe.Event>().
+  stripe<TEvent = StripeWebhookEvent>(opts?: { toleranceSeconds?: number }): WebhookSource<TEvent> {
+    return {
+      provider: "stripe",
+      verifier: { kind: "preset", preset: "stripe", config: stripeVerifierConfig(opts) },
+      secretProvisioning: "provider",
+    };
+  },
+
+  // GitHub: `X-Hub-Signature-256: sha256=<hex>` (prefixed), signed raw body.
+  // Defaults to an open shape; pass your event type for full typing: github<MyPushEvent>().
+  github<TEvent = GitHubWebhookEvent>(): WebhookSource<TEvent> {
+    return {
+      provider: "github",
+      verifier: { kind: "preset", preset: "github", config: githubVerifierConfig() },
+      secretProvisioning: "integrator",
+    };
+  },
+
+  // Svix family (Svix, Clerk, Resend): `svix-signature: v1,<b64> v1,<b64>` (space-list),
+  // signed `{id}.{timestamp}.{body}`, base64; the `whsec_` secret is base64-decoded.
+  svix<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "svix",
+      verifier: { kind: "preset", preset: "svix", config: svixVerifierConfig() },
+      secretProvisioning: "provider",
+    };
+  },
+
+  // Square: bare base64 signature over `{notificationURL}{body}` (URL template var, no separator).
+  square<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "square",
+      verifier: { kind: "preset", preset: "square", config: squareVerifierConfig() },
+      secretProvisioning: "provider",
+    };
+  },
+
+  // Discord: asymmetric Ed25519 over `{timestamp}{body}`. The "secret" stored on the endpoint is
+  // the application PUBLIC KEY (hex by default). No shared secret.
+  discord<T = unknown>(opts: { publicKeyEncoding?: "raw-hex" | "pem" } = {}): WebhookSource<T> {
+    return {
+      provider: "discord",
+      verifier: { kind: "preset", preset: "discord", config: discordVerifierConfig(opts) },
+      secretProvisioning: "provider",
+    };
+  },
+
+  /**
+   * Per-provider producers over shared presets. Each is a thin wrapper: same verifier config as the
+   * preset it references, differing only in `provider` (routing + picker identity) and who provisions
+   * the secret. Pass the provider's own published type for full typing, e.g. clerk<WebhookEvent>().
+   */
+  clerk<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "clerk",
+      verifier: { kind: "preset", preset: "svix", config: svixVerifierConfig() },
+      secretProvisioning: "provider",
+    };
+  },
+
+  resend<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "resend",
+      verifier: { kind: "preset", preset: "svix", config: svixVerifierConfig() },
+      secretProvisioning: "provider",
+    };
+  },
+
+  openai<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "openai",
+      verifier: { kind: "preset", preset: "svix", config: svixVerifierConfig() },
+      secretProvisioning: "provider",
+    };
+  },
+
+  replicate<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "replicate",
+      verifier: { kind: "preset", preset: "svix", config: svixVerifierConfig() },
+      secretProvisioning: "provider",
+    };
+  },
+
+  recallai<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "recall-ai",
+      verifier: { kind: "preset", preset: "svix", config: svixVerifierConfig() },
+      secretProvisioning: "provider",
+    };
+  },
+
+  brex<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "brex",
+      verifier: { kind: "preset", preset: "svix", config: svixVerifierConfig() },
+      secretProvisioning: "provider",
+    };
+  },
+
+  gitlab<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "gitlab",
+      verifier: {
+        kind: "config",
+        config: { scheme: "shared-secret", placement: "header", fieldName: "x-gitlab-token" },
+      },
+      secretProvisioning: "integrator",
+    };
+  },
+
+  whatsapp<T = unknown>(): WebhookSource<T> {
+    return {
+      provider: "whatsapp",
+      verifier: { kind: "preset", preset: "github", config: githubVerifierConfig() },
+      secretProvisioning: "integrator",
+    };
+  },
+} as const;
+
+/**
+ * Per-provider producers generated from the core config table (kind "config"). Each carries the
+ * provider's own HMAC verifier config and stays in lockstep with the round-trip-tested configs.
+ */
+export type ProviderProducers = {
+  [K in WebhookProviderId]: <TEvent = unknown>() => WebhookSource<TEvent>;
+};
+
+export const providerProducers = Object.fromEntries(
+  Object.entries(webhookProviderConfigs)
+    .filter(([provider]) => provider !== "slack")
+    .map(([provider, entry]) => [
+      provider,
+      () => ({
+        provider,
+        verifier: { kind: "config" as const, config: entry.config() },
+        secretProvisioning: entry.secretProvisioning,
+      }),
+    ])
+) as Omit<ProviderProducers, "slack">;
+
+// ── webhook() entry: single-callback IoC, infers event from source ──
+export type WebhookOnEventParams<TEvent> = {
+  /** The verified event body, typed by the source (a preset type, or the `<T>` you supply). */
+  event: TEvent;
+  /** The inbound request headers (case-insensitive, Web `Headers`). e.g. headers.get("x-github-event"). */
+  headers: Headers;
+  ctx: TaskRunContext;
+};
+
+export type WebhookOptions<TIdentifier extends string, TSource extends AnyWebhookSource> = {
+  id: TIdentifier;
+  source: TSource;
+  /**
+   * Optional server-side filter (a type-safe string DSL checked against the event shape). A delivery
+   * that doesn't match is received and recorded but not routed (no run). e.g.
+   * `"event.action == 'created' && event.repository.private == false"`.
+   */
+  filter?: string;
+  onEvent: (params: WebhookOnEventParams<InferWebhookEvent<TSource>>) => Promise<void> | void;
+};
+
+export type WebhookHandle<TIdentifier extends string, TEvent> = Task<TIdentifier, TEvent, void>;
+
+export function webhook<
+  TIdentifier extends string,
+  TSource extends AnyWebhookSource,
+  const TFilter extends string = string,
+>(
+  options: WebhookOptions<TIdentifier, TSource> & {
+    filter?: TFilter & ValidateWebhookFilter<InferWebhookEvent<TSource>, TFilter>;
+  }
+): WebhookHandle<TIdentifier, InferWebhookEvent<TSource>> {
+  const { id, source, onEvent, filter } = options;
+
+  // 1. The task half: webhook IS a first-class task kind (triggerSource "webhook").
+  // The platform delivers a { event, headers } envelope; unwrap it for onEvent. The handle's
+  // payload type stays the event (webhook tasks are triggered by the ingress, not tasks.trigger).
+  const task = createTask<TIdentifier, InferWebhookEvent<TSource>, void>({
+    id,
+    triggerSource: "webhook",
+    run: async (payload, runOptions) => {
+      const envelope = payload as unknown as WebhookRunPayload<InferWebhookEvent<TSource>>;
+      await onEvent({
+        event: envelope.event,
+        headers: new Headers(envelope.headers ?? {}),
+        ctx: runOptions.ctx,
+      });
+    },
+  });
+
+  // 2. The endpoint half: register the verifier + default routing target (this task) + filter.
+  resourceCatalog.registerWebhookMetadata({
+    id,
+    source: source.provider,
+    verifierArtifact: source.verifier,
+    routingTarget: { type: "task", taskId: id },
+    secretProvisioning: source.secretProvisioning,
+    filter,
+  });
+
+  return task;
+}
+
+// P2 seam (TYPE only):
+export type { CreateWebhookEndpointParams } from "@trigger.dev/core/v3";
 
 /**
  * Interface describing the webhook utilities
@@ -50,14 +291,43 @@ interface Webhooks {
 
   /** Header name used for webhook signatures */
   SIGNATURE_HEADER_NAME: string;
+  custom: typeof webhookSources.custom;
+  stripe: typeof webhookSources.stripe;
+  github: typeof webhookSources.github;
+  svix: typeof webhookSources.svix;
+  square: typeof webhookSources.square;
+  discord: typeof webhookSources.discord;
+  clerk: typeof webhookSources.clerk;
+  resend: typeof webhookSources.resend;
+  openai: typeof webhookSources.openai;
+  replicate: typeof webhookSources.replicate;
+  recallai: typeof webhookSources.recallai;
+  brex: typeof webhookSources.brex;
+  gitlab: typeof webhookSources.gitlab;
+  whatsapp: typeof webhookSources.whatsapp;
 }
 
 /**
  * Webhook utilities for handling incoming webhook requests
  */
-export const webhooks: Webhooks = {
+export const webhooks: Webhooks & Omit<ProviderProducers, "slack"> = {
+  ...providerProducers,
   constructEvent,
   SIGNATURE_HEADER_NAME,
+  custom: webhookSources.custom,
+  stripe: webhookSources.stripe,
+  github: webhookSources.github,
+  svix: webhookSources.svix,
+  square: webhookSources.square,
+  discord: webhookSources.discord,
+  clerk: webhookSources.clerk,
+  resend: webhookSources.resend,
+  openai: webhookSources.openai,
+  replicate: webhookSources.replicate,
+  recallai: webhookSources.recallai,
+  brex: webhookSources.brex,
+  gitlab: webhookSources.gitlab,
+  whatsapp: webhookSources.whatsapp,
 };
 
 async function constructEvent(

--- a/packages/trigger-sdk/test/chatChannels.test.ts
+++ b/packages/trigger-sdk/test/chatChannels.test.ts
@@ -6,9 +6,10 @@ import {
   __makeChannelStreamEditorForTests,
   __makeChannelStreamTapForTests,
 } from "../src/v3/ai.js";
-import { simulateReadableStream, streamText } from "ai";
+import { simulateReadableStream, streamText, tool } from "ai";
 import { MockLanguageModelV3 } from "ai/test";
 import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import { z } from "zod";
 
 function textStream(text: string) {
   const chunks: LanguageModelV3StreamPart[] = [
@@ -172,6 +173,109 @@ describe("chat.agent channels", () => {
       expect(finalSend.ctx.final).toBe(true);
       expect(finalSend.ctx.previousRef).toBe(channel.acks[0]!.ref);
       expect(finalSend.message.text).toBe("turn exploded");
+    } finally {
+      await harness.close();
+    }
+  });
+});
+
+describe("chat.agent channel interactions", () => {
+  function toolCallStream(toolCallId: string, toolName: string, input: unknown) {
+    return simulateReadableStream({
+      chunks: [
+        { type: "tool-input-start", id: toolCallId, toolName },
+        { type: "tool-input-delta", id: toolCallId, delta: JSON.stringify(input) },
+        { type: "tool-input-end", id: toolCallId },
+        { type: "tool-call", toolCallId, toolName, input: JSON.stringify(input) },
+        {
+          type: "finish",
+          finishReason: { unified: "tool-calls", raw: "tool_calls" },
+          usage: {
+            inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+            outputTokens: { total: 10, text: 0, reasoning: undefined },
+          },
+        },
+      ] as LanguageModelV3StreamPart[],
+    });
+  }
+
+  it("resumes a pending tool from an interaction callback and finalizes the controls", async () => {
+    const TC = "tc_approve_1";
+    const requestApproval = tool({
+      description: "Request human approval before acting.",
+      inputSchema: z.object({ action: z.string() }),
+    });
+
+    let call = 0;
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({
+        stream:
+          call++ === 0
+            ? toolCallStream(TC, "requestApproval", { action: "refund" })
+            : textStream("refund issued"),
+      }),
+    });
+
+    const channel = recordingChannelConnector<{ text?: string; callback?: boolean }>({
+      renderInteraction: (pending) => ({
+        text: `Approve ${(pending[0]!.input as { action: string }).action}?`,
+      }),
+      onInteraction: (event) =>
+        event?.callback ? { toolCallId: TC, output: { approved: true } } : null,
+    });
+
+    const agent = chat.agent({
+      id: "chatChannels.hitl-resolve",
+      channels: [channel],
+      run: async ({ messages, signal }) =>
+        streamText({ model, messages, tools: { requestApproval }, abortSignal: signal }),
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "chan-hitl-1" });
+    try {
+      await harness.sendChannelEvent({ event: { text: "please refund", threadId: "chan-hitl-1" } });
+      expect(channel.finalText()).toBe("Approve refund?");
+      expect(channel.finalized).toHaveLength(0);
+
+      await harness.sendChannelEvent({ event: { callback: true } });
+      expect(channel.finalized).toHaveLength(1);
+      expect(channel.finalText()).toBe("refund issued");
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("drops a stale interaction callback and runs no turn", async () => {
+    let modelCalls = 0;
+    const model = new MockLanguageModelV3({
+      doStream: async () => {
+        modelCalls += 1;
+        return { stream: textStream("should not run") };
+      },
+    });
+
+    const interactionEvents: unknown[] = [];
+    const channel = recordingChannelConnector<{ text?: string; callback?: boolean }>({
+      onInteraction: (event) => {
+        interactionEvents.push(event);
+        return event?.callback ? { toolCallId: "does-not-exist", output: {} } : null;
+      },
+    });
+
+    const agent = chat.agent({
+      id: "chatChannels.hitl-stale",
+      channels: [channel],
+      run: async ({ messages, signal }) => streamText({ model, messages, abortSignal: signal }),
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "chan-hitl-2" });
+    try {
+      await harness.deliverChannelEvent({ event: { callback: true } });
+
+      expect(interactionEvents).toHaveLength(1);
+      expect(modelCalls).toBe(0);
+      expect(channel.sent).toHaveLength(0);
+      expect(channel.finalized).toHaveLength(0);
     } finally {
       await harness.close();
     }

--- a/packages/trigger-sdk/test/chatChannels.test.ts
+++ b/packages/trigger-sdk/test/chatChannels.test.ts
@@ -1,7 +1,11 @@
 import { mockChatAgent, recordingChannelConnector } from "../src/v3/test/index.js";
 
-import { describe, expect, it } from "vitest";
-import { chat } from "../src/v3/ai.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  chat,
+  __makeChannelStreamEditorForTests,
+  __makeChannelStreamTapForTests,
+} from "../src/v3/ai.js";
 import { simulateReadableStream, streamText } from "ai";
 import { MockLanguageModelV3 } from "ai/test";
 import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
@@ -146,5 +150,128 @@ describe("chat.agent channels", () => {
     } finally {
       await harness.close();
     }
+  });
+
+  it("edits the placeholder to the error when a channel turn throws", async () => {
+    const channel = recordingChannelConnector();
+
+    const agent = chat.agent({
+      id: "chatChannels.error-egress",
+      channels: [channel],
+      run: async () => {
+        throw new Error("turn exploded");
+      },
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "chan-5" });
+    try {
+      await harness.sendChannelEvent({ event: { text: "cause an error", threadId: "chan-5" } });
+
+      expect(channel.acks).toHaveLength(1);
+      const finalSend = channel.sent[channel.sent.length - 1]!;
+      expect(finalSend.ctx.final).toBe(true);
+      expect(finalSend.ctx.previousRef).toBe(channel.acks[0]!.ref);
+      expect(finalSend.message.text).toBe("turn exploded");
+    } finally {
+      await harness.close();
+    }
+  });
+});
+
+describe("makeChannelStreamEditor", () => {
+  function streamConnector(send: (message: { text: string }) => Promise<{ ref?: string }>) {
+    return { delivery: "stream" as const, send } as never;
+  }
+
+  it("re-arms the debounce timer so text buffered during an in-flight edit still lands", async () => {
+    vi.useFakeTimers();
+    try {
+      const sends: string[] = [];
+      let releaseFirst!: () => void;
+      const firstGate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let call = 0;
+      const editor = __makeChannelStreamEditorForTests(
+        streamConnector(async (message) => {
+          sends.push(message.text);
+          call += 1;
+          if (call === 1) await firstGate;
+          return { ref: "r1" };
+        }),
+        { event: {}, deliveryId: "d1" },
+        "r1"
+      );
+
+      editor.observe({ type: "text-delta", delta: "a" });
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(sends).toEqual(["a"]);
+
+      editor.observe({ type: "text-delta", delta: "b" });
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(sends).toEqual(["a"]);
+
+      releaseFirst();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(sends).toEqual(["a", "ab"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not fire a pending edit after stop()", async () => {
+    vi.useFakeTimers();
+    try {
+      const sends: string[] = [];
+      const editor = __makeChannelStreamEditorForTests(
+        streamConnector(async (message) => {
+          sends.push(message.text);
+          return { ref: "r1" };
+        }),
+        { event: {}, deliveryId: "d1" },
+        "r1"
+      );
+
+      editor.observe({ type: "text-delta", delta: "a" });
+      editor.stop();
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(sends).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("makeChannelStreamTap", () => {
+  it("stops the editor when the stream completes (flush)", async () => {
+    let stops = 0;
+    const tap = __makeChannelStreamTapForTests({ observe: () => {}, stop: () => (stops += 1) });
+    const source = new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: "text-delta", delta: "x" });
+        controller.close();
+      },
+    });
+    const reader = source.pipeThrough(tap).getReader();
+    let done = false;
+    while (!done) {
+      done = (await reader.read()).done;
+    }
+    expect(stops).toBeGreaterThan(0);
+  });
+
+  it("stops the editor when the stream is cancelled mid-flight (abort)", async () => {
+    let stops = 0;
+    const tap = __makeChannelStreamTapForTests({ observe: () => {}, stop: () => (stops += 1) });
+    const source = new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: "text-delta", delta: "x" });
+      },
+    });
+    const reader = source.pipeThrough(tap).getReader();
+    await reader.read();
+    await reader.cancel("aborted");
+    expect(stops).toBeGreaterThan(0);
   });
 });

--- a/packages/trigger-sdk/test/chatChannels.test.ts
+++ b/packages/trigger-sdk/test/chatChannels.test.ts
@@ -1,0 +1,150 @@
+import { mockChatAgent, recordingChannelConnector } from "../src/v3/test/index.js";
+
+import { describe, expect, it } from "vitest";
+import { chat } from "../src/v3/ai.js";
+import { simulateReadableStream, streamText } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+
+function textStream(text: string) {
+  const chunks: LanguageModelV3StreamPart[] = [
+    { type: "text-start", id: "t1" },
+    { type: "text-delta", id: "t1", delta: text },
+    { type: "text-end", id: "t1" },
+    {
+      type: "finish",
+      finishReason: { unified: "stop", raw: "stop" },
+      usage: {
+        inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+        outputTokens: { total: 10, text: 10, reasoning: undefined },
+      },
+    },
+  ];
+  return simulateReadableStream({ chunks });
+}
+
+describe("chat.agent channels", () => {
+  it("delivers a channel event as a turn and posts the reply back through the connector", async () => {
+    const seenText: string[] = [];
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({ stream: textStream("hello world") }),
+    });
+
+    const channel = recordingChannelConnector();
+
+    const agent = chat.agent({
+      id: "chatChannels.final-roundtrip",
+      channels: [channel],
+      run: async ({ messages, signal }) => {
+        const last = messages[messages.length - 1];
+        const content = last?.content;
+        seenText.push(
+          typeof content === "string"
+            ? content
+            : (content ?? [])
+                .map((p) => (typeof p === "object" && p.type === "text" ? p.text : ""))
+                .join("")
+        );
+        return streamText({ model, messages, abortSignal: signal });
+      },
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "chan-1" });
+    try {
+      await harness.sendChannelEvent({ event: { text: "hi there", threadId: "chan-1" } });
+
+      expect(seenText).toEqual(["hi there"]);
+
+      expect(channel.acks).toHaveLength(1);
+      expect(channel.acks[0]!.message.text).toBe("...");
+      expect(channel.finalText()).toBe("hello world");
+
+      const finalSend = channel.sent[channel.sent.length - 1]!;
+      expect(finalSend.ctx.final).toBe(true);
+      expect(finalSend.ctx.previousRef).toBe(channel.acks[0]!.ref);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("posts only the final answer when ack is null", async () => {
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({ stream: textStream("done") }),
+    });
+
+    const channel = recordingChannelConnector({ ack: null });
+
+    const agent = chat.agent({
+      id: "chatChannels.no-ack",
+      channels: [channel],
+      run: async ({ messages, signal }) => streamText({ model, messages, abortSignal: signal }),
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "chan-2" });
+    try {
+      await harness.sendChannelEvent({ event: { text: "yo", threadId: "chan-2" } });
+
+      expect(channel.acks).toHaveLength(0);
+      expect(channel.sent).toHaveLength(1);
+      expect(channel.finalText()).toBe("done");
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("records lifecycle reactions around a channel turn", async () => {
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({ stream: textStream("ok") }),
+    });
+
+    const channel = recordingChannelConnector({
+      reactions: { working: "eyes", done: "white_check_mark" },
+    });
+
+    const agent = chat.agent({
+      id: "chatChannels.reactions",
+      channels: [channel],
+      run: async ({ messages, signal }) => streamText({ model, messages, abortSignal: signal }),
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "chan-3" });
+    try {
+      await harness.sendChannelEvent({ event: { text: "go", threadId: "chan-3" } });
+
+      const names = channel.reactionsApplied.map((r) => ({
+        name: r.reaction.name,
+        remove: r.reaction.remove ?? false,
+      }));
+      expect(names).toEqual([
+        { name: "eyes", remove: false },
+        { name: "eyes", remove: true },
+        { name: "white_check_mark", remove: false },
+      ]);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("still posts an authoritative final reply in stream delivery", async () => {
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({ stream: textStream("streamed answer") }),
+    });
+
+    const channel = recordingChannelConnector({ delivery: "stream" });
+
+    const agent = chat.agent({
+      id: "chatChannels.stream-final",
+      channels: [channel],
+      run: async ({ messages, signal }) => streamText({ model, messages, abortSignal: signal }),
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "chan-4" });
+    try {
+      await harness.sendChannelEvent({ event: { text: "stream please", threadId: "chan-4" } });
+
+      expect(channel.finalText()).toBe("streamed answer");
+    } finally {
+      await harness.close();
+    }
+  });
+});

--- a/packages/trigger-sdk/test/chatChannels.test.ts
+++ b/packages/trigger-sdk/test/chatChannels.test.ts
@@ -1,0 +1,391 @@
+import { mockChatAgent, recordingChannelConnector } from "../src/v3/test/index.js";
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  chat,
+  __makeChannelStreamEditorForTests,
+  __makeChannelStreamTapForTests,
+} from "../src/v3/ai.js";
+import { simulateReadableStream, streamText, tool } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import { z } from "zod";
+
+function textStream(text: string) {
+  const chunks: LanguageModelV3StreamPart[] = [
+    { type: "text-start", id: "t1" },
+    { type: "text-delta", id: "t1", delta: text },
+    { type: "text-end", id: "t1" },
+    {
+      type: "finish",
+      finishReason: { unified: "stop", raw: "stop" },
+      usage: {
+        inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+        outputTokens: { total: 10, text: 10, reasoning: undefined },
+      },
+    },
+  ];
+  return simulateReadableStream({ chunks });
+}
+
+describe("chat.agent channels", () => {
+  it("delivers a channel event as a turn and posts the reply back through the connector", async () => {
+    const seenText: string[] = [];
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({ stream: textStream("hello world") }),
+    });
+
+    const channel = recordingChannelConnector();
+
+    const agent = chat.agent({
+      id: "chatChannels.final-roundtrip",
+      channels: [channel],
+      run: async ({ messages, signal }) => {
+        const last = messages[messages.length - 1];
+        const content = last?.content;
+        seenText.push(
+          typeof content === "string"
+            ? content
+            : (content ?? [])
+                .map((p) => (typeof p === "object" && p.type === "text" ? p.text : ""))
+                .join("")
+        );
+        return streamText({ model, messages, abortSignal: signal });
+      },
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "chan-1" });
+    try {
+      await harness.sendChannelEvent({ event: { text: "hi there", threadId: "chan-1" } });
+
+      expect(seenText).toEqual(["hi there"]);
+
+      expect(channel.acks).toHaveLength(1);
+      expect(channel.acks[0]!.message.text).toBe("...");
+      expect(channel.finalText()).toBe("hello world");
+
+      const finalSend = channel.sent[channel.sent.length - 1]!;
+      expect(finalSend.ctx.final).toBe(true);
+      expect(finalSend.ctx.previousRef).toBe(channel.acks[0]!.ref);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("posts only the final answer when ack is null", async () => {
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({ stream: textStream("done") }),
+    });
+
+    const channel = recordingChannelConnector({ ack: null });
+
+    const agent = chat.agent({
+      id: "chatChannels.no-ack",
+      channels: [channel],
+      run: async ({ messages, signal }) => streamText({ model, messages, abortSignal: signal }),
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "chan-2" });
+    try {
+      await harness.sendChannelEvent({ event: { text: "yo", threadId: "chan-2" } });
+
+      expect(channel.acks).toHaveLength(0);
+      expect(channel.sent).toHaveLength(1);
+      expect(channel.finalText()).toBe("done");
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("records lifecycle reactions around a channel turn", async () => {
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({ stream: textStream("ok") }),
+    });
+
+    const channel = recordingChannelConnector({
+      reactions: { working: "eyes", done: "white_check_mark" },
+    });
+
+    const agent = chat.agent({
+      id: "chatChannels.reactions",
+      channels: [channel],
+      run: async ({ messages, signal }) => streamText({ model, messages, abortSignal: signal }),
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "chan-3" });
+    try {
+      await harness.sendChannelEvent({ event: { text: "go", threadId: "chan-3" } });
+
+      const names = channel.reactionsApplied.map((r) => ({
+        name: r.reaction.name,
+        remove: r.reaction.remove ?? false,
+      }));
+      expect(names).toEqual([
+        { name: "eyes", remove: false },
+        { name: "eyes", remove: true },
+        { name: "white_check_mark", remove: false },
+      ]);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("still posts an authoritative final reply in stream delivery", async () => {
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({ stream: textStream("streamed answer") }),
+    });
+
+    const channel = recordingChannelConnector({ delivery: "stream" });
+
+    const agent = chat.agent({
+      id: "chatChannels.stream-final",
+      channels: [channel],
+      run: async ({ messages, signal }) => streamText({ model, messages, abortSignal: signal }),
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "chan-4" });
+    try {
+      await harness.sendChannelEvent({ event: { text: "stream please", threadId: "chan-4" } });
+
+      expect(channel.finalText()).toBe("streamed answer");
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("edits the placeholder to the error when a channel turn throws", async () => {
+    const channel = recordingChannelConnector();
+
+    const agent = chat.agent({
+      id: "chatChannels.error-egress",
+      channels: [channel],
+      run: async () => {
+        throw new Error("turn exploded");
+      },
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "chan-5" });
+    try {
+      await harness.sendChannelEvent({ event: { text: "cause an error", threadId: "chan-5" } });
+
+      expect(channel.acks).toHaveLength(1);
+      const finalSend = channel.sent[channel.sent.length - 1]!;
+      expect(finalSend.ctx.final).toBe(true);
+      expect(finalSend.ctx.previousRef).toBe(channel.acks[0]!.ref);
+      expect(finalSend.message.text).toBe("turn exploded");
+    } finally {
+      await harness.close();
+    }
+  });
+});
+
+describe("chat.agent channel interactions", () => {
+  function toolCallStream(toolCallId: string, toolName: string, input: unknown) {
+    return simulateReadableStream({
+      chunks: [
+        { type: "tool-input-start", id: toolCallId, toolName },
+        { type: "tool-input-delta", id: toolCallId, delta: JSON.stringify(input) },
+        { type: "tool-input-end", id: toolCallId },
+        { type: "tool-call", toolCallId, toolName, input: JSON.stringify(input) },
+        {
+          type: "finish",
+          finishReason: { unified: "tool-calls", raw: "tool_calls" },
+          usage: {
+            inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+            outputTokens: { total: 10, text: 0, reasoning: undefined },
+          },
+        },
+      ] as LanguageModelV3StreamPart[],
+    });
+  }
+
+  it("resumes a pending tool from an interaction callback and finalizes the controls", async () => {
+    const TC = "tc_approve_1";
+    const requestApproval = tool({
+      description: "Request human approval before acting.",
+      inputSchema: z.object({ action: z.string() }),
+    });
+
+    let call = 0;
+    const model = new MockLanguageModelV3({
+      doStream: async () => ({
+        stream:
+          call++ === 0
+            ? toolCallStream(TC, "requestApproval", { action: "refund" })
+            : textStream("refund issued"),
+      }),
+    });
+
+    const channel = recordingChannelConnector<{ text?: string; callback?: boolean }>({
+      renderInteraction: (pending) => ({
+        text: `Approve ${(pending[0]!.input as { action: string }).action}?`,
+      }),
+      onInteraction: (event) =>
+        event?.callback ? { toolCallId: TC, output: { approved: true } } : null,
+    });
+
+    const agent = chat.agent({
+      id: "chatChannels.hitl-resolve",
+      channels: [channel],
+      run: async ({ messages, signal }) =>
+        streamText({ model, messages, tools: { requestApproval }, abortSignal: signal }),
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "chan-hitl-1" });
+    try {
+      await harness.sendChannelEvent({ event: { text: "please refund", threadId: "chan-hitl-1" } });
+      expect(channel.finalText()).toBe("Approve refund?");
+      expect(channel.finalized).toHaveLength(0);
+
+      await harness.sendChannelEvent({ event: { callback: true } });
+      expect(channel.finalized).toHaveLength(1);
+      expect(channel.finalText()).toBe("refund issued");
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("drops a stale interaction callback and runs no turn", async () => {
+    let modelCalls = 0;
+    const model = new MockLanguageModelV3({
+      doStream: async () => {
+        modelCalls += 1;
+        return { stream: textStream("should not run") };
+      },
+    });
+
+    const interactionEvents: unknown[] = [];
+    const channel = recordingChannelConnector<{ text?: string; callback?: boolean }>({
+      onInteraction: (event) => {
+        interactionEvents.push(event);
+        return event?.callback ? { toolCallId: "does-not-exist", output: {} } : null;
+      },
+    });
+
+    const agent = chat.agent({
+      id: "chatChannels.hitl-stale",
+      channels: [channel],
+      run: async ({ messages, signal }) => streamText({ model, messages, abortSignal: signal }),
+    });
+
+    const harness = mockChatAgent(agent, { chatId: "chan-hitl-2" });
+    try {
+      await harness.deliverChannelEvent({ event: { callback: true } });
+
+      expect(interactionEvents).toHaveLength(1);
+      expect(modelCalls).toBe(0);
+      expect(channel.sent).toHaveLength(0);
+      expect(channel.finalized).toHaveLength(0);
+    } finally {
+      await harness.close();
+    }
+  });
+});
+
+describe("makeChannelStreamEditor", () => {
+  function streamConnector(send: (message: { text: string }) => Promise<{ ref?: string }>) {
+    return { delivery: "stream" as const, send } as never;
+  }
+
+  it("re-arms the debounce timer so text buffered during an in-flight edit still lands", async () => {
+    vi.useFakeTimers();
+    try {
+      const sends: string[] = [];
+      let releaseFirst!: () => void;
+      const firstGate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let call = 0;
+      const editor = __makeChannelStreamEditorForTests(
+        streamConnector(async (message) => {
+          sends.push(message.text);
+          call += 1;
+          if (call === 1) await firstGate;
+          return { ref: "r1" };
+        }),
+        { event: {}, deliveryId: "d1" },
+        "r1"
+      );
+
+      editor.observe({ type: "text-delta", delta: "a" });
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(sends).toEqual(["a"]);
+
+      editor.observe({ type: "text-delta", delta: "b" });
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(sends).toEqual(["a"]);
+
+      releaseFirst();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(sends).toEqual(["a", "ab"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not fire a pending edit after stop()", async () => {
+    vi.useFakeTimers();
+    try {
+      const sends: string[] = [];
+      const editor = __makeChannelStreamEditorForTests(
+        streamConnector(async (message) => {
+          sends.push(message.text);
+          return { ref: "r1" };
+        }),
+        { event: {}, deliveryId: "d1" },
+        "r1"
+      );
+
+      editor.observe({ type: "text-delta", delta: "a" });
+      editor.stop();
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(sends).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("makeChannelStreamTap", () => {
+  it("stops the editor when the stream completes (flush)", async () => {
+    let stops = 0;
+    const tap = __makeChannelStreamTapForTests({
+      observe: () => {},
+      stop: () => {
+        stops += 1;
+      },
+    });
+    const source = new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: "text-delta", delta: "x" });
+        controller.close();
+      },
+    });
+    const reader = source.pipeThrough(tap).getReader();
+    let done = false;
+    while (!done) {
+      done = (await reader.read()).done;
+    }
+    expect(stops).toBeGreaterThan(0);
+  });
+
+  it("stops the editor when the stream is cancelled mid-flight (abort)", async () => {
+    let stops = 0;
+    const tap = __makeChannelStreamTapForTests({
+      observe: () => {},
+      stop: () => {
+        stops += 1;
+      },
+    });
+    const source = new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: "text-delta", delta: "x" });
+      },
+    });
+    const reader = source.pipeThrough(tap).getReader();
+    await reader.read();
+    await reader.cancel("aborted");
+    expect(stops).toBeGreaterThan(0);
+  });
+});

--- a/packages/trigger-sdk/test/chatChannels.test.ts
+++ b/packages/trigger-sdk/test/chatChannels.test.ts
@@ -350,7 +350,12 @@ describe("makeChannelStreamEditor", () => {
 describe("makeChannelStreamTap", () => {
   it("stops the editor when the stream completes (flush)", async () => {
     let stops = 0;
-    const tap = __makeChannelStreamTapForTests({ observe: () => {}, stop: () => (stops += 1) });
+    const tap = __makeChannelStreamTapForTests({
+      observe: () => {},
+      stop: () => {
+        stops += 1;
+      },
+    });
     const source = new ReadableStream({
       start(controller) {
         controller.enqueue({ type: "text-delta", delta: "x" });
@@ -367,7 +372,12 @@ describe("makeChannelStreamTap", () => {
 
   it("stops the editor when the stream is cancelled mid-flight (abort)", async () => {
     let stops = 0;
-    const tap = __makeChannelStreamTapForTests({ observe: () => {}, stop: () => (stops += 1) });
+    const tap = __makeChannelStreamTapForTests({
+      observe: () => {},
+      stop: () => {
+        stops += 1;
+      },
+    });
     const source = new ReadableStream({
       start(controller) {
         controller.enqueue({ type: "text-delta", delta: "x" });

--- a/packages/trigger-sdk/test/normalizeKeyString.test.ts
+++ b/packages/trigger-sdk/test/normalizeKeyString.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { normalizeKeyString } from "../src/v3/webhooks.js";
+
+describe("normalizeKeyString", () => {
+  it("passes through webhook./header./body. placeholders unchanged", () => {
+    expect(normalizeKeyString("{body.event.id}")).toBe("{body.event.id}");
+    expect(normalizeKeyString("{header.x-github-event}")).toBe("{header.x-github-event}");
+    expect(normalizeKeyString("{webhook.deliveryId}")).toBe("{webhook.deliveryId}");
+  });
+
+  it("defaults an unqualified placeholder to the event body", () => {
+    expect(normalizeKeyString("{event.id}")).toBe("{body.event.id}");
+    expect(normalizeKeyString("{conversationId}")).toBe("{body.conversationId}");
+  });
+
+  it("normalizes every placeholder in a composite template", () => {
+    expect(normalizeKeyString("{team}/{body.channel}/{event.ts}")).toBe(
+      "{body.team}/{body.channel}/{body.event.ts}"
+    );
+  });
+
+  it("namespaces every alternative in a fallback placeholder", () => {
+    expect(normalizeKeyString("{a || b}")).toBe("{body.a || body.b}");
+    expect(normalizeKeyString("{body.a || event.b}")).toBe("{body.a || body.event.b}");
+    expect(normalizeKeyString("{header.x || body.y || z}")).toBe("{header.x || body.y || body.z}");
+  });
+
+  it("leaves literal text and unmatched braces alone", () => {
+    expect(normalizeKeyString("no-placeholders")).toBe("no-placeholders");
+    expect(normalizeKeyString("{{body.x}}")).toBe("{{body.x}}");
+  });
+
+  it("handles a pathological brace run in linear time", { timeout: 1000 }, () => {
+    const input = "{".repeat(500_000);
+    expect(normalizeKeyString(input)).toBe(input);
+  });
+});

--- a/packages/trigger-sdk/test/normalizeKeyString.test.ts
+++ b/packages/trigger-sdk/test/normalizeKeyString.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { normalizeKeyString } from "../src/v3/webhooks.js";
+
+describe("normalizeKeyString", () => {
+  it("passes through webhook./header./body. placeholders unchanged", () => {
+    expect(normalizeKeyString("{body.event.id}")).toBe("{body.event.id}");
+    expect(normalizeKeyString("{header.x-github-event}")).toBe("{header.x-github-event}");
+    expect(normalizeKeyString("{webhook.deliveryId}")).toBe("{webhook.deliveryId}");
+  });
+
+  it("defaults an unqualified placeholder to the event body", () => {
+    expect(normalizeKeyString("{event.id}")).toBe("{body.event.id}");
+    expect(normalizeKeyString("{conversationId}")).toBe("{body.conversationId}");
+  });
+
+  it("normalizes every placeholder in a composite template", () => {
+    expect(normalizeKeyString("{team}/{body.channel}/{event.ts}")).toBe(
+      "{body.team}/{body.channel}/{body.event.ts}"
+    );
+  });
+
+  it("leaves literal text and unmatched braces alone", () => {
+    expect(normalizeKeyString("no-placeholders")).toBe("no-placeholders");
+    expect(normalizeKeyString("{{body.x}}")).toBe("{{body.x}}");
+  });
+
+  it("handles a pathological brace run in linear time", { timeout: 1000 }, () => {
+    const input = "{".repeat(500_000);
+    expect(normalizeKeyString(input)).toBe(input);
+  });
+});

--- a/packages/trigger-sdk/test/normalizeKeyString.test.ts
+++ b/packages/trigger-sdk/test/normalizeKeyString.test.ts
@@ -19,6 +19,12 @@ describe("normalizeKeyString", () => {
     );
   });
 
+  it("namespaces every alternative in a fallback placeholder", () => {
+    expect(normalizeKeyString("{a || b}")).toBe("{body.a || body.b}");
+    expect(normalizeKeyString("{body.a || event.b}")).toBe("{body.a || body.event.b}");
+    expect(normalizeKeyString("{header.x || body.y || z}")).toBe("{header.x || body.y || body.z}");
+  });
+
   it("leaves literal text and unmatched braces alone", () => {
     expect(normalizeKeyString("no-placeholders")).toBe("no-placeholders");
     expect(normalizeKeyString("{{body.x}}")).toBe("{{body.x}}");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2273,6 +2273,9 @@ importers:
       '@trigger.dev/sdk':
         specifier: workspace:4.5.0-rc.7
         version: link:../trigger-sdk
+      '@types/node':
+        specifier: 24.13.3
+        version: 24.13.3
       rimraf:
         specifier: 6.0.1
         version: 6.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2261,6 +2261,28 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0
 
+  packages/slack:
+    dependencies:
+      '@trigger.dev/core':
+        specifier: workspace:4.5.0-rc.7
+        version: link:../core
+    devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: ^0.18.5
+        version: 0.18.5
+      '@trigger.dev/sdk':
+        specifier: workspace:4.5.0-rc.7
+        version: link:../trigger-sdk
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      tshy:
+        specifier: ^3.0.2
+        version: 3.3.2
+      tsx:
+        specifier: 4.17.0
+        version: 4.17.0
+
   packages/trigger-sdk:
     dependencies:
       '@ai-sdk/otel':
@@ -8293,10 +8315,22 @@ packages:
   '@types/ws@8.5.4':
     resolution: {integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==}
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-BvaaQAHWaHA0nl26DsWTsXsKkCHqUTm7f5FMuNDyCU83Hvo7zHx0vpSTrzL+1KEWeWLUVVGA7U224dk+3yIosQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
     resolution: {integrity: sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-a2JJezvJAqWXgTAD1tKdWs7iA/4s3EakLcCYx4rg3ptEbBF6ADWv7A9ySHxT/+CQWYCD0DYIb9du1JUWL85fRw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
     os: [darwin]
 
   '@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2':
@@ -8305,10 +8339,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-MQ0JcRucLdcR6MT14wlrGNz9HaxJrFF8Axmo0IN6e5gSou2UrKKUvvAH1i8zU5Gm7jl8CWCLzzX/qGCi1TsinA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
   '@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2':
     resolution: {integrity: sha512-iITBa2WjjTI5N9t5l7Z4KoOSI+2zBlhbvFzsD/f8qX8QoKjz/Y4DPyBDgezYi8nkqjjksbgSOJ3/ykzhwrB9cg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-GLsTfJQiGfTN+r1ezlxMcTd5MNYRB/tADD6Y1j1jfLjZsFYSVkNfCnDQA/jwUG6GddBBF+0Um7tBUP16emej9w==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
     os: [linux]
 
   '@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2':
@@ -8317,11 +8363,23 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-u6gvCiVGSDagdR2+GI5VJLPxJbGevATJgjZ2QFLKBLWI3re7liTGlPAuaINNDq/r0m9rUPj2rEn0zwqtcLK0nQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
   '@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2':
     resolution: {integrity: sha512-du0dzi6y97Po5vDNdPJTyyijHCpaS22JLRnKZEJXBDaO9gCIymOv/5QQokFRuOlQm0bWl3i9PF4OVdGP6uAOQA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-slxm6HBYs+jk0GpIBC2o03uY5qHgW7wIH+OTjK8JHbd2sUCgYV7P7bfZHUVZYi/cJZcVrnDW6MxXx734TuFn+w==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
 
   '@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2':
     resolution: {integrity: sha512-SsAwfhyHJ1akgBc+99z4+hwdbHsdWaKB8EwCNIMA6JfSLMeUjffrYvxu+vfMyxVtOVOz7RrRXRoiDiu4a2sCtg==}
@@ -8329,11 +8387,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-G7SDZJn2Z9+c1qsAFzI/JL0OsRjJ18diQ39ycWKmJikilZZeL7iS7j933bemWY4ODaLTfxhMRKPMHf9292gpDA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2':
     resolution: {integrity: sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-CO519Ccw5rji4JIG0DGVMR5owraCeQhm94jM53eRhMdlzz0nAJcAZ63Y6m1u3dUwqGssqlYxh4CcwTFPxTpMYw==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
 
   '@typescript/native-preview@7.0.0-dev.20260707.2':
     resolution: {integrity: sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg==}
@@ -15260,6 +15329,11 @@ packages:
       unrun:
         optional: true
 
+  tshy@3.3.2:
+    resolution: {integrity: sha512-vOIXkqMtBWNjKUR/c99+6N50LhWdnKG1xE3+5wf8IPdzxx2lcIFPvbGgFdBBgoTMbdNb8mz06MUm7hY+TFnJcw==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+
   tshy@4.1.3:
     resolution: {integrity: sha512-uEaLO1lFhu5X58KZxS5gKCabh+xd72MfXDOHhAIvnoreBAP1F4HNpbK2m0DUmrrzpcgxvXbsdXn1A0OaQxFYqw==}
     engines: {node: 20 || >=22}
@@ -19457,7 +19531,7 @@ snapshots:
       json-parse-even-better-errors: 3.0.0
       normalize-package-data: 5.0.0
       proc-log: 3.0.0
-      semver: 7.8.1
+      semver: 7.8.5
     transitivePeerDependencies:
       - bluebird
 
@@ -23326,26 +23400,57 @@ snapshots:
     dependencies:
       '@types/node': 24.13.3
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260603.1':
+    optional: true
+
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260603.1':
     optional: true
 
   '@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2':
     optional: true
 
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260603.1':
+    optional: true
+
   '@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260603.1':
     optional: true
 
   '@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2':
     optional: true
 
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260603.1':
+    optional: true
+
   '@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260603.1':
     optional: true
 
   '@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2':
     optional: true
 
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260603.1':
+    optional: true
+
   '@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2':
     optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260603.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260603.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260603.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260603.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260603.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260603.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260603.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260603.1
 
   '@typescript/native-preview@7.0.0-dev.20260707.2':
     optionalDependencies:
@@ -31409,6 +31514,22 @@ snapshots:
       - '@volar/typescript'
       - oxc-resolver
       - vue-tsc
+
+  tshy@3.3.2:
+    dependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260603.1
+      chalk: 5.6.2
+      chokidar: 4.0.3
+      foreground-child: 4.0.3
+      jsonc-simple-parser: 3.0.0
+      minimatch: 10.2.5
+      mkdirp: 3.0.1
+      polite-json: 5.0.0
+      resolve-import: 2.4.0
+      rimraf: 6.1.3
+      sync-content: 2.0.4
+      typescript: 5.9.3
+      walk-up-path: 4.0.0
 
   tshy@4.1.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2085,6 +2085,31 @@ importers:
         specifier: npm:zod@3.25.56
         version: zod@3.25.56
 
+  packages/slack:
+    dependencies:
+      '@trigger.dev/core':
+        specifier: workspace:4.5.0-rc.7
+        version: link:../core
+    devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: ^0.18.5
+        version: 0.18.5
+      '@trigger.dev/sdk':
+        specifier: workspace:4.5.0-rc.7
+        version: link:../trigger-sdk
+      '@types/node':
+        specifier: 24.13.3
+        version: 24.13.3
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      tshy:
+        specifier: ^3.0.2
+        version: 3.3.2
+      tsx:
+        specifier: 4.17.0
+        version: 4.17.0
+
   packages/trigger-sdk:
     dependencies:
       '@ai-sdk/otel':
@@ -7918,10 +7943,22 @@ packages:
   '@types/ws@8.5.4':
     resolution: {integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==}
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-BvaaQAHWaHA0nl26DsWTsXsKkCHqUTm7f5FMuNDyCU83Hvo7zHx0vpSTrzL+1KEWeWLUVVGA7U224dk+3yIosQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
     resolution: {integrity: sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-a2JJezvJAqWXgTAD1tKdWs7iA/4s3EakLcCYx4rg3ptEbBF6ADWv7A9ySHxT/+CQWYCD0DYIb9du1JUWL85fRw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
     os: [darwin]
 
   '@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2':
@@ -7930,10 +7967,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-MQ0JcRucLdcR6MT14wlrGNz9HaxJrFF8Axmo0IN6e5gSou2UrKKUvvAH1i8zU5Gm7jl8CWCLzzX/qGCi1TsinA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
   '@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2':
     resolution: {integrity: sha512-iITBa2WjjTI5N9t5l7Z4KoOSI+2zBlhbvFzsD/f8qX8QoKjz/Y4DPyBDgezYi8nkqjjksbgSOJ3/ykzhwrB9cg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-GLsTfJQiGfTN+r1ezlxMcTd5MNYRB/tADD6Y1j1jfLjZsFYSVkNfCnDQA/jwUG6GddBBF+0Um7tBUP16emej9w==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
     os: [linux]
 
   '@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2':
@@ -7942,11 +7991,23 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-u6gvCiVGSDagdR2+GI5VJLPxJbGevATJgjZ2QFLKBLWI3re7liTGlPAuaINNDq/r0m9rUPj2rEn0zwqtcLK0nQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
   '@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2':
     resolution: {integrity: sha512-du0dzi6y97Po5vDNdPJTyyijHCpaS22JLRnKZEJXBDaO9gCIymOv/5QQokFRuOlQm0bWl3i9PF4OVdGP6uAOQA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-slxm6HBYs+jk0GpIBC2o03uY5qHgW7wIH+OTjK8JHbd2sUCgYV7P7bfZHUVZYi/cJZcVrnDW6MxXx734TuFn+w==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
 
   '@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2':
     resolution: {integrity: sha512-SsAwfhyHJ1akgBc+99z4+hwdbHsdWaKB8EwCNIMA6JfSLMeUjffrYvxu+vfMyxVtOVOz7RrRXRoiDiu4a2sCtg==}
@@ -7954,11 +8015,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-G7SDZJn2Z9+c1qsAFzI/JL0OsRjJ18diQ39ycWKmJikilZZeL7iS7j933bemWY4ODaLTfxhMRKPMHf9292gpDA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2':
     resolution: {integrity: sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260603.1':
+    resolution: {integrity: sha512-CO519Ccw5rji4JIG0DGVMR5owraCeQhm94jM53eRhMdlzz0nAJcAZ63Y6m1u3dUwqGssqlYxh4CcwTFPxTpMYw==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
 
   '@typescript/native-preview@7.0.0-dev.20260707.2':
     resolution: {integrity: sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg==}
@@ -14388,6 +14460,11 @@ packages:
         optional: true
       unrun:
         optional: true
+
+  tshy@3.3.2:
+    resolution: {integrity: sha512-vOIXkqMtBWNjKUR/c99+6N50LhWdnKG1xE3+5wf8IPdzxx2lcIFPvbGgFdBBgoTMbdNb8mz06MUm7hY+TFnJcw==}
+    engines: {node: 20 || >=22}
+    hasBin: true
 
   tshy@4.1.3:
     resolution: {integrity: sha512-uEaLO1lFhu5X58KZxS5gKCabh+xd72MfXDOHhAIvnoreBAP1F4HNpbK2m0DUmrrzpcgxvXbsdXn1A0OaQxFYqw==}
@@ -22264,26 +22341,57 @@ snapshots:
     dependencies:
       '@types/node': 24.13.3
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260603.1':
+    optional: true
+
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260603.1':
     optional: true
 
   '@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2':
     optional: true
 
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260603.1':
+    optional: true
+
   '@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260603.1':
     optional: true
 
   '@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2':
     optional: true
 
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260603.1':
+    optional: true
+
   '@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260603.1':
     optional: true
 
   '@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2':
     optional: true
 
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260603.1':
+    optional: true
+
   '@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2':
     optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260603.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260603.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260603.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260603.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260603.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260603.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260603.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260603.1
 
   '@typescript/native-preview@7.0.0-dev.20260707.2':
     optionalDependencies:
@@ -29801,6 +29909,22 @@ snapshots:
       - '@volar/typescript'
       - oxc-resolver
       - vue-tsc
+
+  tshy@3.3.2:
+    dependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260603.1
+      chalk: 5.6.2
+      chokidar: 4.0.3
+      foreground-child: 4.0.3
+      jsonc-simple-parser: 3.0.0
+      minimatch: 10.2.5
+      mkdirp: 3.0.1
+      polite-json: 5.0.0
+      resolve-import: 2.4.0
+      rimraf: 6.1.3
+      sync-content: 2.0.4
+      typescript: 5.9.3
+      walk-up-path: 4.0.0
 
   tshy@4.1.3:
     dependencies:


### PR DESCRIPTION
## Summary

The chat.agent half of hosted webhooks, rebased onto current main and narrowed to the agent surface. The plain `webhook()` API now lives in #4923, which this PR is stacked on: the diff here includes that branch's commit until it merges.

- `chat.event({ source, key, type })` routes verified deliveries that share a key template to one durable session (per customer, installation, or issue) and delivers them to an agent's `onAction` as a typed envelope.
- Channels turn a chat surface into an agent frontend: `chat.channels.custom({ source, key, inbound, send })`, or the new `@trigger.dev/slack` package's `slack()` (Slack Events API verification, per-thread sessions, `chat.postMessage` / `chat.update` egress, `mentions()`, `startOn`, lifecycle reactions). Inbound messages run as turns and the reply posts back.
- Human-in-the-loop: a tool with no `execute` pauses the turn, the connector posts controls (Slack ships Approve / Deny buttons), and a verified click resolves the tool and resumes the run.
- `chat.createWatchToken(externalId)` mints a read-only token to watch a session from another surface.
- The chat.agent test harness gains `recordingChannelConnector()`, `sendChannelEvent()`, and `deliverChannelEvent()`.
- The CLI warns about a `chat.event` no agent lists.

```ts
import { webhooks } from "@trigger.dev/sdk";
import { chat } from "@trigger.dev/sdk/ai";
import { slack } from "@trigger.dev/slack";

export const orderEvents = chat.event({
  id: "order-events",
  source: webhooks.stripe(),
  key: "{body.data.object.customer}",
  type: "order.event",
});

export const support = chat.agent({
  id: "support",
  events: [orderEvents],
  channels: [slack({ id: "support-slack", token: process.env.SLACK_BOT_TOKEN! })],
  onAction: async ({ action }) => { /* order.event arrives here */ },
  run: async (payload) => { /* Slack messages run here as turns */ },
});
```

## Stack

Merges after #4923 (the `webhook()` SDK branch). The server half (#4344) is already on main behind a flag. Review only the top commit here; the bottom one is #4923.

## Rebase notes

Main's transcript-storage and input-router work landed since this branch was cut. Three integration points changed, and reviewers should look at these first:

- Interaction hydration (locating the pending tool call for a button click on a fresh run) goes through `loadContextHook`, which covers both the deprecated `hydrateMessages` and a storage's `loadContext`, and resets the lane state the same way the action path does.
- The pending-messages router observer skips channel records, so a channel delivery is never steered mid-turn and stays queued to run as its own turn.
- A dropped channel delivery (a stale interaction click or an event for a connector the agent does not list) takes the no-op turn path: it writes turn-complete and advances the input cursor. Before the rebase it only decremented the turn counter.

## Testing

- `tsc --noEmit` clean for `@trigger.dev/sdk`, `@trigger.dev/slack`, and `trigger.dev`.
- Full `@trigger.dev/sdk` vitest suite: 677 tests across 76 files pass, including the channel round-trip, HITL, reaction, and key-template suites.
- `@trigger.dev/slack` suite: 20 tests pass.

## Changelog

Adds `chat.event`, `chat.channels`, channel human-in-the-loop, and `chat.createWatchToken` to `@trigger.dev/sdk`, introduces `@trigger.dev/slack`, and documents session routing, channels, and human-in-the-loop. One changeset bumps sdk, slack, and the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PPzBQgFgqD8aPQcEYZXty
