### PR TITLE
fix(webapp): hard-navigate after creating a project

### DIFF
--- a/.server-changes/fix-project-creation-navigation.md
+++ b/.server-changes/fix-project-creation-navigation.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Ensure creating a project completes instead of returning to its creation form after a navigation error.

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug_.projects.new/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug_.projects.new/route.tsx
@@ -3,7 +3,6 @@ import { parseWithZod } from "@conform-to/zod";
 import { CommandLineIcon, FolderIcon } from "@heroicons/react/20/solid";
 import {
   json,
-  redirect,
   redirectDocument,
   type ActionFunction,
   type LoaderFunctionArgs,
@@ -11,7 +10,7 @@ import {
 import { Form, useActionData, useNavigation } from "@remix-run/react";
 import type { Prisma } from "@trigger.dev/database";
 import React, { useEffect, useState } from "react";
-import { typedjson, useTypedLoaderData } from "remix-typedjson";
+import { redirect, typedjson, useTypedLoaderData } from "remix-typedjson";
 import invariant from "tiny-invariant";
 import { z } from "zod";
 import { BackgroundWrapper } from "~/components/BackgroundWrapper";

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug_.projects.new/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug_.projects.new/route.tsx
@@ -1,11 +1,16 @@
 import { getFormProps, getInputProps, useForm } from "@conform-to/react";
 import { parseWithZod } from "@conform-to/zod";
 import { CommandLineIcon, FolderIcon } from "@heroicons/react/20/solid";
-import { json, type ActionFunction, type LoaderFunctionArgs } from "@remix-run/node";
+import {
+  json,
+  redirectDocument,
+  type ActionFunction,
+  type LoaderFunctionArgs,
+} from "@remix-run/node";
 import { Form, useActionData, useNavigation } from "@remix-run/react";
 import type { Prisma } from "@trigger.dev/database";
 import React, { useEffect, useState } from "react";
-import { redirect, typedjson, useTypedLoaderData } from "remix-typedjson";
+import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import invariant from "tiny-invariant";
 import { z } from "zod";
 import { BackgroundWrapper } from "~/components/BackgroundWrapper";
@@ -285,14 +290,17 @@ export const action: ActionFunction = async ({ request, params }) => {
       if (next) {
         params.set("next", next);
       }
-      return redirect(`/vercel/connect?${params.toString()}`);
+      return redirectDocument(`/vercel/connect?${params.toString()}`);
     }
 
-    return redirectWithSuccessMessage(
-      v3ProjectPath(project.organization, project),
+    const destination = v3ProjectPath(project.organization, project);
+    const response = await redirectWithSuccessMessage(
+      destination,
       request,
       `${submission.value.projectName} created`
     );
+
+    return redirectDocument(destination, { headers: response.headers });
   } catch (error) {
     if (error instanceof ExceededProjectLimitError) {
       return redirectWithErrorMessage(

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug_.projects.new/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug_.projects.new/route.tsx
@@ -3,6 +3,7 @@ import { parseWithZod } from "@conform-to/zod";
 import { CommandLineIcon, FolderIcon } from "@heroicons/react/20/solid";
 import {
   json,
+  redirect,
   redirectDocument,
   type ActionFunction,
   type LoaderFunctionArgs,


### PR DESCRIPTION
## Summary

Creating a project now uses a document navigation after successful submission. This prevents an interrupted client-side route load from returning users to a creation form after the project already exists.

## Design

The success redirect retains the existing toast cookie and adds Remix's document-navigation marker. The Vercel connection redirect uses the same navigation path.
