### PR TITLE
fix(webapp): preserve React hook order

### DIFF
--- a/apps/webapp/app/components/SetupCommands.tsx
+++ b/apps/webapp/app/components/SetupCommands.tsx
@@ -57,7 +57,7 @@ function useApiUrl() {
   }
 }
 
-function getApiUrlArg() {
+function useApiUrlArg() {
   const apiUrl = useApiUrl();
   return apiUrl ? `-a ${apiUrl}` : undefined;
 }
@@ -70,7 +70,7 @@ type TabsProps = {
 export function InitCommandV3({ title }: TabsProps) {
   const project = useProject();
   const projectRef = project.externalRef;
-  const apiUrlArg = getApiUrlArg();
+  const apiUrlArg = useApiUrlArg();
   const triggerCliTag = useTriggerCliTag();
 
   const initCommandParts = [`trigger.dev@${triggerCliTag}`, "init", `-p ${projectRef}`, apiUrlArg];

--- a/apps/webapp/app/components/primitives/Tabs.tsx
+++ b/apps/webapp/app/components/primitives/Tabs.tsx
@@ -234,17 +234,15 @@ export function TabButton({
 } & React.ButtonHTMLAttributes<HTMLButtonElement>) {
   const ref = useRef<HTMLButtonElement>(null);
 
-  if (shortcut) {
-    useShortcutKeys({
-      shortcut: shortcut,
-      action: () => {
-        if (ref.current) {
-          ref.current.click();
-        }
-      },
-      disabled: props.disabled,
-    });
-  }
+  useShortcutKeys({
+    shortcut,
+    action: () => {
+      if (ref.current) {
+        ref.current.click();
+      }
+    },
+    disabled: props.disabled,
+  });
 
   const title = variant === "title";
 

--- a/apps/webapp/app/hooks/useTypedMatchData.ts
+++ b/apps/webapp/app/hooks/useTypedMatchData.ts
@@ -23,11 +23,9 @@ export function useTypedMatchesData<T = AppData>({
   id: string;
   matches?: UIMatch[];
 }): UseDataFunctionReturn<T> | undefined {
-  if (!matches) {
-    matches = useMatches();
-  }
+  const routeMatches = useMatches();
 
-  return useTypedDataFromMatches<T>({ id, matches });
+  return useTypedDataFromMatches<T>({ id, matches: matches ?? routeMatches });
 }
 
 function useTypedMatchData<T = AppData>(


### PR DESCRIPTION
## Summary

Call dashboard hooks unconditionally so components keep a stable hook order when their props change.

Base: [#4680](https://github.com/triggerdotdev/trigger.dev/pull/4680)
