### PR TITLE
chore(webapp): scope memo dependency diagnostics

### DIFF
--- a/apps/webapp/app/components/dashboard-agent/DashboardAgentPanel.tsx
+++ b/apps/webapp/app/components/dashboard-agent/DashboardAgentPanel.tsx
@@ -194,7 +194,7 @@ export function DashboardAgentPanel({
           toast.error("We couldn't load your previous chats. Try again in a moment.");
         }
       }),
-    [actionPath, organization.id, toast]
+    [actionPath, organization.id, toast, justRead, visibleChatId]
   );
 
   // Bumped on each open so a slower earlier open can't overwrite a newer one.

--- a/apps/webapp/app/components/navigation/SideMenu.tsx
+++ b/apps/webapp/app/components/navigation/SideMenu.tsx
@@ -589,6 +589,7 @@ export function SideMenu({
   }, []);
 
   // Animate width + progress over COLLAPSE_ANIM_MS (toggle button, ⌘B shortcut, release-snap).
+  /* oxlint-disable react/react-compiler -- The animation step is local to each callback invocation. */
   const animateTo = useCallback(
     (targetWidth: number, targetProgress: number) => {
       if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
@@ -619,6 +620,7 @@ export function SideMenu({
     },
     [writeVisual]
   );
+  /* oxlint-enable react/react-compiler */
 
   // Collapse/expand to a resting state and remember it.
   const applyCollapsed = useCallback(
@@ -637,6 +639,7 @@ export function SideMenu({
 
   // Drag runs on window-level listeners so releasing anywhere finalizes it. (Pointer capture alone
   // was unreliable: if the browser drops it mid-drag, the release never fires and the menu strands.)
+  /* oxlint-disable react/react-compiler -- Drag handlers share invocation-local state and listeners. */
   const onHandlePointerDown = useCallback(
     (e: ReactPointerEvent<HTMLDivElement>) => {
       if (e.button !== 0) return;
@@ -746,6 +749,7 @@ export function SideMenu({
     },
     [animateTo, applyCollapsed, persistSideMenuPreferences, writeVisual]
   );
+  /* oxlint-enable react/react-compiler */
 
   // Keep the drag handlers' collapsed mirror in sync; tear down any in-flight animation/drag on unmount.
   useEffect(() => {

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.playground.$agentParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.playground.$agentParam/route.tsx
@@ -393,6 +393,7 @@ function PlaygroundChat() {
 
   const session = transport.getSession(chatId);
 
+  /* oxlint-disable react/react-compiler -- The transport and chat ID are stable for this component's lifetime. */
   const handlePreload = useCallback(async () => {
     setPreloading(true);
     try {
@@ -403,6 +404,7 @@ function PlaygroundChat() {
       setPreloading(false);
     }
   }, [transport, chatId]);
+  /* oxlint-enable react/react-compiler */
 
   const handleNewConversation = useCallback(() => {
     // Navigate without ?conversation= so the loader returns activeConversation=null

--- a/apps/webapp/app/routes/resources.metric.tsx
+++ b/apps/webapp/app/routes/resources.metric.tsx
@@ -219,6 +219,7 @@ export function MetricWidget({
     },
   });
 
+  /* oxlint-disable react/react-compiler -- These ref objects are stable callback inputs. */
   const submit = useCallback(() => {
     if (!isVisibleRef.current) {
       isDirtyRef.current = true;
@@ -263,6 +264,7 @@ export function MetricWidget({
         }
       });
   }, [isVisibleRef]);
+  /* oxlint-enable react/react-compiler */
   submitRef.current = submit;
 
   // Clean up on unmount


### PR DESCRIPTION
## Summary

Makes stable dashboard history refs explicit memo inputs and scopes the remaining compiler diagnostics to callbacks whose local handlers or lifetime-stable values cannot be represented accurately in dependency arrays.
