### PR TITLE
chore(deps): raise the axios floor

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
       "react-dom@^18": "18.3.1",
       "ai@^6": "6.0.116",
       "@ai-sdk/provider-utils@^4": "4.0.29",
+      "axios@>=1.15.2 <1.18.0": "^1.18.0",
       "express@^4>body-parser": "^1.20.6",
       "@remix-run/dev@2.17.5>tar-fs": "2.1.4",
       "tar": "7.5.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   react-dom@^18: 18.3.1
   ai@^6: 6.0.116
   '@ai-sdk/provider-utils@^4': 4.0.29
+  axios@>=1.15.2 <1.18.0: ^1.18.0
   express@^4>body-parser: ^1.20.6
   '@remix-run/dev@2.17.5>tar-fs': 2.1.4
   tar: 7.5.21
@@ -9055,8 +9056,8 @@ packages:
   aws4fetch@1.0.18:
     resolution: {integrity: sha512-3Cf+YaUl07p24MoQ46rFwulAmiyCwH2+1zw1ZyPAX5OtJ34Hh185DwB8y/qRLb6cYYYtSFJ9pthyLc0MD4e8sQ==}
 
-  axios@1.16.1:
-    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
+  axios@1.19.0:
+    resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
 
   b4a@1.6.6:
     resolution: {integrity: sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==}
@@ -21817,7 +21818,7 @@ snapshots:
       '@slack/types': 2.21.1
       '@types/node': 24.13.3
       '@types/retry': 0.12.0
-      axios: 1.16.1
+      axios: 1.19.0
       eventemitter3: 5.0.1
       form-data: 4.0.6
       is-electron: 2.2.2
@@ -23952,7 +23953,7 @@ snapshots:
 
   aws4fetch@1.0.18: {}
 
-  axios@1.16.1:
+  axios@1.19.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6


### PR DESCRIPTION
## Summary

`axios` was resolving to 1.16.1 through `@slack/web-api`, which declares `^1.16.0`. The lockfile had simply not re-resolved since, so the tree sat on an older 1.x release than the range allows.

This adds a scoped override so the 1.x line picks up a current release:

```json
"axios@>=1.15.2 <1.18.0": "^1.18.0"
```

It resolves to 1.19.0. No parent bump is needed, since `^1.16.0` already permits it, and `@slack/web-api` is the only consumer.

Stacked on #4633 so the two lockfile changes do not collide.
