### PR TITLE
chore: prefer direct iteration and function callback types

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -58,6 +58,8 @@
     "react/jsx-fragments": "error",
     "react/self-closing-comp": "error",
     "no-lone-blocks": "error",
+    "typescript/prefer-function-type": "error",
+    "typescript/prefer-for-of": "error",
     "trigger/no-thrown-unawaited-redirect": "error",
     "trigger-prisma/no-unbounded-list-filter": "error",
     "trigger-prisma/no-unbounded-list-filter-in-args-helper": "error"

--- a/apps/webapp/app/services/realtime/redisRealtimeStreams.server.ts
+++ b/apps/webapp/app/services/realtime/redisRealtimeStreams.server.ts
@@ -117,8 +117,7 @@ export class RedisRealtimeStreams implements StreamIngestor, StreamResponder {
                 const [_key, entries] = messages[0];
                 let foundData = false;
 
-                for (let i = 0; i < entries.length; i++) {
-                  const [id, fields] = entries[i];
+                for (const [id, fields] of entries) {
                   lastId = id;
 
                   if (fields && fields.length >= 2) {

--- a/apps/webapp/app/v3/eventRepository/sanitizeRowsOnParseError.server.ts
+++ b/apps/webapp/app/v3/eventRepository/sanitizeRowsOnParseError.server.ts
@@ -172,8 +172,8 @@ export function sanitizeUnknownInPlace(value: unknown): { value: unknown; fixed:
 export function sanitizeRows<T extends object>(rows: T[]): SanitizeResult {
   const result: SanitizeResult = { rowsTouched: 0, fieldsSanitized: 0 };
 
-  for (let i = 0; i < rows.length; i++) {
-    const { fixed } = sanitizeUnknownInPlace(rows[i]);
+  for (const row of rows) {
+    const { fixed } = sanitizeUnknownInPlace(row);
     if (fixed > 0) {
       result.rowsTouched++;
       result.fieldsSanitized += fixed;

--- a/internal-packages/clickhouse/src/client/client.ts
+++ b/internal-packages/clickhouse/src/client/client.ts
@@ -897,8 +897,8 @@ export class ClickhouseClient implements ClickhouseReader, ClickhouseWriter {
 
         // Build compact format: [columns, ...rows]
         const compactData: any[] = [Array.from(req.columns)];
-        for (let i = 0; i < eventsArray.length; i++) {
-          compactData.push(req.toArray(eventsArray[i]));
+        for (const event of eventsArray) {
+          compactData.push(req.toArray(event));
         }
 
         const [clickhouseError, result] = await tryCatch(

--- a/internal-packages/run-engine/src/run-queue/index.ts
+++ b/internal-packages/run-engine/src/run-queue/index.ts
@@ -216,9 +216,9 @@ export type RunQueueOptions = {
   };
 };
 
-interface ConcurrencySweeperCallback {
-  (runIds: string[]): Promise<Array<{ id: string; orgId: string }>>;
-}
+type ConcurrencySweeperCallback = (
+  runIds: string[]
+) => Promise<Array<{ id: string; orgId: string }>>;
 
 type DequeuedMessage = {
   messageId: string;

--- a/internal-packages/schedule-engine/src/engine/types.ts
+++ b/internal-packages/schedule-engine/src/engine/types.ts
@@ -27,13 +27,11 @@ export type TriggerScheduledTaskParams = {
 
 export type TriggerScheduledTaskErrorType = "QUEUE_LIMIT" | "OUT_OF_ENTITLEMENTS" | "SYSTEM_ERROR";
 
-export interface TriggerScheduledTaskCallback {
-  (params: TriggerScheduledTaskParams): Promise<{
-    success: boolean;
-    error?: string;
-    errorType?: TriggerScheduledTaskErrorType;
-  }>;
-}
+export type TriggerScheduledTaskCallback = (params: TriggerScheduledTaskParams) => Promise<{
+  success: boolean;
+  error?: string;
+  errorType?: TriggerScheduledTaskErrorType;
+}>;
 
 export interface ScheduleEngineOptions {
   logger?: Logger;

--- a/internal-packages/webhook-engine/src/engine/types.ts
+++ b/internal-packages/webhook-engine/src/engine/types.ts
@@ -16,14 +16,12 @@ export type TriggerWebhookTaskParams = {
   endpointMetadata: unknown; // endpoint.metadata -> run metadata
 };
 
-export interface TriggerWebhookTaskCallback {
-  (params: TriggerWebhookTaskParams): Promise<{
-    success: boolean;
-    runId?: string; // persisted onto WebhookDelivery.runId on success
-    error?: string;
-    errorType?: WebhookDeliverTaskErrorType;
-  }>;
-}
+export type TriggerWebhookTaskCallback = (params: TriggerWebhookTaskParams) => Promise<{
+  success: boolean;
+  runId?: string; // persisted onto WebhookDelivery.runId on success
+  error?: string;
+  errorType?: WebhookDeliverTaskErrorType;
+}>;
 
 export interface WebhookEngineOptions {
   logger?: Logger;
@@ -82,16 +80,14 @@ export type DeliverWebhookToSessionParams = {
   isSessionStart: boolean;
 };
 
-export interface DeliverWebhookToSessionCallback {
-  (params: DeliverWebhookToSessionParams): Promise<{
-    success: boolean;
-    runId?: string; // the session's current run, persisted onto WebhookDelivery.runId
-    error?: string;
-    errorType?: WebhookDeliverTaskErrorType;
-    skipped?: boolean; // resume-only and no session existed: recorded FILTERED, not routed
-    skippedReason?: string;
-  }>;
-}
+export type DeliverWebhookToSessionCallback = (params: DeliverWebhookToSessionParams) => Promise<{
+  success: boolean;
+  runId?: string; // the session's current run, persisted onto WebhookDelivery.runId
+  error?: string;
+  errorType?: WebhookDeliverTaskErrorType;
+  skipped?: boolean; // resume-only and no session existed: recorded FILTERED, not routed
+  skippedReason?: string;
+}>;
 
 export type IngestInput = {
   opaqueId: string; // Q2: globally unique, so ingest resolves the endpoint (and its env id + type) from it

--- a/packages/redis-worker/src/mollifier/drainer.test.ts
+++ b/packages/redis-worker/src/mollifier/drainer.test.ts
@@ -1310,7 +1310,7 @@ describe("MollifierDrainer per-tick org cap", () => {
     // Cursor advances by 1 each tick. Over envs.length ticks every env
     // appears in exactly `sliceSize` of them (slices overlap — intentional,
     // see the head-of-line fairness test below).
-    for (let i = 0; i < allEnvs.length; i++) {
+    for (const _ of allEnvs) {
       await drainer.runOnce();
     }
 
@@ -1356,7 +1356,7 @@ describe("MollifierDrainer per-tick org cap", () => {
       logger: new Logger("test-drainer", "log"),
     });
 
-    for (let tick = 0; tick < allEnvs.length; tick++) {
+    for (const _ of allEnvs) {
       currentTick = [];
       await drainer.runOnce();
       currentTick.forEach((env, position) => {

--- a/packages/trigger-sdk/src/v3/retry.ts
+++ b/packages/trigger-sdk/src/v3/retry.ts
@@ -434,9 +434,7 @@ const getRetryStrategyForResponse = async (
   const statusCodes = Object.keys(retry);
   const clonedResponse = response.clone();
 
-  for (let i = 0; i < statusCodes.length; i++) {
-    const statusRange = statusCodes[i];
-
+  for (const statusRange of statusCodes) {
     if (!statusRange) {
       continue;
     }


### PR DESCRIPTION
## Summary

Enable lint rules that prefer direct iteration and concise function callback types.

The existing code now uses direct iteration where no index is needed, and callback contracts use function types consistently.

Base: [#4675](https://github.com/triggerdotdev/trigger.dev/pull/4675)
