### PR TITLE
feat(webapp,clickhouse): return an actionable error instead of a 500 when a runs list query is too expensive

### DIFF
--- a/.server-changes/runs-list-query-limit-error.md
+++ b/.server-changes/runs-list-query-limit-error.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+When a runs list or runs.list API request spans too much data to complete, it now returns a clear, actionable error asking you to narrow the time range, instead of failing with a generic error.

--- a/apps/webapp/app/components/runs/v3/RunsListErrorState.tsx
+++ b/apps/webapp/app/components/runs/v3/RunsListErrorState.tsx
@@ -1,0 +1,19 @@
+import { Callout } from "~/components/primitives/Callout";
+
+/**
+ * Error state for a runs list that failed to load. Shown as the `errorElement` of the deferred
+ * runs-list data. The most common recoverable cause is a query that was too expensive over a broad
+ * time range (see `RunsListQueryError`), so the copy guides narrowing the range; a refresh covers
+ * transient failures. The precise reason is not shown because Remix scrubs thrown error messages in
+ * production.
+ */
+export function RunsListErrorState() {
+  return (
+    <div className="flex items-center justify-center px-3 py-12">
+      <Callout variant="error" className="max-w-fit">
+        We couldn't load these runs. If you're filtering over a broad time range, try narrowing it,
+        then refresh to try again.
+      </Callout>
+    </div>
+  );
+}

--- a/apps/webapp/app/components/runs/v3/RunsListErrorState.tsx
+++ b/apps/webapp/app/components/runs/v3/RunsListErrorState.tsx
@@ -17,3 +17,12 @@ export function RunsListErrorState() {
     </div>
   );
 }
+
+/**
+ * Renders nothing. Used as the `errorElement` for secondary awaits of the same runs-list promise
+ * (e.g. the pagination controls), so a rejection is handled locally there and does not bubble to
+ * the route error boundary. The primary awaits render {@link RunsListErrorState}.
+ */
+export function RunsListErrorStateNoop() {
+  return null;
+}

--- a/apps/webapp/app/presenters/v3/ErrorGroupPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/ErrorGroupPresenter.server.ts
@@ -87,7 +87,8 @@ export class ErrorGroupPresenter extends BasePresenter {
   constructor(
     private readonly replica: PrismaClientOrTransaction,
     private readonly logsClickhouse: ClickHouse,
-    private readonly clickhouse: ClickHouse
+    private readonly clickhouse: ClickHouse,
+    private readonly runsListClickhouse: ClickHouse
   ) {
     super(undefined, replica);
   }
@@ -409,7 +410,7 @@ export class ErrorGroupPresenter extends BasePresenter {
       columns?: RunColumnsSelect;
     }
   ): Promise<NextRunList | undefined> {
-    const runListPresenter = new NextRunListPresenter(this.replica, this.clickhouse);
+    const runListPresenter = new NextRunListPresenter(this.replica, this.runsListClickhouse);
 
     const result = await runListPresenter.call(organizationId, environmentId, {
       userId: options.userId,

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentParam/route.tsx
@@ -22,7 +22,10 @@ import { Paragraph } from "~/components/primitives/Paragraph";
 import * as Property from "~/components/primitives/PropertyTable";
 import { Spinner } from "~/components/primitives/Spinner";
 import { TabButton, TabContainer } from "~/components/primitives/Tabs";
-import { RunsListErrorState } from "~/components/runs/v3/RunsListErrorState";
+import {
+  RunsListErrorState,
+  RunsListErrorStateNoop,
+} from "~/components/runs/v3/RunsListErrorState";
 import { RunsListQueryError } from "~/services/runsRepository/runsRepository.server";
 import { TimeFilter, timeFilterFromTo } from "~/components/runs/v3/SharedFilters";
 import { TaskRunsTable } from "~/components/runs/v3/TaskRunsTable";
@@ -348,7 +351,7 @@ export default function Page() {
                   <>
                     <RunsDisplayOptions sampleFilters={{ tasks: agent.slug, rootOnly: "false" }} />
                     <Suspense fallback={null}>
-                      <TypedAwait resolve={runList} errorElement={<></>}>
+                      <TypedAwait resolve={runList} errorElement={<RunsListErrorStateNoop />}>
                         {(list) => (list ? <ListPagination list={list} /> : null)}
                       </TypedAwait>
                     </Suspense>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentParam/route.tsx
@@ -23,6 +23,7 @@ import * as Property from "~/components/primitives/PropertyTable";
 import { Spinner } from "~/components/primitives/Spinner";
 import { TabButton, TabContainer } from "~/components/primitives/Tabs";
 import { RunsListErrorState } from "~/components/runs/v3/RunsListErrorState";
+import { RunsListQueryError } from "~/services/runsRepository/runsRepository.server";
 import { TimeFilter, timeFilterFromTo } from "~/components/runs/v3/SharedFilters";
 import { TaskRunsTable } from "~/components/runs/v3/TaskRunsTable";
 import { SessionsTable } from "~/components/sessions/v1/SessionsTable";
@@ -93,10 +94,10 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const directionRaw = url.searchParams.get("direction") ?? undefined;
   const direction = directionRaw ? DirectionSchema.parse(directionRaw) : undefined;
 
-  const clickhouse = await clickhouseFactory.getClickhouseForOrganization(
-    project.organizationId,
-    "standard"
-  );
+  const [clickhouse, runsListClickhouse] = await Promise.all([
+    clickhouseFactory.getClickhouseForOrganization(project.organizationId, "standard"),
+    clickhouseFactory.getClickhouseForOrganization(project.organizationId, "runsList"),
+  ]);
 
   const presenter = new AgentDetailPresenter($replica, clickhouse);
   const agent = await presenter.findAgent({
@@ -155,7 +156,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     })
     .catch(() => ({ data: [], statuses: [] }) satisfies AgentActivity);
 
-  const runList = new NextRunListPresenter($replica, clickhouse)
+  const runList = new NextRunListPresenter($replica, runsListClickhouse)
     .call(project.organizationId, environment.id, {
       userId,
       projectId: project.id,
@@ -167,7 +168,12 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
       direction,
       columns: getRunColumnsForSelect(request),
     })
-    .catch(() => null);
+    .catch((error) => {
+      if (error instanceof RunsListQueryError) {
+        throw error;
+      }
+      return null;
+    });
 
   const sessionList = new SessionListPresenter($replica, clickhouse)
     .call(project.organizationId, environment.id, {
@@ -342,7 +348,7 @@ export default function Page() {
                   <>
                     <RunsDisplayOptions sampleFilters={{ tasks: agent.slug, rootOnly: "false" }} />
                     <Suspense fallback={null}>
-                      <TypedAwait resolve={runList} errorElement={null}>
+                      <TypedAwait resolve={runList} errorElement={<></>}>
                         {(list) => (list ? <ListPagination list={list} /> : null)}
                       </TypedAwait>
                     </Suspense>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentParam/route.tsx
@@ -22,6 +22,7 @@ import { Paragraph } from "~/components/primitives/Paragraph";
 import * as Property from "~/components/primitives/PropertyTable";
 import { Spinner } from "~/components/primitives/Spinner";
 import { TabButton, TabContainer } from "~/components/primitives/Tabs";
+import { RunsListErrorState } from "~/components/runs/v3/RunsListErrorState";
 import { TimeFilter, timeFilterFromTo } from "~/components/runs/v3/SharedFilters";
 import { TaskRunsTable } from "~/components/runs/v3/TaskRunsTable";
 import { SessionsTable } from "~/components/sessions/v1/SessionsTable";
@@ -395,7 +396,7 @@ function AgentContentArea({
     </Suspense>
   ) : (
     <Suspense fallback={<TableLoading />}>
-      <TypedAwait resolve={runList} errorElement={<TableLoading />}>
+      <TypedAwait resolve={runList} errorElement={<RunsListErrorState />}>
         {(list) =>
           list ? (
             <TaskRunsTable

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.errors.$fingerprint/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.errors.$fingerprint/route.tsx
@@ -255,12 +255,18 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const directionRaw = url.searchParams.get("direction") ?? undefined;
   const direction = directionRaw ? DirectionSchema.parse(directionRaw) : undefined;
 
-  const [logsClickhouseClient, clickhouseClient] = await Promise.all([
+  const [logsClickhouseClient, clickhouseClient, runsListClickhouseClient] = await Promise.all([
     clickhouseFactory.getClickhouseForOrganization(environment.organizationId, "logs"),
     clickhouseFactory.getClickhouseForOrganization(environment.organizationId, "standard"),
+    clickhouseFactory.getClickhouseForOrganization(environment.organizationId, "runsList"),
   ]);
 
-  const presenter = new ErrorGroupPresenter($replica, logsClickhouseClient, clickhouseClient);
+  const presenter = new ErrorGroupPresenter(
+    $replica,
+    logsClickhouseClient,
+    clickhouseClient,
+    runsListClickhouseClient
+  );
 
   const detailPromise = presenter
     .call(project.organizationId, environment.id, {

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.errors.$fingerprint/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.errors.$fingerprint/route.tsx
@@ -55,6 +55,7 @@ import { Spinner } from "~/components/primitives/Spinner";
 import { useToast } from "~/components/primitives/Toast";
 import TooltipPortal from "~/components/primitives/TooltipPortal";
 import type { TaskRunListSearchFilters } from "~/components/runs/v3/RunFilters";
+import { RunsListErrorState } from "~/components/runs/v3/RunsListErrorState";
 import { TimeFilter, timeFilterFromTo } from "~/components/runs/v3/SharedFilters";
 import { TaskRunsTable } from "~/components/runs/v3/TaskRunsTable";
 import { $replica } from "~/db.server";
@@ -393,16 +394,7 @@ export default function Page() {
             </div>
           }
         >
-          <TypedAwait
-            resolve={data}
-            errorElement={
-              <div className="flex items-center justify-center px-3 py-12">
-                <Callout variant="error" className="max-w-fit">
-                  Unable to load error details. Please refresh the page or try again in a moment.
-                </Callout>
-              </div>
-            }
-          >
+          <TypedAwait resolve={data} errorElement={<RunsListErrorState />}>
             {(result) => {
               if ("error" in result) {
                 return (

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs._index/route.tsx
@@ -74,7 +74,7 @@ import {
 import { throwNotFound } from "~/utils/httpErrors";
 import { ListPagination } from "../../components/ListPagination";
 import { CreateBulkActionInspector } from "../resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.runs.bulkaction";
-import { Callout } from "~/components/primitives/Callout";
+import { RunsListErrorState } from "~/components/runs/v3/RunsListErrorState";
 import {
   isRunsListLoading,
   RUNS_BULK_INSPECTOR_OPEN_VALUE,
@@ -208,17 +208,7 @@ export default function Page() {
                 </div>
               }
             >
-              <TypedAwait
-                resolve={data}
-                errorElement={
-                  <div className="flex items-center justify-center px-3 py-12">
-                    <Callout variant="error" className="max-w-fit">
-                      Unable to load your task runs. Please refresh the page or try again in a
-                      moment.
-                    </Callout>
-                  </div>
-                }
-              >
+              <TypedAwait resolve={data} errorElement={<RunsListErrorState />}>
                 {(list) => {
                   return (
                     <RunsList

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.tasks.scheduled.$taskParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.tasks.scheduled.$taskParam/route.tsx
@@ -61,6 +61,7 @@ import { TabButton, TabContainer } from "~/components/primitives/Tabs";
 import { useToast } from "~/components/primitives/Toast";
 import { EnabledStatus } from "~/components/runs/v3/EnabledStatus";
 import { RunsListErrorState } from "~/components/runs/v3/RunsListErrorState";
+import { RunsListQueryError } from "~/services/runsRepository/runsRepository.server";
 import type { TaskRunListSearchFilters } from "~/components/runs/v3/RunFilters";
 import { ScheduleTypeIcon, scheduleTypeName } from "~/components/runs/v3/ScheduleType";
 import { TimeFilter, timeFilterFromTo } from "~/components/runs/v3/SharedFilters";
@@ -144,10 +145,10 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const directionRaw = url.searchParams.get("direction") ?? undefined;
   const direction = directionRaw ? DirectionSchema.parse(directionRaw) : undefined;
 
-  const clickhouse = await clickhouseFactory.getClickhouseForOrganization(
-    project.organizationId,
-    "standard"
-  );
+  const [clickhouse, runsListClickhouse] = await Promise.all([
+    clickhouseFactory.getClickhouseForOrganization(project.organizationId, "standard"),
+    clickhouseFactory.getClickhouseForOrganization(project.organizationId, "runsList"),
+  ]);
 
   const taskPresenter = new TaskDetailPresenter($replica, clickhouse);
   const task = await taskPresenter.findTask({
@@ -212,7 +213,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     })
     .catch(() => null);
 
-  const runList = new NextRunListPresenter($replica, clickhouse)
+  const runList = new NextRunListPresenter($replica, runsListClickhouse)
     .call(project.organizationId, environment.id, {
       userId,
       projectId: project.id,
@@ -225,7 +226,12 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
       includeHasAnyRuns: true,
       columns: getRunColumnsForSelect(request),
     })
-    .catch(() => null);
+    .catch((error) => {
+      if (error instanceof RunsListQueryError) {
+        throw error;
+      }
+      return null;
+    });
 
   return typeddefer({
     task,
@@ -376,7 +382,7 @@ export default function Page() {
                       ) : null}
                       <RunsDisplayOptions sampleFilters={{ tasks: task.slug, rootOnly: "false" }} />
                       <Suspense fallback={null}>
-                        <TypedAwait resolve={runList} errorElement={null}>
+                        <TypedAwait resolve={runList} errorElement={<></>}>
                           {(list) => (list ? <ListPagination list={list} /> : null)}
                         </TypedAwait>
                       </Suspense>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.tasks.scheduled.$taskParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.tasks.scheduled.$taskParam/route.tsx
@@ -60,6 +60,7 @@ import {
 import { TabButton, TabContainer } from "~/components/primitives/Tabs";
 import { useToast } from "~/components/primitives/Toast";
 import { EnabledStatus } from "~/components/runs/v3/EnabledStatus";
+import { RunsListErrorState } from "~/components/runs/v3/RunsListErrorState";
 import type { TaskRunListSearchFilters } from "~/components/runs/v3/RunFilters";
 import { ScheduleTypeIcon, scheduleTypeName } from "~/components/runs/v3/ScheduleType";
 import { TimeFilter, timeFilterFromTo } from "~/components/runs/v3/SharedFilters";
@@ -382,7 +383,7 @@ export default function Page() {
                     </TitleBar>
                     <div className="min-h-0 overflow-hidden">
                       <Suspense fallback={<TableLoading />}>
-                        <TypedAwait resolve={runList} errorElement={<TableLoading />}>
+                        <TypedAwait resolve={runList} errorElement={<RunsListErrorState />}>
                           {(list) =>
                             list ? (
                               <TaskRunsList

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.tasks.scheduled.$taskParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.tasks.scheduled.$taskParam/route.tsx
@@ -60,7 +60,10 @@ import {
 import { TabButton, TabContainer } from "~/components/primitives/Tabs";
 import { useToast } from "~/components/primitives/Toast";
 import { EnabledStatus } from "~/components/runs/v3/EnabledStatus";
-import { RunsListErrorState } from "~/components/runs/v3/RunsListErrorState";
+import {
+  RunsListErrorState,
+  RunsListErrorStateNoop,
+} from "~/components/runs/v3/RunsListErrorState";
 import { RunsListQueryError } from "~/services/runsRepository/runsRepository.server";
 import type { TaskRunListSearchFilters } from "~/components/runs/v3/RunFilters";
 import { ScheduleTypeIcon, scheduleTypeName } from "~/components/runs/v3/ScheduleType";
@@ -382,7 +385,7 @@ export default function Page() {
                       ) : null}
                       <RunsDisplayOptions sampleFilters={{ tasks: task.slug, rootOnly: "false" }} />
                       <Suspense fallback={null}>
-                        <TypedAwait resolve={runList} errorElement={<></>}>
+                        <TypedAwait resolve={runList} errorElement={<RunsListErrorStateNoop />}>
                           {(list) => (list ? <ListPagination list={list} /> : null)}
                         </TypedAwait>
                       </Suspense>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.tasks.standard.$taskParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.tasks.standard.$taskParam/route.tsx
@@ -30,7 +30,10 @@ import {
 } from "~/components/primitives/Resizable";
 import { Spinner } from "~/components/primitives/Spinner";
 import { TextLink } from "~/components/primitives/TextLink";
-import { RunsListErrorState } from "~/components/runs/v3/RunsListErrorState";
+import {
+  RunsListErrorState,
+  RunsListErrorStateNoop,
+} from "~/components/runs/v3/RunsListErrorState";
 import { RunsListQueryError } from "~/services/runsRepository/runsRepository.server";
 import { TimeFilter, timeFilterFromTo } from "~/components/runs/v3/SharedFilters";
 import {
@@ -278,7 +281,7 @@ export default function Page() {
                       ) : null}
                       <RunsDisplayOptions sampleFilters={{ tasks: task.slug, rootOnly: "false" }} />
                       <Suspense fallback={null}>
-                        <TypedAwait resolve={runList} errorElement={<></>}>
+                        <TypedAwait resolve={runList} errorElement={<RunsListErrorStateNoop />}>
                           {(list) => (list ? <ListPagination list={list} /> : null)}
                         </TypedAwait>
                       </Suspense>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.tasks.standard.$taskParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.tasks.standard.$taskParam/route.tsx
@@ -31,6 +31,7 @@ import {
 import { Spinner } from "~/components/primitives/Spinner";
 import { TextLink } from "~/components/primitives/TextLink";
 import { RunsListErrorState } from "~/components/runs/v3/RunsListErrorState";
+import { RunsListQueryError } from "~/services/runsRepository/runsRepository.server";
 import { TimeFilter, timeFilterFromTo } from "~/components/runs/v3/SharedFilters";
 import {
   QUEUE_METRIC_COLORS,
@@ -104,10 +105,10 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const direction = directionRaw ? DirectionSchema.parse(directionRaw) : undefined;
   const versions = url.searchParams.getAll("versions").filter((v) => v.length > 0);
 
-  const clickhouse = await clickhouseFactory.getClickhouseForOrganization(
-    project.organizationId,
-    "standard"
-  );
+  const [clickhouse, runsListClickhouse] = await Promise.all([
+    clickhouseFactory.getClickhouseForOrganization(project.organizationId, "standard"),
+    clickhouseFactory.getClickhouseForOrganization(project.organizationId, "runsList"),
+  ]);
 
   const presenter = new TaskDetailPresenter($replica, clickhouse);
   const task = await presenter.findTask({
@@ -154,7 +155,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     })
     .catch(() => ({ data: [], statuses: [] }) satisfies TaskActivity);
 
-  const runList = new NextRunListPresenter($replica, clickhouse)
+  const runList = new NextRunListPresenter($replica, runsListClickhouse)
     .call(project.organizationId, environment.id, {
       userId,
       projectId: project.id,
@@ -168,7 +169,12 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
       includeHasAnyRuns: true,
       columns: getRunColumnsForSelect(request),
     })
-    .catch(() => null);
+    .catch((error) => {
+      if (error instanceof RunsListQueryError) {
+        throw error;
+      }
+      return null;
+    });
 
   return typeddefer({
     task,
@@ -272,7 +278,7 @@ export default function Page() {
                       ) : null}
                       <RunsDisplayOptions sampleFilters={{ tasks: task.slug, rootOnly: "false" }} />
                       <Suspense fallback={null}>
-                        <TypedAwait resolve={runList} errorElement={null}>
+                        <TypedAwait resolve={runList} errorElement={<></>}>
                           {(list) => (list ? <ListPagination list={list} /> : null)}
                         </TypedAwait>
                       </Suspense>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.tasks.standard.$taskParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.tasks.standard.$taskParam/route.tsx
@@ -30,6 +30,7 @@ import {
 } from "~/components/primitives/Resizable";
 import { Spinner } from "~/components/primitives/Spinner";
 import { TextLink } from "~/components/primitives/TextLink";
+import { RunsListErrorState } from "~/components/runs/v3/RunsListErrorState";
 import { TimeFilter, timeFilterFromTo } from "~/components/runs/v3/SharedFilters";
 import {
   QUEUE_METRIC_COLORS,
@@ -278,7 +279,7 @@ export default function Page() {
                     </TitleBar>
                     <div className="min-h-0 overflow-hidden">
                       <Suspense fallback={<TableLoading />}>
-                        <TypedAwait resolve={runList} errorElement={<TableLoading />}>
+                        <TypedAwait resolve={runList} errorElement={<RunsListErrorState />}>
                           {(list) =>
                             list ? (
                               <TaskRunsList

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.webhooks.$webhookParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.webhooks.$webhookParam/route.tsx
@@ -29,7 +29,10 @@ import {
 import { PulsingDot } from "~/components/primitives/PulsingDot";
 import { Spinner } from "~/components/primitives/Spinner";
 import { TabButton, TabContainer } from "~/components/primitives/Tabs";
-import { RunsListErrorState } from "~/components/runs/v3/RunsListErrorState";
+import {
+  RunsListErrorState,
+  RunsListErrorStateNoop,
+} from "~/components/runs/v3/RunsListErrorState";
 import { RunsListQueryError } from "~/services/runsRepository/runsRepository.server";
 import { TimeFilter, timeFilterFromTo } from "~/components/runs/v3/SharedFilters";
 import { TaskRunsTable } from "~/components/runs/v3/TaskRunsTable";
@@ -336,7 +339,7 @@ export default function Page() {
                       </Suspense>
                     ) : (
                       <Suspense fallback={null}>
-                        <TypedAwait resolve={runList} errorElement={<></>}>
+                        <TypedAwait resolve={runList} errorElement={<RunsListErrorStateNoop />}>
                           {(list) =>
                             list ? (
                               <ListPagination

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.webhooks.$webhookParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.webhooks.$webhookParam/route.tsx
@@ -30,6 +30,7 @@ import { PulsingDot } from "~/components/primitives/PulsingDot";
 import { Spinner } from "~/components/primitives/Spinner";
 import { TabButton, TabContainer } from "~/components/primitives/Tabs";
 import { RunsListErrorState } from "~/components/runs/v3/RunsListErrorState";
+import { RunsListQueryError } from "~/services/runsRepository/runsRepository.server";
 import { TimeFilter, timeFilterFromTo } from "~/components/runs/v3/SharedFilters";
 import { TaskRunsTable } from "~/components/runs/v3/TaskRunsTable";
 import { DeliveriesTable } from "~/components/webhookDeliveries/v1/DeliveriesTable";
@@ -117,10 +118,10 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const runsDirectionRaw = url.searchParams.get("runsDirection") ?? undefined;
   const runsDirection = runsDirectionRaw ? DirectionSchema.parse(runsDirectionRaw) : undefined;
 
-  const clickhouse = await clickhouseFactory.getClickhouseForOrganization(
-    project.organizationId,
-    "standard"
-  );
+  const [clickhouse, runsListClickhouse] = await Promise.all([
+    clickhouseFactory.getClickhouseForOrganization(project.organizationId, "standard"),
+    clickhouseFactory.getClickhouseForOrganization(project.organizationId, "runsList"),
+  ]);
 
   const presenter = new WebhookDetailPresenter($replica, clickhouse);
   const webhook = await presenter.findWebhook({
@@ -157,7 +158,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     })
     .catch(() => ({ data: [], statuses: [] }) satisfies WebhookActivity);
 
-  const runList = new NextRunListPresenter($replica, clickhouse)
+  const runList = new NextRunListPresenter($replica, runsListClickhouse)
     .call(project.organizationId, environment.id, {
       userId,
       projectId: project.id,
@@ -168,7 +169,12 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
       cursor: runsCursor,
       direction: runsDirection,
     })
-    .catch(() => null);
+    .catch((error) => {
+      if (error instanceof RunsListQueryError) {
+        throw error;
+      }
+      return null;
+    });
 
   const deliveriesList = presenter
     .listDeliveries({
@@ -330,7 +336,7 @@ export default function Page() {
                       </Suspense>
                     ) : (
                       <Suspense fallback={null}>
-                        <TypedAwait resolve={runList} errorElement={<RunsListErrorState />}>
+                        <TypedAwait resolve={runList} errorElement={<></>}>
                           {(list) =>
                             list ? (
                               <ListPagination
@@ -483,7 +489,7 @@ function WebhookContentArea({
         </Suspense>
       ) : (
         <Suspense fallback={<TableLoading />}>
-          <TypedAwait resolve={runList} errorElement={<TableLoading />}>
+          <TypedAwait resolve={runList} errorElement={<RunsListErrorState />}>
             {(list) =>
               list ? (
                 <div className="h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-charcoal-600">

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.webhooks.$webhookParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.webhooks.$webhookParam/route.tsx
@@ -29,6 +29,7 @@ import {
 import { PulsingDot } from "~/components/primitives/PulsingDot";
 import { Spinner } from "~/components/primitives/Spinner";
 import { TabButton, TabContainer } from "~/components/primitives/Tabs";
+import { RunsListErrorState } from "~/components/runs/v3/RunsListErrorState";
 import { TimeFilter, timeFilterFromTo } from "~/components/runs/v3/SharedFilters";
 import { TaskRunsTable } from "~/components/runs/v3/TaskRunsTable";
 import { DeliveriesTable } from "~/components/webhookDeliveries/v1/DeliveriesTable";
@@ -329,7 +330,7 @@ export default function Page() {
                       </Suspense>
                     ) : (
                       <Suspense fallback={null}>
-                        <TypedAwait resolve={runList} errorElement={null}>
+                        <TypedAwait resolve={runList} errorElement={<RunsListErrorState />}>
                           {(list) =>
                             list ? (
                               <ListPagination

--- a/apps/webapp/app/routes/api.v1.runs.ts
+++ b/apps/webapp/app/routes/api.v1.runs.ts
@@ -8,6 +8,7 @@ import {
   createLoaderApiRoute,
   everyResource,
 } from "~/services/routeBuilders/apiBuilder.server";
+import { RunsListQueryError } from "~/services/runsRepository/runsRepository.server";
 
 export const loader = createLoaderApiRoute(
   {
@@ -40,13 +41,23 @@ export const loader = createLoaderApiRoute(
   },
   async ({ searchParams, authentication, apiVersion }) => {
     const presenter = new ApiRunListPresenter();
-    const result = await presenter.call(
-      authentication.environment.project,
-      searchParams,
-      apiVersion,
-      authentication.environment
-    );
+    try {
+      const result = await presenter.call(
+        authentication.environment.project,
+        searchParams,
+        apiVersion,
+        authentication.environment
+      );
 
-    return json(result);
+      return json(result);
+    } catch (error) {
+      if (error instanceof RunsListQueryError) {
+        return json(
+          { error: error.message },
+          { status: error.status, headers: { "x-should-retry": "false" } }
+        );
+      }
+      throw error;
+    }
   }
 );

--- a/apps/webapp/app/services/runsRepository/clickhouseRunsRepository.server.ts
+++ b/apps/webapp/app/services/runsRepository/clickhouseRunsRepository.server.ts
@@ -1,4 +1,4 @@
-import { type ClickhouseQueryBuilder } from "@internal/clickhouse";
+import { type ClickhouseQueryBuilder, isClickhouseResourceLimitError } from "@internal/clickhouse";
 import { ErrorId, RunId } from "@trigger.dev/core/v3/isomorphic";
 import {
   type FilterRunsOptions,
@@ -10,6 +10,7 @@ import {
   type RunsRepositoryOptions,
   type TagListOptions,
   convertRunListInputOptionsToFilterRunsOptions,
+  RunsListQueryError,
 } from "./runsRepository.server";
 import parseDuration from "parse-duration";
 import { decodeRunsCursor, encodeRunsCursor } from "./runsCursor.server";
@@ -18,6 +19,18 @@ import { type PrismaClientOrTransaction } from "~/db.server";
 
 import { boundedIn, type Prisma } from "@trigger.dev/database";
 type RunCursorRow = { runId: string; createdAt: number };
+
+/**
+ * Re-throws a runs-list query error, converting a ClickHouse resource-limit rejection (execution
+ * time or memory) into a typed {@link RunsListQueryError} so callers can surface an actionable 4xx
+ * instead of an opaque 500. Any other error is re-thrown unchanged.
+ */
+function rethrowRunsListQueryError(queryError: unknown): never {
+  if (isClickhouseResourceLimitError(queryError)) {
+    throw new RunsListQueryError(undefined, { cause: queryError });
+  }
+  throw queryError;
+}
 
 /**
  * Default hydrate select for the runs list, used when a caller does not derive
@@ -102,7 +115,7 @@ export class ClickHouseRunsRepository implements IRunsRepository {
     const [queryError, result] = await queryBuilder.execute();
 
     if (queryError) {
-      throw queryError;
+      rethrowRunsListQueryError(queryError);
     }
 
     return (result?.length ?? 0) > 0;
@@ -166,7 +179,7 @@ export class ClickHouseRunsRepository implements IRunsRepository {
     const [queryError, result] = await queryBuilder.execute();
 
     if (queryError) {
-      throw queryError;
+      rethrowRunsListQueryError(queryError);
     }
 
     return result.map((row) => ({ runId: row.run_id, createdAt: row.created_at_ms }));
@@ -349,7 +362,7 @@ export class ClickHouseRunsRepository implements IRunsRepository {
     const [queryError, result] = await queryBuilder.execute();
 
     if (queryError) {
-      throw queryError;
+      rethrowRunsListQueryError(queryError);
     }
 
     if (result.length === 0) {
@@ -402,7 +415,7 @@ export class ClickHouseRunsRepository implements IRunsRepository {
     const [queryError, result] = await queryBuilder.execute();
 
     if (queryError) {
-      throw queryError;
+      rethrowRunsListQueryError(queryError);
     }
 
     return {

--- a/apps/webapp/app/services/runsRepository/runsRepository.server.ts
+++ b/apps/webapp/app/services/runsRepository/runsRepository.server.ts
@@ -13,6 +13,33 @@ import { runStore as defaultRunStore } from "~/v3/runStore.server";
 import { startActiveSpan } from "~/v3/tracer.server";
 import { ClickHouseRunsRepository } from "./clickhouseRunsRepository.server";
 
+/**
+ * User-facing message when a runs-list query exceeds a ClickHouse resource limit. It tells the
+ * caller how to recover (a narrower time range restores partition pruning), and is safe to show
+ * on the dashboard and return from the public API.
+ */
+const RUNS_LIST_QUERY_TOO_EXPENSIVE_MESSAGE =
+  "This query was too expensive to run over the selected time range. Narrow the time window (a shorter period, or a smaller createdAt from/to range) and try again.";
+
+/**
+ * Thrown when a runs-list ClickHouse query hits a server-side resource limit (execution time or
+ * memory). It is the caller's query being too broad, not a service fault, so it carries a 4xx
+ * status and a recovery message rather than surfacing as a 500.
+ */
+export class RunsListQueryError extends Error {
+  public readonly name = "RunsListQueryError";
+  public readonly status = 422;
+  constructor(
+    message: string = RUNS_LIST_QUERY_TOO_EXPENSIVE_MESSAGE,
+    options?: { cause?: unknown }
+  ) {
+    super(message);
+    if (options?.cause !== undefined) {
+      this.cause = options.cause;
+    }
+  }
+}
+
 export type RunsRepositoryOptions = {
   clickhouse: ClickHouse;
   prisma: PrismaClientOrTransaction;

--- a/apps/webapp/test/clickhouseQueryMetrics.test.ts
+++ b/apps/webapp/test/clickhouseQueryMetrics.test.ts
@@ -1,0 +1,93 @@
+import { ClickHouse } from "@internal/clickhouse";
+import { containerTest } from "@internal/testcontainers";
+import { describe, expect, vi } from "vitest";
+import { RunsRepository } from "~/services/runsRepository/runsRepository.server";
+import {
+  createRun,
+  insertTaskRunV2Rows,
+  seedParents,
+} from "./helpers/apiRunListPresenterTestHelpers";
+import { createInMemoryMetrics } from "./utils/tracing";
+import { histogramCount, latestMetrics, metricSum } from "./otlpMetrics.helpers";
+
+vi.mock("~/db.server", () => ({ prisma: {}, $replica: {} }));
+
+vi.setConfig({ testTimeout: 90_000 });
+
+describe("clickhouse query metrics", () => {
+  containerTest(
+    "records duration + read_rows on success and an error metric with the ClickHouse error type",
+    async ({ clickhouseContainer, prisma }) => {
+      const ctx = await seedParents(prisma, "chm");
+      const run = await createRun(prisma, ctx, { friendlyId: "run_chm" });
+
+      const seedClient = new ClickHouse({
+        url: clickhouseContainer.getConnectionUrl(),
+        name: "clickhouse-metrics-seed",
+      });
+      await insertTaskRunV2Rows(seedClient, [{ ...run, createdAt: new Date() }]);
+
+      const listArgs = {
+        page: { size: 10 } as const,
+        organizationId: ctx.organizationId,
+        projectId: ctx.projectId,
+        environmentId: ctx.environmentId,
+      };
+
+      const okMetrics = createInMemoryMetrics();
+      const okClient = new ClickHouse({
+        url: clickhouseContainer.getConnectionUrl(),
+        name: "clickhouse-metrics-ok",
+        meter: okMetrics.meter,
+      });
+      const okRepo = new RunsRepository({ prisma, clickhouse: okClient });
+      const result = await okRepo.listRuns(listArgs);
+      expect(result.runs.map((r) => r.friendlyId)).toEqual(["run_chm"]);
+
+      await vi.waitFor(
+        async () => {
+          const rm = await latestMetrics(okMetrics);
+          expect(
+            histogramCount(rm, "clickhouse.query.duration", {
+              client: "clickhouse-metrics-ok",
+              status: "ok",
+            })
+          ).toBeGreaterThanOrEqual(1);
+        },
+        { timeout: 5000, interval: 50 }
+      );
+      const okRm = await latestMetrics(okMetrics);
+      expect(
+        histogramCount(okRm, "clickhouse.query.read_rows", { client: "clickhouse-metrics-ok" })
+      ).toBeGreaterThanOrEqual(1);
+      expect(
+        histogramCount(okRm, "clickhouse.query.memory_usage", { client: "clickhouse-metrics-ok" })
+      ).toBeGreaterThanOrEqual(1);
+      await okMetrics.shutdown();
+
+      const errMetrics = createInMemoryMetrics();
+      const cappedClient = new ClickHouse({
+        url: clickhouseContainer.getConnectionUrl(),
+        name: "clickhouse-metrics-capped",
+        clickhouseSettings: { max_memory_usage: "1" },
+        meter: errMetrics.meter,
+      });
+      const errRepo = new RunsRepository({ prisma, clickhouse: cappedClient });
+      await expect(errRepo.listRuns(listArgs)).rejects.toThrow();
+
+      await vi.waitFor(
+        async () => {
+          const rm = await latestMetrics(errMetrics);
+          expect(
+            metricSum(rm, "clickhouse.query.errors", {
+              client: "clickhouse-metrics-capped",
+              error_type: "MEMORY_LIMIT_EXCEEDED",
+            })
+          ).toBeGreaterThanOrEqual(1);
+        },
+        { timeout: 5000, interval: 50 }
+      );
+      await errMetrics.shutdown();
+    }
+  );
+});

--- a/apps/webapp/test/runsListQueryError.test.ts
+++ b/apps/webapp/test/runsListQueryError.test.ts
@@ -1,0 +1,52 @@
+import { ClickHouse } from "@internal/clickhouse";
+import { containerTest } from "@internal/testcontainers";
+import { describe, expect, vi } from "vitest";
+import {
+  RunsListQueryError,
+  RunsRepository,
+} from "~/services/runsRepository/runsRepository.server";
+import {
+  createRun,
+  insertTaskRunV2Rows,
+  seedParents,
+} from "./helpers/apiRunListPresenterTestHelpers";
+
+vi.mock("~/db.server", () => ({ prisma: {}, $replica: {} }));
+
+vi.setConfig({ testTimeout: 90_000 });
+
+describe("runs list query error handling", () => {
+  containerTest(
+    "a ClickHouse resource-limit error surfaces as RunsListQueryError",
+    async ({ clickhouseContainer, prisma }) => {
+      const ctx = await seedParents(prisma, "qerr");
+      const run = await createRun(prisma, ctx, { friendlyId: "run_qerr" });
+
+      const seedClient = new ClickHouse({
+        url: clickhouseContainer.getConnectionUrl(),
+        name: "runs-list-query-error-seed",
+      });
+      await insertTaskRunV2Rows(seedClient, [{ ...run, createdAt: new Date() }]);
+
+      const listArgs = {
+        page: { size: 10 } as const,
+        organizationId: ctx.organizationId,
+        projectId: ctx.projectId,
+        environmentId: ctx.environmentId,
+      };
+
+      const cappedClient = new ClickHouse({
+        url: clickhouseContainer.getConnectionUrl(),
+        name: "runs-list-query-error-capped",
+        clickhouseSettings: { max_memory_usage: "1" },
+      });
+      const capped = new RunsRepository({ prisma, clickhouse: cappedClient });
+      await expect(capped.listRuns(listArgs)).rejects.toBeInstanceOf(RunsListQueryError);
+      await expect(capped.countRuns(listArgs)).rejects.toBeInstanceOf(RunsListQueryError);
+
+      const ok = new RunsRepository({ prisma, clickhouse: seedClient });
+      const result = await ok.listRuns(listArgs);
+      expect(result.runs.map((r) => r.friendlyId)).toEqual(["run_qerr"]);
+    }
+  );
+});

--- a/internal-packages/clickhouse/src/client/client.ts
+++ b/internal-packages/clickhouse/src/client/client.ts
@@ -187,9 +187,11 @@ export class ClickhouseClient implements ClickhouseReader, ClickhouseWriter {
           recordClickhouseError(span, clickhouseError);
 
           return [
-            new QueryError(`Unable to query clickhouse: ${clickhouseError.message}`, {
-              query: req.query,
-            }),
+            new QueryError(
+              `Unable to query clickhouse: ${clickhouseError.message}`,
+              { query: req.query },
+              clickhouseError instanceof ClickHouseError ? clickhouseError.type : undefined
+            ),
             null,
           ];
         }
@@ -358,9 +360,11 @@ export class ClickhouseClient implements ClickhouseReader, ClickhouseWriter {
           recordClickhouseError(span, clickhouseError);
 
           return [
-            new QueryError(`Unable to query clickhouse: ${clickhouseError.message}`, {
-              query: req.query,
-            }),
+            new QueryError(
+              `Unable to query clickhouse: ${clickhouseError.message}`,
+              { query: req.query },
+              clickhouseError instanceof ClickHouseError ? clickhouseError.type : undefined
+            ),
             null,
           ];
         }
@@ -493,9 +497,11 @@ export class ClickhouseClient implements ClickhouseReader, ClickhouseWriter {
           recordClickhouseError(span, clickhouseError);
 
           return [
-            new QueryError(`Unable to query clickhouse: ${clickhouseError.message}`, {
-              query: req.query,
-            }),
+            new QueryError(
+              `Unable to query clickhouse: ${clickhouseError.message}`,
+              { query: req.query },
+              clickhouseError instanceof ClickHouseError ? clickhouseError.type : undefined
+            ),
             null,
           ];
         }

--- a/internal-packages/clickhouse/src/client/client.ts
+++ b/internal-packages/clickhouse/src/client/client.ts
@@ -7,8 +7,8 @@ import {
   type BaseQueryParams,
   type InsertResult,
 } from "@clickhouse/client";
-import type { Span, Tracer } from "@internal/tracing";
-import { recordSpanError, startSpan, trace } from "@internal/tracing";
+import type { Counter, Histogram, Meter, Span, Tracer, UpDownCounter } from "@internal/tracing";
+import { getMeter, recordSpanError, startSpan, trace } from "@internal/tracing";
 import { flattenAttributes, tryCatch, type Result } from "@trigger.dev/core/v3";
 import { z } from "zod";
 import { InsertError, QueryError } from "./errors.js";
@@ -43,6 +43,7 @@ export type ClickhouseConfig = {
   httpAgent?: HttpAgent | HttpsAgent;
   clickhouseSettings?: ClickHouseSettings;
   logger?: Logger;
+  meter?: Meter;
   maxOpenConnections?: number;
   requestTimeoutMs?: number;
   logLevel?: LogLevel;
@@ -57,10 +58,48 @@ export class ClickhouseClient implements ClickhouseReader, ClickhouseWriter {
   private readonly tracer: Tracer;
   private readonly name: string;
   private readonly logger: Logger;
+  private readonly meter: Meter;
+  private readonly queryInFlight: UpDownCounter;
+  private readonly queryDuration: Histogram;
+  private readonly queryServerDuration: Histogram;
+  private readonly queryReadRows: Histogram;
+  private readonly queryReadBytes: Histogram;
+  private readonly queryMemoryUsage: Histogram;
+  private readonly queryErrors: Counter;
 
   constructor(config: ClickhouseConfig) {
     this.name = config.name;
     this.logger = config.logger ?? new Logger("ClickhouseClient", config.logLevel ?? "info");
+
+    this.meter = config.meter ?? getMeter("clickhouse");
+    this.queryInFlight = this.meter.createUpDownCounter("clickhouse.query.in_flight", {
+      description: "Concurrent in-flight ClickHouse queries per client, a pool-saturation signal",
+    });
+    this.queryDuration = this.meter.createHistogram("clickhouse.query.duration", {
+      description:
+        "Wall-clock ClickHouse query duration, includes client-side connection-pool wait",
+      unit: "ms",
+    });
+    this.queryServerDuration = this.meter.createHistogram("clickhouse.query.server_duration", {
+      description: "Server-side ClickHouse query duration from the x-clickhouse-summary elapsed_ns",
+      unit: "ms",
+    });
+    this.queryReadRows = this.meter.createHistogram("clickhouse.query.read_rows", {
+      description: "Rows read by a ClickHouse query, from the x-clickhouse-summary header",
+      unit: "{row}",
+    });
+    this.queryReadBytes = this.meter.createHistogram("clickhouse.query.read_bytes", {
+      description: "Bytes read by a ClickHouse query, from the x-clickhouse-summary header",
+      unit: "By",
+    });
+    this.queryMemoryUsage = this.meter.createHistogram("clickhouse.query.memory_usage", {
+      description: "Peak memory used by a ClickHouse query, from the x-clickhouse-summary header",
+      unit: "By",
+    });
+    this.queryErrors = this.meter.createCounter("clickhouse.query.errors", {
+      description:
+        "ClickHouse query errors by type, e.g. MEMORY_LIMIT_EXCEEDED or TIMEOUT_EXCEEDED",
+    });
 
     this.client = createClient({
       url: config.url,
@@ -85,6 +124,40 @@ export class ClickhouseClient implements ClickhouseReader, ClickhouseWriter {
 
   public async close() {
     await this.client.close();
+  }
+
+  private recordQueryMetrics(
+    operation: string,
+    startedAt: number,
+    result: { errorType?: string; summary?: Record<string, unknown> }
+  ) {
+    const attributes = { client: this.name, operation };
+    this.queryDuration.record(performance.now() - startedAt, {
+      ...attributes,
+      status: result.errorType ? "error" : "ok",
+    });
+    if (result.errorType) {
+      this.queryErrors.add(1, { ...attributes, error_type: result.errorType });
+    }
+    const summary = result.summary;
+    if (summary) {
+      const elapsedNs = Number(summary.elapsed_ns);
+      if (Number.isFinite(elapsedNs) && elapsedNs > 0) {
+        this.queryServerDuration.record(elapsedNs / 1_000_000, attributes);
+      }
+      const readRows = Number(summary.read_rows);
+      if (Number.isFinite(readRows)) {
+        this.queryReadRows.record(readRows, attributes);
+      }
+      const readBytes = Number(summary.read_bytes);
+      if (Number.isFinite(readBytes)) {
+        this.queryReadBytes.record(readBytes, attributes);
+      }
+      const memoryUsage = Number(summary.memory_usage);
+      if (Number.isFinite(memoryUsage) && memoryUsage > 0) {
+        this.queryMemoryUsage.record(memoryUsage, attributes);
+      }
+    }
   }
 
   public query<TIn extends z.ZodSchema<any>, TOut extends z.ZodSchema<any>>(req: {
@@ -117,126 +190,142 @@ export class ClickhouseClient implements ClickhouseReader, ClickhouseWriter {
   }): ClickhouseQueryFunction<z.input<TIn>, z.output<TOut>> {
     return async (params, options) => {
       const queryId = randomUUID();
+      const startedAt = performance.now();
+      this.queryInFlight.add(1, { client: this.name });
+      let summary: Record<string, unknown> | undefined;
 
-      return await startSpan(this.tracer, "query", async (span) => {
-        this.logger.debug("Querying clickhouse", {
-          name: req.name,
-          query: req.query.replace(/\s+/g, " "),
-          params,
-          settings: req.settings,
-          attributes: options?.attributes,
-          queryId,
-        });
-
-        span.setAttributes({
-          "clickhouse.clientName": this.name,
-          "clickhouse.operationName": req.name,
-          "clickhouse.queryId": queryId,
-          ...flattenAttributes(req.settings, "clickhouse.settings"),
-          ...flattenAttributes(options?.attributes),
-        });
-
-        const validParams = req.params?.safeParse(params);
-
-        if (validParams?.error) {
-          recordSpanError(span, validParams.error);
-
-          this.logger.error("Error parsing query params", {
+      const result = await startSpan(
+        this.tracer,
+        "query",
+        async (span): Promise<Result<z.output<TOut>[], QueryError>> => {
+          this.logger.debug("Querying clickhouse", {
             name: req.name,
-            error: validParams.error,
-            query: req.query,
+            query: req.query.replace(/\s+/g, " "),
             params,
+            settings: req.settings,
+            attributes: options?.attributes,
             queryId,
           });
 
-          return [
-            new QueryError(`Bad params: ${generateErrorMessage(validParams.error.issues)}`, {
-              query: req.query,
-            }),
-            null,
-          ];
-        }
-
-        let unparsedRows: Array<TOut> = [];
-
-        const [clickhouseError, res] = await tryCatch(
-          this.client.query({
-            query: req.query,
-            query_params: validParams?.data,
-            format: "JSONEachRow",
-            query_id: queryId,
-            ...options?.params,
-            clickhouse_settings: {
-              ...req.settings,
-              ...options?.params?.clickhouse_settings,
-            },
-          })
-        );
-
-        if (clickhouseError) {
-          const errorLogFields = {
-            name: req.name,
-            error: clickhouseError,
-            query: req.query,
-            params,
-            queryId,
-          };
-
-          this.logger.error("Error querying clickhouse", errorLogFields);
-
-          recordClickhouseError(span, clickhouseError);
-
-          return [
-            new QueryError(
-              `Unable to query clickhouse: ${clickhouseError.message}`,
-              { query: req.query },
-              clickhouseError instanceof ClickHouseError ? clickhouseError.type : undefined
-            ),
-            null,
-          ];
-        }
-
-        unparsedRows = await res.json();
-
-        span.setAttributes({
-          "clickhouse.query_id": res.query_id,
-          ...flattenAttributes(res.response_headers, "clickhouse.response_headers"),
-        });
-
-        const summaryHeader = res.response_headers["x-clickhouse-summary"];
-
-        if (typeof summaryHeader === "string") {
           span.setAttributes({
-            ...flattenAttributes(JSON.parse(summaryHeader), "clickhouse.summary"),
+            "clickhouse.clientName": this.name,
+            "clickhouse.operationName": req.name,
+            "clickhouse.queryId": queryId,
+            ...flattenAttributes(req.settings, "clickhouse.settings"),
+            ...flattenAttributes(options?.attributes),
           });
+
+          const validParams = req.params?.safeParse(params);
+
+          if (validParams?.error) {
+            recordSpanError(span, validParams.error);
+
+            this.logger.error("Error parsing query params", {
+              name: req.name,
+              error: validParams.error,
+              query: req.query,
+              params,
+              queryId,
+            });
+
+            return [
+              new QueryError(`Bad params: ${generateErrorMessage(validParams.error.issues)}`, {
+                query: req.query,
+              }),
+              null,
+            ];
+          }
+
+          let unparsedRows: Array<TOut> = [];
+
+          const [clickhouseError, res] = await tryCatch(
+            this.client.query({
+              query: req.query,
+              query_params: validParams?.data,
+              format: "JSONEachRow",
+              query_id: queryId,
+              ...options?.params,
+              clickhouse_settings: {
+                ...req.settings,
+                ...options?.params?.clickhouse_settings,
+              },
+            })
+          );
+
+          if (clickhouseError) {
+            const errorLogFields = {
+              name: req.name,
+              error: clickhouseError,
+              query: req.query,
+              params,
+              queryId,
+            };
+
+            this.logger.error("Error querying clickhouse", errorLogFields);
+
+            recordClickhouseError(span, clickhouseError);
+
+            return [
+              new QueryError(
+                `Unable to query clickhouse: ${clickhouseError.message}`,
+                { query: req.query },
+                clickhouseError instanceof ClickHouseError ? clickhouseError.type : undefined
+              ),
+              null,
+            ];
+          }
+
+          unparsedRows = await res.json();
+
+          span.setAttributes({
+            "clickhouse.query_id": res.query_id,
+            ...flattenAttributes(res.response_headers, "clickhouse.response_headers"),
+          });
+
+          const summaryHeader = res.response_headers["x-clickhouse-summary"];
+
+          if (typeof summaryHeader === "string") {
+            summary = JSON.parse(summaryHeader);
+            span.setAttributes({
+              ...flattenAttributes(summary, "clickhouse.summary"),
+            });
+          }
+
+          const parsed = z.array(req.schema).safeParse(unparsedRows);
+
+          if (parsed.error) {
+            this.logger.error("Error parsing clickhouse query result", {
+              name: req.name,
+              error: parsed.error,
+              query: req.query,
+              params,
+              queryId,
+            });
+
+            const queryError = new QueryError(generateErrorMessage(parsed.error.issues), {
+              query: req.query,
+            });
+
+            recordSpanError(span, queryError);
+
+            return [queryError, null];
+          }
+
+          span.setAttributes({
+            "clickhouse.rows": unparsedRows.length,
+          });
+
+          return [null, parsed.data];
         }
+      ).finally(() => this.queryInFlight.add(-1, { client: this.name }));
 
-        const parsed = z.array(req.schema).safeParse(unparsedRows);
-
-        if (parsed.error) {
-          this.logger.error("Error parsing clickhouse query result", {
-            name: req.name,
-            error: parsed.error,
-            query: req.query,
-            params,
-            queryId,
-          });
-
-          const queryError = new QueryError(generateErrorMessage(parsed.error.issues), {
-            query: req.query,
-          });
-
-          recordSpanError(span, queryError);
-
-          return [queryError, null];
-        }
-
-        span.setAttributes({
-          "clickhouse.rows": unparsedRows.length,
-        });
-
-        return [null, parsed.data];
+      this.recordQueryMetrics(req.name, startedAt, {
+        errorType:
+          result[0] instanceof QueryError ? (result[0].clickhouseErrorType ?? "other") : undefined,
+        summary,
       });
+
+      return result;
     };
   }
 
@@ -280,165 +369,183 @@ export class ClickhouseClient implements ClickhouseReader, ClickhouseWriter {
   }): ClickhouseQueryWithStatsFunction<z.input<TIn>, z.output<TOut>> {
     return async (params, options) => {
       const queryId = randomUUID();
+      const startedAt = performance.now();
+      this.queryInFlight.add(1, { client: this.name });
+      let summary: Record<string, unknown> | undefined;
 
-      return await startSpan(this.tracer, "queryWithStats", async (span) => {
-        this.logger.debug("Querying clickhouse with stats", {
-          name: req.name,
-          query: req.query.replace(/\s+/g, " "),
-          params,
-          settings: req.settings,
-          attributes: options?.attributes,
-          queryId,
-        });
-
-        span.setAttributes({
-          "clickhouse.clientName": this.name,
-          "clickhouse.operationName": req.name,
-          "clickhouse.queryId": queryId,
-          ...flattenAttributes(req.settings, "clickhouse.settings"),
-          ...flattenAttributes(options?.attributes),
-        });
-
-        const validParams = req.params?.safeParse(params);
-
-        if (validParams?.error) {
-          recordSpanError(span, validParams.error);
-
-          this.logger.error("Error parsing query params", {
+      const result = await startSpan(
+        this.tracer,
+        "queryWithStats",
+        async (
+          span
+        ): Promise<Result<{ rows: z.output<TOut>[]; stats: QueryStats }, QueryError>> => {
+          this.logger.debug("Querying clickhouse with stats", {
             name: req.name,
-            error: validParams.error,
-            query: req.query,
+            query: req.query.replace(/\s+/g, " "),
             params,
+            settings: req.settings,
+            attributes: options?.attributes,
             queryId,
           });
 
-          return [
-            new QueryError(`Bad params: ${generateErrorMessage(validParams.error.issues)}`, {
+          span.setAttributes({
+            "clickhouse.clientName": this.name,
+            "clickhouse.operationName": req.name,
+            "clickhouse.queryId": queryId,
+            ...flattenAttributes(req.settings, "clickhouse.settings"),
+            ...flattenAttributes(options?.attributes),
+          });
+
+          const validParams = req.params?.safeParse(params);
+
+          if (validParams?.error) {
+            recordSpanError(span, validParams.error);
+
+            this.logger.error("Error parsing query params", {
+              name: req.name,
+              error: validParams.error,
               query: req.query,
-            }),
-            null,
-          ];
-        }
+              params,
+              queryId,
+            });
 
-        let unparsedRows: Array<TOut> = [];
-
-        const [clickhouseError, res] = await tryCatch(
-          this.client.query({
-            query: req.query,
-            query_params: validParams?.data,
-            format: "JSONEachRow",
-            query_id: queryId,
-            ...options?.params,
-            clickhouse_settings: {
-              ...req.settings,
-              ...options?.params?.clickhouse_settings,
-            },
-          })
-        );
-
-        if (clickhouseError) {
-          const errorLogFields = {
-            ...req.logFields,
-            name: req.name,
-            error: clickhouseError,
-            query: req.query,
-            params,
-            queryId,
-          };
-
-          switch (classifyClickhouseError(clickhouseError, req.userAuthoredQuery)) {
-            case "quota":
-              this.logger.warn("Query exceeded a ClickHouse limit", errorLogFields);
-              break;
-            case "invalid-sql":
-              this.logger.warn("ClickHouse rejected an invalid query", errorLogFields);
-              break;
-            default:
-              this.logger.error("Error querying clickhouse", errorLogFields);
+            return [
+              new QueryError(`Bad params: ${generateErrorMessage(validParams.error.issues)}`, {
+                query: req.query,
+              }),
+              null,
+            ];
           }
 
-          recordClickhouseError(span, clickhouseError);
+          let unparsedRows: Array<TOut> = [];
 
-          return [
-            new QueryError(
-              `Unable to query clickhouse: ${clickhouseError.message}`,
-              { query: req.query },
-              clickhouseError instanceof ClickHouseError ? clickhouseError.type : undefined
-            ),
-            null,
-          ];
-        }
+          const [clickhouseError, res] = await tryCatch(
+            this.client.query({
+              query: req.query,
+              query_params: validParams?.data,
+              format: "JSONEachRow",
+              query_id: queryId,
+              ...options?.params,
+              clickhouse_settings: {
+                ...req.settings,
+                ...options?.params?.clickhouse_settings,
+              },
+            })
+          );
 
-        unparsedRows = await res.json();
+          if (clickhouseError) {
+            const errorLogFields = {
+              ...req.logFields,
+              name: req.name,
+              error: clickhouseError,
+              query: req.query,
+              params,
+              queryId,
+            };
 
-        span.setAttributes({
-          "clickhouse.query_id": res.query_id,
-          ...flattenAttributes(res.response_headers, "clickhouse.response_headers"),
-        });
+            switch (classifyClickhouseError(clickhouseError, req.userAuthoredQuery)) {
+              case "quota":
+                this.logger.warn("Query exceeded a ClickHouse limit", errorLogFields);
+                break;
+              case "invalid-sql":
+                this.logger.warn("ClickHouse rejected an invalid query", errorLogFields);
+                break;
+              default:
+                this.logger.error("Error querying clickhouse", errorLogFields);
+            }
 
-        // Parse the summary header to get stats
-        const summaryHeader = res.response_headers["x-clickhouse-summary"];
-        let stats: QueryStats = {
-          read_rows: "0",
-          read_bytes: "0",
-          written_rows: "0",
-          written_bytes: "0",
-          total_rows_to_read: "0",
-          result_rows: "0",
-          result_bytes: "0",
-          elapsed_ns: "0",
-          byte_seconds: "0",
-        };
+            recordClickhouseError(span, clickhouseError);
 
-        if (typeof summaryHeader === "string") {
-          const parsedSummary = JSON.parse(summaryHeader);
-          this.logger.debug("parsedSummary", parsedSummary);
-          const readBytes = parsedSummary.read_bytes ? parseInt(parsedSummary.read_bytes, 10) : 0;
-          const elapsedNs = parsedSummary.elapsed_ns ? parseInt(parsedSummary.elapsed_ns, 10) : 0;
-          const elapsedSeconds = elapsedNs / 1_000_000_000;
-          const byteSeconds = elapsedSeconds > 0 ? readBytes / elapsedSeconds : 0;
-          stats = {
-            read_rows: parsedSummary.read_rows ?? "0",
-            read_bytes: parsedSummary.read_bytes ?? "0",
-            written_rows: parsedSummary.written_rows ?? "0",
-            written_bytes: parsedSummary.written_bytes ?? "0",
-            total_rows_to_read: parsedSummary.total_rows_to_read ?? "0",
-            result_rows: parsedSummary.result_rows ?? "0",
-            result_bytes: parsedSummary.result_bytes ?? "0",
-            elapsed_ns: parsedSummary.elapsed_ns ?? "0",
-            byte_seconds: byteSeconds.toString(),
-          };
+            return [
+              new QueryError(
+                `Unable to query clickhouse: ${clickhouseError.message}`,
+                { query: req.query },
+                clickhouseError instanceof ClickHouseError ? clickhouseError.type : undefined
+              ),
+              null,
+            ];
+          }
+
+          unparsedRows = await res.json();
+
           span.setAttributes({
-            ...flattenAttributes(parsedSummary, "clickhouse.summary"),
+            "clickhouse.query_id": res.query_id,
+            ...flattenAttributes(res.response_headers, "clickhouse.response_headers"),
           });
+
+          // Parse the summary header to get stats
+          const summaryHeader = res.response_headers["x-clickhouse-summary"];
+          let stats: QueryStats = {
+            read_rows: "0",
+            read_bytes: "0",
+            written_rows: "0",
+            written_bytes: "0",
+            total_rows_to_read: "0",
+            result_rows: "0",
+            result_bytes: "0",
+            elapsed_ns: "0",
+            byte_seconds: "0",
+          };
+
+          if (typeof summaryHeader === "string") {
+            const parsedSummary = JSON.parse(summaryHeader);
+            summary = parsedSummary;
+            this.logger.debug("parsedSummary", parsedSummary);
+            const readBytes = parsedSummary.read_bytes ? parseInt(parsedSummary.read_bytes, 10) : 0;
+            const elapsedNs = parsedSummary.elapsed_ns ? parseInt(parsedSummary.elapsed_ns, 10) : 0;
+            const elapsedSeconds = elapsedNs / 1_000_000_000;
+            const byteSeconds = elapsedSeconds > 0 ? readBytes / elapsedSeconds : 0;
+            stats = {
+              read_rows: parsedSummary.read_rows ?? "0",
+              read_bytes: parsedSummary.read_bytes ?? "0",
+              written_rows: parsedSummary.written_rows ?? "0",
+              written_bytes: parsedSummary.written_bytes ?? "0",
+              total_rows_to_read: parsedSummary.total_rows_to_read ?? "0",
+              result_rows: parsedSummary.result_rows ?? "0",
+              result_bytes: parsedSummary.result_bytes ?? "0",
+              elapsed_ns: parsedSummary.elapsed_ns ?? "0",
+              byte_seconds: byteSeconds.toString(),
+            };
+            span.setAttributes({
+              ...flattenAttributes(parsedSummary, "clickhouse.summary"),
+            });
+          }
+
+          const parsed = z.array(req.schema).safeParse(unparsedRows);
+
+          if (parsed.error) {
+            this.logger.error("Error parsing clickhouse query result", {
+              name: req.name,
+              error: parsed.error,
+              query: req.query,
+              params,
+              queryId,
+            });
+
+            const queryError = new QueryError(generateErrorMessage(parsed.error.issues), {
+              query: req.query,
+            });
+
+            recordSpanError(span, queryError);
+
+            return [queryError, null];
+          }
+
+          span.setAttributes({
+            "clickhouse.rows": unparsedRows.length,
+          });
+
+          return [null, { rows: parsed.data, stats }];
         }
+      ).finally(() => this.queryInFlight.add(-1, { client: this.name }));
 
-        const parsed = z.array(req.schema).safeParse(unparsedRows);
-
-        if (parsed.error) {
-          this.logger.error("Error parsing clickhouse query result", {
-            name: req.name,
-            error: parsed.error,
-            query: req.query,
-            params,
-            queryId,
-          });
-
-          const queryError = new QueryError(generateErrorMessage(parsed.error.issues), {
-            query: req.query,
-          });
-
-          recordSpanError(span, queryError);
-
-          return [queryError, null];
-        }
-
-        span.setAttributes({
-          "clickhouse.rows": unparsedRows.length,
-        });
-
-        return [null, { rows: parsed.data, stats }];
+      this.recordQueryMetrics(req.name, startedAt, {
+        errorType:
+          result[0] instanceof QueryError ? (result[0].clickhouseErrorType ?? "other") : undefined,
+        summary,
       });
+
+      return result;
     };
   }
 
@@ -450,105 +557,121 @@ export class ClickhouseClient implements ClickhouseReader, ClickhouseWriter {
   }): ClickhouseQueryFunction<TParams, TOut> {
     return async (params, options) => {
       const queryId = randomUUID();
+      const startedAt = performance.now();
+      this.queryInFlight.add(1, { client: this.name });
+      let summary: Record<string, unknown> | undefined;
 
-      return await startSpan(this.tracer, "queryFast", async (span) => {
-        this.logger.debug("Querying clickhouse fast", {
-          name: req.name,
-          query: req.query.replace(/\s+/g, " "),
-          params,
-          settings: req.settings,
-          attributes: options?.attributes,
-          queryId,
-        });
-
-        span.setAttributes({
-          "clickhouse.clientName": this.name,
-          "clickhouse.operationName": req.name,
-          "clickhouse.queryId": queryId,
-          ...flattenAttributes(req.settings, "clickhouse.settings"),
-          ...flattenAttributes(options?.attributes),
-        });
-
-        const [clickhouseError, resultSet] = await tryCatch(
-          this.client.query({
-            query: req.query,
-            query_params: params,
-            format: "JSONCompactEachRow",
-            query_id: queryId,
-            ...options?.params,
-            clickhouse_settings: {
-              ...req.settings,
-              ...options?.params?.clickhouse_settings,
-            },
-          })
-        );
-
-        if (clickhouseError) {
-          const errorLogFields = {
+      const result = await startSpan(
+        this.tracer,
+        "queryFast",
+        async (span): Promise<Result<TOut[], QueryError>> => {
+          this.logger.debug("Querying clickhouse fast", {
             name: req.name,
-            error: clickhouseError,
-            query: req.query,
+            query: req.query.replace(/\s+/g, " "),
             params,
+            settings: req.settings,
+            attributes: options?.attributes,
             queryId,
-          };
-
-          this.logger.error("Error querying clickhouse", errorLogFields);
-
-          recordClickhouseError(span, clickhouseError);
-
-          return [
-            new QueryError(
-              `Unable to query clickhouse: ${clickhouseError.message}`,
-              { query: req.query },
-              clickhouseError instanceof ClickHouseError ? clickhouseError.type : undefined
-            ),
-            null,
-          ];
-        }
-
-        span.setAttributes({
-          "clickhouse.query_id": resultSet.query_id,
-          ...flattenAttributes(resultSet.response_headers, "clickhouse.response_headers"),
-        });
-
-        const summaryHeader = resultSet.response_headers["x-clickhouse-summary"];
-
-        if (typeof summaryHeader === "string") {
-          span.setAttributes({
-            ...flattenAttributes(JSON.parse(summaryHeader), "clickhouse.summary"),
           });
-        }
 
-        const resultRows: Array<TOut> = [];
+          span.setAttributes({
+            "clickhouse.clientName": this.name,
+            "clickhouse.operationName": req.name,
+            "clickhouse.queryId": queryId,
+            ...flattenAttributes(req.settings, "clickhouse.settings"),
+            ...flattenAttributes(options?.attributes),
+          });
 
-        for await (const rows of resultSet.stream()) {
-          if (rows.length === 0) {
-            continue;
+          const [clickhouseError, resultSet] = await tryCatch(
+            this.client.query({
+              query: req.query,
+              query_params: params,
+              format: "JSONCompactEachRow",
+              query_id: queryId,
+              ...options?.params,
+              clickhouse_settings: {
+                ...req.settings,
+                ...options?.params?.clickhouse_settings,
+              },
+            })
+          );
+
+          if (clickhouseError) {
+            const errorLogFields = {
+              name: req.name,
+              error: clickhouseError,
+              query: req.query,
+              params,
+              queryId,
+            };
+
+            this.logger.error("Error querying clickhouse", errorLogFields);
+
+            recordClickhouseError(span, clickhouseError);
+
+            return [
+              new QueryError(
+                `Unable to query clickhouse: ${clickhouseError.message}`,
+                { query: req.query },
+                clickhouseError instanceof ClickHouseError ? clickhouseError.type : undefined
+              ),
+              null,
+            ];
           }
 
-          for (const row of rows) {
-            const rowData = row.json() as any[];
+          span.setAttributes({
+            "clickhouse.query_id": resultSet.query_id,
+            ...flattenAttributes(resultSet.response_headers, "clickhouse.response_headers"),
+          });
 
-            const hydratedRow: Record<string, any> = {};
-            for (let i = 0; i < req.columns.length; i++) {
-              const column = req.columns[i];
+          const summaryHeader = resultSet.response_headers["x-clickhouse-summary"];
 
-              if (typeof column === "string") {
-                hydratedRow[column] = rowData[i];
-              } else {
-                hydratedRow[column.name] = rowData[i];
-              }
+          if (typeof summaryHeader === "string") {
+            summary = JSON.parse(summaryHeader);
+            span.setAttributes({
+              ...flattenAttributes(summary, "clickhouse.summary"),
+            });
+          }
+
+          const resultRows: Array<TOut> = [];
+
+          for await (const rows of resultSet.stream()) {
+            if (rows.length === 0) {
+              continue;
             }
-            resultRows.push(hydratedRow as TOut);
+
+            for (const row of rows) {
+              const rowData = row.json() as any[];
+
+              const hydratedRow: Record<string, any> = {};
+              for (let i = 0; i < req.columns.length; i++) {
+                const column = req.columns[i];
+
+                if (typeof column === "string") {
+                  hydratedRow[column] = rowData[i];
+                } else {
+                  hydratedRow[column.name] = rowData[i];
+                }
+              }
+              resultRows.push(hydratedRow as TOut);
+            }
           }
+
+          span.setAttributes({
+            "clickhouse.rows": resultRows.length,
+          });
+
+          return [null, resultRows];
         }
+      ).finally(() => this.queryInFlight.add(-1, { client: this.name }));
 
-        span.setAttributes({
-          "clickhouse.rows": resultRows.length,
-        });
-
-        return [null, resultRows];
+      this.recordQueryMetrics(req.name, startedAt, {
+        errorType:
+          result[0] instanceof QueryError ? (result[0].clickhouseErrorType ?? "other") : undefined,
+        summary,
       });
+
+      return result;
     };
   }
 

--- a/internal-packages/clickhouse/src/client/client.ts
+++ b/internal-packages/clickhouse/src/client/client.ts
@@ -317,7 +317,12 @@ export class ClickhouseClient implements ClickhouseReader, ClickhouseWriter {
 
           return [null, parsed.data];
         }
-      ).finally(() => this.queryInFlight.add(-1, { client: this.name }));
+      )
+        .catch((error) => {
+          this.recordQueryMetrics(req.name, startedAt, { errorType: "exception" });
+          throw error;
+        })
+        .finally(() => this.queryInFlight.add(-1, { client: this.name }));
 
       this.recordQueryMetrics(req.name, startedAt, {
         errorType:
@@ -537,7 +542,12 @@ export class ClickhouseClient implements ClickhouseReader, ClickhouseWriter {
 
           return [null, { rows: parsed.data, stats }];
         }
-      ).finally(() => this.queryInFlight.add(-1, { client: this.name }));
+      )
+        .catch((error) => {
+          this.recordQueryMetrics(req.name, startedAt, { errorType: "exception" });
+          throw error;
+        })
+        .finally(() => this.queryInFlight.add(-1, { client: this.name }));
 
       this.recordQueryMetrics(req.name, startedAt, {
         errorType:
@@ -663,7 +673,12 @@ export class ClickhouseClient implements ClickhouseReader, ClickhouseWriter {
 
           return [null, resultRows];
         }
-      ).finally(() => this.queryInFlight.add(-1, { client: this.name }));
+      )
+        .catch((error) => {
+          this.recordQueryMetrics(req.name, startedAt, { errorType: "exception" });
+          throw error;
+        })
+        .finally(() => this.queryInFlight.add(-1, { client: this.name }));
 
       this.recordQueryMetrics(req.name, startedAt, {
         errorType:

--- a/internal-packages/clickhouse/src/client/errors.ts
+++ b/internal-packages/clickhouse/src/client/errors.ts
@@ -45,10 +45,39 @@ export class InsertError extends BaseError {
 export class QueryError extends BaseError<{ query: string }> {
   public readonly retry = true;
   public readonly name = QueryError.name;
-  constructor(message: string, context: { query: string }) {
+  /**
+   * The underlying ClickHouse error type (e.g. `TIMEOUT_EXCEEDED`) when the failure came from
+   * ClickHouse rejecting the query, else undefined. Lets callers distinguish a query that hit a
+   * server-side resource limit from an unexpected failure.
+   */
+  public readonly clickhouseErrorType?: string;
+  constructor(message: string, context: { query: string }, clickhouseErrorType?: string) {
     super({
       message,
       context,
     });
+    this.clickhouseErrorType = clickhouseErrorType;
   }
+}
+
+/**
+ * ClickHouse error types raised when a query exceeds a server-side resource limit
+ * (`max_execution_time`, `max_memory_usage`, etc.). These mean the caller's query was too
+ * expensive, not a service fault, so callers can turn them into an actionable 4xx.
+ */
+const CLICKHOUSE_RESOURCE_LIMIT_ERROR_TYPES = new Set([
+  "MEMORY_LIMIT_EXCEEDED",
+  "TIMEOUT_EXCEEDED",
+  "TOO_SLOW",
+  "TOO_MANY_ROWS",
+  "TOO_MANY_BYTES",
+  "TOO_MANY_ROWS_OR_BYTES",
+]);
+
+export function isClickhouseResourceLimitError(error: unknown): boolean {
+  return (
+    error instanceof QueryError &&
+    error.clickhouseErrorType !== undefined &&
+    CLICKHOUSE_RESOURCE_LIMIT_ERROR_TYPES.has(error.clickhouseErrorType)
+  );
 }

--- a/internal-packages/clickhouse/src/index.ts
+++ b/internal-packages/clickhouse/src/index.ts
@@ -75,6 +75,7 @@ import {
 } from "./errors.js";
 export { msToClickHouseInterval } from "./intervals.js";
 import { Logger, type LogLevel } from "@trigger.dev/core/logger";
+import type { Meter } from "@internal/tracing";
 import type { Agent as HttpAgent } from "http";
 import type { Agent as HttpsAgent } from "https";
 
@@ -133,6 +134,7 @@ export type ClickhouseCommonConfig = {
   httpAgent?: HttpAgent | HttpsAgent;
   clickhouseSettings?: ClickHouseSettings;
   logger?: Logger;
+  meter?: Meter;
   logLevel?: LogLevel;
   compression?: {
     request?: boolean;
@@ -178,6 +180,7 @@ export class ClickHouse {
         url: config.url,
         clickhouseSettings: config.clickhouseSettings,
         logger: this.logger,
+        meter: config.meter,
         logLevel: config.logLevel,
         keepAlive: config.keepAlive,
         httpAgent: config.httpAgent,
@@ -195,6 +198,7 @@ export class ClickHouse {
         url: config.readerUrl,
         clickhouseSettings: config.clickhouseSettings,
         logger: this.logger,
+        meter: config.meter,
         logLevel: config.logLevel,
         keepAlive: config.keepAlive,
         httpAgent: config.httpAgent,
@@ -207,6 +211,7 @@ export class ClickHouse {
         url: config.writerUrl,
         clickhouseSettings: config.clickhouseSettings,
         logger: this.logger,
+        meter: config.meter,
         logLevel: config.logLevel,
         keepAlive: config.keepAlive,
         httpAgent: config.httpAgent,

--- a/internal-packages/clickhouse/src/index.ts
+++ b/internal-packages/clickhouse/src/index.ts
@@ -123,7 +123,7 @@ export {
 export type { ColumnFormatType, OutputColumnMetadata } from "@internal/tsql";
 
 // Errors
-export { QueryError } from "./client/errors.js";
+export { QueryError, isClickhouseResourceLimitError } from "./client/errors.js";
 
 export type ClickhouseCommonConfig = {
   keepAlive?: {


### PR DESCRIPTION
## Summary

When a runs list query is too expensive to complete, it now fails with a clear, actionable error instead of a generic 500.

Previously, a runs list query that exceeded ClickHouse resource limits threw an opaque error. On the public `runs.list` API that surfaced as a retryable 500, so a customer task calling it would keep retrying a query that could never succeed. On the dashboard it rendered as a generic error page with no hint about what to do.

## Fix

The ClickHouse client now tags resource-limit failures (memory, time, rows, bytes) with their error type, and the runs repository maps those to a dedicated `RunsListQueryError` (HTTP 422).

- `runs.list` API returns 422 with a message telling the user to narrow their `created_at` range, plus an `x-should-retry: false` header so the SDK does not retry it.
- The dashboard runs list (and the errors, scheduled, standard-task, agents, and webhooks list views) render a shared error state with the same guidance, so a too-broad time filter is recoverable by the user.