### PR TITLE
fix(clickhouse): use compatible logs text index syntax

### DIFF
--- a/internal-packages/clickhouse/schema/040_create_task_events_search_v2.sql
+++ b/internal-packages/clickhouse/schema/040_create_task_events_search_v2.sql
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS trigger_dev.task_events_search_v2
 
   INDEX idx_run_id run_id TYPE bloom_filter(0.001) GRANULARITY 1,
   INDEX idx_search_text search_text
-    TYPE text(tokenizer = 'ngrams', preprocessor = lowerUTF8(search_text))
+    TYPE text(tokenizer = 'ngrams')
 )
 ENGINE = ReplacingMergeTree
 PARTITION BY toDate(inserted_at)


### PR DESCRIPTION
## Summary

Allow the logs search schema migration to run on ClickHouse versions that require text index options to be literals.

## Root cause

The text index declared `lowerUTF8(search_text)` as a preprocessor option. Some ClickHouse versions reject that column expression while parsing index settings. The projected `search_text` is already normalized to lowercase before insertion, so removing the redundant preprocessor preserves search behavior.

Verified with the task events search integration tests.
