### PR TITLE
chore: vouch Jakub-Vacek

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -28,3 +28,4 @@ brentshulman-silkline
 Leafgard
 Rohan170603
 NERLOE
+Jakub-Vacek


### PR DESCRIPTION
Adds [Jakub-Vacek](https://github.com/Jakub-Vacek) to the list of vouched outside contributors so their PRs aren't auto-closed by the vouch check.