### PR TITLE
fix(sdk): guard against null output in wait token timeout error

### DIFF
--- a/.changeset/fix-wait-token-null-output-crash.md
+++ b/.changeset/fix-wait-token-null-output-crash.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+Fix crash when a timed-out waitpoint token has no output payload. When `result.output` is null, `data` is `undefined` and accessing `data.message` throws a `TypeError` before the timeout error reaches the caller. Uses optional chaining with a fallback message, matching the pattern already used in `sharedRuntimeManager` for the same case.

--- a/packages/trigger-sdk/src/v3/wait.ts
+++ b/packages/trigger-sdk/src/v3/wait.ts
@@ -269,7 +269,7 @@ async function retrieveToken<T>(
   let output: T | undefined = undefined;
 
   if (result.outputIsError) {
-    error = new WaitpointTimeoutError(data.message);
+    error = new WaitpointTimeoutError(data?.message ?? "Waitpoint timed out");
   } else {
     output = data as T;
   }
@@ -615,7 +615,7 @@ export const wait = {
                 output: data,
               } as WaitpointTokenTypedResult<T>;
             } else {
-              const error = new WaitpointTimeoutError(data.message);
+              const error = new WaitpointTimeoutError(data?.message ?? "Waitpoint timed out");
 
               span.recordException(error);
               span.setStatus({


### PR DESCRIPTION
## What?

`wait.retrieveToken` and `wait.forToken` both set `data = undefined` when a waitpoint token's `output` is null/absent, then immediately access `data.message` in the error path. This throws a `TypeError` that crashes the runtime before the caller ever sees the `WaitpointTimeoutError`.

## Why?

A timed-out waitpoint with `outputIsError = true` but `output = null` (null stored in DB) sends no `output` field from the API presenter. The existing code assumed output is always present when `outputIsError` is true, but `ApiWaitpointPresenter` already handles this case at line 84, confirming the scenario is real.

## Fix

Use optional chaining with a fallback message (`data?.message ?? "Waitpoint timed out"`), matching the pattern `sharedRuntimeManager` already uses for the identical case at line 292-302.

## Changes

- `packages/trigger-sdk/src/v3/wait.ts` — two null guards in `retrieveToken` and `forToken`
- `.changeset/fix-wait-token-null-output-crash.md` — patch changeset