### PR TITLE
fix(webapp): use native selectable row controls

### DIFF
--- a/apps/webapp/app/components/code/TSQLResultsTable.tsx
+++ b/apps/webapp/app/components/code/TSQLResultsTable.tsx
@@ -926,8 +926,21 @@ function HeaderCellContent({
   const [isFilterHovered, setIsFilterHovered] = useState(false);
 
   const sortHighlighted = isCellHovered && !isFilterHovered;
-  const headerContent = (
-    <>
+
+  /* oxlint-disable jsx-a11y/click-events-have-key-events -- The sortable header contains separate tooltip and filter controls that cannot be nested in a button. */
+  /* oxlint-disable jsx-a11y/no-static-element-interactions -- Preserve the existing full-header pointer target rather than nesting its child controls. */
+  return (
+    <div
+      className={cn(
+        "flex w-full items-center gap-1 overflow-hidden bg-background-bright py-2 pl-2 pr-3",
+        "font-mono text-xs font-medium text-text-bright",
+        alignment === "right" && "justify-end",
+        canSort && "cursor-pointer select-none"
+      )}
+      onMouseEnter={() => setIsCellHovered(true)}
+      onMouseLeave={() => setIsCellHovered(false)}
+      onClick={onSortClick}
+    >
       {tooltip ? (
         <div
           className={cn("flex min-w-0 flex-1 items-center gap-1 truncate", {
@@ -947,6 +960,7 @@ function HeaderCellContent({
       ) : (
         <span className="min-w-0 flex-1 truncate text-left">{children}</span>
       )}
+      {/* Sort indicator */}
       {canSort && (
         <span
           className={cn(
@@ -962,33 +976,6 @@ function HeaderCellContent({
             <ChevronUpDownIcon className="size-4" />
           )}
         </span>
-      )}
-    </>
-  );
-
-  return (
-    <div
-      className={cn(
-        "flex w-full items-center gap-1 overflow-hidden bg-background-bright py-2 pl-2 pr-3",
-        "font-mono text-xs font-medium text-text-bright",
-        alignment === "right" && "justify-end"
-      )}
-      onMouseEnter={() => setIsCellHovered(true)}
-      onMouseLeave={() => setIsCellHovered(false)}
-    >
-      {canSort ? (
-        <button
-          type="button"
-          onClick={onSortClick}
-          className={cn(
-            "flex min-w-0 flex-1 cursor-pointer select-none items-center gap-1 overflow-hidden text-left focus-custom",
-            alignment === "right" && "justify-end"
-          )}
-        >
-          {headerContent}
-        </button>
-      ) : (
-        headerContent
       )}
       {onFilterClick && (
         <button
@@ -1008,6 +995,8 @@ function HeaderCellContent({
     </div>
   );
 }
+/* oxlint-enable jsx-a11y/click-events-have-key-events */
+/* oxlint-enable jsx-a11y/no-static-element-interactions */
 
 /**
  * Filter input cell for the filter row

--- a/apps/webapp/app/components/code/TSQLResultsTable.tsx
+++ b/apps/webapp/app/components/code/TSQLResultsTable.tsx
@@ -948,7 +948,7 @@ function HeaderCellContent({
           })}
         >
           <span className="truncate text-left">{children}</span>
-          <span className="flex shrink-0">
+          <span className="flex shrink-0" onClick={(event) => event.stopPropagation()}>
             <InfoIconTooltip
               content={tooltip}
               contentClassName="normal-case tracking-normal"

--- a/apps/webapp/app/components/code/TSQLResultsTable.tsx
+++ b/apps/webapp/app/components/code/TSQLResultsTable.tsx
@@ -960,11 +960,17 @@ function HeaderCellContent({
       ) : (
         <span className="min-w-0 flex-1 truncate text-left">{children}</span>
       )}
-      {/* Sort indicator */}
+      {/* The full header remains a pointer target, while this dedicated control makes sorting keyboard-accessible without nesting the tooltip or filter controls. */}
       {canSort && (
-        <span
+        <button
+          type="button"
+          aria-label="Toggle sort"
+          onClick={(event) => {
+            event.stopPropagation();
+            onSortClick?.(event);
+          }}
           className={cn(
-            "shrink-0 transition-colors",
+            "shrink-0 rounded transition-colors focus-custom",
             sortHighlighted ? "text-text-bright" : "text-text-dimmed"
           )}
         >
@@ -975,7 +981,7 @@ function HeaderCellContent({
           ) : (
             <ChevronUpDownIcon className="size-4" />
           )}
-        </span>
+        </button>
       )}
       {onFilterClick && (
         <button

--- a/apps/webapp/app/components/code/TSQLResultsTable.tsx
+++ b/apps/webapp/app/components/code/TSQLResultsTable.tsx
@@ -926,19 +926,8 @@ function HeaderCellContent({
   const [isFilterHovered, setIsFilterHovered] = useState(false);
 
   const sortHighlighted = isCellHovered && !isFilterHovered;
-
-  return (
-    <div
-      className={cn(
-        "flex w-full items-center gap-1 overflow-hidden bg-background-bright py-2 pl-2 pr-3",
-        "font-mono text-xs font-medium text-text-bright",
-        alignment === "right" && "justify-end",
-        canSort && "cursor-pointer select-none"
-      )}
-      onMouseEnter={() => setIsCellHovered(true)}
-      onMouseLeave={() => setIsCellHovered(false)}
-      onClick={onSortClick}
-    >
+  const headerContent = (
+    <>
       {tooltip ? (
         <div
           className={cn("flex min-w-0 flex-1 items-center gap-1 truncate", {
@@ -958,7 +947,6 @@ function HeaderCellContent({
       ) : (
         <span className="min-w-0 flex-1 truncate text-left">{children}</span>
       )}
-      {/* Sort indicator */}
       {canSort && (
         <span
           className={cn(
@@ -974,6 +962,33 @@ function HeaderCellContent({
             <ChevronUpDownIcon className="size-4" />
           )}
         </span>
+      )}
+    </>
+  );
+
+  return (
+    <div
+      className={cn(
+        "flex w-full items-center gap-1 overflow-hidden bg-background-bright py-2 pl-2 pr-3",
+        "font-mono text-xs font-medium text-text-bright",
+        alignment === "right" && "justify-end"
+      )}
+      onMouseEnter={() => setIsCellHovered(true)}
+      onMouseLeave={() => setIsCellHovered(false)}
+    >
+      {canSort ? (
+        <button
+          type="button"
+          onClick={onSortClick}
+          className={cn(
+            "flex min-w-0 flex-1 cursor-pointer select-none items-center gap-1 overflow-hidden text-left focus-custom",
+            alignment === "right" && "justify-end"
+          )}
+        >
+          {headerContent}
+        </button>
+      ) : (
+        headerContent
       )}
       {onFilterClick && (
         <button

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments/route.tsx
@@ -340,10 +340,7 @@ export default function Page() {
                             {hasVercelIntegration && (
                               <TableCell isSelected={isSelected}>
                                 {deployment.vercelDeploymentUrl ? (
-                                  <div
-                                    className="-ml-1 flex items-center"
-                                    onClick={(e) => e.stopPropagation()}
-                                  >
+                                  <div className="-ml-1 flex items-center">
                                     <VercelLink
                                       vercelDeploymentUrl={deployment.vercelDeploymentUrl}
                                     />

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.prompts.$promptSlug/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.prompts.$promptSlug/route.tsx
@@ -2093,7 +2093,9 @@ function VersionsTab({
         const isOverride = v.labels.includes("override");
 
         return (
-          <div
+          <button
+            type="button"
+            aria-pressed={isSelected}
             key={v.id}
             onClick={() => onSelectVersion(v.version)}
             className={cn(
@@ -2143,7 +2145,7 @@ function VersionsTab({
             <span className="shrink-0 text-xs text-text-dimmed">
               <DateTime date={v.createdAt} />
             </span>
-          </div>
+          </button>
         );
       })}
     </div>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.prompts.$promptSlug/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.prompts.$promptSlug/route.tsx
@@ -2099,7 +2099,7 @@ function VersionsTab({
             key={v.id}
             onClick={() => onSelectVersion(v.version)}
             className={cn(
-              "flex cursor-pointer items-center gap-3 px-3 py-3 text-sm transition",
+              "flex w-full cursor-pointer items-center gap-3 px-3 py-3 text-left text-sm transition focus-custom",
               isSelected
                 ? "bg-indigo-500/10 hover:bg-indigo-500/[0.07]"
                 : "hover:bg-background-hover"


### PR DESCRIPTION
## Summary

Use native controls for sortable columns and selectable prompt versions.

Table headers keep filter actions separate from sort buttons, prompt version rows expose pressed state, and a redundant deployment click interceptor is removed.

Base: [#4699](https://github.com/triggerdotdev/trigger.dev/pull/4699)
