### PR TITLE
ci: correct testcontainer pre-pull image lists

### DIFF
--- a/.github/workflows/e2e-webapp-auth-full.yml
+++ b/.github/workflows/e2e-webapp-auth-full.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           docker pull postgres:14
           docker pull redis:7.2
-          docker pull testcontainers/ryuk:0.11.0
+          docker pull testcontainers/ryuk:0.14.0
 
       - name: 📥 Download deps
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/e2e-webapp.yml
+++ b/.github/workflows/e2e-webapp.yml
@@ -78,7 +78,7 @@ jobs:
           echo "Pre-pulling Docker images with authenticated session..."
           docker pull postgres:14
           docker pull redis:7.2
-          docker pull testcontainers/ryuk:0.11.0
+          docker pull testcontainers/ryuk:0.14.0
           docker pull ghcr.io/s2-streamstore/s2:0.40.0@sha256:b26249e2ede0949755f5af8028185dc2bcfc3aa2db21eb9610543d144eb6ee9d
           docker pull minio/minio:latest
           echo "Image pre-pull complete"

--- a/.github/workflows/unit-tests-internal.yml
+++ b/.github/workflows/unit-tests-internal.yml
@@ -95,7 +95,6 @@ jobs:
           pull clickhouse/clickhouse-server:26.2.19.43-alpine@sha256:c6ad6a7eb2fb5999df3adfb8b69a0c7222c68fa9b8f6b04a088564ebbc959251
           pull redis:7.2
           pull testcontainers/ryuk:0.14.0
-          pull electricsql/electric:1.2.4
           echo "Image pre-pull complete"
 
       - name: 📥 Download deps

--- a/.github/workflows/unit-tests-packages.yml
+++ b/.github/workflows/unit-tests-packages.yml
@@ -97,7 +97,6 @@ jobs:
           pull clickhouse/clickhouse-server:26.2.19.43-alpine@sha256:c6ad6a7eb2fb5999df3adfb8b69a0c7222c68fa9b8f6b04a088564ebbc959251
           pull redis:7.2
           pull testcontainers/ryuk:0.14.0
-          pull electricsql/electric:1.2.4
           pull otel/opentelemetry-collector-k8s:0.158.0@sha256:c09130a633196a5becee164411473a0932ecf223f94fda6dab5f22798ff9f376
           echo "Image pre-pull complete"
 

--- a/.github/workflows/unit-tests-webapp.yml
+++ b/.github/workflows/unit-tests-webapp.yml
@@ -99,10 +99,11 @@ jobs:
           }
           echo "Pre-pulling Docker images with authenticated session..."
           pull postgres:14
+          pull postgres:17
           pull clickhouse/clickhouse-server:26.2.19.43-alpine@sha256:c6ad6a7eb2fb5999df3adfb8b69a0c7222c68fa9b8f6b04a088564ebbc959251
           pull redis:7.2
           pull testcontainers/ryuk:0.14.0
-          pull electricsql/electric:1.2.4
+          pull electricsql/electric:1.2.4@sha256:20da3d0b0e74926c5623392db67fd56698b9e374c4aeb6cb5cadeb8fea171c36
           pull minio/minio:latest
           echo "Image pre-pull complete"
 


### PR DESCRIPTION
## What

Three corrections to the pre-pull lists, each verified against what the suites actually use.

## Changes

**`ryuk:0.11.0` -> `0.14.0`** in `e2e-webapp.yml` and `e2e-webapp-auth-full.yml`. The installed testcontainers hardcodes the image it starts:

```js
// testcontainers@11.14.0 build/reaper/reaper.js
: ImageName.fromString("testcontainers/ryuk:0.14.0").string;
```

So those two lines were pre-pulling an image nothing starts, and the one actually used was never pre-pulled. The other three workflows already say 0.14.0.

**`postgres:17` added** to `unit-tests-webapp.yml`. The webapp suite references `docker.io/postgres:17` across 10 files but only `postgres:14` was pre-pulled. `unit-tests-internal.yml` already pulls both.

**Electric pinned to its digest** in `unit-tests-webapp.yml`. The tests run `electricsql/electric:1.2.4@sha256:20da...` while the pre-pull asked for the bare tag, so the pre-pull did not necessarily populate the manifest the tests then request.

## Not changed

The otel collector and s2 images are pulled by other workflows but are not used by the webapp suite, so they are deliberately not added here. `postgresAndRedisTest` uses per-test containers by design and needs nothing pre-pulled.