### PR TITLE
fix(webapp): hide misleading root API key creation dates

### DIFF
--- a/.server-changes/hide-root-api-key-creation-date.md
+++ b/.server-changes/hide-root-api-key-creation-date.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Root API keys no longer show an environment creation timestamp as their creation date.

--- a/apps/webapp/app/presenters/v3/ApiKeysPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ApiKeysPresenter.server.ts
@@ -71,7 +71,6 @@ export class ApiKeysPresenter {
           id: true,
           apiKey: true,
           type: true,
-          createdAt: true,
           apiKeys: {
             where: showRevoked ? undefined : { revokedAt: null },
             orderBy: { createdAt: "desc" },
@@ -133,7 +132,6 @@ export class ApiKeysPresenter {
         name: "Root API key",
         value: keyEnvironment.apiKey,
         obfuscated: obfuscateApiKey(keyEnvironment.type, keyEnvironment.apiKey.slice(-4)),
-        createdAt: keyEnvironment.createdAt,
       },
       apiKeys: keyEnvironment.apiKeys.map((apiKey, index) => {
         const { presetId, scopes, ...apiKeyData } = apiKey;

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.apikeys/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.apikeys/route.tsx
@@ -404,9 +404,7 @@ export default function Page() {
                     <ApiKeyAccess label="No restrictions" />
                   </TableCell>
                   <TableCell>–</TableCell>
-                  <TableCell>
-                    <DateTime date={rootApiKey.createdAt} />
-                  </TableCell>
+                  <TableCell>–</TableCell>
                   <TableCell>–</TableCell>
                   <TableCellMenu
                     isSticky

--- a/apps/webapp/test/apiKeysPresenter.test.ts
+++ b/apps/webapp/test/apiKeysPresenter.test.ts
@@ -127,6 +127,7 @@ containerTest(
     });
     expect(apiKeyPresets).toHaveBeenCalledWith(organization.id);
     expect(result.rootApiKey.obfuscated).toBe(`tr_prod_••••••••${environment.apiKey.slice(-4)}`);
+    expect(result.rootApiKey).not.toHaveProperty("createdAt");
     expect(keysByName.get("Full access")?.obfuscated).toBe("tr_prod_sk_••••••••full");
     expect(keysByName.get("Full access")?.access).toMatchObject({
       presetId: null,

--- a/apps/webapp/test/apiKeysPresenter.test.ts
+++ b/apps/webapp/test/apiKeysPresenter.test.ts
@@ -127,7 +127,6 @@ containerTest(
     });
     expect(apiKeyPresets).toHaveBeenCalledWith(organization.id);
     expect(result.rootApiKey.obfuscated).toBe(`tr_prod_••••••••${environment.apiKey.slice(-4)}`);
-    expect(result.rootApiKey).not.toHaveProperty("createdAt");
     expect(keysByName.get("Full access")?.obfuscated).toBe("tr_prod_sk_••••••••full");
     expect(keysByName.get("Full access")?.access).toMatchObject({
       presetId: null,


### PR DESCRIPTION
fix(webapp): hide misleading root API key creation dates
fix(webapp): hide misleading root API key creation dates
## Summary

Root API key rows no longer show an environment timestamp as their credential creation date. Additional API keys continue to show their creation dates.
