### PR TITLE
fix(webapp): use native controls for inline actions

### DIFF
--- a/apps/webapp/app/components/AskAI.tsx
+++ b/apps/webapp/app/components/AskAI.tsx
@@ -544,7 +544,9 @@ function ChatInterface({ initialQuery }: { initialQuery?: string }) {
           {isGeneratingAnswer ? (
             <SimpleTooltip
               button={
-                <span
+                <button
+                  type="button"
+                  aria-label="Stop generating"
                   onClick={() => stopGeneration()}
                   className="group relative z-10 flex size-10 min-w-10 cursor-pointer items-center justify-center"
                 >
@@ -553,7 +555,7 @@ function ChatInterface({ initialQuery }: { initialQuery?: string }) {
                     className="absolute inset-0 animate-spin"
                     hoverEffect
                   />
-                </span>
+                </button>
               }
               content="Stop generating"
             />

--- a/apps/webapp/app/components/AskAI.tsx
+++ b/apps/webapp/app/components/AskAI.tsx
@@ -543,6 +543,7 @@ function ChatInterface({ initialQuery }: { initialQuery?: string }) {
           />
           {isGeneratingAnswer ? (
             <SimpleTooltip
+              asChild
               button={
                 <button
                   type="button"

--- a/apps/webapp/app/components/AskAI.tsx
+++ b/apps/webapp/app/components/AskAI.tsx
@@ -544,6 +544,7 @@ function ChatInterface({ initialQuery }: { initialQuery?: string }) {
           {isGeneratingAnswer ? (
             <SimpleTooltip
               asChild
+              tabbable
               button={
                 <button
                   type="button"

--- a/apps/webapp/app/components/code/TSQLResultsTable.tsx
+++ b/apps/webapp/app/components/code/TSQLResultsTable.tsx
@@ -857,6 +857,7 @@ function CopyableCell({
     >
       <span className="flex items-center truncate">{children}</span>
       <SimpleTooltip
+        asChild
         button={
           <button
             type="button"

--- a/apps/webapp/app/components/code/TSQLResultsTable.tsx
+++ b/apps/webapp/app/components/code/TSQLResultsTable.tsx
@@ -856,37 +856,34 @@ function CopyableCell({
       onMouseLeave={() => setIsHovered(false)}
     >
       <span className="flex items-center truncate">{children}</span>
-      {isHovered && (
-        <span
-          onClick={(e) => {
-            e.stopPropagation();
-            e.preventDefault();
-            copy();
-          }}
-          className="absolute right-1 top-1/2 z-10 flex -translate-y-1/2 cursor-pointer"
-        >
-          <SimpleTooltip
-            button={
-              <span
-                className={cn(
-                  "flex size-6 items-center justify-center rounded border border-border-bright bg-background-hover",
-                  copied
-                    ? "text-green-500"
-                    : "text-text-dimmed hover:border-border-bright hover:bg-background-raised hover:text-text-bright"
-                )}
-              >
-                {copied ? (
-                  <ClipboardCheckIcon className="size-3.5" />
-                ) : (
-                  <ClipboardIcon className="size-3.5" />
-                )}
-              </span>
-            }
-            content={copied ? "Copied!" : "Copy"}
-            disableHoverableContent
-          />
-        </span>
-      )}
+      <SimpleTooltip
+        button={
+          <button
+            type="button"
+            aria-label={copied ? "Copied" : "Copy"}
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              copy();
+            }}
+            className={cn(
+              "absolute right-1 top-1/2 z-10 flex size-6 -translate-y-1/2 items-center justify-center rounded border border-border-bright bg-background-hover transition-opacity focus:opacity-100",
+              isHovered ? "opacity-100" : "pointer-events-none opacity-0",
+              copied
+                ? "text-green-500"
+                : "text-text-dimmed hover:border-border-bright hover:bg-background-raised hover:text-text-bright"
+            )}
+          >
+            {copied ? (
+              <ClipboardCheckIcon className="size-3.5" />
+            ) : (
+              <ClipboardIcon className="size-3.5" />
+            )}
+          </button>
+        }
+        content={copied ? "Copied!" : "Copy"}
+        disableHoverableContent
+      />
     </div>
   );
 }

--- a/apps/webapp/app/components/code/TSQLResultsTable.tsx
+++ b/apps/webapp/app/components/code/TSQLResultsTable.tsx
@@ -843,6 +843,35 @@ function CopyableCell({
   const [isHovered, setIsHovered] = useState(false);
   const { copy, copied } = useCopy(value);
 
+  // The button (with its aria-label) stays mounted at all times so keyboard users can always
+  // reach it. The Radix tooltip subtree is comparatively expensive to keep alive for every
+  // visible cell of a virtualized grid, so it's only mounted while the cell is hovered - the
+  // tooltip is a hover affordance, not required for the button's accessible name.
+  const copyButton = (
+    <button
+      type="button"
+      aria-label={copied ? "Copied" : "Copy"}
+      onClick={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        copy();
+      }}
+      className={cn(
+        "absolute right-1 top-1/2 z-10 flex size-6 -translate-y-1/2 items-center justify-center rounded border border-border-bright bg-background-hover transition-opacity focus:opacity-100",
+        isHovered ? "opacity-100" : "pointer-events-none opacity-0",
+        copied
+          ? "text-green-500"
+          : "text-text-dimmed hover:border-border-bright hover:bg-background-raised hover:text-text-bright"
+      )}
+    >
+      {copied ? (
+        <ClipboardCheckIcon className="size-3.5" />
+      ) : (
+        <ClipboardIcon className="size-3.5" />
+      )}
+    </button>
+  );
+
   return (
     <div
       className={cn(
@@ -856,36 +885,17 @@ function CopyableCell({
       onMouseLeave={() => setIsHovered(false)}
     >
       <span className="flex items-center truncate">{children}</span>
-      <SimpleTooltip
-        asChild
-        tabbable
-        button={
-          <button
-            type="button"
-            aria-label={copied ? "Copied" : "Copy"}
-            onClick={(e) => {
-              e.stopPropagation();
-              e.preventDefault();
-              copy();
-            }}
-            className={cn(
-              "absolute right-1 top-1/2 z-10 flex size-6 -translate-y-1/2 items-center justify-center rounded border border-border-bright bg-background-hover transition-opacity focus:opacity-100",
-              isHovered ? "opacity-100" : "pointer-events-none opacity-0",
-              copied
-                ? "text-green-500"
-                : "text-text-dimmed hover:border-border-bright hover:bg-background-raised hover:text-text-bright"
-            )}
-          >
-            {copied ? (
-              <ClipboardCheckIcon className="size-3.5" />
-            ) : (
-              <ClipboardIcon className="size-3.5" />
-            )}
-          </button>
-        }
-        content={copied ? "Copied!" : "Copy"}
-        disableHoverableContent
-      />
+      {isHovered ? (
+        <SimpleTooltip
+          asChild
+          tabbable
+          button={copyButton}
+          content={copied ? "Copied!" : "Copy"}
+          disableHoverableContent
+        />
+      ) : (
+        copyButton
+      )}
     </div>
   );
 }

--- a/apps/webapp/app/components/code/TSQLResultsTable.tsx
+++ b/apps/webapp/app/components/code/TSQLResultsTable.tsx
@@ -845,9 +845,9 @@ function CopyableCell({
 
   // The button (with its aria-label) always sits in the same position in the tree, wrapped by
   // the same SimpleTooltip, so it is never unmounted/remounted on hover (which would drop
-  // keyboard focus). Only the tooltip's open state, not its mounted tree, follows hover; Radix
-  // still only renders the (comparatively expensive) tooltip content into the DOM of this
-  // virtualized grid while `open` is true.
+  // keyboard focus). The tooltip is left uncontrolled so Radix opens it only when the pointer or
+  // keyboard focus is actually on the button, not whenever the pointer is anywhere in this
+  // virtualized grid's cell.
   const copyButton = (
     <button
       type="button"
@@ -889,7 +889,6 @@ function CopyableCell({
       <SimpleTooltip
         asChild
         tabbable
-        open={isHovered}
         button={copyButton}
         content={copied ? "Copied!" : "Copy"}
         disableHoverableContent

--- a/apps/webapp/app/components/code/TSQLResultsTable.tsx
+++ b/apps/webapp/app/components/code/TSQLResultsTable.tsx
@@ -847,7 +847,8 @@ function CopyableCell({
   // the same SimpleTooltip, so it is never unmounted/remounted on hover (which would drop
   // keyboard focus). The tooltip is left uncontrolled so Radix opens it only when the pointer or
   // keyboard focus is actually on the button, not whenever the pointer is anywhere in this
-  // virtualized grid's cell.
+  // virtualized grid's cell. `focus-visible:` (not `focus:`) ensures keyboard focus reveals the
+  // button without leaving it visible after a mouse click moves outside the cell.
   const copyButton = (
     <button
       type="button"
@@ -858,7 +859,7 @@ function CopyableCell({
         copy();
       }}
       className={cn(
-        "absolute right-1 top-1/2 z-10 flex size-6 -translate-y-1/2 items-center justify-center rounded border border-border-bright bg-background-hover transition-opacity focus:opacity-100",
+        "absolute right-1 top-1/2 z-10 flex size-6 -translate-y-1/2 items-center justify-center rounded border border-border-bright bg-background-hover transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100",
         isHovered ? "opacity-100" : "pointer-events-none opacity-0",
         copied
           ? "text-green-500"

--- a/apps/webapp/app/components/code/TSQLResultsTable.tsx
+++ b/apps/webapp/app/components/code/TSQLResultsTable.tsx
@@ -858,6 +858,7 @@ function CopyableCell({
       <span className="flex items-center truncate">{children}</span>
       <SimpleTooltip
         asChild
+        tabbable
         button={
           <button
             type="button"

--- a/apps/webapp/app/components/code/TSQLResultsTable.tsx
+++ b/apps/webapp/app/components/code/TSQLResultsTable.tsx
@@ -843,10 +843,11 @@ function CopyableCell({
   const [isHovered, setIsHovered] = useState(false);
   const { copy, copied } = useCopy(value);
 
-  // The button (with its aria-label) stays mounted at all times so keyboard users can always
-  // reach it. The Radix tooltip subtree is comparatively expensive to keep alive for every
-  // visible cell of a virtualized grid, so it's only mounted while the cell is hovered - the
-  // tooltip is a hover affordance, not required for the button's accessible name.
+  // The button (with its aria-label) always sits in the same position in the tree, wrapped by
+  // the same SimpleTooltip, so it is never unmounted/remounted on hover (which would drop
+  // keyboard focus). Only the tooltip's open state, not its mounted tree, follows hover; Radix
+  // still only renders the (comparatively expensive) tooltip content into the DOM of this
+  // virtualized grid while `open` is true.
   const copyButton = (
     <button
       type="button"
@@ -885,17 +886,14 @@ function CopyableCell({
       onMouseLeave={() => setIsHovered(false)}
     >
       <span className="flex items-center truncate">{children}</span>
-      {isHovered ? (
-        <SimpleTooltip
-          asChild
-          tabbable
-          button={copyButton}
-          content={copied ? "Copied!" : "Copy"}
-          disableHoverableContent
-        />
-      ) : (
-        copyButton
-      )}
+      <SimpleTooltip
+        asChild
+        tabbable
+        open={isHovered}
+        button={copyButton}
+        content={copied ? "Copied!" : "Copy"}
+        disableHoverableContent
+      />
     </div>
   );
 }

--- a/apps/webapp/app/components/dashboard-agent/tooltip-accessible-name.test.ts
+++ b/apps/webapp/app/components/dashboard-agent/tooltip-accessible-name.test.ts
@@ -60,7 +60,6 @@ const NO_AS_CHILD_BASELINE = new Set([
   "app/components/GitMetadata.tsx::LinkButton",
   "app/components/code/TSQLResultsTable.tsx::TextLink",
   "app/components/integrations/VercelLink.tsx::LinkButton",
-  "app/components/primitives/CopyButton.tsx::Button",
   "app/components/runs/v3/RunTag.tsx::Link",
   "app/components/runs/v3/TaskRunsTable.tsx::DialogTrigger",
   "app/routes/account.tokens/route.tsx::DialogTrigger",

--- a/apps/webapp/app/components/dashboard-agent/tooltip-accessible-name.test.ts
+++ b/apps/webapp/app/components/dashboard-agent/tooltip-accessible-name.test.ts
@@ -89,6 +89,16 @@ function attrOf(node: JsxNode, name: string) {
   return open.attributes.properties.find((p) => ts.isJsxAttribute(p) && p.name.getText() === name);
 }
 
+function hasStaticTrueAttribute(node: JsxNode, name: string): boolean {
+  const attribute = attrOf(node, name);
+  if (!attribute || !ts.isJsxAttribute(attribute)) return false;
+  if (!attribute.initializer) return true;
+  return (
+    ts.isJsxExpression(attribute.initializer) &&
+    attribute.initializer.expression?.kind === ts.SyntaxKind.TrueKeyword
+  );
+}
+
 /** Text anywhere under the element, ignoring an expression that can render nothing. */
 function hasText(node: TsNode): boolean {
   if (!ts.isJsxElement(node)) return false;
@@ -178,7 +188,7 @@ function scanFile(file: string, relative: string): Violation[] {
       const initializer =
         buttonAttr && ts.isJsxAttribute(buttonAttr) ? buttonAttr.initializer : undefined;
       if (initializer && ts.isJsxExpression(initializer)) {
-        const asChild = !!attrOf(node, "asChild");
+        const asChild = hasStaticTrueAttribute(node, "asChild");
         for (const trigger of resolve(initializer.expression).flatMap(triggersIn)) {
           const named =
             !!attrOf(trigger, "aria-label") ||

--- a/apps/webapp/app/components/primitives/ClipboardField.tsx
+++ b/apps/webapp/app/components/primitives/ClipboardField.tsx
@@ -127,14 +127,7 @@ export function ClipboardField({
 
   return (
     <span className={cn(container, fullWidth ? "w-full" : "max-w-fit", className)}>
-      {icon && (
-        <span
-          onClick={() => inputIcon.current && inputIcon.current.focus()}
-          className="flex items-center pl-1"
-        >
-          {icon}
-        </span>
-      )}
+      {icon && <span className="flex items-center pl-1">{icon}</span>}
       <input
         type="text"
         ref={inputIcon}

--- a/apps/webapp/app/components/primitives/ClipboardField.tsx
+++ b/apps/webapp/app/components/primitives/ClipboardField.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { cn } from "~/utils/cn";
 import { CopyButton } from "./CopyButton";
 
@@ -116,7 +116,7 @@ export function ClipboardField({
   fullWidth = true,
 }: ClipboardFieldProps) {
   const [isSecure, setIsSecure] = useState(secure !== undefined && secure);
-  const inputIcon = useRef<HTMLInputElement>(null);
+  const inputId = useId();
   const { container, input, buttonVariant, button, size } = variants[variant];
 
   useEffect(() => {
@@ -127,10 +127,14 @@ export function ClipboardField({
 
   return (
     <span className={cn(container, fullWidth ? "w-full" : "max-w-fit", className)}>
-      {icon && <span className="flex items-center pl-1">{icon}</span>}
+      {icon && (
+        <label htmlFor={inputId} className="flex items-center pl-1">
+          {icon}
+        </label>
+      )}
       <input
+        id={inputId}
         type="text"
-        ref={inputIcon}
         value={isSecure ? maskedValue : value}
         readOnly={true}
         className={cn(

--- a/apps/webapp/app/components/primitives/CopyButton.tsx
+++ b/apps/webapp/app/components/primitives/CopyButton.tsx
@@ -46,7 +46,9 @@ export function CopyButton({
 
   const button =
     variant === "icon" ? (
-      <span
+      <button
+        type="button"
+        aria-label={copied ? "Copied" : "Copy"}
         onClick={copy}
         className={cn(
           buttonSize,
@@ -62,7 +64,7 @@ export function CopyButton({
         ) : (
           <ClipboardIcon className={iconSize} />
         )}
-      </span>
+      </button>
     ) : (
       <Button
         variant={`${buttonVariant}/${size === "extra-small" ? "small" : size}`}

--- a/apps/webapp/app/components/primitives/CopyButton.tsx
+++ b/apps/webapp/app/components/primitives/CopyButton.tsx
@@ -44,61 +44,68 @@ export function CopyButton({
 
   const { icon: iconSize, button: buttonSize } = sizes[size];
 
-  const button =
-    variant === "icon" ? (
-      <button
-        type="button"
-        aria-label={copied ? "Copied" : "Copy"}
-        onClick={copy}
-        className={cn(
-          buttonSize,
-          "flex shrink-0 items-center justify-center rounded border border-border-bright bg-background-hover",
-          copied
-            ? "text-green-500"
-            : "text-text-dimmed hover:border-border-bright hover:bg-background-raised hover:text-text-bright",
-          buttonClassName
-        )}
-      >
-        {copied ? (
-          <ClipboardCheckIcon className={iconSize} />
-        ) : (
-          <ClipboardIcon className={iconSize} />
-        )}
-      </button>
-    ) : (
-      <Button
-        variant={`${buttonVariant}/${size === "extra-small" ? "small" : size}`}
-        onClick={copy}
-        className={cn("shrink-0", buttonClassName)}
-        LeadingIcon={
-          copied ? (
-            <ClipboardCheckIcon
-              className={cn(
-                iconSize,
-                buttonVariant === "primary" ? "text-background-dimmed" : "text-green-500"
-              )}
-            />
-          ) : (
-            <ClipboardIcon
-              className={cn(
-                iconSize,
-                buttonVariant === "primary" ? "text-background-dimmed" : "text-text-dimmed"
-              )}
-            />
-          )
-        }
-      >
-        {children}
-      </Button>
+  if (variant === "button") {
+    return (
+      <span className={className}>
+        <Button
+          variant={`${buttonVariant}/${size === "extra-small" ? "small" : size}`}
+          onClick={copy}
+          className={cn("shrink-0", buttonClassName)}
+          tooltip={showTooltip ? (copied ? "Copied!" : "Copy") : undefined}
+          LeadingIcon={
+            copied ? (
+              <ClipboardCheckIcon
+                className={cn(
+                  iconSize,
+                  buttonVariant === "primary" ? "text-background-dimmed" : "text-green-500"
+                )}
+              />
+            ) : (
+              <ClipboardIcon
+                className={cn(
+                  iconSize,
+                  buttonVariant === "primary" ? "text-background-dimmed" : "text-text-dimmed"
+                )}
+              />
+            )
+          }
+        >
+          {children}
+        </Button>
+      </span>
     );
+  }
 
-  if (!showTooltip) return <span className={className}>{button}</span>;
+  const iconButton = (
+    <button
+      type="button"
+      aria-label={copied ? "Copied" : "Copy"}
+      onClick={copy}
+      className={cn(
+        buttonSize,
+        "flex shrink-0 items-center justify-center rounded border border-border-bright bg-background-hover",
+        copied
+          ? "text-green-500"
+          : "text-text-dimmed hover:border-border-bright hover:bg-background-raised hover:text-text-bright",
+        buttonClassName
+      )}
+    >
+      {copied ? (
+        <ClipboardCheckIcon className={iconSize} />
+      ) : (
+        <ClipboardIcon className={iconSize} />
+      )}
+    </button>
+  );
+
+  if (!showTooltip) return <span className={className}>{iconButton}</span>;
 
   return (
     <span className={className}>
       <SimpleTooltip
         asChild
-        button={button}
+        tabbable
+        button={iconButton}
         content={copied ? "Copied!" : "Copy"}
         className="font-sans"
         disableHoverableContent

--- a/apps/webapp/app/components/primitives/CopyButton.tsx
+++ b/apps/webapp/app/components/primitives/CopyButton.tsx
@@ -97,6 +97,7 @@ export function CopyButton({
   return (
     <span className={className}>
       <SimpleTooltip
+        asChild
         button={button}
         content={copied ? "Copied!" : "Copy"}
         className="font-sans"

--- a/apps/webapp/app/components/primitives/CopyButton.tsx
+++ b/apps/webapp/app/components/primitives/CopyButton.tsx
@@ -52,6 +52,7 @@ export function CopyButton({
           onClick={copy}
           className={cn("shrink-0", buttonClassName)}
           tooltip={showTooltip ? (copied ? "Copied!" : "Copy") : undefined}
+          aria-label={children ? undefined : copied ? "Copied" : "Copy"}
           LeadingIcon={
             copied ? (
               <ClipboardCheckIcon

--- a/apps/webapp/app/components/primitives/CopyableText.tsx
+++ b/apps/webapp/app/components/primitives/CopyableText.tsx
@@ -77,7 +77,7 @@ export function CopyableText({
         </span>
         <span
           className={cn(
-            "absolute top-0 z-10 flex size-6 font-sans transition-opacity focus-within:opacity-100",
+            "absolute top-0 z-10 flex size-6 font-sans transition-opacity has-focus-visible:pointer-events-auto has-focus-visible:opacity-100",
             // Truncated values reserve a right gutter, so the button sits inside it
             truncate ? "right-0" : "-right-6",
             isHovered ? "opacity-100" : "pointer-events-none opacity-0"

--- a/apps/webapp/app/components/primitives/CopyableText.tsx
+++ b/apps/webapp/app/components/primitives/CopyableText.tsx
@@ -39,7 +39,11 @@ export function CopyableText({
 
   if (resolvedVariant === "icon-right") {
     const iconButton = (
-      <span
+      <button
+        type="button"
+        aria-label={copied ? "Copied" : "Copy"}
+        onClick={copy}
+        onMouseDown={(e) => e.stopPropagation()}
         className={cn(
           "ml-1 flex size-6 items-center justify-center rounded border border-border-bright bg-background-hover",
           asChild && "p-1",
@@ -53,7 +57,7 @@ export function CopyableText({
         ) : (
           <ClipboardIcon className="size-3.5" />
         )}
-      </span>
+      </button>
     );
 
     return (
@@ -72,13 +76,11 @@ export function CopyableText({
           {value}
         </span>
         <span
-          onClick={copy}
-          onMouseDown={(e) => e.stopPropagation()}
           className={cn(
-            "absolute top-0 z-10 size-6 font-sans",
+            "absolute top-0 z-10 flex size-6 font-sans transition-opacity focus-within:opacity-100",
             // Truncated values reserve a right gutter, so the button sits inside it
             truncate ? "right-0" : "-right-6",
-            isHovered ? "flex" : "hidden"
+            isHovered ? "opacity-100" : "pointer-events-none opacity-0"
           )}
         >
           {hideTooltip ? (

--- a/apps/webapp/app/components/primitives/CopyableText.tsx
+++ b/apps/webapp/app/components/primitives/CopyableText.tsx
@@ -87,11 +87,12 @@ export function CopyableText({
             iconButton
           ) : (
             <SimpleTooltip
+              asChild
+              tabbable
               button={iconButton}
               content={copied ? "Copied!" : "Copy"}
               className="font-sans"
               disableHoverableContent
-              asChild={asChild}
             />
           )}
         </span>

--- a/apps/webapp/app/components/primitives/Table.tsx
+++ b/apps/webapp/app/components/primitives/Table.tsx
@@ -478,6 +478,34 @@ export const CopyableTableCell = forwardRef<HTMLTableCellElement, CopyableTableC
     const [isHovered, setIsHovered] = useState(false);
     const { copy, copied } = useCopy(value);
 
+    // The button (with its aria-label) stays mounted at all times so keyboard users can always
+    // reach it. The Radix tooltip subtree is only mounted while the cell is hovered - the
+    // tooltip is a hover affordance, not required for the button's accessible name.
+    const copyButton = (
+      <button
+        type="button"
+        aria-label={copied ? "Copied" : "Copy"}
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          copy();
+        }}
+        className={cn(
+          "absolute -right-2 top-1/2 z-10 flex size-6 -translate-y-1/2 items-center justify-center rounded border border-border-bright bg-background-hover transition-opacity focus:opacity-100",
+          isHovered ? "opacity-100" : "pointer-events-none opacity-0",
+          copied
+            ? "text-green-500"
+            : "text-text-dimmed hover:border-border-bright hover:bg-background-raised hover:text-text-bright"
+        )}
+      >
+        {copied ? (
+          <ClipboardCheckIcon className="size-3.5" />
+        ) : (
+          <ClipboardIcon className="size-3.5" />
+        )}
+      </button>
+    );
+
     return (
       <TableCell ref={ref} className={className} {...props}>
         <div
@@ -486,36 +514,17 @@ export const CopyableTableCell = forwardRef<HTMLTableCellElement, CopyableTableC
           onMouseLeave={() => setIsHovered(false)}
         >
           {children}
-          <SimpleTooltip
-            asChild
-            tabbable
-            button={
-              <button
-                type="button"
-                aria-label={copied ? "Copied" : "Copy"}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                  copy();
-                }}
-                className={cn(
-                  "absolute -right-2 top-1/2 z-10 flex size-6 -translate-y-1/2 items-center justify-center rounded border border-border-bright bg-background-hover transition-opacity focus:opacity-100",
-                  isHovered ? "opacity-100" : "pointer-events-none opacity-0",
-                  copied
-                    ? "text-green-500"
-                    : "text-text-dimmed hover:border-border-bright hover:bg-background-raised hover:text-text-bright"
-                )}
-              >
-                {copied ? (
-                  <ClipboardCheckIcon className="size-3.5" />
-                ) : (
-                  <ClipboardIcon className="size-3.5" />
-                )}
-              </button>
-            }
-            content={copied ? "Copied!" : "Copy"}
-            disableHoverableContent
-          />
+          {isHovered ? (
+            <SimpleTooltip
+              asChild
+              tabbable
+              button={copyButton}
+              content={copied ? "Copied!" : "Copy"}
+              disableHoverableContent
+            />
+          ) : (
+            copyButton
+          )}
         </div>
       </TableCell>
     );

--- a/apps/webapp/app/components/primitives/Table.tsx
+++ b/apps/webapp/app/components/primitives/Table.tsx
@@ -478,9 +478,10 @@ export const CopyableTableCell = forwardRef<HTMLTableCellElement, CopyableTableC
     const [isHovered, setIsHovered] = useState(false);
     const { copy, copied } = useCopy(value);
 
-    // The button (with its aria-label) stays mounted at all times so keyboard users can always
-    // reach it. The Radix tooltip subtree is only mounted while the cell is hovered - the
-    // tooltip is a hover affordance, not required for the button's accessible name.
+    // The button (with its aria-label) always sits in the same position in the tree, wrapped by
+    // the same SimpleTooltip, so it is never unmounted/remounted on hover (which would drop
+    // keyboard focus). Only the tooltip's open state, not its mounted tree, follows hover; Radix
+    // still only renders the tooltip content into the DOM while `open` is true.
     const copyButton = (
       <button
         type="button"
@@ -514,17 +515,14 @@ export const CopyableTableCell = forwardRef<HTMLTableCellElement, CopyableTableC
           onMouseLeave={() => setIsHovered(false)}
         >
           {children}
-          {isHovered ? (
-            <SimpleTooltip
-              asChild
-              tabbable
-              button={copyButton}
-              content={copied ? "Copied!" : "Copy"}
-              disableHoverableContent
-            />
-          ) : (
-            copyButton
-          )}
+          <SimpleTooltip
+            asChild
+            tabbable
+            open={isHovered}
+            button={copyButton}
+            content={copied ? "Copied!" : "Copy"}
+            disableHoverableContent
+          />
         </div>
       </TableCell>
     );

--- a/apps/webapp/app/components/primitives/Table.tsx
+++ b/apps/webapp/app/components/primitives/Table.tsx
@@ -487,6 +487,7 @@ export const CopyableTableCell = forwardRef<HTMLTableCellElement, CopyableTableC
         >
           {children}
           <SimpleTooltip
+            asChild
             button={
               <button
                 type="button"

--- a/apps/webapp/app/components/primitives/Table.tsx
+++ b/apps/webapp/app/components/primitives/Table.tsx
@@ -480,8 +480,8 @@ export const CopyableTableCell = forwardRef<HTMLTableCellElement, CopyableTableC
 
     // The button (with its aria-label) always sits in the same position in the tree, wrapped by
     // the same SimpleTooltip, so it is never unmounted/remounted on hover (which would drop
-    // keyboard focus). Only the tooltip's open state, not its mounted tree, follows hover; Radix
-    // still only renders the tooltip content into the DOM while `open` is true.
+    // keyboard focus). The tooltip is left uncontrolled so Radix opens it only when the pointer
+    // or keyboard focus is actually on the button, not whenever the pointer is anywhere in the cell.
     const copyButton = (
       <button
         type="button"
@@ -518,7 +518,6 @@ export const CopyableTableCell = forwardRef<HTMLTableCellElement, CopyableTableC
           <SimpleTooltip
             asChild
             tabbable
-            open={isHovered}
             button={copyButton}
             content={copied ? "Copied!" : "Copy"}
             disableHoverableContent

--- a/apps/webapp/app/components/primitives/Table.tsx
+++ b/apps/webapp/app/components/primitives/Table.tsx
@@ -488,6 +488,7 @@ export const CopyableTableCell = forwardRef<HTMLTableCellElement, CopyableTableC
           {children}
           <SimpleTooltip
             asChild
+            tabbable
             button={
               <button
                 type="button"

--- a/apps/webapp/app/components/primitives/Table.tsx
+++ b/apps/webapp/app/components/primitives/Table.tsx
@@ -486,37 +486,34 @@ export const CopyableTableCell = forwardRef<HTMLTableCellElement, CopyableTableC
           onMouseLeave={() => setIsHovered(false)}
         >
           {children}
-          {isHovered && (
-            <span
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                copy();
-              }}
-              className="absolute -right-2 top-1/2 z-10 flex -translate-y-1/2 cursor-pointer"
-            >
-              <SimpleTooltip
-                button={
-                  <span
-                    className={cn(
-                      "flex size-6 items-center justify-center rounded border border-border-bright bg-background-hover",
-                      copied
-                        ? "text-green-500"
-                        : "text-text-dimmed hover:border-border-bright hover:bg-background-raised hover:text-text-bright"
-                    )}
-                  >
-                    {copied ? (
-                      <ClipboardCheckIcon className="size-3.5" />
-                    ) : (
-                      <ClipboardIcon className="size-3.5" />
-                    )}
-                  </span>
-                }
-                content={copied ? "Copied!" : "Copy"}
-                disableHoverableContent
-              />
-            </span>
-          )}
+          <SimpleTooltip
+            button={
+              <button
+                type="button"
+                aria-label={copied ? "Copied" : "Copy"}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  copy();
+                }}
+                className={cn(
+                  "absolute -right-2 top-1/2 z-10 flex size-6 -translate-y-1/2 items-center justify-center rounded border border-border-bright bg-background-hover transition-opacity focus:opacity-100",
+                  isHovered ? "opacity-100" : "pointer-events-none opacity-0",
+                  copied
+                    ? "text-green-500"
+                    : "text-text-dimmed hover:border-border-bright hover:bg-background-raised hover:text-text-bright"
+                )}
+              >
+                {copied ? (
+                  <ClipboardCheckIcon className="size-3.5" />
+                ) : (
+                  <ClipboardIcon className="size-3.5" />
+                )}
+              </button>
+            }
+            content={copied ? "Copied!" : "Copy"}
+            disableHoverableContent
+          />
         </div>
       </TableCell>
     );

--- a/apps/webapp/app/components/primitives/Table.tsx
+++ b/apps/webapp/app/components/primitives/Table.tsx
@@ -482,6 +482,8 @@ export const CopyableTableCell = forwardRef<HTMLTableCellElement, CopyableTableC
     // the same SimpleTooltip, so it is never unmounted/remounted on hover (which would drop
     // keyboard focus). The tooltip is left uncontrolled so Radix opens it only when the pointer
     // or keyboard focus is actually on the button, not whenever the pointer is anywhere in the cell.
+    // `focus-visible:` reveals keyboard focus without leaving the button visible after a mouse click
+    // moves outside the cell.
     const copyButton = (
       <button
         type="button"
@@ -492,7 +494,7 @@ export const CopyableTableCell = forwardRef<HTMLTableCellElement, CopyableTableC
           copy();
         }}
         className={cn(
-          "absolute -right-2 top-1/2 z-10 flex size-6 -translate-y-1/2 items-center justify-center rounded border border-border-bright bg-background-hover transition-opacity focus:opacity-100",
+          "absolute -right-2 top-1/2 z-10 flex size-6 -translate-y-1/2 items-center justify-center rounded border border-border-bright bg-background-hover transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100",
           isHovered ? "opacity-100" : "pointer-events-none opacity-0",
           copied
             ? "text-green-500"

--- a/apps/webapp/app/components/runs/v3/RunTag.tsx
+++ b/apps/webapp/app/components/runs/v3/RunTag.tsx
@@ -122,7 +122,7 @@ function CopyButton({ textToCopy, isHovered }: { textToCopy: string; isHovered: 
           onClick={copy}
           onMouseDown={(e) => e.stopPropagation()}
           className={cn(
-            "absolute -right-6 top-0 z-10 flex size-6 items-center justify-center rounded-r-sm border-y border-r border-border-bright bg-background-hover transition-opacity focus:opacity-100",
+            "absolute -right-6 top-0 z-10 flex size-6 items-center justify-center rounded-r-sm border-y border-r border-border-bright bg-background-hover transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100",
             isHovered ? "opacity-100" : "pointer-events-none opacity-0",
             copied
               ? "text-green-500"
@@ -171,7 +171,7 @@ function DeleteButton({
           onClick={handleDelete}
           onMouseDown={(e) => e.stopPropagation()}
           className={cn(
-            "absolute -right-6 top-0 z-10 flex size-6 items-center justify-center rounded-r-sm border-y border-r border-border-bright bg-background-hover transition-opacity focus:opacity-100",
+            "absolute -right-6 top-0 z-10 flex size-6 items-center justify-center rounded-r-sm border-y border-r border-border-bright bg-background-hover transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100",
             isHovered ? "opacity-100" : "pointer-events-none opacity-0",
             "text-text-dimmed hover:border-border-bright hover:bg-background-raised hover:text-rose-400"
           )}

--- a/apps/webapp/app/components/runs/v3/RunTag.tsx
+++ b/apps/webapp/app/components/runs/v3/RunTag.tsx
@@ -114,12 +114,14 @@ function CopyButton({ textToCopy, isHovered }: { textToCopy: string; isHovered: 
   return (
     <SimpleTooltip
       button={
-        <span
+        <button
+          type="button"
+          aria-label={copied ? "Copied" : "Copy tag"}
           onClick={copy}
           onMouseDown={(e) => e.stopPropagation()}
           className={cn(
-            "absolute -right-6 top-0 z-10 size-6 items-center justify-center rounded-r-sm border-y border-r border-border-bright bg-background-hover",
-            isHovered ? "flex" : "hidden",
+            "absolute -right-6 top-0 z-10 flex size-6 items-center justify-center rounded-r-sm border-y border-r border-border-bright bg-background-hover transition-opacity focus:opacity-100",
+            isHovered ? "opacity-100" : "pointer-events-none opacity-0",
             copied
               ? "text-green-500"
               : "text-text-dimmed hover:border-border-bright hover:bg-background-raised hover:text-text-bright"
@@ -130,7 +132,7 @@ function CopyButton({ textToCopy, isHovered }: { textToCopy: string; isHovered: 
           ) : (
             <ClipboardIcon className="size-3.5" />
           )}
-        </span>
+        </button>
       }
       content={copied ? "Copied!" : "Copy tag"}
       disableHoverableContent
@@ -159,17 +161,19 @@ function DeleteButton({
   return (
     <SimpleTooltip
       button={
-        <span
+        <button
+          type="button"
+          aria-label="Remove tag"
           onClick={handleDelete}
           onMouseDown={(e) => e.stopPropagation()}
           className={cn(
-            "absolute -right-6 top-0 z-10 size-6 items-center justify-center rounded-r-sm border-y border-r border-border-bright bg-background-hover",
-            isHovered ? "flex" : "hidden",
+            "absolute -right-6 top-0 z-10 flex size-6 items-center justify-center rounded-r-sm border-y border-r border-border-bright bg-background-hover transition-opacity focus:opacity-100",
+            isHovered ? "opacity-100" : "pointer-events-none opacity-0",
             "text-text-dimmed hover:border-border-bright hover:bg-background-raised hover:text-rose-400"
           )}
         >
           <XIcon className="size-3.5" />
-        </span>
+        </button>
       }
       content="Remove tag"
       disableHoverableContent

--- a/apps/webapp/app/components/runs/v3/RunTag.tsx
+++ b/apps/webapp/app/components/runs/v3/RunTag.tsx
@@ -113,6 +113,7 @@ function CopyButton({ textToCopy, isHovered }: { textToCopy: string; isHovered: 
 
   return (
     <SimpleTooltip
+      asChild
       button={
         <button
           type="button"
@@ -160,6 +161,7 @@ function DeleteButton({
 
   return (
     <SimpleTooltip
+      asChild
       button={
         <button
           type="button"

--- a/apps/webapp/app/components/runs/v3/RunTag.tsx
+++ b/apps/webapp/app/components/runs/v3/RunTag.tsx
@@ -114,6 +114,7 @@ function CopyButton({ textToCopy, isHovered }: { textToCopy: string; isHovered: 
   return (
     <SimpleTooltip
       asChild
+      tabbable
       button={
         <button
           type="button"
@@ -162,6 +163,7 @@ function DeleteButton({
   return (
     <SimpleTooltip
       asChild
+      tabbable
       button={
         <button
           type="button"


### PR DESCRIPTION
## Summary

Replace mouse-only dashboard actions with native buttons.

Copy, remove, and stop-generation controls now expose keyboard focus and accessible names. Hover-revealed actions remain mounted so keyboard users can discover them, and a decorative clipboard icon no longer captures clicks.

Base: [#4697](https://github.com/triggerdotdev/trigger.dev/pull/4697)
