### PR TITLE
feat(deployments): split project dependencies and code into separate layers

### DIFF
--- a/.changeset/split-image-dependency-layers.md
+++ b/.changeset/split-image-dependency-layers.md
@@ -2,4 +2,4 @@
 "trigger.dev": patch
 ---
 
-Deployed images now ship dependencies and bundled task code as separate layers. Repeat deploys with unchanged dependencies push and pull far less data, making deploys and worker image pulls faster.
+Deployed images now ship dependencies and bundled task code as separate layers. Repeat deploys with unchanged dependencies typically push and pull far less data, making deploys and worker image pulls faster.

--- a/.changeset/split-image-dependency-layers.md
+++ b/.changeset/split-image-dependency-layers.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Deployed images now ship dependencies and bundled task code as separate layers. Repeat deploys with unchanged dependencies push and pull far less data, making deploys and worker image pulls faster.

--- a/packages/cli-v3/src/deploy/buildImage.test.ts
+++ b/packages/cli-v3/src/deploy/buildImage.test.ts
@@ -44,8 +44,7 @@ describe("generateContainerfile", () => {
         `COPY --from=build --chown=${user} /app/node_modules ./node_modules`
       );
       expect(containerfile).toContain(`COPY --from=code --chown=${user} /app ./`);
-      // The final stage must not copy all of /app from the build stage anymore,
-      // or node_modules would be duplicated across two layers
+      // copying all of /app from build would duplicate node_modules across two layers
       expect(containerfile).not.toContain(`COPY --from=build --chown=${user} /app ./`);
     }
   );
@@ -62,12 +61,11 @@ describe("generateContainerfile", () => {
       });
 
       const postInstall = containerfile.indexOf("RUN echo post-install");
-      // The guard must run after post-install commands so a command that prunes
-      // node_modules can't break the final-stage COPY of /app/node_modules
+      // guard after post-install so a command that prunes node_modules can't break the COPY
       const mkdirGuard = containerfile.indexOf("RUN mkdir -p node_modules");
       const codeStage = containerfile.indexOf("FROM build AS code");
       const rmNodeModules = containerfile.indexOf(
-        "RUN chmod -R u+w node_modules && rm -rf node_modules"
+        "RUN chmod -R u+rwX node_modules && rm -rf node_modules"
       );
 
       expect(postInstall).toBeGreaterThan(-1);

--- a/packages/cli-v3/src/deploy/buildImage.test.ts
+++ b/packages/cli-v3/src/deploy/buildImage.test.ts
@@ -40,7 +40,6 @@ describe("generateContainerfile", () => {
       const user = runtime === "bun" ? "bun:bun" : "node:node";
 
       expect(containerfile).toContain("FROM build AS code");
-      expect(containerfile).toContain("RUN rm -rf node_modules");
       expect(containerfile).toContain(
         `COPY --from=build --chown=${user} /app/node_modules ./node_modules`
       );
@@ -48,9 +47,33 @@ describe("generateContainerfile", () => {
       // The final stage must not copy all of /app from the build stage anymore,
       // or node_modules would be duplicated across two layers
       expect(containerfile).not.toContain(`COPY --from=build --chown=${user} /app ./`);
+    }
+  );
 
-      // node_modules must exist even for projects with zero external dependencies
-      expect(containerfile).toContain("mkdir -p node_modules");
+  it.each(["node", "bun"] as BuildRuntime[])(
+    "orders post-install commands, the node_modules guard, and the code stage for %s",
+    async (runtime) => {
+      const containerfile = await generateContainerfile({
+        runtime,
+        build: { commands: ["echo post-install"] },
+        image: undefined,
+        indexScript: "index.js",
+        entrypoint: "entrypoint.js",
+      });
+
+      const postInstall = containerfile.indexOf("RUN echo post-install");
+      // The guard must run after post-install commands so a command that prunes
+      // node_modules can't break the final-stage COPY of /app/node_modules
+      const mkdirGuard = containerfile.indexOf("RUN mkdir -p node_modules");
+      const codeStage = containerfile.indexOf("FROM build AS code");
+      const rmNodeModules = containerfile.indexOf(
+        "RUN chmod -R u+w node_modules && rm -rf node_modules"
+      );
+
+      expect(postInstall).toBeGreaterThan(-1);
+      expect(mkdirGuard).toBeGreaterThan(postInstall);
+      expect(codeStage).toBeGreaterThan(mkdirGuard);
+      expect(rmNodeModules).toBeGreaterThan(codeStage);
     }
   );
 });

--- a/packages/cli-v3/src/deploy/buildImage.test.ts
+++ b/packages/cli-v3/src/deploy/buildImage.test.ts
@@ -25,4 +25,32 @@ describe("generateContainerfile", () => {
 
     expect(containerfile).toContain(`FROM ${image} AS base`);
   });
+
+  it.each(["node", "bun"] as BuildRuntime[])(
+    "splits node_modules and app code into separate layers for %s",
+    async (runtime) => {
+      const containerfile = await generateContainerfile({
+        runtime,
+        build: {},
+        image: undefined,
+        indexScript: "index.js",
+        entrypoint: "entrypoint.js",
+      });
+
+      const user = runtime === "bun" ? "bun:bun" : "node:node";
+
+      expect(containerfile).toContain("FROM build AS code");
+      expect(containerfile).toContain("RUN rm -rf node_modules");
+      expect(containerfile).toContain(
+        `COPY --from=build --chown=${user} /app/node_modules ./node_modules`
+      );
+      expect(containerfile).toContain(`COPY --from=code --chown=${user} /app ./`);
+      // The final stage must not copy all of /app from the build stage anymore,
+      // or node_modules would be duplicated across two layers
+      expect(containerfile).not.toContain(`COPY --from=build --chown=${user} /app ./`);
+
+      // node_modules must exist even for projects with zero external dependencies
+      expect(containerfile).toContain("mkdir -p node_modules");
+    }
+  );
 });

--- a/packages/cli-v3/src/deploy/buildImage.ts
+++ b/packages/cli-v3/src/deploy/buildImage.ts
@@ -772,13 +772,19 @@ ${buildArgs}
 ${buildEnvVars}
 
 COPY --chown=bun:bun package.json ./
-RUN bun install --production --no-save
+# mkdir guards against bun not creating node_modules when there are no dependencies
+RUN bun install --production --no-save && mkdir -p node_modules
 
 # Now copy all the files
 # IMPORTANT: Do this after running npm install because npm i will wipe out the node_modules directory
 COPY --chown=bun:bun . .
 
 ${postInstallCommands}
+
+# App files without node_modules, so the final stage can layer them separately
+FROM build AS code
+
+RUN rm -rf node_modules
 
 FROM build AS indexer
 
@@ -831,8 +837,12 @@ ENV TRIGGER_PROJECT_ID=\${TRIGGER_PROJECT_ID} \
     NODE_EXTRA_CA_CERTS=\${NODE_EXTRA_CA_CERTS} \
     NODE_ENV=production
 
-# Copy the files from the build stage
-COPY --from=build --chown=bun:bun /app ./
+# Dependencies as their own layer: unchanged deps produce an identical blob
+# that registries and workers already have, so repeat deploys skip it
+COPY --from=build --chown=bun:bun /app/node_modules ./node_modules
+
+# Copy the app files (without node_modules) from the code stage
+COPY --from=code --chown=bun:bun /app ./
 
 # Copy the index.json file from the indexer stage
 COPY --from=indexer --chown=bun:bun /app/index.json ./
@@ -877,7 +887,8 @@ ENV NODE_ENV=production
 ENV NPM_CONFIG_UPDATE_NOTIFIER=false
 
 COPY --chown=node:node package.json ./
-RUN npm i --no-audit --no-fund --no-save --no-package-lock
+# mkdir guards against npm not creating node_modules when there are no dependencies
+RUN npm i --no-audit --no-fund --no-save --no-package-lock && mkdir -p node_modules
 
 # Now copy all the files
 # IMPORTANT: Do this after running npm install because npm i will wipe out the node_modules directory
@@ -887,6 +898,11 @@ ${postInstallCommands}
 
 # IMPORTANT: Doing this again to fix an issue with prisma generate removing the files in node_modules/trigger.dev for some reason...
 COPY --chown=node:node . .
+
+# App files without node_modules, so the final stage can layer them separately
+FROM build AS code
+
+RUN rm -rf node_modules
 
 FROM build AS indexer
 
@@ -941,8 +957,12 @@ ENV TRIGGER_PROJECT_ID=\${TRIGGER_PROJECT_ID} \
     NODE_EXTRA_CA_CERTS=\${NODE_EXTRA_CA_CERTS} \
     NODE_ENV=production
 
-# Copy the files from the install stage
-COPY --from=build --chown=node:node /app ./
+# Dependencies as their own layer: unchanged deps produce an identical blob
+# that registries and workers already have, so repeat deploys skip it
+COPY --from=build --chown=node:node /app/node_modules ./node_modules
+
+# Copy the app files (without node_modules) from the code stage
+COPY --from=code --chown=node:node /app ./
 
 # Copy the index.json file from the indexer stage
 COPY --from=indexer --chown=node:node /app/index.json ./

--- a/packages/cli-v3/src/deploy/buildImage.ts
+++ b/packages/cli-v3/src/deploy/buildImage.ts
@@ -783,11 +783,10 @@ ${postInstallCommands}
 # node_modules may not exist when there are no dependencies to install
 RUN mkdir -p node_modules
 
-# App files without node_modules, so the final stage can layer them separately
 FROM build AS code
 
-# u+w first: rm as a non-root user fails on read-only directories
-RUN chmod -R u+w node_modules && rm -rf node_modules
+# u+rwX first: non-root rm fails on read-only or non-traversable directories
+RUN chmod -R u+rwX node_modules && rm -rf node_modules
 
 FROM build AS indexer
 
@@ -840,11 +839,9 @@ ENV TRIGGER_PROJECT_ID=\${TRIGGER_PROJECT_ID} \
     NODE_EXTRA_CA_CERTS=\${NODE_EXTRA_CA_CERTS} \
     NODE_ENV=production
 
-# Dependencies as their own layer: unchanged deps produce an identical blob
-# that registries and workers already have, so repeat deploys skip it
+# Unchanged dependencies produce an identical layer that repeat deploys skip
 COPY --from=build --chown=bun:bun /app/node_modules ./node_modules
 
-# Copy the app files (without node_modules) from the code stage
 COPY --from=code --chown=bun:bun /app ./
 
 # Copy the index.json file from the indexer stage
@@ -904,11 +901,10 @@ COPY --chown=node:node . .
 # node_modules may not exist when there are no dependencies to install
 RUN mkdir -p node_modules
 
-# App files without node_modules, so the final stage can layer them separately
 FROM build AS code
 
-# u+w first: rm as a non-root user fails on read-only directories
-RUN chmod -R u+w node_modules && rm -rf node_modules
+# u+rwX first: non-root rm fails on read-only or non-traversable directories
+RUN chmod -R u+rwX node_modules && rm -rf node_modules
 
 FROM build AS indexer
 
@@ -963,11 +959,9 @@ ENV TRIGGER_PROJECT_ID=\${TRIGGER_PROJECT_ID} \
     NODE_EXTRA_CA_CERTS=\${NODE_EXTRA_CA_CERTS} \
     NODE_ENV=production
 
-# Dependencies as their own layer: unchanged deps produce an identical blob
-# that registries and workers already have, so repeat deploys skip it
+# Unchanged dependencies produce an identical layer that repeat deploys skip
 COPY --from=build --chown=node:node /app/node_modules ./node_modules
 
-# Copy the app files (without node_modules) from the code stage
 COPY --from=code --chown=node:node /app ./
 
 # Copy the index.json file from the indexer stage

--- a/packages/cli-v3/src/deploy/buildImage.ts
+++ b/packages/cli-v3/src/deploy/buildImage.ts
@@ -772,8 +772,7 @@ ${buildArgs}
 ${buildEnvVars}
 
 COPY --chown=bun:bun package.json ./
-# mkdir guards against bun not creating node_modules when there are no dependencies
-RUN bun install --production --no-save && mkdir -p node_modules
+RUN bun install --production --no-save
 
 # Now copy all the files
 # IMPORTANT: Do this after running npm install because npm i will wipe out the node_modules directory
@@ -781,10 +780,14 @@ COPY --chown=bun:bun . .
 
 ${postInstallCommands}
 
+# node_modules may not exist when there are no dependencies to install
+RUN mkdir -p node_modules
+
 # App files without node_modules, so the final stage can layer them separately
 FROM build AS code
 
-RUN rm -rf node_modules
+# u+w first: rm as a non-root user fails on read-only directories
+RUN chmod -R u+w node_modules && rm -rf node_modules
 
 FROM build AS indexer
 
@@ -887,8 +890,7 @@ ENV NODE_ENV=production
 ENV NPM_CONFIG_UPDATE_NOTIFIER=false
 
 COPY --chown=node:node package.json ./
-# mkdir guards against npm not creating node_modules when there are no dependencies
-RUN npm i --no-audit --no-fund --no-save --no-package-lock && mkdir -p node_modules
+RUN npm i --no-audit --no-fund --no-save --no-package-lock
 
 # Now copy all the files
 # IMPORTANT: Do this after running npm install because npm i will wipe out the node_modules directory
@@ -899,10 +901,14 @@ ${postInstallCommands}
 # IMPORTANT: Doing this again to fix an issue with prisma generate removing the files in node_modules/trigger.dev for some reason...
 COPY --chown=node:node . .
 
+# node_modules may not exist when there are no dependencies to install
+RUN mkdir -p node_modules
+
 # App files without node_modules, so the final stage can layer them separately
 FROM build AS code
 
-RUN rm -rf node_modules
+# u+w first: rm as a non-root user fails on read-only directories
+RUN chmod -R u+w node_modules && rm -rf node_modules
 
 FROM build AS indexer
 


### PR DESCRIPTION
Deploy images previously shipped node_modules and the bundled task code in a single layer, so every deploy re-pushed and re-pulled the full dependency tree even when nothing in it changed. The generated Containerfile now copies `/app/node_modules` as its own layer and the app files separately. With unchanged dependencies the dependency layer is identical across deploys, so registries and workers already have it and only the code layer moves.