### PR TITLE
chore(webapp): scope unsupported React Compiler diagnostics

### DIFF
--- a/apps/webapp/app/components/code/TSQLResultsTable.tsx
+++ b/apps/webapp/app/components/code/TSQLResultsTable.tsx
@@ -1064,6 +1064,7 @@ function ColumnResizeHandle({ header }: { header: Header<RowData, unknown> }) {
 }
 /* oxlint-enable jsx-a11y/no-static-element-interactions */
 
+// oxlint-disable-next-line react/react-compiler -- TanStack Table is not compatible with compiler memoization.
 export const TSQLResultsTable = memo(function TSQLResultsTable({
   rows,
   columns,

--- a/apps/webapp/app/components/primitives/InputNumberStepper.tsx
+++ b/apps/webapp/app/components/primitives/InputNumberStepper.tsx
@@ -10,6 +10,7 @@ type InputNumberStepperProps = Omit<JSX.IntrinsicElements["input"], "min" | "max
   controlSize?: "base" | "large";
 };
 
+// oxlint-disable-next-line react/react-compiler -- The compiler cannot currently rewrite these hoisted function references.
 export function InputNumberStepper({
   value,
   onChange,

--- a/apps/webapp/app/components/primitives/TreeView/TreeView.tsx
+++ b/apps/webapp/app/components/primitives/TreeView/TreeView.tsx
@@ -193,6 +193,7 @@ export type UseTreeStateOutput = {
   scrollToNode: (id: string) => void;
 };
 
+// oxlint-disable-next-line react/react-compiler -- TanStack Virtual is not compatible with compiler memoization.
 export function useTree<TData, TFilterValue>({
   tree,
   selectedId,

--- a/apps/webapp/app/components/scheduled/timezones.tsx
+++ b/apps/webapp/app/components/scheduled/timezones.tsx
@@ -2,6 +2,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { useRef } from "react";
 import { SelectItem } from "../primitives/Select";
 
+// oxlint-disable-next-line react/react-compiler -- TanStack Virtual is not compatible with compiler memoization.
 export function TimezoneList({ timezones }: { timezones: string[] }) {
   const parentRef = useRef<HTMLDivElement>(null);
 

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.environment-variables/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.environment-variables/route.tsx
@@ -743,6 +743,7 @@ function EnvironmentVariableTableRow({
   );
 }
 
+// oxlint-disable-next-line react/react-compiler -- TanStack Virtual is not compatible with compiler memoization.
 function EnvironmentVariablesVirtualTableBody({
   groupedEnvironmentVariables,
   scrollRef,

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.sessions.$sessionParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.sessions.$sessionParam/route.tsx
@@ -264,6 +264,7 @@ const ROW_NUMBER_COL_MIN_CH = 3;
 const TIME_COL_WIDTH = "7rem";
 const TYPE_COL_WIDTH = "5rem";
 
+// oxlint-disable-next-line react/react-compiler -- TanStack Virtual is not compatible with compiler memoization.
 function RawConversationView({
   inResourcePath,
   outResourcePath,

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.streams.$streamKey/route.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.$runParam.streams.$streamKey/route.tsx
@@ -105,6 +105,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   );
 };
 
+// oxlint-disable-next-line react/react-compiler -- TanStack Virtual is not compatible with compiler memoization.
 export function RealtimeStreamViewer({
   runId,
   streamKey,


### PR DESCRIPTION
## Summary

Adds targeted lint suppressions for components built around libraries that React Compiler intentionally declines to memoize, plus one unsupported function-reference pattern. Each suppression is scoped to the affected component so other compiler diagnostics remain actionable.
