### PR TITLE
fix(hosting): disable ClickHouse system-log telemetry tables and apply profile settings via users.d

### DIFF
--- a/.server-changes/hosting-clickhouse-system-logs.md
+++ b/.server-changes/hosting-clickhouse-system-logs.md
@@ -3,4 +3,4 @@ area: hosting
 type: fix
 ---
 
-Self-hosted ClickHouse no longer accumulates unbounded system-log telemetry (metric_log, text_log, asynchronous_metric_log, ...) that eventually pins the CPU in a background merge-retry loop on the recommended machine size; query_log and error_log are kept with a TTL, and the low-memory profile settings now actually apply (moved from config.d to users.d).
+Self-hosted ClickHouse now disables its unbounded internal telemetry tables and keeps query/error logs on a bounded retention, fixing runaway CPU and memory usage on the recommended machine size. Existing self-hosted deployments must drop the previously written disabled log tables separately to reclaim disk.

--- a/.server-changes/hosting-clickhouse-system-logs.md
+++ b/.server-changes/hosting-clickhouse-system-logs.md
@@ -1,0 +1,6 @@
+---
+area: hosting
+type: fix
+---
+
+Self-hosted ClickHouse no longer accumulates unbounded system-log telemetry (metric_log, text_log, asynchronous_metric_log, ...) that eventually pins the CPU in a background merge-retry loop on the recommended machine size; query_log and error_log are kept with a TTL, and the low-memory profile settings now actually apply (moved from config.d to users.d).

--- a/hosting/docker/clickhouse/override.xml
+++ b/hosting/docker/clickhouse/override.xml
@@ -9,12 +9,42 @@
     <!-- Official recommendations for systems with <16GB RAM -->
     <mark_cache_size>524288000</mark_cache_size> <!-- 500MB -->
     <concurrent_threads_soft_limit_num>1</concurrent_threads_soft_limit_num>
-    <profiles>
-        <default>
-        <max_block_size>8192</max_block_size>
-        <max_download_threads>1</max_download_threads>
-        <input_format_parallel_parsing>0</input_format_parallel_parsing>
-        <output_format_parallel_formatting>0</output_format_parallel_formatting>
-        </default>
-    </profiles>
+
+    <!-- ClickHouse's own telemetry tables have no TTL and grow without bound; on the
+         recommended webapp machine size their background merges eventually stop fitting
+         in memory and are retried forever (there is no backoff for failed merges),
+         pinning the CPU and ultimately failing the webapp's own inserts (#4343).
+         The ClickHouse low-RAM guide recommends disabling exactly these tables:
+         https://clickhouse.com/docs/operations/tips
+         Same list as the dev stack (docker/config/clickhouse-disable-system-logs.xml),
+         extended with the newer log tables. -->
+    <metric_log remove="1"/>
+    <asynchronous_metric_log remove="1"/>
+    <part_log remove="1"/>
+    <trace_log remove="1"/>
+    <query_thread_log remove="1"/>
+    <session_log remove="1"/>
+    <text_log remove="1"/>
+    <zookeeper_log remove="1"/>
+    <processors_profile_log remove="1"/>
+    <asynchronous_insert_log remove="1"/>
+    <backup_log remove="1"/>
+    <latency_log remove="1"/>
+    <query_metric_log remove="1"/>
+    <opentelemetry_span_log remove="1"/>
+    <query_views_log remove="1"/>
+
+    <!-- Keep query_log and error_log (small and useful for debugging), but bounded.
+         A config-level TTL survives log-table recreation, unlike ALTER ... MODIFY TTL.
+         Note: ClickHouse renames the existing table to *_log_<N> when this changes;
+         drop those leftovers to reclaim disk. -->
+    <query_log>
+        <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
+    </query_log>
+    <error_log>
+        <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+    </error_log>
+
+    <!-- Profile settings do NOT live here: config.d is silently ignored for them.
+         See users-override.xml, mounted under users.d. -->
 </clickhouse>

--- a/hosting/docker/clickhouse/users-override.xml
+++ b/hosting/docker/clickhouse/users-override.xml
@@ -1,0 +1,21 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <!-- Low-memory settings for the recommended webapp machine size. These were
+                 previously in config.d/override.xml where profile settings are silently
+                 ignored — they only take effect from the users config tree (#4343). -->
+            <max_block_size>8192</max_block_size>
+            <max_download_threads>1</max_download_threads>
+            <input_format_parallel_parsing>0</input_format_parallel_parsing>
+            <output_format_parallel_formatting>0</output_format_parallel_formatting>
+            <!-- The memory/query profilers sample stacks into system.trace_log
+                 (a Memory/MemoryPeak sample every 4 MB allocated, by default) — the main
+                 firehose that fills it. trace_log is disabled in override.xml; turn the
+                 samplers off too so they don't burn CPU producing discarded rows. -->
+            <memory_profiler_step>0</memory_profiler_step>
+            <memory_profiler_sample_probability>0</memory_profiler_sample_probability>
+            <query_profiler_real_time_period_ns>0</query_profiler_real_time_period_ns>
+            <query_profiler_cpu_time_period_ns>0</query_profiler_cpu_time_period_ns>
+        </default>
+    </profiles>
+</clickhouse>

--- a/hosting/docker/webapp/docker-compose.yml
+++ b/hosting/docker/webapp/docker-compose.yml
@@ -177,6 +177,7 @@ services:
       - clickhouse:/var/lib/clickhouse
       - ../clickhouse/data-paths.xml:/etc/clickhouse-server/config.d/data-paths.xml:ro
       - ../clickhouse/override.xml:/etc/clickhouse-server/config.d/override.xml:ro
+      - ../clickhouse/users-override.xml:/etc/clickhouse-server/users.d/override.xml:ro
     networks:
       - webapp
     healthcheck:


### PR DESCRIPTION
fixes #4343

## Problem

The self-hosting ClickHouse ships with every system log table enabled and unbounded (no TTL by default). On the recommended webapp machine (3+ vCPU / 6+ GB), the wide telemetry tables (`metric_log` ~1200 columns, `text_log`, `asynchronous_metric_log`) grow until their background merges no longer fit under the memory cap (`max_server_memory_usage_to_ram_ratio` 0.9 ≈ 5.2 GiB on a 6 GB box — ClickHouse measured a default `metric_log` merge peaking around **6 GB** in ClickHouse/ClickHouse#89811). Failed non-replicated merges have **no retry backoff**, so ClickHouse retries them forever: in our production this burned ~270% CPU at ~350k `MEMORY_LIMIT_EXCEEDED`/day, each failure logging a stack trace into `text_log` and feeding the loop — and eventually the webapp's own inserts into `trigger_dev.task_runs_v2`/`metrics_v1` started failing with the same error, so runs went missing from the dashboard. 14 days after a fresh data dir, **5.96 GiB of the 6.0 GiB** of MergeTree data on the box was ClickHouse telemetry; actual Trigger data was ~40 MiB.

The dev stack fixed exactly this in #3565 (`docker/config/clickhouse-disable-system-logs.xml`); it was never ported to `hosting/docker`. The ClickHouse low-RAM guide prescribes disabling these tables on <16 GB machines: https://clickhouse.com/docs/operations/tips

Separately, the `<profiles>` block in `hosting/docker/clickhouse/override.xml` is silently ignored: profile settings only apply from the users config tree (`users.d`), never from `config.d` — so the advertised low-memory settings (`max_block_size` 8192, etc.) have never applied.

## Changes

- `hosting/docker/clickhouse/override.xml`: disable the same system log tables as the dev stack, extended with the newer ones (`latency_log`, `query_metric_log`, `opentelemetry_span_log`, `query_views_log`). Keep `query_log` and `error_log`, bounded with a config-level `<ttl>` (7/30 days) — config-level TTL survives table recreation, unlike `ALTER … MODIFY TTL`. The ineffective `<profiles>` block is removed.
- New `hosting/docker/clickhouse/users-override.xml`, mounted at `/etc/clickhouse-server/users.d/override.xml`: carries those profile settings so they actually apply, plus explicit zeros for the memory/query profilers (their samples were the main `trace_log` firehose).
- `hosting/docker/webapp/docker-compose.yml`: add the `users.d` mount.

## Validation

Deployed on our production for 7 days (see #4343 for the full soak log): ClickHouse CPU 275% → ~2%, `MEMORY_LIMIT_EXCEEDED` from ~350k/day to zero for 7 straight days, webapp insert failures from ~40/day to zero — including a 79-database backup fleet run (~470 task runs) — and 6 GiB of disk reclaimed.

Note for existing deployments: disabling a log table stops new writes but doesn't delete existing data. To reclaim disk: `DROP TABLE system.<name> SYNC` for each disabled table (plus any `*_log_<N>` leftovers from config-change renames). Happy to add that to the self-hosting docs if useful.
