### PR TITLE
chore: enable additional correctness lint rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -34,7 +34,7 @@
     ],
     "no-empty-pattern": "off",
     "no-control-regex": "off",
-    "typescript/no-non-null-asserted-optional-chain": "off",
+    "typescript/no-non-null-asserted-optional-chain": "error",
     "no-unused-expressions": [
       "error",
       {
@@ -47,6 +47,9 @@
     "import/namespace": "off",
     "react-hooks/exhaustive-deps": "off",
     "react-hooks/rules-of-hooks": "off",
+    "guard-for-in": "error",
+    "symbol-description": "error",
+    "react/jsx-no-target-blank": "error",
     "trigger/no-thrown-unawaited-redirect": "error",
     "trigger-prisma/no-unbounded-list-filter": "error",
     "trigger-prisma/no-unbounded-list-filter-in-args-helper": "error"

--- a/apps/webapp/app/components/primitives/Callout.tsx
+++ b/apps/webapp/app/components/primitives/Callout.tsx
@@ -92,6 +92,7 @@ export function Callout({
         <a
           href={to}
           target="_blank"
+          rel="noreferrer"
           className={cn(
             `flex w-full items-start justify-between gap-2.5 rounded-md border py-2 pl-2 pr-3 shadow-md backdrop-blur-xs`,
             variantDefinition.className,

--- a/apps/webapp/app/services/metadata/updateMetadata.server.ts
+++ b/apps/webapp/app/services/metadata/updateMetadata.server.ts
@@ -589,7 +589,7 @@ export class UpdateMetadataService {
       await this._runStore.updateMetadata(
         runId,
         {
-          metadata: metadataPacket?.data!,
+          metadata: metadataPacket.data!,
           metadataType: metadataPacket?.dataType,
           metadataVersion: {
             increment: 1,

--- a/apps/webapp/app/services/routeBuilders/permissions.server.ts
+++ b/apps/webapp/app/services/routeBuilders/permissions.server.ts
@@ -29,6 +29,7 @@ export function checkPermissions<K extends string>(
 ): Record<K, boolean> {
   const result = {} as Record<K, boolean>;
   for (const key in checks) {
+    if (!Object.hasOwn(checks, key)) continue;
     const check = checks[key];
     result[key] =
       "requireSuper" in check ? ability.canSuper() : ability.can(check.action, check.resource);

--- a/apps/webapp/server.ts
+++ b/apps/webapp/server.ts
@@ -37,6 +37,7 @@ function installPrimarySignalHandlers() {
 
   const forward = (signal: NodeJS.Signals) => {
     for (const id in cluster.workers) {
+      if (!Object.hasOwn(cluster.workers, id)) continue;
       const w = cluster.workers[id];
       if (w?.process?.pid) {
         try {

--- a/packages/core/src/v3/apiClient/core.ts
+++ b/packages/core/src/v3/apiClient/core.ts
@@ -605,7 +605,9 @@ async function waitForRetry(
 // https://stackoverflow.com/a/34491287
 export function isEmptyObj(obj: object | null | undefined): boolean {
   if (!obj) return true;
-  for (const _k in obj) return false;
+  for (const key in obj) {
+    if (Object.hasOwn(obj, key)) return false;
+  }
   return true;
 }
 

--- a/packages/core/src/v3/errors.ts
+++ b/packages/core/src/v3/errors.ts
@@ -1172,6 +1172,7 @@ export function createTaskMetadataFailedErrorStack(
   const groupedIssues = groupTaskMetadataIssuesByTask(data.tasks, data.zodIssues);
 
   for (const key in groupedIssues) {
+    if (!Object.hasOwn(groupedIssues, key)) continue;
     const taskWithIssues = groupedIssues[key];
 
     if (!taskWithIssues) {

--- a/packages/core/src/v3/locals/manager.ts
+++ b/packages/core/src/v3/locals/manager.ts
@@ -3,7 +3,7 @@ import type { LocalsKey, LocalsManager } from "./types.js";
 export class NoopLocalsManager implements LocalsManager {
   createLocal<T>(id: string): LocalsKey<T> {
     return {
-      __type: Symbol(),
+      __type: Symbol(id),
       id,
     };
   }

--- a/packages/core/src/v3/serverOnly/httpServer.ts
+++ b/packages/core/src/v3/serverOnly/httpServer.ts
@@ -346,6 +346,7 @@ export class HttpServer {
 
   private findRoute(url: string): string | null {
     for (const route in this.routes) {
+      if (!Object.hasOwn(this.routes, route)) continue;
       const routeParts = route.split("/");
       const urlWithoutQueryParams = url.split("?")[0];
 

--- a/packages/core/src/v3/utils/flattenAttributes.ts
+++ b/packages/core/src/v3/utils/flattenAttributes.ts
@@ -346,6 +346,7 @@ export function unflattenAttributes(
     const maxIndex = Math.max(...Object.keys(result).map((k) => parseInt(k)));
     const arrayResult = Array(maxIndex + 1);
     for (const key in result) {
+      if (!Object.hasOwn(result, key)) continue;
       arrayResult[parseInt(key)] = result[key];
     }
     return arrayResult as any;

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -10444,6 +10444,10 @@ function createChatStartSessionAction<TChat extends AnyTask = AnyTask>(
 
     const clientDataMetadata =
       params.clientData !== undefined ? { metadata: params.clientData } : {};
+    const maxAttempts = params.triggerConfig?.maxAttempts ?? options?.triggerConfig?.maxAttempts;
+    const maxDuration = params.triggerConfig?.maxDuration ?? options?.triggerConfig?.maxDuration;
+    const idleTimeoutInSeconds =
+      params.triggerConfig?.idleTimeoutInSeconds ?? options?.triggerConfig?.idleTimeoutInSeconds;
 
     const triggerConfig: SessionTriggerConfig = {
       basePayload: {
@@ -10461,18 +10465,8 @@ function createChatStartSessionAction<TChat extends AnyTask = AnyTask>(
         ? { queue: params.triggerConfig?.queue ?? options?.triggerConfig?.queue }
         : {}),
       tags,
-      ...(options?.triggerConfig?.maxAttempts !== undefined ||
-      params.triggerConfig?.maxAttempts !== undefined
-        ? {
-            maxAttempts: params.triggerConfig?.maxAttempts ?? options?.triggerConfig?.maxAttempts!,
-          }
-        : {}),
-      ...(options?.triggerConfig?.maxDuration !== undefined ||
-      params.triggerConfig?.maxDuration !== undefined
-        ? {
-            maxDuration: params.triggerConfig?.maxDuration ?? options?.triggerConfig?.maxDuration!,
-          }
-        : {}),
+      ...(maxAttempts !== undefined ? { maxAttempts } : {}),
+      ...(maxDuration !== undefined ? { maxDuration } : {}),
       ...(options?.triggerConfig?.region || params.triggerConfig?.region
         ? { region: params.triggerConfig?.region ?? options?.triggerConfig?.region }
         : {}),
@@ -10482,14 +10476,7 @@ function createChatStartSessionAction<TChat extends AnyTask = AnyTask>(
               params.triggerConfig?.lockToVersion ?? options?.triggerConfig?.lockToVersion,
           }
         : {}),
-      ...(options?.triggerConfig?.idleTimeoutInSeconds !== undefined ||
-      params.triggerConfig?.idleTimeoutInSeconds !== undefined
-        ? {
-            idleTimeoutInSeconds:
-              params.triggerConfig?.idleTimeoutInSeconds ??
-              options?.triggerConfig?.idleTimeoutInSeconds!,
-          }
-        : {}),
+      ...(idleTimeoutInSeconds !== undefined ? { idleTimeoutInSeconds } : {}),
     };
 
     const startBody = {

--- a/packages/trigger-sdk/src/v3/chat-client.ts
+++ b/packages/trigger-sdk/src/v3/chat-client.ts
@@ -653,6 +653,9 @@ export class AgentChat<TAgent = unknown> {
   private async ensureStarted(options?: { idleTimeoutInSeconds?: number }): Promise<void> {
     if (this.state.started) return;
 
+    const idleTimeoutInSeconds =
+      options?.idleTimeoutInSeconds ?? this.triggerConfigDefault?.idleTimeoutInSeconds;
+
     const triggerConfig: SessionTriggerConfig = {
       basePayload: {
         // `trigger: "preload"` mirrors the browser-mediated
@@ -672,13 +675,7 @@ export class AgentChat<TAgent = unknown> {
       ...(this.triggerConfigDefault?.maxAttempts !== undefined
         ? { maxAttempts: this.triggerConfigDefault.maxAttempts }
         : {}),
-      ...(options?.idleTimeoutInSeconds !== undefined ||
-      this.triggerConfigDefault?.idleTimeoutInSeconds !== undefined
-        ? {
-            idleTimeoutInSeconds:
-              options?.idleTimeoutInSeconds ?? this.triggerConfigDefault?.idleTimeoutInSeconds!,
-          }
-        : {}),
+      ...(idleTimeoutInSeconds !== undefined ? { idleTimeoutInSeconds } : {}),
     };
 
     const created = await sessions.start({


### PR DESCRIPTION
## Summary

Enable additional lint rules that catch unsafe optional-chain assertions, inherited-property iteration, anonymous symbols, and unsafe external links.

The existing violations now use explicit values and own-property checks, so the rules can prevent those patterns from returning.
