### PR TITLE
fix(webapp): keep branches list pagination when archiving a branch

### DIFF
--- a/.server-changes/preserve-branches-pagination-on-archive.md
+++ b/.server-changes/preserve-branches-pagination-on-archive.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Archiving a preview branch now returns you to the same page of the branches list instead of resetting to the first page.

--- a/apps/webapp/app/presenters/v3/BranchesPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/BranchesPresenter.server.ts
@@ -180,6 +180,10 @@ export class BranchesPresenter {
       },
     });
 
+    // Archiving shrinks the list, so a restored page number can point past the end.
+    const totalPages = Math.ceil(visibleCount / BRANCHES_PER_PAGE);
+    const currentPage = totalPages > 0 ? Math.min(page, totalPages) : 1;
+
     const limits = await checkBranchLimit({
       prisma: this.#prismaClient,
       organizationId: project.organizationId,
@@ -222,7 +226,7 @@ export class BranchesPresenter {
       orderBy: {
         branchName: "asc",
       },
-      skip: (page - 1) * BRANCHES_PER_PAGE,
+      skip: (currentPage - 1) * BRANCHES_PER_PAGE,
       take: BRANCHES_PER_PAGE,
     });
 
@@ -252,8 +256,8 @@ export class BranchesPresenter {
 
     return {
       branchableEnvironment,
-      currentPage: page,
-      totalPages: Math.ceil(visibleCount / BRANCHES_PER_PAGE),
+      currentPage,
+      totalPages,
       hasBranches: totalBranches > 0,
       branches: branchesSorted,
       hasFilters,

--- a/apps/webapp/app/routes/resources.branches.archive.tsx
+++ b/apps/webapp/app/routes/resources.branches.archive.tsx
@@ -25,6 +25,11 @@ const schema = ArchiveBranchOptions.and(
   })
 );
 
+// Only same-origin paths are safe to redirect to, since redirectPath comes from the form.
+function internalRedirectPath(path: string): string | undefined {
+  return path.startsWith("/") && !path.startsWith("//") ? path : undefined;
+}
+
 export async function action({ request }: ActionFunctionArgs) {
   const userId = await requireUserId(request);
 
@@ -45,16 +50,24 @@ export async function action({ request }: ActionFunctionArgs) {
   );
 
   if (result.success) {
-    return redirectWithSuccessMessage(
+    const listPath =
       result.branch.type === "DEVELOPMENT"
         ? branchesDevPath(result.organization, result.project, result.branch)
-        : branchesPath(result.organization, result.project, result.branch),
+        : branchesPath(result.organization, result.project, result.branch);
+
+    // Return to the page the user archived from, so filters and pagination survive.
+    return redirectWithSuccessMessage(
+      internalRedirectPath(submission.value.redirectPath) ?? listPath,
       request,
       `Branch "${result.branch.branchName}" archived`
     );
   }
 
-  return redirectWithErrorMessage(submission.value.redirectPath, request, result.error);
+  return redirectWithErrorMessage(
+    internalRedirectPath(submission.value.redirectPath) ?? "/",
+    request,
+    result.error
+  );
 }
 
 export function ArchiveButton({


### PR DESCRIPTION
## Summary

Archiving a preview branch reset the branches list back to the first page. Working down a long list meant re-navigating to the last page after every single archive.

## Fix

The archive form already submits the current path and query string as `redirectPath`, and the action already validates it. But only the failure branch used it. On success the action built a fresh branches path with no search params, dropping `?page=` along with any filters:

```ts
if (result.success) {
  return redirectWithSuccessMessage(
    branchesDevPath(...) | branchesPath(...),   // bare path, no query string
    ...
  );
}
return redirectWithErrorMessage(submission.value.redirectPath, ...);   // used here only
```

Success now redirects to `redirectPath` too, so pagination and filters survive. Since that value comes from the form, both branches run it through a same-origin check first and fall back to a built path if it isn't a relative path.

Restoring the page number introduces one new case: archiving the last item on the last page would leave you on an empty page, because archiving removes the branch from the default list and shrinks it. The presenter now clamps a requested page beyond the end to the last page with results, which also covers a hand-edited URL.
