### PR TITLE
perf(webapp): scope env var create pre-check to submitted keys

### DIFF
--- a/.server-changes/scope-env-var-create-precheck.md
+++ b/.server-changes/scope-env-var-create-precheck.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+Speed up setting and importing environment variables for projects with many variables.

--- a/apps/webapp/app/v3/environmentVariables/environmentVariablesRepository.server.ts
+++ b/apps/webapp/app/v3/environmentVariables/environmentVariablesRepository.server.ts
@@ -1,5 +1,10 @@
 import type { AuthenticatedEnvironment } from "@trigger.dev/core/v3/auth/environment";
-import { Prisma, type PrismaClient, type RuntimeEnvironmentType } from "@trigger.dev/database";
+import {
+  boundedIn,
+  Prisma,
+  type PrismaClient,
+  type RuntimeEnvironmentType,
+} from "@trigger.dev/database";
 import { z } from "zod";
 import { environmentFullTitle } from "~/components/environments/EnvironmentLabel";
 import { $replica, $transaction, prisma, type PrismaReplicaClient } from "~/db.server";
@@ -66,9 +71,15 @@ export class EnvironmentVariablesRepository implements Repository {
           },
         },
         environmentVariables: {
+          where: {
+            key: { in: boundedIn(options.variables.map((v) => v.key)) },
+          },
           select: {
             key: true,
             values: {
+              where: {
+                environmentId: { in: boundedIn(options.environmentIds) },
+              },
               select: {
                 environment: {
                   select: { id: true, type: true },


### PR DESCRIPTION
## Summary

Setting or importing environment variables ran a conflict pre-check that loaded every variable in the project and every value across all of its environments, only to decide whether the submitted keys already had a value in the target environments. On projects with many variables and environments that meant reading tens of thousands of rows on each create/import call.

This scopes the pre-check to the submitted keys and target environments, so it reads only the rows it actually inspects (submitted keys × target envs), wrapped in `boundedIn` to keep the prepared-statement cache stable. Same conflict detection, a handful of rows instead of the whole project's env-var values.
