### PR TITLE
fix(webapp): convert epoch ms to nanoseconds with exact BigInt math

### DIFF
--- a/.server-changes/fix-nanosecond-timestamp-precision.md
+++ b/.server-changes/fix-nanosecond-timestamp-precision.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Fix a rare sub-microsecond rounding error in trace and span timestamps

--- a/apps/webapp/app/v3/eventRepository/common.server.test.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { calculateDurationFromStart } from "./common.server";
+
+describe("calculateDurationFromStart", () => {
+  it("converts to nanoseconds with exact BigInt math", () => {
+    // 1754000000001 is one of the ~0.2% of epoch-ms where Number(ms * 1_000_000)
+    // rounds (ms * 1e6 exceeds Number.MAX_SAFE_INTEGER). The duration from the
+    // exact nanoseconds of the previous whole millisecond must be exactly 1ms.
+    const startTime = BigInt(1754000000000) * BigInt(1_000_000);
+    const endTime = new Date(1754000000001);
+    expect(calculateDurationFromStart(startTime, endTime)).toBe(1_000_000);
+  });
+});

--- a/apps/webapp/app/v3/eventRepository/common.server.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.ts
@@ -25,7 +25,7 @@ export function extractContextFromCarrier(carrier: Record<string, unknown>) {
 }
 
 export function getNowInNanoseconds(): bigint {
-  return BigInt(new Date().getTime() * 1_000_000);
+  return BigInt(new Date().getTime()) * BigInt(1_000_000);
 }
 
 export function getDateFromNanoseconds(nanoseconds: bigint): Date {
@@ -39,7 +39,7 @@ export function calculateDurationFromStart(
 ) {
   const $endtime = typeof endTime === "string" ? new Date(endTime) : endTime;
 
-  const duration = Number(BigInt($endtime.getTime() * 1_000_000) - startTime);
+  const duration = Number(BigInt($endtime.getTime()) * BigInt(1_000_000) - startTime);
 
   if (minimumDuration && duration < minimumDuration) {
     return minimumDuration;

--- a/apps/webapp/app/v3/eventRepository/index.server.ts
+++ b/apps/webapp/app/v3/eventRepository/index.server.ts
@@ -240,7 +240,7 @@ async function recordRunEvent(
         runId: foundRun.friendlyId,
         ...attributes,
       },
-      startTime: BigInt((startTime?.getTime() ?? Date.now()) * 1_000_000),
+      startTime: BigInt(startTime?.getTime() ?? Date.now()) * BigInt(1_000_000),
       ...optionsRest,
     });
 

--- a/apps/webapp/app/v3/runEngineHandlers.server.ts
+++ b/apps/webapp/app/v3/runEngineHandlers.server.ts
@@ -555,7 +555,7 @@ export function registerRunEngineEventBusHandlers() {
         );
 
         await eventRepository.recordEvent(retryMessage, {
-          startTime: BigInt(time.getTime() * 1000000),
+          startTime: BigInt(time.getTime()) * BigInt(1_000_000),
           taskSlug: run.taskIdentifier,
           environment,
           attributes: {


### PR DESCRIPTION
Fixes #3292

A few functions in the webapp build nanosecond timestamps as `BigInt(ms * 1_000_000)`, multiplying in float-land before the BigInt conversion. Since `epoch-ms * 1e6` is around 1.7e18, well past `Number.MAX_SAFE_INTEGER` (~9e15), the multiply rounds to the nearest representable double first, so the resulting span timestamp is off by up to a few hundred nanoseconds in roughly 0.2% of cases (256ns for the example `1754000000001`, which becomes `...000999936`). `convertDateToNanoseconds` in the same file already does it the right way with `BigInt(ms) * BigInt(1_000_000)`, the other call sites just didn't.

Fixed all four:
- `eventRepository/common.server.ts`: `getNowInNanoseconds`, `calculateDurationFromStart`
- `eventRepository/index.server.ts`: `recordRunDebugLog` start time
- `runEngineHandlers.server.ts`: retry event start time

`calculateDurationFromStartJsDate` was left alone: it multiplies a duration (a small difference of two ms values), which stays inside the safe-integer range.

Added a test in `common.server.test.ts`. `1754000000001` is one of the ~0.2% of timestamps that round, so the duration from the previous whole millisecond must be exactly `1_000_000` ns. On main that assertion returns `999936`, with the fix it returns `1_000_000`. I verified the fix and the failing-on-main case by running the exact BigInt vs float math directly, since the full webapp pnpm workspace is heavy to spin up locally.

Impact is low (sub-microsecond), but it is an easy correctness fix and removes a source of span-ordering jitter. Added a `.server-changes` note.