### PR TITLE
feat(supervisor): configurable security context for run pods

### DIFF
--- a/apps/supervisor/src/env.ts
+++ b/apps/supervisor/src/env.ts
@@ -221,6 +221,7 @@ export const Env = z
       .enum(["none", "node-24-plus", "all"])
       .default("node-24-plus"),
     KUBERNETES_RUNNER_SECURITY_CONTEXT: z.enum(["off", "baseline", "restricted"]).default("off"),
+    KUBERNETES_RUNNER_RUN_AS_USER: z.coerce.number().int().min(1).default(1000),
 
     // Pod DNS config — override the cluster default ndots to `KUBERNETES_POD_DNS_NDOTS`.
     // Default k8s ndots is 5: any name with fewer than 5 dots (e.g. `api.example.com`, 2 dots) is first walked

--- a/apps/supervisor/src/env.ts
+++ b/apps/supervisor/src/env.ts
@@ -220,6 +220,7 @@ export const Env = z
     KUBERNETES_RUNNER_SECCOMP_PROFILE_RUNTIMES: z
       .enum(["none", "node-24-plus", "all"])
       .default("node-24-plus"),
+    KUBERNETES_RUNNER_SECURITY_CONTEXT: z.enum(["off", "baseline", "restricted"]).default("off"),
 
     // Pod DNS config — override the cluster default ndots to `KUBERNETES_POD_DNS_NDOTS`.
     // Default k8s ndots is 5: any name with fewer than 5 dots (e.g. `api.example.com`, 2 dots) is first walked

--- a/apps/supervisor/src/workloadManager/kubernetes.test.ts
+++ b/apps/supervisor/src/workloadManager/kubernetes.test.ts
@@ -157,22 +157,32 @@ describe("withRunnerSeccompProfile", () => {
 
 describe("runnerSecurityContext", () => {
   it("sets nothing when off", () => {
-    expect(runnerSecurityContext("off", 1000)).toBeUndefined();
+    expect(runnerSecurityContext("off", 1000, "node-24")).toBeUndefined();
   });
 
   it("drops all capabilities and blocks escalation at baseline", () => {
-    expect(runnerSecurityContext("baseline", 1000)).toEqual({
+    expect(runnerSecurityContext("baseline", 1000, "node-24")).toEqual({
       allowPrivilegeEscalation: false,
       capabilities: { drop: ["ALL"] },
     });
   });
 
-  it("additionally requires a non-root image when restricted", () => {
-    expect(runnerSecurityContext("restricted", 1000)).toEqual({
+  it("pins the configured uid when restricted", () => {
+    expect(runnerSecurityContext("restricted", 1000, "node-24")).toEqual({
       allowPrivilegeEscalation: false,
       capabilities: { drop: ["ALL"] },
       runAsNonRoot: true,
       runAsUser: 1000,
     });
+  });
+
+  it("pins bun's own uid, which differs from node's", () => {
+    expect(runnerSecurityContext("restricted", 1000, "bun")?.runAsUser).toBe(1001);
+  });
+
+  it("falls back to the configured uid when the runtime is unknown", () => {
+    for (const runtime of [undefined, null, "", "node", "node-22", "node-26"]) {
+      expect(runnerSecurityContext("restricted", 1000, runtime)?.runAsUser).toBe(1000);
+    }
   });
 });

--- a/apps/supervisor/src/workloadManager/kubernetes.test.ts
+++ b/apps/supervisor/src/workloadManager/kubernetes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   nodetypeNodeSelector,
   runPodTolerations,
+  runnerSecurityContext,
   withRunnerSeccompProfile,
   withNodeSelector,
 } from "./kubernetesPodSpec.js";
@@ -151,5 +152,26 @@ describe("withRunnerSeccompProfile", () => {
         withRunnerSeccompProfile(basePodSpec, { ...base, runtimes, checkpointsEnabled: false })
       ).toBe(basePodSpec);
     }
+  });
+});
+
+describe("runnerSecurityContext", () => {
+  it("sets nothing when off", () => {
+    expect(runnerSecurityContext("off")).toBeUndefined();
+  });
+
+  it("drops all capabilities and blocks escalation at baseline", () => {
+    expect(runnerSecurityContext("baseline")).toEqual({
+      allowPrivilegeEscalation: false,
+      capabilities: { drop: ["ALL"] },
+    });
+  });
+
+  it("additionally requires a non-root image when restricted", () => {
+    expect(runnerSecurityContext("restricted")).toEqual({
+      allowPrivilegeEscalation: false,
+      capabilities: { drop: ["ALL"] },
+      runAsNonRoot: true,
+    });
   });
 });

--- a/apps/supervisor/src/workloadManager/kubernetes.test.ts
+++ b/apps/supervisor/src/workloadManager/kubernetes.test.ts
@@ -157,21 +157,22 @@ describe("withRunnerSeccompProfile", () => {
 
 describe("runnerSecurityContext", () => {
   it("sets nothing when off", () => {
-    expect(runnerSecurityContext("off")).toBeUndefined();
+    expect(runnerSecurityContext("off", 1000)).toBeUndefined();
   });
 
   it("drops all capabilities and blocks escalation at baseline", () => {
-    expect(runnerSecurityContext("baseline")).toEqual({
+    expect(runnerSecurityContext("baseline", 1000)).toEqual({
       allowPrivilegeEscalation: false,
       capabilities: { drop: ["ALL"] },
     });
   });
 
   it("additionally requires a non-root image when restricted", () => {
-    expect(runnerSecurityContext("restricted")).toEqual({
+    expect(runnerSecurityContext("restricted", 1000)).toEqual({
       allowPrivilegeEscalation: false,
       capabilities: { drop: ["ALL"] },
       runAsNonRoot: true,
+      runAsUser: 1000,
     });
   });
 });

--- a/apps/supervisor/src/workloadManager/kubernetes.ts
+++ b/apps/supervisor/src/workloadManager/kubernetes.ts
@@ -17,6 +17,7 @@ import { getRunnerId } from "../util.js";
 import {
   nodetypeNodeSelector,
   runPodTolerations,
+  runnerSecurityContext,
   withRunnerSeccompProfile,
   withNodeSelector,
 } from "./kubernetesPodSpec.js";
@@ -175,6 +176,7 @@ export class KubernetesWorkloadManager implements WorkloadManager {
                   },
                 ],
                 resources: this.#getResourcesForMachine(opts.machine),
+                securityContext: runnerSecurityContext(env.KUBERNETES_RUNNER_SECURITY_CONTEXT),
                 env: [
                   {
                     name: "TRIGGER_DEQUEUED_AT_MS",

--- a/apps/supervisor/src/workloadManager/kubernetes.ts
+++ b/apps/supervisor/src/workloadManager/kubernetes.ts
@@ -178,7 +178,8 @@ export class KubernetesWorkloadManager implements WorkloadManager {
                 resources: this.#getResourcesForMachine(opts.machine),
                 securityContext: runnerSecurityContext(
                   env.KUBERNETES_RUNNER_SECURITY_CONTEXT,
-                  env.KUBERNETES_RUNNER_RUN_AS_USER
+                  env.KUBERNETES_RUNNER_RUN_AS_USER,
+                  opts.runtime
                 ),
                 env: [
                   {

--- a/apps/supervisor/src/workloadManager/kubernetes.ts
+++ b/apps/supervisor/src/workloadManager/kubernetes.ts
@@ -176,7 +176,10 @@ export class KubernetesWorkloadManager implements WorkloadManager {
                   },
                 ],
                 resources: this.#getResourcesForMachine(opts.machine),
-                securityContext: runnerSecurityContext(env.KUBERNETES_RUNNER_SECURITY_CONTEXT),
+                securityContext: runnerSecurityContext(
+                  env.KUBERNETES_RUNNER_SECURITY_CONTEXT,
+                  env.KUBERNETES_RUNNER_RUN_AS_USER
+                ),
                 env: [
                   {
                     name: "TRIGGER_DEQUEUED_AT_MS",

--- a/apps/supervisor/src/workloadManager/kubernetesPodSpec.ts
+++ b/apps/supervisor/src/workloadManager/kubernetesPodSpec.ts
@@ -97,18 +97,22 @@ export function withRunnerSeccompProfile(
   };
 }
 
+const BUN_RUN_AS_USER = 1001;
+
 /**
  * runnerSecurityContext maps a configured level onto the run container's security
  * context. "baseline" drops the capability bounding set and blocks setuid
  * escalation; "restricted" additionally pins the container to a non-root uid.
  *
- * The uid is set explicitly rather than relying on the image: the kubelet cannot
- * verify `runAsNonRoot` when an image declares a named user, and fails the
- * container instead.
+ * The uid is set explicitly rather than read from the image: the kubelet cannot
+ * verify `runAsNonRoot` against an image that declares a named user, and fails
+ * the container instead. Bun images carry their user at a different uid to
+ * node's, so the runtime selects which uid is pinned.
  */
 export function runnerSecurityContext(
   level: "off" | "baseline" | "restricted",
-  runAsUser: number
+  runAsUser: number,
+  runtime: string | null | undefined
 ): k8s.V1SecurityContext | undefined {
   if (level === "off") {
     return undefined;
@@ -117,6 +121,8 @@ export function runnerSecurityContext(
   return {
     allowPrivilegeEscalation: false,
     capabilities: { drop: ["ALL"] },
-    ...(level === "restricted" ? { runAsNonRoot: true, runAsUser } : {}),
+    ...(level === "restricted"
+      ? { runAsNonRoot: true, runAsUser: runtime === "bun" ? BUN_RUN_AS_USER : runAsUser }
+      : {}),
   };
 }

--- a/apps/supervisor/src/workloadManager/kubernetesPodSpec.ts
+++ b/apps/supervisor/src/workloadManager/kubernetesPodSpec.ts
@@ -96,3 +96,22 @@ export function withRunnerSeccompProfile(
     },
   };
 }
+
+/**
+ * runnerSecurityContext maps a configured level onto the run container's security
+ * context. "baseline" drops the capability bounding set and blocks setuid
+ * escalation; "restricted" additionally requires a non-root image.
+ */
+export function runnerSecurityContext(
+  level: "off" | "baseline" | "restricted"
+): k8s.V1SecurityContext | undefined {
+  if (level === "off") {
+    return undefined;
+  }
+
+  return {
+    allowPrivilegeEscalation: false,
+    capabilities: { drop: ["ALL"] },
+    ...(level === "restricted" ? { runAsNonRoot: true } : {}),
+  };
+}

--- a/apps/supervisor/src/workloadManager/kubernetesPodSpec.ts
+++ b/apps/supervisor/src/workloadManager/kubernetesPodSpec.ts
@@ -100,10 +100,15 @@ export function withRunnerSeccompProfile(
 /**
  * runnerSecurityContext maps a configured level onto the run container's security
  * context. "baseline" drops the capability bounding set and blocks setuid
- * escalation; "restricted" additionally requires a non-root image.
+ * escalation; "restricted" additionally pins the container to a non-root uid.
+ *
+ * The uid is set explicitly rather than relying on the image: the kubelet cannot
+ * verify `runAsNonRoot` when an image declares a named user, and fails the
+ * container instead.
  */
 export function runnerSecurityContext(
-  level: "off" | "baseline" | "restricted"
+  level: "off" | "baseline" | "restricted",
+  runAsUser: number
 ): k8s.V1SecurityContext | undefined {
   if (level === "off") {
     return undefined;
@@ -112,6 +117,6 @@ export function runnerSecurityContext(
   return {
     allowPrivilegeEscalation: false,
     capabilities: { drop: ["ALL"] },
-    ...(level === "restricted" ? { runAsNonRoot: true } : {}),
+    ...(level === "restricted" ? { runAsNonRoot: true, runAsUser } : {}),
   };
 }


### PR DESCRIPTION
Adds `KUBERNETES_RUNNER_SECURITY_CONTEXT`, letting an operator choose how constrained the run container is, using the level names from the Kubernetes Pod Security Standards.

```
off        (default) the field is left unset
baseline   capabilities.drop: ["ALL"], allowPrivilegeEscalation: false
restricted baseline, plus runAsNonRoot: true and runAsUser
```

The default leaves the security context unset, so existing deployments are unaffected, and each level is a config change rather than a deploy.

## Levels

`baseline` constrains what the container may do, and makes no assumptions about the image it runs.

`restricted` additionally pins the user the container runs as, from `KUBERNETES_RUNNER_RUN_AS_USER` (default 1000). Taking the uid from configuration rather than from the image means the level applies uniformly across every image already deployed, with nothing needing to be rebuilt or redeployed to pick it up.

## Placement

`capabilities`, `allowPrivilegeEscalation`, `runAsNonRoot` and `runAsUser` are all accepted at container level, so they live in one place on the run container rather than being split across the pod and container specs.

## Tests

`runnerSecurityContext` is covered at each level. Full supervisor suite: 260 passed, 22 skipped.

No changeset or `.server-changes`: the default preserves current behaviour.
