### PR TITLE
fix(webapp): back to app returns to the current org

### DIFF
--- a/.server-changes/settings-back-to-app-org.md
+++ b/.server-changes/settings-back-to-app-org.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+The "Back to app" button in organization settings now returns you to that organization instead of your most recently used one.

--- a/apps/webapp/app/components/navigation/OrganizationSettingsSideMenu.tsx
+++ b/apps/webapp/app/components/navigation/OrganizationSettingsSideMenu.tsx
@@ -14,13 +14,13 @@ import { useFeatures } from "~/hooks/useFeatures";
 import { type MatchedOrganization } from "~/hooks/useOrganizations";
 import { cn } from "~/utils/cn";
 import {
+  organizationPath,
   organizationRolesPath,
   organizationSettingsPath,
   organizationSlackIntegrationPath,
   organizationSsoPath,
   organizationTeamPath,
   organizationVercelIntegrationPath,
-  rootPath,
   v3BillingLimitsPath,
   v3BillingPath,
   v3PrivateConnectionsPath,
@@ -72,7 +72,7 @@ export function OrganizationSettingsSideMenu({
         <LinkButton
           variant="minimal/medium"
           LeadingIcon={ArrowLeftIcon}
-          to={rootPath()}
+          to={organizationPath(organization)}
           fullWidth
           textAlignLeft
         >


### PR DESCRIPTION
## Summary

Following a link straight into an organization's settings (for example the usage limit link in a billing email) and then clicking "Back to app" took you to `/`, which resolves to whichever organization you last had selected, not the one whose settings you were looking at. The button now links to the organization in the URL, so you land back in the org you came from.

The org index route already redirects to the best project in that org, so the destination is unchanged apart from being the right org.

Account settings still links to `/`, since that page is not org scoped and has no org to return to.
