### PR TITLE
fix(hosting): disable clickhouse system-log telemetry and apply profile settings via users.d

### DIFF
--- a/.server-changes/hosting-clickhouse-system-logs.md
+++ b/.server-changes/hosting-clickhouse-system-logs.md
@@ -3,4 +3,4 @@ area: hosting
 type: fix
 ---
 
-Self-hosted ClickHouse no longer accumulates unbounded system-log telemetry (metric_log, text_log, asynchronous_metric_log, ...) that eventually pins the CPU in a background merge-retry loop on the recommended machine size; query_log and error_log are kept with a TTL, and the low-memory profile settings now actually apply (moved from config.d to users.d).
+Self-hosted ClickHouse now disables its unbounded internal telemetry tables and keeps query/error logs on a bounded retention, fixing runaway CPU and memory usage on the recommended machine size. Existing self-hosted deployments must drop the previously written disabled log tables separately to reclaim disk.

--- a/.server-changes/hosting-clickhouse-system-logs.md
+++ b/.server-changes/hosting-clickhouse-system-logs.md
@@ -1,6 +1,0 @@
----
-area: hosting
-type: fix
----
-
-Self-hosted ClickHouse now disables its unbounded internal telemetry tables and keeps query/error logs on a bounded retention, fixing runaway CPU and memory usage on the recommended machine size. Existing self-hosted deployments must drop the previously written disabled log tables separately to reclaim disk.

--- a/.server-changes/hosting-clickhouse-system-logs.md
+++ b/.server-changes/hosting-clickhouse-system-logs.md
@@ -1,0 +1,6 @@
+---
+area: hosting
+type: fix
+---
+
+Self-hosted ClickHouse no longer accumulates unbounded system-log telemetry (metric_log, text_log, asynchronous_metric_log, ...) that eventually pins the CPU in a background merge-retry loop on the recommended machine size; query_log and error_log are kept with a TTL, and the low-memory profile settings now actually apply (moved from config.d to users.d).

--- a/hosting/docker/clickhouse/override.xml
+++ b/hosting/docker/clickhouse/override.xml
@@ -10,14 +10,7 @@
     <mark_cache_size>524288000</mark_cache_size> <!-- 500MB -->
     <concurrent_threads_soft_limit_num>1</concurrent_threads_soft_limit_num>
 
-    <!-- ClickHouse's own telemetry tables have no TTL and grow without bound; on the
-         recommended webapp machine size their background merges eventually stop fitting
-         in memory and are retried forever (there is no backoff for failed merges),
-         pinning the CPU and ultimately failing the webapp's own inserts (#4343).
-         The ClickHouse low-RAM guide recommends disabling exactly these tables:
-         https://clickhouse.com/docs/operations/tips
-         Same list as the dev stack (docker/config/clickhouse-disable-system-logs.xml),
-         extended with the newer log tables. -->
+    <!-- ClickHouse's own telemetry, too heavy for the recommended machine size -->
     <metric_log remove="1"/>
     <asynchronous_metric_log remove="1"/>
     <part_log remove="1"/>
@@ -34,10 +27,7 @@
     <opentelemetry_span_log remove="1"/>
     <query_views_log remove="1"/>
 
-    <!-- Keep query_log and error_log (small and useful for debugging), but bounded.
-         A config-level TTL survives log-table recreation, unlike ALTER ... MODIFY TTL.
-         Note: ClickHouse renames the existing table to *_log_<N> when this changes;
-         drop those leftovers to reclaim disk. -->
+    <!-- A config-level ttl survives log-table recreation, unlike ALTER ... MODIFY TTL -->
     <query_log>
         <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
     </query_log>
@@ -45,6 +35,5 @@
         <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
     </error_log>
 
-    <!-- Profile settings do NOT live here: config.d is silently ignored for them.
-         See users-override.xml, mounted under users.d. -->
+    <!-- Profile settings only apply from users.d, see users-override.xml -->
 </clickhouse>

--- a/hosting/docker/clickhouse/override.xml
+++ b/hosting/docker/clickhouse/override.xml
@@ -13,7 +13,6 @@
     <!-- ClickHouse's own telemetry, too heavy for the recommended machine size -->
     <metric_log remove="1"/>
     <asynchronous_metric_log remove="1"/>
-    <part_log remove="1"/>
     <trace_log remove="1"/>
     <query_thread_log remove="1"/>
     <session_log remove="1"/>
@@ -28,6 +27,9 @@
     <query_views_log remove="1"/>
 
     <!-- A config-level ttl survives log-table recreation, unlike ALTER ... MODIFY TTL -->
+    <part_log>
+        <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
+    </part_log>
     <query_log>
         <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
     </query_log>

--- a/hosting/docker/clickhouse/override.xml
+++ b/hosting/docker/clickhouse/override.xml
@@ -9,12 +9,42 @@
     <!-- Official recommendations for systems with <16GB RAM -->
     <mark_cache_size>524288000</mark_cache_size> <!-- 500MB -->
     <concurrent_threads_soft_limit_num>1</concurrent_threads_soft_limit_num>
-    <profiles>
-        <default>
-        <max_block_size>8192</max_block_size>
-        <max_download_threads>1</max_download_threads>
-        <input_format_parallel_parsing>0</input_format_parallel_parsing>
-        <output_format_parallel_formatting>0</output_format_parallel_formatting>
-        </default>
-    </profiles>
+
+    <!-- ClickHouse's own telemetry tables have no TTL and grow without bound; on the
+         recommended webapp machine size their background merges eventually stop fitting
+         in memory and are retried forever (there is no backoff for failed merges),
+         pinning the CPU and ultimately failing the webapp's own inserts (#4343).
+         The ClickHouse low-RAM guide recommends disabling exactly these tables:
+         https://clickhouse.com/docs/operations/tips
+         Same list as the dev stack (docker/config/clickhouse-disable-system-logs.xml),
+         extended with the newer log tables. -->
+    <metric_log remove="1"/>
+    <asynchronous_metric_log remove="1"/>
+    <part_log remove="1"/>
+    <trace_log remove="1"/>
+    <query_thread_log remove="1"/>
+    <session_log remove="1"/>
+    <text_log remove="1"/>
+    <zookeeper_log remove="1"/>
+    <processors_profile_log remove="1"/>
+    <asynchronous_insert_log remove="1"/>
+    <backup_log remove="1"/>
+    <latency_log remove="1"/>
+    <query_metric_log remove="1"/>
+    <opentelemetry_span_log remove="1"/>
+    <query_views_log remove="1"/>
+
+    <!-- Keep query_log and error_log (small and useful for debugging), but bounded.
+         A config-level TTL survives log-table recreation, unlike ALTER ... MODIFY TTL.
+         Note: ClickHouse renames the existing table to *_log_<N> when this changes;
+         drop those leftovers to reclaim disk. -->
+    <query_log>
+        <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
+    </query_log>
+    <error_log>
+        <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+    </error_log>
+
+    <!-- Profile settings do NOT live here: config.d is silently ignored for them.
+         See users-override.xml, mounted under users.d. -->
 </clickhouse>

--- a/hosting/docker/clickhouse/users-override.xml
+++ b/hosting/docker/clickhouse/users-override.xml
@@ -1,17 +1,11 @@
 <clickhouse>
     <profiles>
         <default>
-            <!-- Low-memory settings for the recommended webapp machine size. These were
-                 previously in config.d/override.xml where profile settings are silently
-                 ignored — they only take effect from the users config tree (#4343). -->
             <max_block_size>8192</max_block_size>
             <max_download_threads>1</max_download_threads>
             <input_format_parallel_parsing>0</input_format_parallel_parsing>
             <output_format_parallel_formatting>0</output_format_parallel_formatting>
-            <!-- The memory/query profilers sample stacks into system.trace_log
-                 (a Memory/MemoryPeak sample every 4 MB allocated, by default) — the main
-                 firehose that fills it. trace_log is disabled in override.xml; turn the
-                 samplers off too so they don't burn CPU producing discarded rows. -->
+            <!-- Samplers only feed trace_log, which is disabled -->
             <memory_profiler_step>0</memory_profiler_step>
             <memory_profiler_sample_probability>0</memory_profiler_sample_probability>
             <query_profiler_real_time_period_ns>0</query_profiler_real_time_period_ns>

--- a/hosting/docker/clickhouse/users-override.xml
+++ b/hosting/docker/clickhouse/users-override.xml
@@ -1,6 +1,7 @@
 <clickhouse>
     <profiles>
         <default>
+            <max_threads>1</max_threads>
             <max_block_size>8192</max_block_size>
             <max_download_threads>1</max_download_threads>
             <input_format_parallel_parsing>0</input_format_parallel_parsing>

--- a/hosting/docker/clickhouse/users-override.xml
+++ b/hosting/docker/clickhouse/users-override.xml
@@ -1,0 +1,21 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <!-- Low-memory settings for the recommended webapp machine size. These were
+                 previously in config.d/override.xml where profile settings are silently
+                 ignored — they only take effect from the users config tree (#4343). -->
+            <max_block_size>8192</max_block_size>
+            <max_download_threads>1</max_download_threads>
+            <input_format_parallel_parsing>0</input_format_parallel_parsing>
+            <output_format_parallel_formatting>0</output_format_parallel_formatting>
+            <!-- The memory/query profilers sample stacks into system.trace_log
+                 (a Memory/MemoryPeak sample every 4 MB allocated, by default) — the main
+                 firehose that fills it. trace_log is disabled in override.xml; turn the
+                 samplers off too so they don't burn CPU producing discarded rows. -->
+            <memory_profiler_step>0</memory_profiler_step>
+            <memory_profiler_sample_probability>0</memory_profiler_sample_probability>
+            <query_profiler_real_time_period_ns>0</query_profiler_real_time_period_ns>
+            <query_profiler_cpu_time_period_ns>0</query_profiler_cpu_time_period_ns>
+        </default>
+    </profiles>
+</clickhouse>

--- a/hosting/docker/webapp/docker-compose.yml
+++ b/hosting/docker/webapp/docker-compose.yml
@@ -177,6 +177,7 @@ services:
       - clickhouse:/var/lib/clickhouse
       - ../clickhouse/data-paths.xml:/etc/clickhouse-server/config.d/data-paths.xml:ro
       - ../clickhouse/override.xml:/etc/clickhouse-server/config.d/override.xml:ro
+      - ../clickhouse/users-override.xml:/etc/clickhouse-server/users.d/override.xml:ro
     networks:
       - webapp
     healthcheck:


### PR DESCRIPTION
Carries over the self-hosted ClickHouse fix from #4546 by @Leafgard, whose commits are preserved here, plus follow-up polish. Opened in-repo because the fork is org-owned, which GitHub's "Allow edits from maintainers" doesn't cover.

fixes #4343

## What was wrong

Two independent problems in `hosting/docker/clickhouse/`:

1. **The `<profiles>` block never applied.** It sits in `override.xml`, mounted under `config.d` - but ClickHouse only reads profile settings from the users config tree. Verified on the pinned image: before this change `max_block_size` sat at its default `65409` with `changed=0`, so the advertised low-memory settings had never taken effect at all.
2. **Every ClickHouse system log table was enabled and unbounded.** On a sub-16GB machine their background merges outgrow the memory cap; ClickHouse's [low-RAM guide](https://clickhouse.com/docs/operations/tips) recommends disabling them. The dev stack already does this - `hosting/docker` never got it.

## What this does

- `clickhouse/override.xml`: disables the high-frequency telemetry tables, and bounds the ones worth keeping with a config-level `<ttl>` - `query_log` and `part_log` at 7 days, `error_log` at 30. A config-level TTL survives log-table recreation, unlike `ALTER ... MODIFY TTL`.
- New `clickhouse/users-override.xml`, mounted at `users.d/override.xml`: carries the profile settings so they actually apply, completes the sub-16GB set with `max_threads=1`, and zeroes the memory/query profilers, whose samples were the main source feeding `trace_log`.
- `webapp/docker-compose.yml`: adds the `users.d` mount.

## Verification

Ran `clickhouse/clickhouse-server:26.2` with these exact mounts, and `25.12` to cover the documented 25.8 floor:

- All 9 profile settings report `changed=1`, and a custom `CLICKHOUSE_USER` inherits them.
- `users.d` merges rather than replaces: the `default` user, its password, `access_management` and the `readonly` profile all survive, so the compose healthcheck still passes.
- `remove="1"` is a clean no-op on keys absent from a given version - no empty section, no accidental table, no startup error - so pinning `CLICKHOUSE_IMAGE_TAG` to an older supported tag won't crash-loop.
- TTLs land in the real DDL: `TTL event_date + toIntervalDay(7)` / `(30)`.
- In-place upgrade on a populated volume: clean restart, data preserved, and ClickHouse lazily renames the pre-existing `query_log`/`error_log` to `query_log_0`/`error_log_0` as it applies the new retention.

## Notes for review

- **`part_log` is kept (bounded) rather than disabled.** It appears in neither report behind this change and isn't on ClickHouse's sub-16GB list, but it's the merge history you'd need to diagnose a recurrence. Measured at ~0.18 KiB per part event under insert churn - about 10x cheaper than `text_log` over the same window - so a TTL bounds it rather than removing it.
- **The profile settings go live for the first time here.** On larger machines that's a real, intended throughput change: `max_threads=1`, `max_download_threads=1`, parallel parsing and formatting off.
- **Disabling a log table stops new writes but doesn't delete existing data.** Reclaiming disk on an existing deployment needs `DROP TABLE system.<name> SYNC`, including the `*_log_0` leftovers.

## Known gaps, deliberately not in this PR

- The Helm chart carries the same ineffective `<profiles>` block in `values.yaml` and mounts nothing into `users.d`, so this fix isn't currently expressible there.
- `background_schedule_pool_log` is enabled by default with no TTL and is disabled by neither stack.
- The dev stack's disable list has drifted from this one.
- The compose healthcheck still logs a query every 5 seconds.
