### PR TITLE
chore(deps): raise the find-my-way floor

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
       "mermaid@>=11 <11.16.1": "^11.16.1",
       "@jsonhero/json-infer-types>ip-address": "^10.3.1",
       "express-rate-limit>ip-address": "^10.3.1",
+      "find-my-way@>=9 <9.7.0": "^9.7.0",
       "@modelcontextprotocol/sdk@>=1.26.0>express-rate-limit": "^8.6.0"
     },
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,7 @@ overrides:
   mermaid@>=11 <11.16.1: ^11.16.1
   '@jsonhero/json-infer-types>ip-address': ^10.3.1
   express-rate-limit>ip-address: ^10.3.1
+  find-my-way@>=9 <9.7.0: ^9.7.0
   '@modelcontextprotocol/sdk@>=1.26.0>express-rate-limit': ^8.6.0
 
 patchedDependencies:
@@ -10932,8 +10933,8 @@ packages:
     resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
     engines: {node: '>= 0.8'}
 
-  find-my-way@9.3.0:
-    resolution: {integrity: sha512-eRoFWQw+Yv2tuYlK2pjFS2jGXSxSppAs3hSQjfxVKxM5amECzIgYYc1FEI8ZmhSh/Ig+FrKEz43NLRKJjYCZVg==}
+  find-my-way@9.7.0:
+    resolution: {integrity: sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==}
     engines: {node: '>=20'}
 
   find-up@4.1.0:
@@ -26018,7 +26019,7 @@ snapshots:
       abstract-logging: 2.0.1
       avvio: 9.1.0
       fast-json-stringify: 6.0.1
-      find-my-way: 9.3.0
+      find-my-way: 9.7.0
       light-my-request: 6.6.0
       pino: 10.3.1
       process-warning: 5.0.0
@@ -26106,7 +26107,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  find-my-way@9.3.0:
+  find-my-way@9.7.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2


### PR DESCRIPTION
## Summary

`find-my-way` was resolving `9.3.0` even though its only parent, `fastify@5.8.5`, declares `^9.0.0` and so already permitted a newer release. The lockfile had not re-resolved since. This adds a floor so it lands on a current 9.x:

```json
"find-my-way@>=9 <9.7.0": "^9.7.0"
```

It resolves to `9.7.0`. Nothing outside the 9.x line is touched, and no parent is asked to accept anything its declared range did not already allow.

The whole path is development only: `find-my-way` arrives through `fastify`, which arrives through `evalite`, a devDependency of `apps/webapp` used by the `eval:dev` harness.

Stacked on #4638.
