### PR TITLE
feat(schema): add WorkerDeployment.externalId and task_runs_v2.external_deployment_id

### DIFF
--- a/internal-packages/clickhouse/schema/040_add_task_runs_v2_external_deployment_id.sql
+++ b/internal-packages/clickhouse/schema/040_add_task_runs_v2_external_deployment_id.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE trigger_dev.task_runs_v2
+ADD COLUMN IF NOT EXISTS external_deployment_id String DEFAULT '';
+
+-- +goose Down
+ALTER TABLE trigger_dev.task_runs_v2
+DROP COLUMN IF EXISTS external_deployment_id;

--- a/internal-packages/database/prisma/migrations/20260818120000_add_worker_deployment_external_id/migration.sql
+++ b/internal-packages/database/prisma/migrations/20260818120000_add_worker_deployment_external_id/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."WorkerDeployment" ADD COLUMN IF NOT EXISTS "externalId" TEXT;

--- a/internal-packages/database/prisma/migrations/20260818120100_add_worker_deployment_environment_id_external_id_index/migration.sql
+++ b/internal-packages/database/prisma/migrations/20260818120100_add_worker_deployment_environment_id_external_id_index/migration.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "WorkerDeployment_environmentId_externalId_idx" ON "public"."WorkerDeployment"("environmentId", "externalId");

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -2288,6 +2288,7 @@ model WorkerDeployment {
   triggeredById String?
   triggeredVia  String?
   commitSHA     String?
+  externalId    String?
 
   startedAt   DateTime?
   installedAt DateTime?
@@ -2316,6 +2317,7 @@ model WorkerDeployment {
   @@index([commitSHA])
   @@index([environmentId, createdAt])
   @@index([environmentId, status, id])
+  @@index([environmentId, externalId])
 }
 
 enum WorkerDeploymentStatus {


### PR DESCRIPTION
Migrations only, no code reads them yet. Postgres: nullable non-unique externalId on WorkerDeployment plus a CONCURRENTLY-built (environmentId, externalId) index in its own migration file. ClickHouse: external_deployment_id String DEFAULT '' on task_runs_v2 (plain String, not LowCardinality - commit SHAs are high-cardinality). Part of task run version skew protection (TRI-12998).