### PR TITLE
chore(webapp): enforce React Compiler lint

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -124,6 +124,7 @@
         "react/button-has-type": "error",
         "react/jsx-no-useless-fragment": "error",
         "react/no-unstable-nested-components": "error",
+        "react/react-compiler": "error",
         "react/rules-of-hooks": "error",
         "trigger-runops/no-control-plane-run-graph-access": "error",
         "trigger-runops/no-control-plane-in-runops-slot": "error"


### PR DESCRIPTION
## Summary

Enforces `react/react-compiler` as an error for the webapp now that all reported compiler diagnostics are fixed or narrowly scoped. Removes the unused lazy-ref helper made obsolete by the ref initialization cleanup.
