### PR TITLE
chore(core): drop the unused socket.io dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -224,7 +224,6 @@
     "jose": "^5.4.0",
     "nanoid": "3.3.18",
     "prom-client": "^15.1.0",
-    "socket.io": "4.8.3",
     "socket.io-client": "4.7.5",
     "std-env": "^3.8.1",
     "tinyexec": "^0.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1947,9 +1947,6 @@ importers:
       prom-client:
         specifier: ^15.1.0
         version: 15.1.0
-      socket.io:
-        specifier: 4.8.3
-        version: 4.8.3(bufferutil@4.0.9)
       socket.io-client:
         specifier: 4.7.5
         version: 4.7.5(bufferutil@4.0.9)(supports-color@10.0.0)


### PR DESCRIPTION
## Summary

`packages/core` declared `socket.io`, the server package, but never imported it. Its only Socket.IO usage is the client:

```
packages/core/src/v3/zodSocket.ts
packages/core/src/v3/runEngineWorker/supervisor/session.ts
  import { io } from "socket.io-client";
```

The only occurrence of `socket.io` outside those client imports was the `package.json` line itself. Since `@trigger.dev/core` is published, that line meant every consumer installed a server package nothing in the tree imports.

`socket.io-client` is untouched. `apps/webapp` and `apps/supervisor` keep their own `socket.io` dependencies, so the server side is unaffected.

Found with `pnpm run knip:deps`, which the repo already ships.

`pnpm run typecheck` passes across all 57 workspaces, and `@trigger.dev/core` builds clean.

Stacked on #4639.
