### PR TITLE
chore: enable lint cleanup rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -49,6 +49,11 @@
     "react-hooks/rules-of-hooks": "off",
     "guard-for-in": "error",
     "symbol-description": "error",
+    "no-unneeded-ternary": "error",
+    "prefer-object-has-own": "error",
+    "no-redeclare": "error",
+    "no-multi-assign": "error",
+    "prefer-object-spread": "error",
     "react/jsx-no-target-blank": "error",
     "trigger/no-thrown-unawaited-redirect": "error",
     "trigger-prisma/no-unbounded-list-filter": "error",
@@ -74,6 +79,12 @@
       "rules": {
         "trigger-prisma/no-unbounded-list-filter": "off",
         "trigger-prisma/no-unbounded-list-filter-in-args-helper": "off"
+      }
+    },
+    {
+      "files": ["internal-packages/tsql/**"],
+      "rules": {
+        "prefer-object-has-own": "off"
       }
     }
   ]

--- a/apps/webapp/app/components/billing/UsageBar.tsx
+++ b/apps/webapp/app/components/billing/UsageBar.tsx
@@ -106,7 +106,7 @@ type LegendProps = {
 
 function Legend({ text, value, position, percentage, tooltipContent }: LegendProps) {
   const flipLegendPositionValue = 80;
-  const flipLegendPosition = percentage > flipLegendPositionValue ? true : false;
+  const flipLegendPosition = percentage > flipLegendPositionValue;
   return (
     <div
       className={cn(

--- a/apps/webapp/app/components/primitives/TreeView/utils.ts
+++ b/apps/webapp/app/components/primitives/TreeView/utils.ts
@@ -78,7 +78,7 @@ export function applyVisibility<TData>(tree: FlatTree<TData>, state: NodesState)
     const parent = node.parentId
       ? acc[node.parentId]
       : { selected: defaultSelected, expanded: defaultExpanded, visible: true };
-    const visible = parent.expanded && parent.visible === true ? true : false;
+    const visible = parent.expanded && parent.visible === true;
     acc[node.id] = { ...nodeState, visible };
 
     return acc;

--- a/apps/webapp/app/hooks/useThemeColor.ts
+++ b/apps/webapp/app/hooks/useThemeColor.ts
@@ -7,7 +7,8 @@ import { useEffect, useState } from "react";
  */
 function toRgb(color: string): string {
   const canvas = document.createElement("canvas");
-  canvas.width = canvas.height = 1;
+  canvas.width = 1;
+  canvas.height = 1;
   const ctx = canvas.getContext("2d");
   if (!ctx) return color;
   ctx.fillStyle = color;

--- a/apps/webapp/app/presenters/v3/ApiErrorListPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ApiErrorListPresenter.server.ts
@@ -48,9 +48,7 @@ export const ApiErrorListSearchParams = z.object({
       const statuses = value.split(",");
       // hasOwnProperty, not `in`: `in` walks the prototype chain, so
       // `filter[status]=toString` would pass and map to a function.
-      const invalid = statuses.filter(
-        (status) => !Object.prototype.hasOwnProperty.call(API_STATUS_TO_DB, status)
-      );
+      const invalid = statuses.filter((status) => !Object.hasOwn(API_STATUS_TO_DB, status));
 
       if (invalid.length > 0) {
         ctx.addIssue({

--- a/apps/webapp/app/presenters/v3/ApiWebhookDeliveryPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ApiWebhookDeliveryPresenter.server.ts
@@ -55,9 +55,7 @@ export const ApiWebhookDeliveryListSearchParams = z.object({
     .transform((value, ctx) => {
       if (!value) return undefined;
       const statuses = value.split(",");
-      const invalid = statuses.filter(
-        (s) => !Object.prototype.hasOwnProperty.call(API_STATUS_TO_DB, s)
-      );
+      const invalid = statuses.filter((s) => !Object.hasOwn(API_STATUS_TO_DB, s));
       if (invalid.length > 0) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,

--- a/apps/webapp/app/v3/eventRepository/common.server.ts
+++ b/apps/webapp/app/v3/eventRepository/common.server.ts
@@ -172,7 +172,7 @@ export function removePrivateProperties(
 
 export function isEmptyObject(obj: object) {
   for (var prop in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, prop)) {
+    if (Object.hasOwn(obj, prop)) {
       return false;
     }
   }

--- a/apps/webapp/app/v3/eventRepository/eventRepository.server.ts
+++ b/apps/webapp/app/v3/eventRepository/eventRepository.server.ts
@@ -1692,13 +1692,11 @@ function parseStyleField(style: Prisma.JsonValue): TaskEventStyle {
   }
 
   if (typeof unsafe === "object") {
-    return Object.assign(
-      {
-        icon: undefined,
-        variant: undefined,
-      },
-      unsafe
-    ) as TaskEventStyle;
+    return {
+      icon: undefined,
+      variant: undefined,
+      ...unsafe,
+    } as TaskEventStyle;
   }
 
   return {};

--- a/apps/webapp/app/v3/eventRepository/traceExport.server.ts
+++ b/apps/webapp/app/v3/eventRepository/traceExport.server.ts
@@ -199,7 +199,7 @@ const FORMATS: Record<TraceExportFormatName, TraceExportFormat> = {
 
 /** Resolve a `?format=` value to a format, defaulting to `log`. */
 export function getTraceExportFormat(name: string | null | undefined): TraceExportFormat {
-  if (name && Object.prototype.hasOwnProperty.call(FORMATS, name)) {
+  if (name && Object.hasOwn(FORMATS, name)) {
     return FORMATS[name as TraceExportFormatName];
   }
   return logFormat;

--- a/apps/webapp/app/v3/services/alerts/createAlertChannel.server.ts
+++ b/apps/webapp/app/v3/services/alerts/createAlertChannel.server.ts
@@ -104,7 +104,7 @@ export class CreateAlertChannelService extends BaseService {
         properties: await this.#createProperties(options.channel),
         enabled: true,
         deduplicationKey: options.deduplicationKey,
-        userProvidedDeduplicationKey: options.deduplicationKey ? true : false,
+        userProvidedDeduplicationKey: Boolean(options.deduplicationKey),
         environmentTypes,
       },
     });

--- a/apps/webapp/memory-leak-detector.js
+++ b/apps/webapp/memory-leak-detector.js
@@ -544,6 +544,8 @@ class MemoryLeakDetector {
     const snapshot3 = this.results.snapshots[2]; // after second load test
 
     let analysis = {};
+    let heapGrowth;
+    let heapGrowthPercent;
 
     // Handle different snapshot types
     if (
@@ -592,8 +594,8 @@ class MemoryLeakDetector {
       };
 
       // Use total growth for recommendations
-      var heapGrowth = totalGrowth;
-      var heapGrowthPercent = totalGrowthPercent;
+      heapGrowth = totalGrowth;
+      heapGrowthPercent = totalGrowthPercent;
     } else if (snapshot1.processMemory && snapshot2.processMemory && snapshot3.processMemory) {
       // Traditional process memory analysis with 3 snapshots
       const heap1 = snapshot1.processMemory.heapUsed;
@@ -632,8 +634,8 @@ class MemoryLeakDetector {
         snapshots: this.results.snapshots.length,
       };
 
-      var heapGrowth = totalHeapGrowth;
-      var heapGrowthPercent = (totalHeapGrowth / heap1) * 100;
+      heapGrowth = totalHeapGrowth;
+      heapGrowthPercent = (totalHeapGrowth / heap1) * 100;
     } else {
       this.log("Mixed or incompatible snapshot types - cannot analyze memory growth", "warn");
       analysis = {

--- a/internal-packages/run-store/src/PostgresRunStore.ts
+++ b/internal-packages/run-store/src/PostgresRunStore.ts
@@ -1950,7 +1950,7 @@ export class PostgresRunStore implements RunStore {
           ?.filter((c) => c.index !== undefined)
           .sort((a, b) => a.index! - b.index!)
           .map((w) => w.id),
-        isValid: error ? false : true,
+        isValid: !error,
         error,
       },
       include: { checkpoint: true },

--- a/internal-packages/tsql/src/query/parser.ts
+++ b/internal-packages/tsql/src/query/parser.ts
@@ -1385,7 +1385,7 @@ export class TSQLParseTreeConverter implements TSQLParserVisitor<any> {
     }
 
     const args: Expression[] = ctx._columnArgList ? this.visitExprList(ctx._columnArgList) : [];
-    const distinct = ctx.DISTINCT() ? true : false;
+    const distinct = ctx.DISTINCT() !== undefined;
     return { expression_type: "call", name, params: parameters, args, distinct };
   }
 

--- a/packages/cli-v3/src/deploy/buildImage.ts
+++ b/packages/cli-v3/src/deploy/buildImage.ts
@@ -1158,11 +1158,11 @@ function shouldPush(imageTag: string, push?: boolean) {
       return false;
     }
     case undefined: {
-      return imageTag.startsWith("localhost") ||
+      return !(
+        imageTag.startsWith("localhost") ||
         imageTag.startsWith("127.0.0.1") ||
         imageTag.startsWith("0.0.0.0")
-        ? false
-        : true;
+      );
     }
     default: {
       assertExhaustive(push);
@@ -1180,7 +1180,7 @@ function shouldLoad(load?: boolean, push?: boolean) {
       return false;
     }
     case undefined: {
-      return push ? false : true;
+      return !push;
     }
     default: {
       assertExhaustive(load);

--- a/packages/core/src/v3/apiClient/core.ts
+++ b/packages/core/src/v3/apiClient/core.ts
@@ -613,7 +613,7 @@ export function isEmptyObj(obj: object | null | undefined): boolean {
 
 // https://eslint.org/docs/latest/rules/no-prototype-builtins
 export function hasOwn(obj: object, key: string): boolean {
-  return Object.prototype.hasOwnProperty.call(obj, key);
+  return Object.hasOwn(obj, key);
 }
 
 // If the requestInit has a header x-trigger-worker = true, then we will do

--- a/packages/core/src/v3/workers/populateEnv.ts
+++ b/packages/core/src/v3/workers/populateEnv.ts
@@ -39,7 +39,7 @@ export function populateEnv(
 
   // Set process.env values
   for (const key of Object.keys(envObject)) {
-    if (Object.prototype.hasOwnProperty.call(process.env, key)) {
+    if (Object.hasOwn(process.env, key)) {
       if (override) {
         process.env[key] = envObject[key];
 
@@ -57,7 +57,7 @@ export function populateEnv(
   if (previousEnv) {
     // if there are any keys in previousEnv that are not in envObject, remove them from process.env
     for (const key of Object.keys(previousEnv)) {
-      if (!Object.prototype.hasOwnProperty.call(envObject, key)) {
+      if (!Object.hasOwn(envObject, key)) {
         delete process.env[key];
       }
     }

--- a/scripts/recover-stuck-runs.ts
+++ b/scripts/recover-stuck-runs.ts
@@ -142,7 +142,7 @@ async function main() {
         ? {
             tls: {
               // If connecting via localhost tunnel to a remote Redis, disable cert verification
-              rejectUnauthorized: redisReadUrlObj.hostname === "localhost" ? false : true,
+              rejectUnauthorized: redisReadUrlObj.hostname !== "localhost",
             },
           }
         : {}),
@@ -165,7 +165,7 @@ async function main() {
           ? {
               tls: {
                 // If connecting via localhost tunnel to a remote Redis, disable cert verification
-                rejectUnauthorized: redisWriteUrlObj.hostname === "localhost" ? false : true,
+                rejectUnauthorized: redisWriteUrlObj.hostname !== "localhost",
               },
             }
           : {}),


### PR DESCRIPTION
## Summary

Enable small cleanup rules for redundant boolean expressions, object ownership checks, assignments, and object construction.

The existing call sites now use the simpler equivalent forms, keeping future code consistent without changing behavior.

Base: [#4672](https://github.com/triggerdotdev/trigger.dev/pull/4672)
