### PR TITLE
fix(webapp): disable browser autofill on environment variable inputs

### DIFF
--- a/.server-changes/env-var-inputs-autocomplete-off.md
+++ b/.server-changes/env-var-inputs-autocomplete-off.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: improvement
+---
+
+Stop the browser offering to autofill or save environment variable values as saved credentials.

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.environment-variables.new/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.environment-variables.new/route.tsx
@@ -677,6 +677,7 @@ function VariableField({
             onChange={(e) => onChange({ ...value, key: e.currentTarget.value })}
             autoFocus={index === 0}
             onPaste={onPaste}
+            autoComplete="off"
           />
           <FormError id={fields.key.errorId}>{fields.key.errors}</FormError>
         </div>
@@ -689,6 +690,7 @@ function VariableField({
               placeholder="Not set"
               value={value.value}
               onChange={(e) => onChange({ ...value, value: e.currentTarget.value })}
+              autoComplete="off"
             />
             <FormError id={fields.value.errorId}>{fields.value.errors}</FormError>
           </div>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.environment-variables/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.environment-variables/route.tsx
@@ -865,6 +865,7 @@ function EditEnvironmentVariablePanel({
                 placeholder={variable.isSecret ? "Set new secret value" : "Not set"}
                 defaultValue={variable.value}
                 type={"text"}
+                autoComplete="off"
               />
               <FormError id={value.errorId}>{value.errors}</FormError>
             </InputGroup>


### PR DESCRIPTION
The environment variable key and value inputs did not set an autocomplete attribute, so browsers could offer to autofill or save typed values as saved credentials. This sets `autoComplete="off"` on those inputs in both the create and edit forms, matching the `autoComplete="off"` convention already used on the other credential-name inputs.

`autoComplete="off"` is a best-effort hint. Browsers may still ignore it for password-typed fields, so this is defense-in-depth hardening, not a hard guarantee that a password manager cannot store the value.