### PR TITLE
feat(webapp): pause deployment log auto-scroll on scroll-up

### DIFF
--- a/.server-changes/deployment-logs-follow-scroll.md
+++ b/.server-changes/deployment-logs-follow-scroll.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: feature
+---
+
+Deployment logs no longer jump to the bottom while you are reading earlier output. Scroll up to pause auto-scroll, and scroll back down or use the new scroll-to-bottom button in the log header to resume following.

--- a/apps/webapp/app/hooks/useFollowScroll.ts
+++ b/apps/webapp/app/hooks/useFollowScroll.ts
@@ -1,0 +1,70 @@
+import { useEffect, useLayoutEffect, useState, type RefObject } from "react";
+
+const AT_BOTTOM_TOLERANCE_PX = 4;
+
+export function useFollowScroll(containerRef: RefObject<HTMLElement | null>, content: unknown) {
+  const [isAtBottom, setIsAtBottom] = useState(true);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let lastScrollTop = container.scrollTop;
+
+    const onScroll = () => {
+      const { scrollTop, scrollHeight, clientHeight } = container;
+      const distance = scrollHeight - scrollTop - clientHeight;
+      const movedUp = scrollTop < lastScrollTop && distance > 1;
+      lastScrollTop = scrollTop;
+      setIsAtBottom(!movedUp && distance <= AT_BOTTOM_TOLERANCE_PX);
+    };
+
+    const onWheel = (event: WheelEvent) => {
+      if (event.deltaY < 0 && canScroll(container)) setIsAtBottom(false);
+    };
+
+    container.addEventListener("scroll", onScroll, { passive: true });
+    container.addEventListener("wheel", onWheel, { passive: true });
+    return () => {
+      container.removeEventListener("scroll", onScroll);
+      container.removeEventListener("wheel", onWheel);
+    };
+  }, [containerRef]);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!isAtBottom || !container) return;
+    container.scrollTop = container.scrollHeight;
+  }, [containerRef, isAtBottom, content]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!isAtBottom || !container) return;
+
+    const observer = new ResizeObserver(() => {
+      container.scrollTop = container.scrollHeight;
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [containerRef, isAtBottom]);
+
+  const scrollToBottom = () => {
+    const container = containerRef.current;
+    if (!container) return;
+    setIsAtBottom(true);
+    container.scrollTop = container.scrollHeight;
+  };
+
+  const scrollToTop = () => {
+    const container = containerRef.current;
+    if (!container || !canScroll(container)) return;
+    setIsAtBottom(false);
+    container.scrollTop = 0;
+  };
+
+  return { isAtBottom, scrollToBottom, scrollToTop };
+}
+
+function canScroll(container: HTMLElement) {
+  return container.scrollHeight - container.clientHeight > AT_BOTTOM_TOLERANCE_PX;
+}

--- a/apps/webapp/app/hooks/useFollowScroll.ts
+++ b/apps/webapp/app/hooks/useFollowScroll.ts
@@ -14,7 +14,7 @@ export function useFollowScroll(containerRef: RefObject<HTMLElement | null>, con
     const onScroll = () => {
       const { scrollTop, scrollHeight, clientHeight } = container;
       const distance = scrollHeight - scrollTop - clientHeight;
-      const movedUp = scrollTop < lastScrollTop && distance > 1;
+      const movedUp = scrollTop < lastScrollTop && distance >= 1;
       lastScrollTop = scrollTop;
       setIsAtBottom(!movedUp && distance <= AT_BOTTOM_TOLERANCE_PX);
     };

--- a/apps/webapp/app/hooks/useFollowScroll.ts
+++ b/apps/webapp/app/hooks/useFollowScroll.ts
@@ -1,26 +1,48 @@
-import { useEffect, useLayoutEffect, useState, type RefObject } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, type RefObject } from "react";
 
 const AT_BOTTOM_TOLERANCE_PX = 4;
 
+type FollowState = {
+  follow: boolean;
+  pinnedScrollTop: number | null;
+  lastScrollTop: number;
+  lastClientHeight: number;
+};
+
 export function useFollowScroll(containerRef: RefObject<HTMLElement | null>, content: unknown) {
   const [isAtBottom, setIsAtBottom] = useState(true);
+  const stateRef = useRef<FollowState>({
+    follow: true,
+    pinnedScrollTop: null,
+    lastScrollTop: 0,
+    lastClientHeight: 0,
+  });
 
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
 
-    let lastScrollTop = container.scrollTop;
+    const state = stateRef.current;
+    state.lastScrollTop = container.scrollTop;
+    state.lastClientHeight = container.clientHeight;
 
     const onScroll = () => {
       const { scrollTop, scrollHeight, clientHeight } = container;
-      const distance = scrollHeight - scrollTop - clientHeight;
-      const movedUp = scrollTop < lastScrollTop && distance >= 1;
-      lastScrollTop = scrollTop;
-      setIsAtBottom(!movedUp && distance <= AT_BOTTOM_TOLERANCE_PX);
+      const isEcho = scrollTop === state.pinnedScrollTop;
+      const movedUp = scrollTop < state.lastScrollTop && clientHeight <= state.lastClientHeight;
+      state.pinnedScrollTop = null;
+      state.lastScrollTop = scrollTop;
+      state.lastClientHeight = clientHeight;
+      if (isEcho) return;
+
+      state.follow = !movedUp && scrollHeight - scrollTop - clientHeight <= AT_BOTTOM_TOLERANCE_PX;
+      setIsAtBottom(state.follow);
     };
 
     const onWheel = (event: WheelEvent) => {
-      if (event.deltaY < 0 && canScroll(container)) setIsAtBottom(false);
+      if (event.deltaY >= 0 || !canScroll(container)) return;
+      state.follow = false;
+      setIsAtBottom(false);
     };
 
     container.addEventListener("scroll", onScroll, { passive: true });
@@ -33,36 +55,44 @@ export function useFollowScroll(containerRef: RefObject<HTMLElement | null>, con
 
   useLayoutEffect(() => {
     const container = containerRef.current;
-    if (!isAtBottom || !container) return;
-    container.scrollTop = container.scrollHeight;
+    if (container && stateRef.current.follow) pinToBottom(container, stateRef.current);
   }, [containerRef, isAtBottom, content]);
 
   useEffect(() => {
     const container = containerRef.current;
-    if (!isAtBottom || !container) return;
+    if (!container) return;
 
     const observer = new ResizeObserver(() => {
-      container.scrollTop = container.scrollHeight;
+      if (stateRef.current.follow) pinToBottom(container, stateRef.current);
     });
     observer.observe(container);
     return () => observer.disconnect();
-  }, [containerRef, isAtBottom]);
+  }, [containerRef]);
 
   const scrollToBottom = () => {
     const container = containerRef.current;
     if (!container) return;
+    stateRef.current.follow = true;
     setIsAtBottom(true);
-    container.scrollTop = container.scrollHeight;
+    pinToBottom(container, stateRef.current);
   };
 
   const scrollToTop = () => {
     const container = containerRef.current;
     if (!container || !canScroll(container)) return;
+    stateRef.current.follow = false;
     setIsAtBottom(false);
     container.scrollTop = 0;
   };
 
   return { isAtBottom, scrollToBottom, scrollToTop };
+}
+
+function pinToBottom(container: HTMLElement, state: FollowState) {
+  container.scrollTop = container.scrollHeight;
+  state.pinnedScrollTop = container.scrollTop;
+  state.lastScrollTop = container.scrollTop;
+  state.lastClientHeight = container.clientHeight;
 }
 
 function canScroll(container: HTMLElement) {

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments.$deploymentParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments.$deploymentParam/route.tsx
@@ -1,7 +1,7 @@
 import { useLocation } from "@remix-run/react";
 import { type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
-import { useEffect, useState, useRef, useCallback } from "react";
+import { useEffect, useLayoutEffect, useState, useRef, useCallback } from "react";
 import {
   Clipboard,
   ClipboardCheck,
@@ -13,6 +13,8 @@ import {
   ServerIcon,
 } from "lucide-react";
 import { ExitIcon } from "~/assets/icons/ExitIcon";
+import { MoveToBottomIcon } from "~/assets/icons/MoveToBottomIcon";
+import { MoveToTopIcon } from "~/assets/icons/MoveToTopIcon";
 import { GitMetadata } from "~/components/GitMetadata";
 import { VercelLink } from "~/components/integrations/VercelLink";
 import { RuntimeIcon } from "~/components/RuntimeIcon";
@@ -176,6 +178,7 @@ function getTriggeredViaDisplay(triggeredVia: string | null | undefined): {
 }
 
 const EXTERNAL_ID_DISPLAY_LENGTH = 24;
+const AT_BOTTOM_TOLERANCE_PX = 16;
 
 function ExternalIdValue({ externalId }: { externalId: string | null }) {
   if (!externalId) {
@@ -307,6 +310,7 @@ export default function Page() {
                 <Property.Item>
                   <Property.Label>Logs</Property.Label>
                   <LogsDisplay
+                    key={deployment.id}
                     logs={logs}
                     isStreaming={isStreaming}
                     streamError={streamError}
@@ -524,6 +528,7 @@ function LogsDisplay({
   const [copied, setCopied] = useState(false);
   const [mouseOver, setMouseOver] = useState(false);
   const [collapsed, setCollapsed] = useState(initialCollapsed);
+  const [isAtBottom, setIsAtBottom] = useState(true);
   const logsContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -531,12 +536,46 @@ function LogsDisplay({
     setCollapsed(initialCollapsed);
   }, [initialCollapsed]);
 
-  // auto-scroll log container to bottom when new logs arrive
   useEffect(() => {
-    if (logsContainerRef.current) {
-      logsContainerRef.current.scrollTop = logsContainerRef.current.scrollHeight;
+    const container = logsContainerRef.current;
+    if (!container) return;
+
+    const updateIsAtBottom = () => {
+      const distance = container.scrollHeight - container.scrollTop - container.clientHeight;
+      setIsAtBottom(distance <= AT_BOTTOM_TOLERANCE_PX);
+    };
+
+    container.addEventListener("scroll", updateIsAtBottom, { passive: true });
+    return () => container.removeEventListener("scroll", updateIsAtBottom);
+  }, []);
+
+  useLayoutEffect(() => {
+    const container = logsContainerRef.current;
+    if (!isAtBottom || !container) return;
+    container.scrollTop = container.scrollHeight;
+  }, [logs, isAtBottom]);
+
+  useEffect(() => {
+    const container = logsContainerRef.current;
+    if (!isAtBottom || !container) return;
+
+    const observer = new ResizeObserver(() => {
+      container.scrollTop = container.scrollHeight;
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [isAtBottom]);
+
+  const onToggleScroll = useCallback(() => {
+    const container = logsContainerRef.current;
+    if (!container) return;
+    if (isAtBottom) {
+      setIsAtBottom(false);
+      container.scrollTo({ top: 0, behavior: "smooth" });
+    } else {
+      container.scrollTop = container.scrollHeight;
     }
-  }, [logs]);
+  }, [isAtBottom]);
 
   const onCopyLogs = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -584,6 +623,27 @@ function LogsDisplay({
         </div>
         {logs.length > 0 && (
           <div className="flex items-center gap-3">
+            <TooltipProvider>
+              <Tooltip disableHoverableContent>
+                <TooltipTrigger
+                  onClick={onToggleScroll}
+                  className={cn(
+                    "transition-colors duration-100 focus-custom hover:cursor-pointer",
+                    "text-text-dimmed hover:text-text-bright"
+                  )}
+                >
+                  {isAtBottom ? (
+                    <MoveToTopIcon className="size-4" />
+                  ) : (
+                    <MoveToBottomIcon className="size-4" />
+                  )}
+                </TooltipTrigger>
+                <TooltipContent side="left" className="text-xs">
+                  {isAtBottom ? "Scroll to top" : "Scroll to bottom"}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+
             <TooltipProvider>
               <Tooltip open={copied || mouseOver} disableHoverableContent>
                 <TooltipTrigger

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments.$deploymentParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments.$deploymentParam/route.tsx
@@ -1,7 +1,7 @@
 import { useLocation } from "@remix-run/react";
 import { type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
-import { useEffect, useLayoutEffect, useState, useRef, useCallback } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import {
   Clipboard,
   ClipboardCheck,
@@ -53,6 +53,7 @@ import { v3DeploymentParams, v3DeploymentsPath, v3RunsPath } from "~/utils/pathB
 import { capitalizeWord } from "~/utils/string";
 import { UserTag } from "../_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments/route";
 import { useDeploymentLogs } from "~/hooks/useDeploymentLogs";
+import { useFollowScroll } from "~/hooks/useFollowScroll";
 import { type DeploymentLogEntry } from "~/components/runs/v3/deploymentLogsCache";
 import { deploymentAgentPageContext } from "~/components/dashboard-agent/suggested-prompts";
 import type { Handle } from "~/utils/handle";
@@ -178,7 +179,6 @@ function getTriggeredViaDisplay(triggeredVia: string | null | undefined): {
 }
 
 const EXTERNAL_ID_DISPLAY_LENGTH = 24;
-const AT_BOTTOM_TOLERANCE_PX = 16;
 
 function ExternalIdValue({ externalId }: { externalId: string | null }) {
   if (!externalId) {
@@ -528,56 +528,13 @@ function LogsDisplay({
   const [copied, setCopied] = useState(false);
   const [mouseOver, setMouseOver] = useState(false);
   const [collapsed, setCollapsed] = useState(initialCollapsed);
-  const [isAtBottom, setIsAtBottom] = useState(true);
   const logsContainerRef = useRef<HTMLDivElement>(null);
+  const { isAtBottom, scrollToBottom, scrollToTop } = useFollowScroll(logsContainerRef, logs);
 
   useEffect(() => {
     // oxlint-disable-next-line react/set-state-in-effect, react/no-deriving-state-in-effects -- Deployment status changes intentionally reset the user-controlled collapse state.
     setCollapsed(initialCollapsed);
   }, [initialCollapsed]);
-
-  useEffect(() => {
-    const container = logsContainerRef.current;
-    if (!container) return;
-
-    const updateIsAtBottom = () => {
-      const distance = container.scrollHeight - container.scrollTop - container.clientHeight;
-      setIsAtBottom(distance <= AT_BOTTOM_TOLERANCE_PX);
-    };
-
-    container.addEventListener("scroll", updateIsAtBottom, { passive: true });
-    return () => container.removeEventListener("scroll", updateIsAtBottom);
-  }, []);
-
-  useLayoutEffect(() => {
-    const container = logsContainerRef.current;
-    if (!isAtBottom || !container) return;
-    container.scrollTop = container.scrollHeight;
-  }, [logs, isAtBottom]);
-
-  useEffect(() => {
-    const container = logsContainerRef.current;
-    if (!isAtBottom || !container) return;
-
-    const observer = new ResizeObserver(() => {
-      container.scrollTop = container.scrollHeight;
-    });
-    observer.observe(container);
-    return () => observer.disconnect();
-  }, [isAtBottom]);
-
-  const onToggleScroll = () => {
-    const container = logsContainerRef.current;
-    if (!container) return;
-    if (!isAtBottom) {
-      setIsAtBottom(true);
-      container.scrollTop = container.scrollHeight;
-      return;
-    }
-    if (container.scrollHeight - container.clientHeight <= AT_BOTTOM_TOLERANCE_PX) return;
-    setIsAtBottom(false);
-    container.scrollTop = 0;
-  };
 
   const onCopyLogs = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -628,7 +585,7 @@ function LogsDisplay({
             <TooltipProvider>
               <Tooltip disableHoverableContent>
                 <TooltipTrigger
-                  onClick={onToggleScroll}
+                  onClick={isAtBottom ? scrollToTop : scrollToBottom}
                   className={cn(
                     "transition-colors duration-100 focus-custom hover:cursor-pointer",
                     "text-text-dimmed hover:text-text-bright"

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments.$deploymentParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments.$deploymentParam/route.tsx
@@ -566,16 +566,18 @@ function LogsDisplay({
     return () => observer.disconnect();
   }, [isAtBottom]);
 
-  const onToggleScroll = useCallback(() => {
+  const onToggleScroll = () => {
     const container = logsContainerRef.current;
     if (!container) return;
-    if (isAtBottom) {
-      setIsAtBottom(false);
-      container.scrollTo({ top: 0, behavior: "smooth" });
-    } else {
+    if (!isAtBottom) {
+      setIsAtBottom(true);
       container.scrollTop = container.scrollHeight;
+      return;
     }
-  }, [isAtBottom]);
+    if (container.scrollHeight - container.clientHeight <= AT_BOTTOM_TOLERANCE_PX) return;
+    setIsAtBottom(false);
+    container.scrollTo({ top: 0, behavior: "smooth" });
+  };
 
   const onCopyLogs = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments.$deploymentParam/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.deployments.$deploymentParam/route.tsx
@@ -576,7 +576,7 @@ function LogsDisplay({
     }
     if (container.scrollHeight - container.clientHeight <= AT_BOTTOM_TOLERANCE_PX) return;
     setIsAtBottom(false);
-    container.scrollTo({ top: 0, behavior: "smooth" });
+    container.scrollTop = 0;
   };
 
   const onCopyLogs = useCallback(


### PR DESCRIPTION
## Summary

While a deployment was building, the log viewer jumped to the bottom on every new line, so you could not scroll up to read earlier output without being yanked back down. Auto-scroll now only follows while you are at the bottom. Scrolling up pauses it; scrolling back to the bottom, or clicking the new scroll-to-bottom button in the log header, resumes it. When you are at the bottom the same button scrolls to the top. Switching to another deployment starts at the bottom again.

## Design

The follow logic lives in a small `useFollowScroll` hook. Any upward intent pauses following immediately: a `wheel` event with a negative delta (caught before the scroll happens, so a log batch landing mid-gesture cannot snap the view back) or a scroll event whose position decreased. Following resumes once the view is within a few pixels of the bottom. Pinning to the bottom on new content or on a container resize records the position it set and ignores the scroll event that echoes it, so a pin can never be mistaken for the user scrolling down, and the browser clamping the position when the container grows (expand) is told apart from a user scroll by the height change rather than a distance threshold. Scroll-to-top is instant rather than smooth, since an eased scroll starts inside the at-bottom band and would re-enable following.

The header button reuses the icons and labels of the run stream and session viewers. `LogsDisplay` is keyed by deployment id so follow and collapse state reset when the selected deployment changes.
