### PR TITLE
chore: reject redundant standalone blocks

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -57,6 +57,7 @@
     "react/jsx-no-target-blank": "error",
     "react/jsx-fragments": "error",
     "react/self-closing-comp": "error",
+    "no-lone-blocks": "error",
     "trigger/no-thrown-unawaited-redirect": "error",
     "trigger-prisma/no-unbounded-list-filter": "error",
     "trigger-prisma/no-unbounded-list-filter-in-args-helper": "error"

--- a/packages/cli-v3/src/utilities/initialBanner.ts
+++ b/packages/cli-v3/src/utilities/initialBanner.ts
@@ -55,7 +55,6 @@ export async function printInitialBanner(performUpdateCheck = true, profile?: st
 Run \`npm install --save-dev trigger.dev@${newMajor}\` to update to the latest version.
 After installation, run Trigger.dev with \`npx trigger.dev\`.`
         );
-      } else {
       }
     } else {
       $spinner.stop("On latest version");

--- a/packages/core/src/v3/apiClient/core.ts
+++ b/packages/core/src/v3/apiClient/core.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { fromZodError, ValidationError } from "zod-validation-error";
+import { fromZodError } from "zod-validation-error";
 import type { RetryOptions } from "../schemas/index.js";
 import { calculateNextRetryDelay } from "../utils/retries.js";
 import { ApiConnectionError, ApiError, ApiSchemaValidationError } from "./errors.js";
@@ -272,9 +272,6 @@ async function _doZodFetchWithRetries<TResponseBodySchema extends z.ZodTypeAny>(
   } catch (error) {
     if (error instanceof ApiError) {
       throw error;
-    }
-
-    if (error instanceof ValidationError) {
     }
 
     if (options?.retry) {


### PR DESCRIPTION
## Summary

Enable the rule that rejects unnecessary standalone blocks.

The existing empty branches are removed so future control flow remains purposeful.

Base: [#4674](https://github.com/triggerdotdev/trigger.dev/pull/4674)
