### PR TITLE
chore(deps): raise nanoid floors, drop unused declarations

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -170,7 +170,7 @@
     "marked": "^4.0.18",
     "match-sorter": "^6.3.4",
     "morgan": "^1.10.0",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.18",
     "neverthrow": "^8.2.0",
     "non.geist": "^1.0.2",
     "octokit": "^3.2.1",

--- a/internal-packages/run-engine/package.json
+++ b/internal-packages/run-engine/package.json
@@ -29,7 +29,7 @@
     "@trigger.dev/database": "workspace:*",
     "@internal/cache": "workspace:*",
     "assert-never": "^1.2.1",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.18",
     "redlock": "5.0.0-beta.2",
     "seedrandom": "^3.0.5",
     "zod": "3.25.76",

--- a/internal-packages/schedule-engine/package.json
+++ b/internal-packages/schedule-engine/package.json
@@ -21,7 +21,6 @@
     "@trigger.dev/database": "workspace:*",
     "cron-parser": "^4.9.0",
     "cronstrue": "^2.50.0",
-    "nanoid": "3.3.8",
     "zod": "3.25.76"
   },
   "devDependencies": {

--- a/internal-packages/webhook-engine/package.json
+++ b/internal-packages/webhook-engine/package.json
@@ -19,7 +19,6 @@
     "@internal/tracing": "workspace:*",
     "@trigger.dev/core": "workspace:*",
     "@trigger.dev/database": "workspace:*",
-    "nanoid": "3.3.8",
     "zod": "3.25.76"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -222,7 +222,7 @@
     "execa": "^8.0.1",
     "humanize-duration": "^3.27.3",
     "jose": "^5.4.0",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.18",
     "prom-client": "^15.1.0",
     "socket.io": "4.8.3",
     "socket.io-client": "4.7.5",

--- a/packages/redis-worker/package.json
+++ b/packages/redis-worker/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@trigger.dev/core": "workspace:4.5.11",
     "lodash.omit": "^4.5.0",
-    "nanoid": "^5.0.7",
+    "nanoid": "^5.1.16",
     "p-limit": "^6.2.0",
     "seedrandom": "^3.0.5",
     "zod": "3.25.76",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -640,8 +640,8 @@ importers:
         specifier: ^1.10.0
         version: 1.10.0
       nanoid:
-        specifier: 3.3.8
-        version: 3.3.8
+        specifier: 3.3.18
+        version: 3.3.18
       neverthrow:
         specifier: ^8.2.0
         version: 8.2.0
@@ -1313,8 +1313,8 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1
       nanoid:
-        specifier: 3.3.8
-        version: 3.3.8
+        specifier: 3.3.18
+        version: 3.3.18
       p-map:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1399,9 +1399,6 @@ importers:
       cronstrue:
         specifier: ^2.50.0
         version: 2.61.0
-      nanoid:
-        specifier: 3.3.8
-        version: 3.3.8
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -1536,9 +1533,6 @@ importers:
       '@trigger.dev/redis-worker':
         specifier: workspace:*
         version: link:../../packages/redis-worker
-      nanoid:
-        specifier: 3.3.8
-        version: 3.3.8
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -1946,8 +1940,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0
       nanoid:
-        specifier: 3.3.8
-        version: 3.3.8
+        specifier: 3.3.18
+        version: 3.3.18
       prom-client:
         specifier: ^15.1.0
         version: 15.1.0
@@ -2133,8 +2127,8 @@ importers:
         specifier: ^4.5.0
         version: 4.5.0
       nanoid:
-        specifier: ^5.0.7
-        version: 5.1.2
+        specifier: ^5.1.16
+        version: 5.1.16
       p-limit:
         specifier: ^6.2.0
         version: 6.2.0
@@ -12731,13 +12725,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@3.3.8:
-    resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@5.1.2:
-    resolution: {integrity: sha512-b+CiXQCNMUGe0Ri64S9SXFcP9hogjAJ2Rd6GdVxhPLRm7mhGaM7VgOvCAJ1ZshfHbqVDI3uqTI5C8/GaKuLI7g==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -16011,7 +16000,7 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 0.0.26
       eventsource-parser: 1.1.2
-      nanoid: 3.3.8
+      nanoid: 3.3.18
       secure-json-parse: 2.7.0
     optionalDependencies:
       zod: 3.25.76
@@ -28322,9 +28311,7 @@ snapshots:
 
   nanoid@3.3.18: {}
 
-  nanoid@3.3.8: {}
-
-  nanoid@5.1.2: {}
+  nanoid@5.1.16: {}
 
   napi-build-utils@2.0.0:
     optional: true


### PR DESCRIPTION
## Summary

`nanoid` was pinned at exactly `3.3.8` in five manifests. Two of those five never imported it: in `internal-packages/schedule-engine` and `internal-packages/webhook-engine` the only occurrence of the string `nanoid` in the entire package was the `package.json` line itself. Both are removed rather than bumped.

The three that genuinely use it move to `3.3.18`, a version already present in the tree via `postcss`, so this pulls in nothing new.

| Package | Uses it | Change |
| --- | --- | --- |
| `internal-packages/schedule-engine` | no | removed |
| `internal-packages/webhook-engine` | no | removed |
| `apps/webapp` | yes | `3.3.8` to `3.3.18` |
| `packages/core` | yes | `3.3.8` to `3.3.18` |
| `internal-packages/run-engine` | yes | `3.3.8` to `3.3.18` |
| `packages/redis-worker` | yes | `^5.0.7` to `^5.1.16` |

`redis-worker` is on the 5.x line and is included because its declared range already permitted a newer release; the lockfile had simply not re-resolved, leaving it on `5.1.2`.

The unused declarations were found with `pnpm run knip:deps`, which the repo already ships.

`pnpm run typecheck` passes across all 57 workspaces.
