### PR TITLE
fix(webapp): show the real app version instead of v0.0.0 in organization settings

### DIFF
--- a/.server-changes/org-settings-app-version.md
+++ b/.server-changes/org-settings-app-version.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+The app version shown on the organization settings page now reports the real version instead of v0.0.0.

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -1,6 +1,41 @@
+import { readFileSync } from "node:fs";
 import { vitePlugin as remix } from "@remix-run/dev";
-import { defaultClientConditions, defaultServerConditions, defineConfig } from "vite";
+import { defaultClientConditions, defaultServerConditions, defineConfig, type Plugin } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
+
+const packageVersions: Record<string, string> = Object.fromEntries(
+  ["core", "trigger-sdk"].map((pkg) => [
+    pkg,
+    (
+      JSON.parse(
+        readFileSync(new URL(`../../packages/${pkg}/package.json`, import.meta.url), "utf-8")
+      ) as { version: string }
+    ).version,
+  ])
+);
+
+/**
+ * The `@triggerdotdev/source` condition resolves workspace packages to TS source, where
+ * each VERSION constant is the "0.0.0" placeholder (scripts/updateVersion.ts stamps the
+ * real version, but only in dist output, which this bundle never reads). Stamp the version
+ * modules during bundling so VERSION carries the real package version everywhere it's used.
+ */
+function stampPackageVersions(): Plugin {
+  return {
+    name: "stamp-package-versions",
+    transform(code, id) {
+      const match = id
+        .split("?")[0]
+        .match(/packages[\/\\](core|trigger-sdk)[\/\\]src[\/\\]version\.ts$/);
+      if (match) {
+        return {
+          code: code.replace('"0.0.0"', JSON.stringify(packageVersions[match[1]])),
+          map: null,
+        };
+      }
+    },
+  };
+}
 
 export default defineConfig({
   plugins: [
@@ -10,6 +45,7 @@ export default defineConfig({
       serverBuildFile: "index.mjs",
     }),
     tsconfigPaths(),
+    stampPackageVersions(),
   ],
   resolve: {
     // Resolve workspace packages to TS source (same condition the CLI uses)

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -26,7 +26,7 @@ function stampPackageVersions(): Plugin {
     transform(code, id) {
       const match = id
         .split("?")[0]
-        .match(/packages[\/\\](core|trigger-sdk)[\/\\]src[\/\\]version\.ts$/);
+        .match(/packages[/\\](core|trigger-sdk)[/\\]src[/\\]version\.ts$/);
       if (match) {
         return {
           code: code.replace('"0.0.0"', JSON.stringify(packageVersions[match[1]])),


### PR DESCRIPTION
## Summary

Since the move from the Remix compiler to Vite ([#4188](https://github.com/triggerdotdev/trigger.dev/pull/4188)), the "App version" on the organization settings page shows `v0.0.0` unless the image was built from a semver release tag (which bakes in `BUILD_APP_VERSION`). Self-hosted builds and any image built from `main` are affected. This restores the real version.

## Root cause

The Vite SSR bundle resolves workspace packages to TS source via the `@triggerdotdev/source` condition, so `@trigger.dev/core`'s `VERSION` constant is bundled as its raw `"0.0.0"` placeholder. `scripts/updateVersion.ts` still stamps the real version at build time, but only into the packages' dist output, which the bundle no longer reads. The old Remix compiler bundled the stamped dist, which is why this used to work.

The fix is a small Vite plugin that applies the same substitution to the source version modules of `@trigger.dev/core` and `@trigger.dev/sdk` during bundling. Beyond the settings page, this also restores real values in the `trigger-version` request header and the version attributes the bundled packages emit.

Verified by building the server bundle and confirming the VERSION constants carry the package versions, with no `"0.0.0"` occurrences left in the build output.
