### PR TITLE
fix(webapp,react-hooks): enforce stable hook ordering

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -46,7 +46,7 @@
     "import/no-duplicates": "error",
     "import/namespace": "off",
     "react-hooks/exhaustive-deps": "off",
-    "react-hooks/rules-of-hooks": "off",
+    "react/rules-of-hooks": "off",
     "guard-for-in": "error",
     "symbol-description": "error",
     "no-unneeded-ternary": "error",
@@ -115,8 +115,15 @@
     {
       "files": ["apps/webapp/app/**/*.ts", "apps/webapp/app/**/*.tsx"],
       "rules": {
+        "react/rules-of-hooks": "error",
         "trigger-runops/no-control-plane-run-graph-access": "error",
         "trigger-runops/no-control-plane-in-runops-slot": "error"
+      }
+    },
+    {
+      "files": ["packages/react-hooks/src/**/*.ts", "packages/react-hooks/src/**/*.tsx"],
+      "rules": {
+        "react/rules-of-hooks": "error"
       }
     },
     {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -45,7 +45,7 @@
     "typescript/consistent-type-imports": "error",
     "import/no-duplicates": "error",
     "import/namespace": "off",
-    "react-hooks/exhaustive-deps": "off",
+    "react/exhaustive-deps": "off",
     "react/rules-of-hooks": "off",
     "guard-for-in": "error",
     "symbol-description": "error",

--- a/apps/webapp/app/components/primitives/Switch.tsx
+++ b/apps/webapp/app/components/primitives/Switch.tsx
@@ -68,17 +68,15 @@ export const Switch = React.forwardRef<React.ElementRef<typeof SwitchPrimitives.
 
     const { container, root, thumb, text } = variations[variant];
 
-    if (props.shortcut) {
-      useShortcutKeys({
-        shortcut: props.shortcut,
-        action: () => {
-          if (innerRef.current) {
-            innerRef.current.click();
-          }
-        },
-        disabled: props.disabled,
-      });
-    }
+    useShortcutKeys({
+      shortcut: props.shortcut,
+      action: () => {
+        if (innerRef.current) {
+          innerRef.current.click();
+        }
+      },
+      disabled: props.disabled,
+    });
 
     const labelElement = label ? (
       <label

--- a/apps/webapp/app/components/primitives/TextLink.tsx
+++ b/apps/webapp/app/components/primitives/TextLink.tsx
@@ -46,16 +46,14 @@ export function TextLink({
   const innerRef = useRef<HTMLAnchorElement>(null);
   const classes = variations[variant];
 
-  if (shortcut) {
-    useShortcutKeys({
-      shortcut: shortcut,
-      action: () => {
-        if (innerRef.current) {
-          innerRef.current.click();
-        }
-      },
-    });
-  }
+  useShortcutKeys({
+    shortcut,
+    action: () => {
+      if (innerRef.current) {
+        innerRef.current.click();
+      }
+    },
+  });
 
   const renderShortcutKey = () =>
     shortcut &&

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
@@ -602,12 +602,11 @@ function shouldLiveReload({
   return true;
 }
 
-function TraceView({
-  run,
-  trace,
-  maximumLiveReloadingSetting,
-  resizable,
-}: Pick<LoaderData, "run" | "trace" | "maximumLiveReloadingSetting" | "resizable">) {
+type TraceViewProps = Pick<LoaderData, "run" | "maximumLiveReloadingSetting" | "resizable"> & {
+  trace: NonNullable<LoaderData["trace"]>;
+};
+
+function TraceView({ run, trace, maximumLiveReloadingSetting, resizable }: TraceViewProps) {
   const organization = useOrganization();
   const project = useProject();
   const environment = useEnvironment();
@@ -615,10 +614,6 @@ function TraceView({
   const selectedSpanId = searchParams.get("span") ?? undefined;
   const frozenSpanId = useFrozenValue(selectedSpanId);
   const displaySpanId = selectedSpanId ?? frozenSpanId;
-
-  if (!trace) {
-    return <></>;
-  }
 
   const {
     events,

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.test.tasks.$taskParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.test.tasks.$taskParam/route.tsx
@@ -295,15 +295,11 @@ export const handle: Handle = {
 export default function Page() {
   const result = useTypedLoaderData<typeof loader>();
 
-  if (!result.foundTask) {
-    return <div />;
-  }
-
   const params = useParams();
   const queueFetcher = useFetcher<typeof queuesLoader>();
 
   useEffect(() => {
-    if (params.organizationSlug && params.projectParam && params.envParam) {
+    if (result.foundTask && params.organizationSlug && params.projectParam && params.envParam) {
       const searchParams = new URLSearchParams();
       searchParams.set("type", "custom");
       searchParams.set("per_page", "100");
@@ -314,9 +310,9 @@ export default function Page() {
         }/queues?${searchParams.toString()}`
       );
     }
-  }, [params.organizationSlug, params.projectParam, params.envParam]);
+  }, [result.foundTask, params.organizationSlug, params.projectParam, params.envParam]);
 
-  const defaultTaskQueue = "queue" in result ? result.queue : undefined;
+  const defaultTaskQueue = result.foundTask && "queue" in result ? result.queue : undefined;
   const queues = useMemo(() => {
     const customQueues = queueFetcher.data?.queues ?? [];
 
@@ -324,6 +320,10 @@ export default function Page() {
       ? [defaultTaskQueue, ...customQueues]
       : customQueues;
   }, [queueFetcher.data?.queues, defaultTaskQueue]);
+
+  if (!result.foundTask) {
+    return <div />;
+  }
 
   const { triggerSource } = result;
 

--- a/packages/react-hooks/src/hooks/useRealtime.ts
+++ b/packages/react-hooks/src/hooks/useRealtime.ts
@@ -750,33 +750,29 @@ export function useRealtimeStream<TPart>(
   streamKeyOrOptionsOrRunId?: string | UseRealtimeStreamOptions<TPart>,
   options?: UseRealtimeStreamOptions<TPart>
 ): UseRealtimeStreamInstance<TPart> {
+  let runId: string;
+  let streamKey: string;
+  let resolvedOptions: UseRealtimeStreamOptions<TPart> | undefined;
+
   if (typeof runIdOrDefinedStream === "string") {
-    if (typeof streamKeyOrOptionsOrRunId === "string") {
-      return useRealtimeStreamImplementation(
-        runIdOrDefinedStream,
-        streamKeyOrOptionsOrRunId,
-        options
-      );
-    } else {
-      return useRealtimeStreamImplementation(
-        runIdOrDefinedStream,
-        "default",
-        streamKeyOrOptionsOrRunId
-      );
-    }
+    runId = runIdOrDefinedStream;
+    streamKey =
+      typeof streamKeyOrOptionsOrRunId === "string" ? streamKeyOrOptionsOrRunId : "default";
+    resolvedOptions =
+      typeof streamKeyOrOptionsOrRunId === "string" ? options : streamKeyOrOptionsOrRunId;
   } else {
-    if (typeof streamKeyOrOptionsOrRunId === "string") {
-      return useRealtimeStreamImplementation(
-        streamKeyOrOptionsOrRunId,
-        runIdOrDefinedStream.id,
-        options
-      );
-    } else {
+    if (typeof streamKeyOrOptionsOrRunId !== "string") {
       throw new Error(
         "Invalid second argument to useRealtimeStream. When using a defined stream instance, the second argument to useRealtimeStream must be a run ID."
       );
     }
+
+    runId = streamKeyOrOptionsOrRunId;
+    streamKey = runIdOrDefinedStream.id;
+    resolvedOptions = options;
   }
+
+  return useRealtimeStreamImplementation(runId, streamKey, resolvedOptions);
 }
 
 function useRealtimeStreamImplementation<TPart>(


### PR DESCRIPTION
## Summary

Enforce stable React hook ordering in the dashboard and React hooks package.

Conditional hook calls now keep a consistent order, and overloaded realtime stream arguments are resolved before entering the shared hook implementation.

Base: `main`
