### PR TITLE
fix(clickhouse): lowercase logs search index terms

### DIFF
--- a/internal-packages/clickhouse/schema/040_create_task_events_search_v2.sql
+++ b/internal-packages/clickhouse/schema/040_create_task_events_search_v2.sql
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS trigger_dev.task_events_search_v2
 
   INDEX idx_run_id run_id TYPE bloom_filter(0.001) GRANULARITY 1,
   INDEX idx_search_text search_text
-    TYPE text(tokenizer = 'ngrams')
+    TYPE text(tokenizer = 'ngrams', preprocessor = lowerUTF8(search_text))
 )
 ENGINE = ReplacingMergeTree
 PARTITION BY toDate(inserted_at)


### PR DESCRIPTION
## Summary

Apply `lowerUTF8` preprocessing when constructing the logs search n-gram index. This keeps lowercase normalization explicit in the index definition as well as in the projected `search_text` values.

## Design

The supported ClickHouse baseline accepts expression-valued text index preprocessors. The index continues using the `ngrams` tokenizer, with the preprocessor ensuring its indexed terms are generated from lowercase text.

Verified with the task events search integration tests.
