### PR TITLE
perf(clickhouse): add task_events_v2 inserted_at minmax index

### DIFF
--- a/internal-packages/clickhouse/schema/038_add_task_events_inserted_at_index.sql
+++ b/internal-packages/clickhouse/schema/038_add_task_events_inserted_at_index.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 -- Source index supporting closed projector windows on newly written parts.
--- ADD INDEX only defines the index for new parts; existing parts are not materialized.
+-- ADD INDEX only defines the index for new parts and does not materialize existing parts.
 ALTER TABLE trigger_dev.task_events_v2
   ADD INDEX IF NOT EXISTS idx_inserted_at_projector inserted_at TYPE minmax GRANULARITY 1;
 

--- a/internal-packages/clickhouse/schema/038_add_task_events_inserted_at_index.sql
+++ b/internal-packages/clickhouse/schema/038_add_task_events_inserted_at_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- Source index supporting closed projector windows on newly written parts.
+-- ADD INDEX only defines the index for new parts; existing parts are not materialized.
+ALTER TABLE trigger_dev.task_events_v2
+  ADD INDEX IF NOT EXISTS idx_inserted_at_projector inserted_at TYPE minmax GRANULARITY 1;
+
+-- +goose Down
+ALTER TABLE trigger_dev.task_events_v2
+  DROP INDEX IF EXISTS idx_inserted_at_projector;


### PR DESCRIPTION
Adds a `minmax` skip index on `task_events_v2.inserted_at` (`idx_inserted_at_projector`) to support bounded, closed time-window scans of the source table.

`ADD INDEX` only defines the index for newly written parts; existing parts are not materialized. New parts (e.g. after the next UTC partition boundary) will carry it.

Split out ahead of the larger log-search-v2 work so the index can be deployed independently for read-path testing.