### PR TITLE
perf(webapp): bound environment loads in the env layout and batches list

### DIFF
--- a/.server-changes/bound-env-layout-environment-load.md
+++ b/.server-changes/bound-env-layout-environment-load.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+Dashboard pages load faster on projects with many preview branches by no longer loading every environment on each page.

--- a/apps/webapp/app/presenters/v3/BatchListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/BatchListPresenter.server.ts
@@ -200,6 +200,7 @@ export class BatchListPresenter extends BasePresenter {
       select: {
         id: true,
         environments: {
+          where: { id: environmentId },
           select: {
             id: true,
             type: true,

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam/route.tsx
@@ -40,6 +40,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
       externalRef: true,
       organization: { select: { id: true, featureFlags: true } },
       environments: {
+        where: { slug: envParam },
         select: {
           id: true,
           type: true,


### PR DESCRIPTION
## Summary

Follow-up to #4595. Dashboard pages under an environment loaded every environment in the project on each page just to resolve the one named in the URL. On projects with many preview branches that meant reading hundreds of (mostly archived) rows on every page load.

## Fix

The environment-scoped layout loader now scopes its lookup to the slug in the URL (`where: { slug: envParam }`), resolving the current environment through the `projectId, slug` composite index instead of loading the whole project. Archived branches stay viewable by slug. `BatchListPresenter` is bounded to the current environment, since every batch in that list already belongs to it.

Verified on a project seeded with 2,000 archived branch environments: the layout lookup drops from all environments to one, and both a normal environment page and an archived branch page render correctly.