### PR TITLE
fix(webapp): show errors on AI tool call and embed spans in the run inspector

### DIFF
--- a/.server-changes/ai-tool-call-span-errors.md
+++ b/.server-changes/ai-tool-call-span-errors.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Failed AI SDK tool call and embedding spans now show the error message and stack trace in the run inspector, below the tool input.

--- a/apps/webapp/app/components/runs/v3/ai/AIEmbedSpanDetails.tsx
+++ b/apps/webapp/app/components/runs/v3/ai/AIEmbedSpanDetails.tsx
@@ -1,5 +1,7 @@
+import type { SpanEvent as OtelSpanEvent } from "@trigger.dev/core/v3";
 import { Header3 } from "~/components/primitives/Headers";
 import { Paragraph } from "~/components/primitives/Paragraph";
+import { SpanEvents } from "~/components/runs/v3/SpanEvents";
 import { formatDuration } from "./aiHelpers";
 import { SpanMetricRow as MetricRow } from "./SpanMetricRow";
 
@@ -35,7 +37,13 @@ export function extractAIEmbedData(
   };
 }
 
-export function AIEmbedSpanDetails({ data }: { data: AIEmbedData }) {
+export function AIEmbedSpanDetails({
+  data,
+  spanEvents,
+}: {
+  data: AIEmbedData;
+  spanEvents?: OtelSpanEvent[];
+}) {
   return (
     <div className="flex h-full flex-col overflow-hidden">
       <div className="flex-1 overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-surface-control">
@@ -56,6 +64,12 @@ export function AIEmbedSpanDetails({ data }: { data: AIEmbedData }) {
               <div className="rounded-md border border-grid-bright bg-background-hover/50 px-3.5 py-2">
                 <Paragraph variant="small/dimmed">{data.value}</Paragraph>
               </div>
+            </div>
+          )}
+
+          {spanEvents && spanEvents.some((event) => !event.name.startsWith("trigger.dev/")) && (
+            <div className="py-2.5">
+              <SpanEvents spanEvents={spanEvents} />
             </div>
           )}
         </div>

--- a/apps/webapp/app/components/runs/v3/ai/AIToolCallSpanDetails.tsx
+++ b/apps/webapp/app/components/runs/v3/ai/AIToolCallSpanDetails.tsx
@@ -1,6 +1,8 @@
+import type { SpanEvent as OtelSpanEvent } from "@trigger.dev/core/v3";
 import { Header3 } from "~/components/primitives/Headers";
 import { CodeBlock } from "~/components/code/CodeBlock";
 import { TruncatedCopyableValue } from "~/components/primitives/TruncatedCopyableValue";
+import { SpanEvents } from "~/components/runs/v3/SpanEvents";
 import { formatDuration, tryPrettyJson } from "./aiHelpers";
 import { SpanMetricRow as MetricRow } from "./SpanMetricRow";
 
@@ -36,7 +38,13 @@ export function extractAIToolCallData(
   };
 }
 
-export function AIToolCallSpanDetails({ data }: { data: AIToolCallData }) {
+export function AIToolCallSpanDetails({
+  data,
+  spanEvents,
+}: {
+  data: AIToolCallData;
+  spanEvents?: OtelSpanEvent[];
+}) {
   return (
     <div className="flex h-full flex-col overflow-hidden">
       <div className="flex-1 overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-surface-control">
@@ -66,6 +74,12 @@ export function AIToolCallSpanDetails({ data }: { data: AIToolCallData }) {
                 showCopyButton
                 language="json"
               />
+            </div>
+          )}
+
+          {spanEvents && spanEvents.some((event) => !event.name.startsWith("trigger.dev/")) && (
+            <div className="py-2.5">
+              <SpanEvents spanEvents={spanEvents} />
             </div>
           )}
         </div>

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.spans.$spanParam/route.tsx
@@ -1777,7 +1777,7 @@ function SpanEntity({ span }: { span: Span }) {
           <div className="px-3">
             <SpanHorizontalTimeline startTime={span.startTime} duration={span.duration} />
           </div>
-          <AIToolCallSpanDetails data={span.entity.object} />
+          <AIToolCallSpanDetails data={span.entity.object} spanEvents={span.events} />
         </div>
       );
     }
@@ -1787,7 +1787,7 @@ function SpanEntity({ span }: { span: Span }) {
           <div className="px-3">
             <SpanHorizontalTimeline startTime={span.startTime} duration={span.duration} />
           </div>
-          <AIEmbedSpanDetails data={span.entity.object} />
+          <AIEmbedSpanDetails data={span.entity.object} spanEvents={span.events} />
         </div>
       );
     }


### PR DESCRIPTION
## Summary

When an AI SDK tool call failed inside a run, the span showed up under the "Errors only" filter but the span inspector gave no hint of what went wrong. The exception was recorded on the span all along; the `ai.toolCall` and `ai.embed` inspector views just never rendered span events. Failed tool call and embedding spans now show the standard error block (message plus stack trace) below the Input section.

## Root cause

Generic spans render exception span events via the `SpanEvents` component, but the AI-specific span entities replace the whole panel with their own layout and dropped the events entirely. The span's events are now passed into `AIToolCallSpanDetails` and `AIEmbedSpanDetails` and rendered with the same `SpanEvents` component the generic view uses.

Errored generation spans (`ai.generateText` and friends) use a tabbed view and still don't surface errors; that needs its own design pass and is left for a follow-up.
