### PR TITLE
fix(sdk): reset skipToTurnComplete when a new chat turn starts

### DIFF
--- a/.changeset/fluffy-pans-argue.md
+++ b/.changeset/fluffy-pans-argue.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+Fix chat transport discarding the next turn after stopping generation. `skipToTurnComplete` is now reset when a new message or action is sent, so a message sent after `stopGeneration` streams normally instead of leaving the chat stuck in a streaming state.

--- a/packages/trigger-sdk/src/v3/chat.ts
+++ b/packages/trigger-sdk/src/v3/chat.ts
@@ -870,6 +870,10 @@ export class TriggerChatTransport implements ChatTransport<UIMessage> {
       this.activeStreams.delete(chatId);
     }
 
+    // A stop that never saw its TURN_COMPLETE leaves the flag set, and the new
+    // turn would be skipped record by record.
+    state.skipToTurnComplete = false;
+
     state.isStreaming = true;
     this.notifySessionChange(chatId, state);
 
@@ -1280,6 +1284,10 @@ export class TriggerChatTransport implements ChatTransport<UIMessage> {
       activeStream.abort();
       this.activeStreams.delete(chatId);
     }
+
+    // A stop that never saw its TURN_COMPLETE leaves the flag set, and the new
+    // turn would be skipped record by record.
+    state.skipToTurnComplete = false;
 
     // Mark streaming + persist so a reload mid-action resumes (reconnectToStream
     // no-ops when the persisted session says isStreaming: false).

--- a/packages/trigger-sdk/test/chat-transport-events.test.ts
+++ b/packages/trigger-sdk/test/chat-transport-events.test.ts
@@ -174,6 +174,70 @@ describe("transport send events", () => {
   });
 });
 
+describe("stopped turn followed by a new turn", () => {
+  /**
+   * `.out` stub that honours the `Last-Event-ID` cursor like the server does, so
+   * a resubscribe cannot replay records the reader already consumed. A stop that
+   * never saw its turn-complete is therefore unrecoverable unless the new send
+   * clears the skip state.
+   */
+  function cursoredOneTurnTransport() {
+    const frames = [
+      { id: "1", data: `{"type":"text-delta","id":"t1","delta":"hello"}` },
+      { id: "2", data: `{"type":"trigger:turn-complete"}` },
+    ];
+
+    return makeTransport({
+      fetch: async (_url, init, ctx) => {
+        if (ctx.endpoint === "in") return jsonOk();
+
+        const cursor = new Headers(init.headers).get("Last-Event-ID");
+        const from = cursor ? frames.findIndex((f) => f.id === cursor) + 1 : 0;
+        const remaining = frames.slice(from);
+        const response = sseResponse(
+          remaining.map((f) => `id: ${f.id}\ndata: ${f.data}\n\n`).join("")
+        );
+        // Nothing left to send: the session is settled, so the reader stops
+        // instead of resubscribing.
+        if (remaining.length === 0) response.headers.set("X-Session-Settled", "true");
+        return response;
+      },
+    });
+  }
+
+  it("streams a sendMessages turn after a stop that never saw turn-complete", async () => {
+    const { transport, events } = cursoredOneTurnTransport();
+
+    expect(await transport.stopGeneration("c1")).toBe(true);
+    events.length = 0;
+
+    const stream = await transport.sendMessages({
+      trigger: "submit-message",
+      chatId: "c1",
+      messageId: undefined,
+      messages: [user("after stop", "u-2")],
+      abortSignal: undefined,
+    });
+    const chunks = await readAll(stream);
+
+    expect(chunks).toEqual([{ type: "text-delta", id: "t1", delta: "hello" }]);
+    expect(events.some((e) => e.type === "turn-completed")).toBe(true);
+  });
+
+  it("streams a sendAction turn after a stop that never saw turn-complete", async () => {
+    const { transport, events } = cursoredOneTurnTransport();
+
+    expect(await transport.stopGeneration("c1")).toBe(true);
+    events.length = 0;
+
+    const stream = await transport.sendAction("c1", { type: "undo" });
+    const chunks = await readAll(stream);
+
+    expect(chunks).toEqual([{ type: "text-delta", id: "t1", delta: "hello" }]);
+    expect(events.some((e) => e.type === "turn-completed")).toBe(true);
+  });
+});
+
 describe("transport stream events", () => {
   it("marks reconnectToStream subscriptions as resumed", async () => {
     const { transport, events } = makeTransport({


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Testing

Reproduced with `useTriggerChatTransport` + `useChat` and the stop pattern from the ai-chat frontend docs:

1. Send a message so a turn is streaming.
2. Call `transport.stopGeneration(chatId)`, then `useChat`'s `stop()`.
3. Send another message.

Before this change the second turn never renders: no parts arrive, `status` stays `streaming`, and the session stays `isStreaming: true`, so a stop button stays on screen until the page is reloaded. The run itself is fine and everything persists, so a reload shows the full response.

Cause: `stopGeneration` sets `state.skipToTurnComplete = true`, and the read loop only clears that when it sees a `TURN_COMPLETE` record. The abort closes the reader before that record arrives, so the flag survives into the next turn and every record of that turn is skipped, including its own `TURN_COMPLETE`.

After this change the same sequence streams the second turn normally. Verified against 4.5.11 and 4.5.12 (both affected) with the equivalent patch applied to the built SDK.

---

## Changelog

Reset `skipToTurnComplete` when a new chat turn or action is sent, so a message sent after `stopGeneration` streams normally instead of leaving the chat stuck in a streaming state.
