### PR TITLE
chore: enable JSX cleanup rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -55,6 +55,8 @@
     "no-multi-assign": "error",
     "prefer-object-spread": "error",
     "react/jsx-no-target-blank": "error",
+    "react/jsx-fragments": "error",
+    "react/self-closing-comp": "error",
     "trigger/no-thrown-unawaited-redirect": "error",
     "trigger-prisma/no-unbounded-list-filter": "error",
     "trigger-prisma/no-unbounded-list-filter-in-args-helper": "error"

--- a/apps/webapp/app/components/code/CodeBlock.tsx
+++ b/apps/webapp/app/components/code/CodeBlock.tsx
@@ -439,7 +439,7 @@ function Chrome({ title }: { title?: string }) {
       <div className="flex items-center justify-center">
         <div className={cn("rounded-sm px-3 py-0.5 text-xs text-text-faint")}>{title}</div>
       </div>
-      <div></div>
+      <div />
     </div>
   );
 }

--- a/apps/webapp/app/components/logs/LogsTable.tsx
+++ b/apps/webapp/app/components/logs/LogsTable.tsx
@@ -220,7 +220,7 @@ export function LogsTable({
 }
 
 function BlankState({ isLoading, onRefresh }: { isLoading?: boolean; onRefresh?: () => void }) {
-  if (isLoading) return <TableBlankRow colSpan={6}></TableBlankRow>;
+  if (isLoading) return <TableBlankRow colSpan={6} />;
 
   const handleRefresh = onRefresh ?? (() => window.location.reload());
 

--- a/apps/webapp/app/components/navigation/HelpAndFeedbackPopover.tsx
+++ b/apps/webapp/app/components/navigation/HelpAndFeedbackPopover.tsx
@@ -1,6 +1,6 @@
 import { ArrowUpRightIcon } from "@heroicons/react/20/solid";
 import { motion } from "framer-motion";
-import { Fragment, useState } from "react";
+import { useState } from "react";
 import { BookIcon } from "~/assets/icons/BookIcon";
 import { BulbIcon } from "~/assets/icons/BulbIcon";
 import { DropdownIcon } from "~/assets/icons/DropdownIcon";
@@ -129,7 +129,7 @@ export function HelpAndFeedback({
           sideOffset={isCollapsed ? 8 : 4}
           align="start"
         >
-          <Fragment>
+          <>
             {/* This popover lives in the app layout, above both AI hosts, so it opens them
                 through their open-request bridges rather than context. The hosts register the
                 keystrokes; this only shows them. */}
@@ -232,7 +232,7 @@ export function HelpAndFeedback({
                 target="_blank"
               />
             </div>
-          </Fragment>
+          </>
         </PopoverContent>
       </Popover>
       {/* Hosted outside the popover so closing the menu can't unmount the form mid-submit. */}

--- a/apps/webapp/app/components/runs/v3/TaskRunsTable.tsx
+++ b/apps/webapp/app/components/runs/v3/TaskRunsTable.tsx
@@ -717,7 +717,7 @@ function BlankState({
   const project = useProject();
   const environment = useEnvironment();
   const colSpan = showRegion ? 16 : 15;
-  if (isLoading) return <TableBlankRow colSpan={colSpan}></TableBlankRow>;
+  if (isLoading) return <TableBlankRow colSpan={colSpan} />;
 
   const { tasks, from, to, ...otherFilters } = filters;
   const singleTaskFromFilters = filters.tasks.length === 1 ? filters.tasks[0] : null;

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.environment-variables/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.environment-variables/route.tsx
@@ -831,12 +831,7 @@ function EditEnvironmentVariablePanel({
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
-        <Button
-          variant="small-menu-item"
-          LeadingIcon={PencilSquareIcon}
-          fullWidth
-          textAlignLeft
-        ></Button>
+        <Button variant="small-menu-item" LeadingIcon={PencilSquareIcon} fullWidth textAlignLeft />
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>Edit environment variable</DialogHeader>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
@@ -1723,7 +1723,7 @@ function LiveReloadingStatus({
               </Paragraph>
             </div>
           }
-        ></SimpleTooltip>
+        />
       )}
     </>
   );

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
@@ -354,7 +354,7 @@ export default function IntegrationsSettingsPage() {
     <>
       <SettingsContainer className="md:mt-6">
         {githubAppEnabled && (
-          <React.Fragment>
+          <>
             <SettingsSection>
               <SettingsHeader title="Git settings" />
               <GitHubSettingsPanel
@@ -396,7 +396,7 @@ export default function IntegrationsSettingsPage() {
               />
               <BuildSettingsForm buildSettings={buildSettings ?? {}} />
             </SettingsSection>
-          </React.Fragment>
+          </>
         )}
       </SettingsContainer>
 

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.test.tasks.$taskParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.test.tasks.$taskParam/route.tsx
@@ -296,7 +296,7 @@ export default function Page() {
   const result = useTypedLoaderData<typeof loader>();
 
   if (!result.foundTask) {
-    return <div></div>;
+    return <div />;
   }
 
   const params = useParams();

--- a/apps/webapp/app/routes/admin.notifications.tsx
+++ b/apps/webapp/app/routes/admin.notifications.tsx
@@ -453,7 +453,7 @@ export default function AdminNotificationsRoute() {
               <TableHeaderCell>Clicked</TableHeaderCell>
               <TableHeaderCell>Dismissed</TableHeaderCell>
               <TableHeaderCell>Status</TableHeaderCell>
-              <TableHeaderCell></TableHeaderCell>
+              <TableHeaderCell />
             </TableRow>
           </TableHeader>
           <TableBody>

--- a/apps/webapp/app/routes/storybook.popover/route.tsx
+++ b/apps/webapp/app/routes/storybook.popover/route.tsx
@@ -1,5 +1,5 @@
 import { FolderIcon, PlusIcon } from "@heroicons/react/20/solid";
-import { Fragment, useState } from "react";
+import { useState } from "react";
 import {
   Popover,
   PopoverArrowTrigger,
@@ -19,14 +19,14 @@ export default function Story() {
           className="min-w-80 overflow-y-auto p-0 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-surface-control"
           align="start"
         >
-          <Fragment>
+          <>
             <PopoverSectionHeader title="Acme Ltd." />
 
             <div className="flex flex-col gap-1 p-1">
               <PopoverMenuItem to="#" title="My Blog" icon={FolderIcon} />
               <PopoverMenuItem to="#" title="New Project" isSelected={false} icon={PlusIcon} />
             </div>
-          </Fragment>
+          </>
           <div className="border-t border-background-bright p-1">
             <PopoverMenuItem to="#" title="New Organization" isSelected={false} icon={PlusIcon} />
           </div>

--- a/apps/webapp/app/routes/storybook.timeline/route.tsx
+++ b/apps/webapp/app/routes/storybook.timeline/route.tsx
@@ -156,7 +156,7 @@ export default function Story() {
 
       {/* The main body */}
       <div className="grid grid-cols-[100px_1fr]">
-        <div></div>
+        <div />
         <div className="overflow-x-auto border-l border-grid-dimmed bg-background-bright">
           <div className="pr-6">
             <Timeline.Root


### PR DESCRIPTION
## Summary

Enable JSX cleanup rules for shorthand fragments and self-closing components.

The existing JSX is automatically simplified, and future components will follow the same concise form.

Base: [#4673](https://github.com/triggerdotdev/trigger.dev/pull/4673)
