### PR TITLE
fix(webapp): show the dev environment's actual limit in the concurrency page Total column

### DIFF
--- a/.server-changes/dev-concurrency-total-display.md
+++ b/.server-changes/dev-concurrency-total-display.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Fix the Concurrency page showing the plan's default concurrency for the dev environment instead of the environment's actual limit.

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.concurrency/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.concurrency/route.tsx
@@ -541,7 +541,9 @@ function Upgradable({
                     </div>
                   </TableCell>
                   <TableCell alignment="right">
-                    {environment.planConcurrencyLimit + (allocation.get(environment.id) ?? 0)}
+                    {environment.type === "DEVELOPMENT"
+                      ? environment.maximumConcurrencyLimit
+                      : environment.planConcurrencyLimit + (allocation.get(environment.id) ?? 0)}
                   </TableCell>
                 </TableRow>
               ))}


### PR DESCRIPTION
## Summary

On the Concurrency page, the dev environment row's Total always showed the plan's included dev concurrency, even when the environment's limit had been raised. The row's own "Extra concurrency" value was already derived from the real limit, so the two columns could disagree with each other.

## Root cause

The Total cell renders `planConcurrencyLimit + allocation`, where `allocation` is the state behind the editable prod/staging inputs. Dev environments are deliberately excluded from that allocation map (dev concurrency is not purchasable), so the dev row's allocation always resolved to 0 and the Total fell back to the plan value. The dev row now renders the environment's actual `maximumConcurrencyLimit` instead.
