### PR TITLE
fix(webapp): align tree mouse and keyboard interactions

### DIFF
--- a/.server-changes/run-trace-tree-interactions.md
+++ b/.server-changes/run-trace-tree-interactions.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Run trace rows now respond consistently to mouse and keyboard selection, including Alt-click expansion controls.

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
@@ -968,13 +968,10 @@ function TasksTreeView({
     },
   });
 
-  const getInteractiveNodeProps = useCallback(
-    (id: string) => ({
-      ...getNodeProps(id),
-      onClick: () => selectNode(id),
-    }),
-    [getNodeProps, selectNode]
-  );
+  const getInteractiveNodeProps = (id: string) => ({
+    ...getNodeProps(id),
+    onClick: () => selectNode(id),
+  });
 
   return (
     <div className="grid h-full grid-rows-[2.5rem_1fr_3.25rem] overflow-hidden">
@@ -1077,6 +1074,7 @@ function TasksTreeView({
                     ))}
                     <button
                       type="button"
+                      tabIndex={-1}
                       disabled={!node.hasChildren}
                       aria-label={state.expanded ? "Collapse task" : "Expand task"}
                       className={cn(
@@ -1095,6 +1093,7 @@ function TasksTreeView({
                           toggleExpandNode(node.id);
                         }
                         scrollToNode(node.id);
+                        parentRef.current?.focus();
                       }}
                     >
                       {node.hasChildren ? (

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
@@ -968,6 +968,14 @@ function TasksTreeView({
     },
   });
 
+  const getInteractiveNodeProps = useCallback(
+    (id: string) => ({
+      ...getNodeProps(id),
+      onClick: () => selectNode(id),
+    }),
+    [getNodeProps, selectNode]
+  );
+
   return (
     <div className="grid h-full grid-rows-[2.5rem_1fr_3.25rem] overflow-hidden">
       <div className="flex items-center justify-between gap-2 border-b border-grid-dimmed px-1.5">
@@ -1047,7 +1055,7 @@ function TasksTreeView({
               autoFocus
               tree={events}
               nodes={nodes}
-              getNodeProps={getNodeProps}
+              getNodeProps={getInteractiveNodeProps}
               getTreeProps={getTreeProps}
               parentClassName="pl-3"
               renderNode={({ node, state, index }) => (
@@ -1058,9 +1066,6 @@ function TasksTreeView({
                       ? "bg-grid-dimmed hover:bg-grid-bright"
                       : "bg-transparent hover:bg-grid-dimmed"
                   )}
-                  onClick={() => {
-                    selectNode(node.id);
-                  }}
                 >
                   <div className="flex h-8 items-center">
                     {Array.from({ length: node.level }).map((_, index) => (
@@ -1070,9 +1075,12 @@ function TasksTreeView({
                         isSelected={state.selected}
                       />
                     ))}
-                    <div
+                    <button
+                      type="button"
+                      disabled={!node.hasChildren}
+                      aria-label={state.expanded ? "Collapse task" : "Expand task"}
                       className={cn(
-                        "flex h-8 w-4 items-center",
+                        "flex h-8 w-4 items-center focus-custom",
                         node.hasChildren && "hover:bg-surface-control"
                       )}
                       onClick={(e) => {
@@ -1098,7 +1106,7 @@ function TasksTreeView({
                       ) : (
                         <div className="h-8 w-4" />
                       )}
-                    </div>
+                    </button>
                   </div>
 
                   <div className="flex w-full items-center justify-between gap-2 pl-1">

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
@@ -1075,8 +1075,13 @@ function TasksTreeView({
                     <button
                       type="button"
                       tabIndex={-1}
-                      aria-disabled={!node.hasChildren}
-                      aria-label={state.expanded ? "Collapse task" : "Expand task"}
+                      aria-label={
+                        node.hasChildren
+                          ? state.expanded
+                            ? "Collapse task"
+                            : "Expand task"
+                          : "Select task"
+                      }
                       className={cn(
                         "flex h-8 w-4 items-center focus-custom",
                         node.hasChildren && "hover:bg-surface-control"
@@ -1091,6 +1096,8 @@ function TasksTreeView({
                           }
                         } else if (node.hasChildren) {
                           toggleExpandNode(node.id);
+                        } else {
+                          selectNode(node.id, false);
                         }
                         scrollToNode(node.id);
                         parentRef.current?.focus({ preventScroll: true });

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam/route.tsx
@@ -1075,7 +1075,7 @@ function TasksTreeView({
                     <button
                       type="button"
                       tabIndex={-1}
-                      disabled={!node.hasChildren}
+                      aria-disabled={!node.hasChildren}
                       aria-label={state.expanded ? "Collapse task" : "Expand task"}
                       className={cn(
                         "flex h-8 w-4 items-center focus-custom",
@@ -1089,11 +1089,11 @@ function TasksTreeView({
                           } else {
                             expandAllBelowDepth(node.level);
                           }
-                        } else {
+                        } else if (node.hasChildren) {
                           toggleExpandNode(node.id);
                         }
                         scrollToNode(node.id);
-                        parentRef.current?.focus();
+                        parentRef.current?.focus({ preventScroll: true });
                       }}
                     >
                       {node.hasChildren ? (

--- a/apps/webapp/app/routes/storybook.tree-view/route.tsx
+++ b/apps/webapp/app/routes/storybook.tree-view/route.tsx
@@ -4,7 +4,7 @@ import {
   FolderOpenIcon,
   MagnifyingGlassIcon,
 } from "@heroicons/react/20/solid";
-import { useCallback, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Button } from "~/components/primitives/Buttons";
 import { Input } from "~/components/primitives/Input";
 import type { Tree } from "~/components/primitives/TreeView/TreeView";
@@ -177,13 +177,10 @@ function TreeViewParent({
     },
   });
 
-  const getInteractiveNodeProps = useCallback(
-    (id: string) => ({
-      ...getNodeProps(id),
-      onClick: () => toggleNodeSelection(id),
-    }),
-    [getNodeProps, toggleNodeSelection]
-  );
+  const getInteractiveNodeProps = (id: string) => ({
+    ...getNodeProps(id),
+    onClick: () => toggleNodeSelection(id),
+  });
 
   return (
     <div className="flex w-72 flex-col items-start gap-y-4 p-4">
@@ -226,6 +223,7 @@ function TreeViewParent({
           >
             <button
               type="button"
+              tabIndex={-1}
               aria-label={
                 node.hasChildren
                   ? state.expanded
@@ -238,6 +236,7 @@ function TreeViewParent({
                 e.stopPropagation();
                 toggleExpandNode(node.id);
                 selectNode(node.id, true);
+                parentRef.current?.focus();
               }}
             >
               {node.hasChildren ? (

--- a/apps/webapp/app/routes/storybook.tree-view/route.tsx
+++ b/apps/webapp/app/routes/storybook.tree-view/route.tsx
@@ -4,7 +4,7 @@ import {
   FolderOpenIcon,
   MagnifyingGlassIcon,
 } from "@heroicons/react/20/solid";
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Button } from "~/components/primitives/Buttons";
 import { Input } from "~/components/primitives/Input";
 import type { Tree } from "~/components/primitives/TreeView/TreeView";
@@ -177,6 +177,14 @@ function TreeViewParent({
     },
   });
 
+  const getInteractiveNodeProps = useCallback(
+    (id: string) => ({
+      ...getNodeProps(id),
+      onClick: () => toggleNodeSelection(id),
+    }),
+    [getNodeProps, toggleNodeSelection]
+  );
+
   return (
     <div className="flex w-72 flex-col items-start gap-y-4 p-4">
       <div className="flex items-center gap-2">
@@ -203,7 +211,7 @@ function TreeViewParent({
         autoFocus
         tree={tree}
         nodes={nodes}
-        getNodeProps={getNodeProps}
+        getNodeProps={getInteractiveNodeProps}
         getTreeProps={getTreeProps}
         parentClassName="h-96 bg-background-deep"
         renderNode={({ node, state, index, virtualizer, virtualItem }) => (
@@ -215,19 +223,21 @@ function TreeViewParent({
               "flex cursor-pointer items-center gap-2 py-1 hover:bg-blue-500/10",
               state.selected && "bg-blue-500/20 hover:bg-blue-500/30"
             )}
-            onClick={() => {
-              toggleNodeSelection(node.id);
-            }}
           >
-            <div
-              className="h-4 w-4"
+            <button
+              type="button"
+              aria-label={
+                node.hasChildren
+                  ? state.expanded
+                    ? "Collapse node"
+                    : "Expand node"
+                  : "Select node"
+              }
+              className="h-4 w-4 focus-custom"
               onClick={(e) => {
                 e.stopPropagation();
                 toggleExpandNode(node.id);
                 selectNode(node.id, true);
-              }}
-              onKeyDown={(e) => {
-                console.log(e.key);
               }}
             >
               {node.hasChildren ? (
@@ -239,7 +249,7 @@ function TreeViewParent({
               ) : (
                 <DocumentIcon className="h-4 w-4" />
               )}
-            </div>
+            </button>
             <div>{node.data.title}</div>
           </div>
         )}


### PR DESCRIPTION
## Summary

Move tree selection onto semantic tree items and use native expansion buttons.

Dashboard and story tree rows now share mouse and keyboard selection through `getNodeProps`. Expand and collapse affordances are named buttons instead of clickable layout elements.

Base: [#4700](https://github.com/triggerdotdev/trigger.dev/pull/4700)
