### PR TITLE
feat(supervisor): optional priority class for run pods

### DIFF
--- a/apps/supervisor/src/env.ts
+++ b/apps/supervisor/src/env.ts
@@ -187,6 +187,7 @@ export const Env = z
     KUBERNETES_STRIP_IMAGE_DIGEST: BoolEnv.default(false),
     KUBERNETES_IMAGE_REGISTRY_REWRITE_FROM: z.string().optional(),
     KUBERNETES_IMAGE_REGISTRY_REWRITE_TO: z.string().optional(),
+    KUBERNETES_RUN_POD_PRIORITY_CLASS_NAME: z.string().optional(),
     KUBERNETES_CPU_REQUEST_MIN_CORES: z.coerce.number().min(0).default(0),
     KUBERNETES_CPU_REQUEST_RATIO: z.coerce.number().min(0).max(1).default(0.75), // Ratio of CPU limit, so 0.75 = 75% of CPU limit
     KUBERNETES_MEMORY_REQUEST_MIN_GB: z.coerce.number().min(0).default(0),

--- a/apps/supervisor/src/workloadManager/kubernetes.ts
+++ b/apps/supervisor/src/workloadManager/kubernetes.ts
@@ -371,6 +371,11 @@ export class KubernetesWorkloadManager implements WorkloadManager {
             schedulerName: env.KUBERNETES_SCHEDULER_NAME,
           }
         : {}),
+      ...(env.KUBERNETES_RUN_POD_PRIORITY_CLASS_NAME
+        ? {
+            priorityClassName: env.KUBERNETES_RUN_POD_PRIORITY_CLASS_NAME,
+          }
+        : {}),
       ...nodetypeNodeSelector(env.KUBERNETES_WORKER_NODETYPE_LABEL),
       ...(env.KUBERNETES_POD_DNS_NDOTS_OVERRIDE_ENABLED
         ? {


### PR DESCRIPTION
Adds an optional priority class for run pods.

```
KUBERNETES_RUN_POD_PRIORITY_CLASS_NAME
```

When set, the value is applied as `priorityClassName` on the run pod spec. When unset, pods are created exactly as before.

Off by default, and inert unless set. It sits beside the existing `KUBERNETES_SCHEDULER_NAME` option and follows the same conditional shape:

```ts
...(env.KUBERNETES_RUN_POD_PRIORITY_CLASS_NAME
  ? { priorityClassName: env.KUBERNETES_RUN_POD_PRIORITY_CLASS_NAME }
  : {}),
```

## Verification

`typecheck --filter supervisor`, `format` and `lint` clean. No changeset or `.server-changes/` note: off by default, no user-visible behaviour change.
