### PR TITLE
fix(webapp): let the dashboard agent use a configurable base URL

### DIFF
--- a/apps/webapp/app/components/dashboard-agent/DashboardAgentPanel.tsx
+++ b/apps/webapp/app/components/dashboard-agent/DashboardAgentPanel.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "r
 import { AgentSpinner } from "~/components/primitives/Spinner";
 import { useToast } from "~/components/primitives/Toast";
 import { useAgentPageContext } from "~/hooks/useAgentPageContext";
-import { useApiOrigin } from "~/hooks/useApiOrigin";
+import { useDashboardAgentBaseUrl } from "~/hooks/useDashboardAgentBaseUrl";
 import { useEnvironment } from "~/hooks/useEnvironment";
 import { useOrganization } from "~/hooks/useOrganizations";
 import { useProject } from "~/hooks/useProject";
@@ -104,7 +104,7 @@ export function DashboardAgentPanel({
   const project = useProject();
   const environment = useEnvironment();
   const user = useUser();
-  const apiOrigin = useApiOrigin();
+  const apiOrigin = useDashboardAgentBaseUrl();
   const location = useLocation();
   const pageContext = useAgentPageContext();
   const toast = useToast();

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -192,6 +192,7 @@ const EnvironmentSchema = z
     // standard chat.agent SDK flow. When unset, the live agent is disabled — the
     // conversation store / History still work, no chat can start.
     DASHBOARD_AGENT_SECRET_KEY: z.string().optional(),
+    DASHBOARD_AGENT_BASE_URL: z.string().optional(),
     // Pins agent sessions to a specific deployed version (paired with
     // --skip-promotion deploys); unset => the project env's current version.
     DASHBOARD_AGENT_VERSION: z.string().optional(),

--- a/apps/webapp/app/hooks/useDashboardAgentBaseUrl.ts
+++ b/apps/webapp/app/hooks/useDashboardAgentBaseUrl.ts
@@ -1,8 +1,8 @@
 import { useTypedRouteLoaderData } from "remix-typedjson";
 import type { loader } from "../root";
 
-export function useApiOrigin() {
+export function useDashboardAgentBaseUrl() {
   const routeMatch = useTypedRouteLoaderData<typeof loader>("root");
 
-  return routeMatch!.apiOrigin;
+  return routeMatch!.dashboardAgentBaseUrl;
 }

--- a/apps/webapp/app/root.tsx
+++ b/apps/webapp/app/root.tsx
@@ -120,6 +120,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       appEnv: env.APP_ENV,
       appOrigin: env.APP_ORIGIN,
       apiOrigin: env.API_ORIGIN ?? env.APP_ORIGIN,
+      dashboardAgentBaseUrl: env.DASHBOARD_AGENT_BASE_URL ?? "https://api.trigger.dev",
       triggerCliTag: env.TRIGGER_CLI_TAG,
       kapa,
       timezone,

--- a/apps/webapp/app/services/dashboardAgent.server.ts
+++ b/apps/webapp/app/services/dashboardAgent.server.ts
@@ -49,7 +49,7 @@ const DASHBOARD_AGENT_UAT_TTL_SECONDS = 10 * 60;
 // The Trigger instance this webapp runs against — the same origin the agent
 // task calls back to (as the user) for its read tools.
 export function dashboardAgentApiOrigin(): string {
-  return env.API_ORIGIN ?? env.APP_ORIGIN;
+  return env.DASHBOARD_AGENT_BASE_URL ?? "https://api.trigger.dev";
 }
 
 // Mint a short-lived, read-only delegated token for the signed-in user. Self


### PR DESCRIPTION
## Summary

Lets the dashboard agent point at a specific Trigger instance instead of assuming it runs on the same instance as the webapp. Adds an optional `DASHBOARD_AGENT_BASE_URL`; when unset it falls back to the SDK default.

## Root cause

The agent's session start, token mint, head start, in-proxy and the client transport all built the agent's base URL from the webapp's own origin (`API_ORIGIN ?? APP_ORIGIN`). That only holds when the agent project runs on the same instance as the webapp. When it runs elsewhere, `DASHBOARD_AGENT_SECRET_KEY` belongs to that other instance, so the webapp's own API rejects it with an "Invalid API key" and the chat can't start.

## Fix

`dashboardAgentApiOrigin()` now returns `DASHBOARD_AGENT_BASE_URL` or the SDK default, never the webapp origin. A concrete default (rather than an unset value) keeps it independent of `TRIGGER_API_URL`, which a webapp may point at a different host. Every server call site already routes through that helper; the client transport reads the value from the root loader via a new `useDashboardAgentBaseUrl` hook.