### PR TITLE
chore: cache and clean up Knip analysis

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -27,7 +27,6 @@
     "eval:dev": "evalite watch"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.0",
     "@ai-sdk/openai": "^3.0.0",
     "@ai-sdk/react": "^3.0.0",
     "@ariakit/react": "^0.4.6",

--- a/internal-packages/dashboard-agent/src/agent-runtime.ts
+++ b/internal-packages/dashboard-agent/src/agent-runtime.ts
@@ -57,7 +57,7 @@ function getDb(): DashboardAgentDbClient {
 
 // Resolves the `"provider:model-id"` strings on our managed prompts to AI SDK
 // models, against whichever provider is switched on.
-export { registry, resolveDashboardAgentModel } from "./model-provider";
+export { resolveDashboardAgentModel } from "./model-provider";
 
 // The agent's persistence, behind an interface so tests can inject a fake via
 // `locals` and never need a real database.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "format:prisma": "pnpm --filter @trigger.dev/database run format:prisma && pnpm --filter @internal/run-ops-database run format:prisma",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
-    "knip": "knip --include files,exports,types,dependencies,unlisted,binaries,unresolved,catalog",
+    "knip": "knip --cache --include files,exports,types,dependencies,unlisted,binaries,unresolved,catalog",
     "docker": "node scripts/docker.mjs -f docker/docker-compose.yml up -d --build --remove-orphans",
     "docker:stop": "node scripts/docker.mjs -f docker/docker-compose.yml stop",
     "docker:full": "node scripts/docker.mjs -f docker/docker-compose.yml -f docker/docker-compose.extras.yml up -d --build --remove-orphans",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,9 +200,6 @@ importers:
 
   apps/webapp:
     dependencies:
-      '@ai-sdk/anthropic':
-        specifier: ^3.0.0
-        version: 3.0.84(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: ^3.0.0
         version: 3.0.41(zod@3.25.76)


### PR DESCRIPTION
## Summary

Caches Knip analysis to speed up repeated checks and removes dependency and export declarations that are no longer used after the dashboard agent provider update.
