### PR TITLE
perf(webapp): select only needed columns in dev current-worker lookup

### DIFF
--- a/apps/webapp/app/v3/models/workerDeployment.server.ts
+++ b/apps/webapp/app/v3/models/workerDeployment.server.ts
@@ -209,6 +209,15 @@ export async function findCurrentWorkerFromEnvironment(
       where: {
         runtimeEnvironmentId: environment.id,
       },
+      select: {
+        id: true,
+        friendlyId: true,
+        version: true,
+        sdkVersion: true,
+        cliVersion: true,
+        supportsLazyAttempts: true,
+        engine: true,
+      },
       orderBy: {
         createdAt: "desc",
       },


### PR DESCRIPTION
## Summary

When resolving the current worker for a development environment,
`findCurrentWorkerFromEnvironment` loaded the entire `BackgroundWorker` row,
including the large `metadata` JSON, even though it only ever returns a handful
of small fields. It is a frequently-run query, so the wasted payload adds up:
every call pulled data it immediately threw away.

## Fix

Add a `select` to the development-environment lookup listing exactly the fields
the function returns (`id`, `friendlyId`, `version`, `sdkVersion`, `cliVersion`,
`supportsLazyAttempts`, `engine`). The query plan is unchanged, still a
single-row indexed lookup; only the row width shrinks. No behavior change: the
dropped columns were never read.