### PR TITLE
feat(run-engine,run-store): completed-waitpoint envelope, read-time resolver, and the fail-loud coverage check

### DIFF
--- a/internal-packages/run-engine/src/engine/index.ts
+++ b/internal-packages/run-engine/src/engine/index.ts
@@ -423,6 +423,9 @@ export class RunEngine {
       resources,
       executionSnapshotSystem: this.executionSnapshotSystem,
       enqueueSystem: this.enqueueSystem,
+      ...(options.completedWaitpointRecordsEnabled && {
+        completedWaitpointRecordsEnabled: options.completedWaitpointRecordsEnabled,
+      }),
     });
 
     this.ttlSystem = new TtlSystem({

--- a/internal-packages/run-engine/src/engine/systems/completedWaitpointFreeze.test.ts
+++ b/internal-packages/run-engine/src/engine/systems/completedWaitpointFreeze.test.ts
@@ -40,7 +40,7 @@ const _pointerKeys: Exact<keyof CompletedWaitpointsPointer, "cycleSeq" | "count"
 
 const _argsKeys: Exact<
   keyof ResolveCompletedWaitpointsArgs,
-  "runId" | "batchId" | "pointer" | "order" | "records"
+  "runId" | "batchId" | "pointer" | "order" | "distinctIds" | "records"
 > = true;
 import { enhanceExecutionSnapshotWithWaitpoints } from "./executionSnapshotSystem.js";
 
@@ -193,6 +193,7 @@ async function assertParity(
     batchId: batchId ?? undefined,
     pointer: { cycleSeq: 1, count: order.length },
     order,
+    distinctIds: [...new Set(waitpoints.map((w) => w.id))],
     records: waitpoints.map(toRecord),
   };
   // count-carried-forward behaviour (order.length, not the record count) is covered by
@@ -406,6 +407,7 @@ describe("the completed-waitpoints freeze", () => {
       batchId: undefined,
       pointer: { cycleSeq: 1, count: 1 },
       order: ["wp_hook"],
+      distinctIds: ["wp_hook"],
       records: [toRecord(w)],
     });
     expect(resolved).toHaveLength(1);
@@ -611,6 +613,7 @@ describe("the exhaustive parity grid", () => {
                           batchId: readingBatchId ?? undefined,
                           pointer: { cycleSeq: 1, count: order.length },
                           order,
+                          distinctIds: [w.id],
                           records: [toRecord(w)],
                         };
                         const resolved = await referenceResolver(

--- a/internal-packages/run-engine/src/engine/systems/enqueueSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/enqueueSystem.ts
@@ -4,7 +4,7 @@ import type {
   TaskRun,
   TaskRunExecutionStatus,
 } from "@trigger.dev/database";
-import type { RunStore } from "@internal/run-store";
+import type { CompletedWaitpointRecord, RunStore } from "@internal/run-store";
 import { parseNaturalLanguageDuration } from "@trigger.dev/core/v3/isomorphic";
 import type { MinimalAuthenticatedEnvironment } from "../../shared/index.js";
 import { QUEUED_SNAPSHOT_DESCRIPTION, QUEUED_SNAPSHOT_STATUS } from "../consts.js";
@@ -34,6 +34,7 @@ export class EnqueueSystem {
     batchId,
     checkpointId,
     completedWaitpoints,
+    completedWaitpointRecords,
     workerId,
     runnerId,
     skipRunLock,
@@ -57,6 +58,7 @@ export class EnqueueSystem {
       id: string;
       index?: number;
     }[];
+    completedWaitpointRecords?: CompletedWaitpointRecord[];
     workerId?: string;
     runnerId?: string;
     skipRunLock?: boolean;
@@ -108,6 +110,7 @@ export class EnqueueSystem {
           organizationId: env.organization.id,
           checkpointId,
           completedWaitpoints,
+          completedWaitpointRecords,
           workerId,
           runnerId,
         },

--- a/internal-packages/run-engine/src/engine/systems/executionSnapshotSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/executionSnapshotSystem.ts
@@ -173,7 +173,7 @@ async function getSnapshotWaitpointIdsWithPresence(
  * This is necessary because waitpoints can have large outputs (100KB+),
  * and fetching many at once can exceed Node.js string limits.
  */
-export async function fetchWaitpointsInChunks(
+async function fetchWaitpointsInChunks(
   prisma: PrismaClientOrTransaction,
   waitpointIds: string[],
   runStore?: RunStore,
@@ -198,6 +198,67 @@ export async function fetchWaitpointsInChunks(
     allWaitpoints.push(...waitpoints);
   }
   return allWaitpoints;
+}
+
+/**
+ * The columns the completion envelope is built from, and only those.
+ *
+ * `fetchWaitpointsInChunks` reads whole rows because the snapshot hydration builds a full
+ * executor waitpoint from them. The envelope needs fewer, so projecting drops `tags`,
+ * `projectId`, `environmentId`, `createdAt`, `updatedAt` and `idempotencyKeyExpiresAt` from a
+ * read that happens on the writer inside the run lock. It cannot drop `output`, which is the
+ * 100KB+ column and also the payload the envelope exists to carry.
+ *
+ * `status` is here for the arm's COMPLETED filter, not for the mapper.
+ */
+const WAITPOINT_ENVELOPE_SELECT = {
+  id: true,
+  friendlyId: true,
+  type: true,
+  status: true,
+  completedAt: true,
+  output: true,
+  outputType: true,
+  outputIsError: true,
+  completedByTaskRunId: true,
+  completedByBatchId: true,
+  completedAfter: true,
+  idempotencyKey: true,
+  userProvidedIdempotencyKey: true,
+  inactiveIdempotencyKey: true,
+} satisfies Prisma.WaitpointSelect;
+
+export type WaitpointEnvelopeRow = Pick<Waitpoint, keyof typeof WAITPOINT_ENVELOPE_SELECT>;
+
+/**
+ * The projected sibling of `fetchWaitpointsInChunks`, for the envelope read.
+ *
+ * Chunked identically, and for the same reason: a waitpoint output can be 100KB+, so a large
+ * fan-in read whole can exceed Node's string limits. `boundedIn` pads for plan-cache stability,
+ * it does not bound the set. `runId` is the routing hint the router needs to read the run's own
+ * store instead of fanning every chunk across both run-ops databases.
+ */
+export async function fetchWaitpointEnvelopeRowsInChunks(
+  prisma: PrismaClientOrTransaction,
+  waitpointIds: string[],
+  runStore?: RunStore,
+  runId?: string
+): Promise<WaitpointEnvelopeRow[]> {
+  if (waitpointIds.length === 0) return [];
+
+  const rows: WaitpointEnvelopeRow[] = [];
+  for (let i = 0; i < waitpointIds.length; i += WAITPOINT_CHUNK_SIZE) {
+    const chunk = waitpointIds.slice(i, i + WAITPOINT_CHUNK_SIZE);
+    const args = {
+      where: { id: { in: boundedIn(chunk) } },
+      select: WAITPOINT_ENVELOPE_SELECT,
+    };
+    const found = runStore
+      ? await runStore.findManyWaitpoints(args, prisma, runId)
+      : await prisma.waitpoint.findMany(args);
+    rows.push(...found);
+  }
+  return rows;
 }
 
 /**

--- a/internal-packages/run-engine/src/engine/systems/executionSnapshotSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/executionSnapshotSystem.ts
@@ -10,7 +10,7 @@ import type {
   TaskRunStatus,
   Waitpoint,
 } from "@trigger.dev/database";
-import type { RunStore } from "@internal/run-store";
+import type { CompletedWaitpointRecord, RunStore } from "@internal/run-store";
 import { ExecutionSnapshotNotFoundError, ServiceValidationError } from "../errors.js";
 import type { HeartbeatTimeouts } from "../types.js";
 import type { SystemResources } from "./systems.js";
@@ -449,6 +449,7 @@ export class ExecutionSnapshotSystem {
       workerId,
       runnerId,
       completedWaitpoints,
+      completedWaitpointRecords,
       error,
     }: {
       run: { id: string; status: TaskRunStatus; attemptNumber?: number | null };
@@ -470,6 +471,7 @@ export class ExecutionSnapshotSystem {
         id: string;
         index?: number;
       }[];
+      completedWaitpointRecords?: CompletedWaitpointRecord[];
       error?: string;
     },
     // When set (inside runStore.runInTransaction), the snapshot write goes through the owning store
@@ -492,6 +494,7 @@ export class ExecutionSnapshotSystem {
         workerId,
         runnerId,
         completedWaitpoints,
+        completedWaitpointRecords,
         error,
       },
       prisma

--- a/internal-packages/run-engine/src/engine/systems/executionSnapshotSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/executionSnapshotSystem.ts
@@ -173,7 +173,7 @@ async function getSnapshotWaitpointIdsWithPresence(
  * This is necessary because waitpoints can have large outputs (100KB+),
  * and fetching many at once can exceed Node.js string limits.
  */
-async function fetchWaitpointsInChunks(
+export async function fetchWaitpointsInChunks(
   prisma: PrismaClientOrTransaction,
   waitpointIds: string[],
   runStore?: RunStore,

--- a/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
@@ -1,4 +1,6 @@
 import { timeoutError } from "@trigger.dev/core/v3";
+import { parseWaitpointId } from "@trigger.dev/core/v3/isomorphic";
+import type { CompletedWaitpointRecord } from "@internal/run-store";
 import type {
   PrismaClientOrTransaction,
   TaskRun,
@@ -10,7 +12,8 @@ import { assertNever } from "assert-never";
 import { sendNotificationToWorker } from "../eventBus.js";
 import { isFinalRunStatus } from "../statuses.js";
 import { LegacyPostgresWaitpointCoordinator } from "../waitpointCoordinator/legacyPostgresCoordinator.js";
-import type { WaitpointCoordinator } from "../waitpointCoordinator/types.js";
+import { buildCompletedWaitpointRecords } from "../waitpointCoordinator/completedWaitpointRecords.js";
+import type { RunBlockEdge, WaitpointCoordinator } from "../waitpointCoordinator/types.js";
 import type { EnqueueSystem } from "./enqueueSystem.js";
 import type { ExecutionSnapshotSystem } from "./executionSnapshotSystem.js";
 import { getLatestExecutionSnapshot } from "./executionSnapshotSystem.js";
@@ -484,6 +487,15 @@ export class WaitpointSystem {
         };
       }
 
+      // The record set rides the wait cycle's key once per resume, so build it here rather
+      // than at each append site. Nothing mints a store-format waitpoint yet, so
+      // #completedWaitpointRecordsFor returns undefined on every live path today.
+      const completedWaitpointRecords = await this.#completedWaitpointRecordsFor(
+        runId,
+        blockingWaitpoints
+      );
+
+
       // 3. Get the run (run-ops scalars) + resolve its environment via the control-plane resolver,
       // so the run-ops DB can split without a cross-provider join.
       const run = await this.$.runStore.findRun(
@@ -623,6 +635,7 @@ export class WaitpointSystem {
                 id: b.waitpoint.id,
                 index: b.batchIndex ?? undefined,
               })),
+              ...(completedWaitpointRecords && { completedWaitpointRecords }),
             }
           );
 
@@ -682,6 +695,7 @@ export class WaitpointSystem {
               id: b.waitpoint.id,
               index: b.batchIndex ?? undefined,
             })),
+            ...(completedWaitpointRecords && { completedWaitpointRecords }),
             checkpointId: snapshot.checkpointId ?? undefined,
           });
 
@@ -726,6 +740,37 @@ export class WaitpointSystem {
     environmentId: string;
   }) {
     return this.coordinator.mintAssociatedWaitpointData({ projectId, environmentId });
+  }
+
+  /**
+   * The record set for one resume, or undefined when this wait has no store-resident half.
+   *
+   * The classification gate is what keeps this inert. `parseWaitpointId` reports legacy for
+   * every id minted today, so no live resume reads an envelope or writes a record until a
+   * waitpoint mints in store format.
+   */
+  async #completedWaitpointRecordsFor(
+    runId: string,
+    blockingWaitpoints: RunBlockEdge[]
+  ): Promise<CompletedWaitpointRecord[] | undefined> {
+    const storeResidentIds = [
+      ...new Set(
+        blockingWaitpoints
+          .map((b) => b.waitpoint.id)
+          .filter((id) => parseWaitpointId(id).format === "b32hexW")
+      ),
+    ];
+
+    if (storeResidentIds.length === 0) {
+      return undefined;
+    }
+
+    const sources = await this.coordinator.readCompletionEnvelopes({
+      runId,
+      waitpointIds: storeResidentIds,
+    });
+
+    return buildCompletedWaitpointRecords(sources);
   }
 
   /**

--- a/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
@@ -499,7 +499,6 @@ export class WaitpointSystem {
         blockingWaitpoints
       );
 
-
       // 3. Get the run (run-ops scalars) + resolve its environment via the control-plane resolver,
       // so the run-ops DB can split without a cross-provider join.
       const run = await this.$.runStore.findRun(

--- a/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
@@ -1,5 +1,7 @@
 import { timeoutError } from "@trigger.dev/core/v3";
+import { parseWaitpointId } from "@trigger.dev/core/v3/isomorphic";
 import type { ShardKey } from "@trigger.dev/core/v3/isomorphic";
+import type { CompletedWaitpointRecord } from "@internal/run-store";
 import type {
   PrismaClientOrTransaction,
   TaskRun,
@@ -11,7 +13,8 @@ import { assertNever } from "assert-never";
 import { sendNotificationToWorker } from "../eventBus.js";
 import { isFinalRunStatus } from "../statuses.js";
 import { LegacyPostgresWaitpointCoordinator } from "../waitpointCoordinator/legacyPostgresCoordinator.js";
-import type { WaitpointCoordinator } from "../waitpointCoordinator/types.js";
+import { buildCompletedWaitpointRecords } from "../waitpointCoordinator/completedWaitpointRecords.js";
+import type { RunBlockEdge, WaitpointCoordinator } from "../waitpointCoordinator/types.js";
 import type { EnqueueSystem } from "./enqueueSystem.js";
 import type { ExecutionSnapshotSystem } from "./executionSnapshotSystem.js";
 import { getLatestExecutionSnapshot } from "./executionSnapshotSystem.js";
@@ -488,6 +491,15 @@ export class WaitpointSystem {
         };
       }
 
+      // The record set rides the wait cycle's key once per resume, so build it here rather
+      // than at each append site. Nothing mints a store-format waitpoint yet, so
+      // #completedWaitpointRecordsFor returns undefined on every live path today.
+      const completedWaitpointRecords = await this.#completedWaitpointRecordsFor(
+        runId,
+        blockingWaitpoints
+      );
+
+
       // 3. Get the run (run-ops scalars) + resolve its environment via the control-plane resolver,
       // so the run-ops DB can split without a cross-provider join.
       const run = await this.$.runStore.findRun(
@@ -627,6 +639,7 @@ export class WaitpointSystem {
                 id: b.waitpoint.id,
                 index: b.batchIndex ?? undefined,
               })),
+              ...(completedWaitpointRecords && { completedWaitpointRecords }),
             }
           );
 
@@ -686,6 +699,7 @@ export class WaitpointSystem {
               id: b.waitpoint.id,
               index: b.batchIndex ?? undefined,
             })),
+            ...(completedWaitpointRecords && { completedWaitpointRecords }),
             checkpointId: snapshot.checkpointId ?? undefined,
           });
 
@@ -736,6 +750,37 @@ export class WaitpointSystem {
       environmentId,
       anchorRunId,
     });
+  }
+
+  /**
+   * The record set for one resume, or undefined when this wait has no store-resident half.
+   *
+   * The classification gate is what keeps this inert. `parseWaitpointId` reports legacy for
+   * every id minted today, so no live resume reads an envelope or writes a record until a
+   * waitpoint mints in store format.
+   */
+  async #completedWaitpointRecordsFor(
+    runId: string,
+    blockingWaitpoints: RunBlockEdge[]
+  ): Promise<CompletedWaitpointRecord[] | undefined> {
+    const storeResidentIds = [
+      ...new Set(
+        blockingWaitpoints
+          .map((b) => b.waitpoint.id)
+          .filter((id) => parseWaitpointId(id).format === "b32hexW")
+      ),
+    ];
+
+    if (storeResidentIds.length === 0) {
+      return undefined;
+    }
+
+    const sources = await this.coordinator.readCompletionEnvelopes({
+      runId,
+      waitpointIds: storeResidentIds,
+    });
+
+    return buildCompletedWaitpointRecords(sources);
   }
 
   /**

--- a/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
@@ -491,14 +491,6 @@ export class WaitpointSystem {
         };
       }
 
-      // The record set rides the wait cycle's key once per resume, so build it here rather
-      // than at each append site. Nothing mints a store-format waitpoint yet, so
-      // #completedWaitpointRecordsFor returns undefined on every live path today.
-      const completedWaitpointRecords = await this.#completedWaitpointRecordsFor(
-        runId,
-        blockingWaitpoints
-      );
-
       // 3. Get the run (run-ops scalars) + resolve its environment via the control-plane resolver,
       // so the run-ops DB can split without a cross-provider join.
       const run = await this.$.runStore.findRun(
@@ -616,6 +608,13 @@ export class WaitpointSystem {
           };
         }
         case "EXECUTING_WITH_WAITPOINTS": {
+          // Built inside the branch, not before the switch: the statuses above return without
+          // appending, and they must not pay an envelope read to do it.
+          const completedWaitpointRecords = await this.#completedWaitpointRecordsFor(
+            runId,
+            blockingWaitpoints
+          );
+
           const newSnapshot = await this.executionSnapshotSystem.createExecutionSnapshot(
             this.$.prisma,
             {
@@ -683,6 +682,11 @@ export class WaitpointSystem {
               `continueRunIfUnblocked: run is suspended, but has no checkpoint: ${runId}`
             );
           }
+
+          const completedWaitpointRecords = await this.#completedWaitpointRecordsFor(
+            runId,
+            blockingWaitpoints
+          );
 
           //put it back in the queue, with the original timestamp (w/ priority)
           //this prioritizes dequeuing waiting runs over new runs
@@ -752,17 +756,22 @@ export class WaitpointSystem {
   }
 
   /**
-   * The record set for one resume, or undefined when this wait has no store-resident half.
+   * The record set for one resume, or undefined when no blocking waitpoint carries a store-format
+   * id.
    *
-   * The classification gate is what keeps this inert. `parseWaitpointId` reports legacy for
-   * every id minted today, so no live resume reads an envelope or writes a record until a
-   * waitpoint mints in store format.
+   * Gated on id FORMAT, not residency. The two are not the same during a migration: a
+   * store-format id can still be served by the Postgres arm, exactly as run-ops ids were for
+   * runs. Whichever arm owns it answers, so the gate only decides whether to ask at all.
+   *
+   * That gate is what keeps this inert. `parseWaitpointId` reports legacy for every id minted
+   * today, so no live resume reads an envelope or writes a record until a waitpoint mints in
+   * store format.
    */
   async #completedWaitpointRecordsFor(
     runId: string,
     blockingWaitpoints: RunBlockEdge[]
   ): Promise<CompletedWaitpointRecord[] | undefined> {
-    const storeResidentIds = [
+    const storeFormatIds = [
       ...new Set(
         blockingWaitpoints
           .map((b) => b.waitpoint.id)
@@ -770,13 +779,13 @@ export class WaitpointSystem {
       ),
     ];
 
-    if (storeResidentIds.length === 0) {
+    if (storeFormatIds.length === 0) {
       return undefined;
     }
 
     const sources = await this.coordinator.readCompletionEnvelopes({
       runId,
-      waitpointIds: storeResidentIds,
+      waitpointIds: storeFormatIds,
     });
 
     return buildCompletedWaitpointRecords(sources);

--- a/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
@@ -38,11 +38,15 @@ export type WaitpointSystemOptions = {
    * transitioning from, so it costs nothing to pass. The run id rides along for logging and for
    * any future per-run override.
    *
+   * Positional rather than an options object, deliberately: an object literal here would be
+   * allocated on every resume, including the ones that exist only to be told no. Two arguments
+   * make the disabled path genuinely free rather than nearly free.
+   *
    * Defaults to never. A record set is only reachable through the snapshot store, so until the
    * ticket that wires that store supplies this predicate there is no run for which one could
    * exist, and no resume does any of this work.
    */
-  completedWaitpointRecordsEnabled?: (args: { runId: string; organizationId: string }) => boolean;
+  completedWaitpointRecordsEnabled?: (runId: string, organizationId: string) => boolean;
 };
 
 type WaitpointContinuationWaitpoint = Pick<Waitpoint, "id" | "type" | "completedAfter" | "status">;
@@ -66,7 +70,7 @@ export class WaitpointSystem {
   private readonly executionSnapshotSystem: ExecutionSnapshotSystem;
   private readonly enqueueSystem: EnqueueSystem;
   private readonly coordinator: WaitpointCoordinator;
-  private readonly recordsEnabled: (args: { runId: string; organizationId: string }) => boolean;
+  private readonly recordsEnabled: (runId: string, organizationId: string) => boolean;
 
   constructor(private readonly options: WaitpointSystemOptions) {
     this.$ = options.resources;
@@ -807,7 +811,7 @@ export class WaitpointSystem {
     // nothing to build, and deciding that by walking its blocking waitpoints made every resume
     // for every organisation pay a scan proportional to its fan-in to reach the same answer.
     // Defaults to never, so today this returns here for everyone.
-    if (!this.recordsEnabled({ runId, organizationId })) {
+    if (!this.recordsEnabled(runId, organizationId)) {
       return undefined;
     }
 

--- a/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
@@ -778,6 +778,15 @@ export class WaitpointSystem {
     runId: string,
     blockingWaitpoints: RunBlockEdge[]
   ): Promise<CompletedWaitpointRecord[] | undefined> {
+    // `.some` before the dedup, so the gate allocates nothing in the case that is universal
+    // today and stays common through a partial rollout: no blocking waitpoint is store-format.
+    // Building the mapped array, the filtered array and the Set first meant three allocations
+    // per resume -- for a 1000-wide batch fan-in too -- to discover there was nothing to ask for.
+    if (!blockingWaitpoints.some((b) => parseWaitpointId(b.waitpoint.id).format === "b32hexW")) {
+      return undefined;
+    }
+
+    // Only a set that really holds one pays for the dedup.
     const storeFormatIds = [
       ...new Set(
         blockingWaitpoints
@@ -785,10 +794,6 @@ export class WaitpointSystem {
           .filter((id) => parseWaitpointId(id).format === "b32hexW")
       ),
     ];
-
-    if (storeFormatIds.length === 0) {
-      return undefined;
-    }
 
     const sources = await this.coordinator.readCompletionEnvelopes({
       runId,

--- a/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
@@ -487,14 +487,6 @@ export class WaitpointSystem {
         };
       }
 
-      // The record set rides the wait cycle's key once per resume, so build it here rather
-      // than at each append site. Nothing mints a store-format waitpoint yet, so
-      // #completedWaitpointRecordsFor returns undefined on every live path today.
-      const completedWaitpointRecords = await this.#completedWaitpointRecordsFor(
-        runId,
-        blockingWaitpoints
-      );
-
       // 3. Get the run (run-ops scalars) + resolve its environment via the control-plane resolver,
       // so the run-ops DB can split without a cross-provider join.
       const run = await this.$.runStore.findRun(
@@ -612,6 +604,13 @@ export class WaitpointSystem {
           };
         }
         case "EXECUTING_WITH_WAITPOINTS": {
+          // Built inside the branch, not before the switch: the statuses above return without
+          // appending, and they must not pay an envelope read to do it.
+          const completedWaitpointRecords = await this.#completedWaitpointRecordsFor(
+            runId,
+            blockingWaitpoints
+          );
+
           const newSnapshot = await this.executionSnapshotSystem.createExecutionSnapshot(
             this.$.prisma,
             {
@@ -680,6 +679,11 @@ export class WaitpointSystem {
             );
           }
 
+          const completedWaitpointRecords = await this.#completedWaitpointRecordsFor(
+            runId,
+            blockingWaitpoints
+          );
+
           //put it back in the queue, with the original timestamp (w/ priority)
           //this prioritizes dequeuing waiting runs over new runs
           const newSnapshot = await this.enqueueSystem.enqueueRun({
@@ -742,17 +746,22 @@ export class WaitpointSystem {
   }
 
   /**
-   * The record set for one resume, or undefined when this wait has no store-resident half.
+   * The record set for one resume, or undefined when no blocking waitpoint carries a store-format
+   * id.
    *
-   * The classification gate is what keeps this inert. `parseWaitpointId` reports legacy for
-   * every id minted today, so no live resume reads an envelope or writes a record until a
-   * waitpoint mints in store format.
+   * Gated on id FORMAT, not residency. The two are not the same during a migration: a
+   * store-format id can still be served by the Postgres arm, exactly as run-ops ids were for
+   * runs. Whichever arm owns it answers, so the gate only decides whether to ask at all.
+   *
+   * That gate is what keeps this inert. `parseWaitpointId` reports legacy for every id minted
+   * today, so no live resume reads an envelope or writes a record until a waitpoint mints in
+   * store format.
    */
   async #completedWaitpointRecordsFor(
     runId: string,
     blockingWaitpoints: RunBlockEdge[]
   ): Promise<CompletedWaitpointRecord[] | undefined> {
-    const storeResidentIds = [
+    const storeFormatIds = [
       ...new Set(
         blockingWaitpoints
           .map((b) => b.waitpoint.id)
@@ -760,13 +769,13 @@ export class WaitpointSystem {
       ),
     ];
 
-    if (storeResidentIds.length === 0) {
+    if (storeFormatIds.length === 0) {
       return undefined;
     }
 
     const sources = await this.coordinator.readCompletionEnvelopes({
       runId,
-      waitpointIds: storeResidentIds,
+      waitpointIds: storeFormatIds,
     });
 
     return buildCompletedWaitpointRecords(sources);

--- a/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
@@ -766,6 +766,13 @@ export class WaitpointSystem {
    * That gate is what keeps this inert. `parseWaitpointId` reports legacy for every id minted
    * today, so no live resume reads an envelope or writes a record until a waitpoint mints in
    * store format.
+   *
+   * ROLLOUT ORDER. Because the gate reads the id and not the organisation, the first store-format
+   * mint is what starts the cost, for every organisation that then holds one -- not the first
+   * snapshot-store flip. The arm that answers here is the Postgres one until a store arm is
+   * wired, so a mint enabled ahead of the store means a projected `Waitpoint` read on the
+   * WRITER, inside the run lock, once per resume. That is bounded and correct, but it is not
+   * free, so store-format minting should follow the snapshot store rather than lead it.
    */
   async #completedWaitpointRecordsFor(
     runId: string,

--- a/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
@@ -24,6 +24,19 @@ export type WaitpointSystemOptions = {
   resources: SystemResources;
   executionSnapshotSystem: ExecutionSnapshotSystem;
   enqueueSystem: EnqueueSystem;
+  /**
+   * Whether this run's snapshots can hold a completed-waitpoint record set. Must be O(1).
+   *
+   * Sits in FRONT of the id-format scan so a run that cannot hold records pays one predicate
+   * call, not one `parseWaitpointId` per blocking waitpoint. It has to be injected rather than
+   * derived here: the answer is per-organisation, since it follows the snapshot store's own
+   * rollout, and the store keeps that state private to itself.
+   *
+   * Defaults to never. A record set is only reachable through the snapshot store, so until the
+   * ticket that wires that store supplies this predicate there is no run for which one could
+   * exist, and no resume does any of this work.
+   */
+  completedWaitpointRecordsEnabled?: (runId: string) => boolean;
 };
 
 type WaitpointContinuationWaitpoint = Pick<Waitpoint, "id" | "type" | "completedAfter" | "status">;
@@ -47,11 +60,13 @@ export class WaitpointSystem {
   private readonly executionSnapshotSystem: ExecutionSnapshotSystem;
   private readonly enqueueSystem: EnqueueSystem;
   private readonly coordinator: WaitpointCoordinator;
+  private readonly recordsEnabled: (runId: string) => boolean;
 
   constructor(private readonly options: WaitpointSystemOptions) {
     this.$ = options.resources;
     this.executionSnapshotSystem = options.executionSnapshotSystem;
     this.enqueueSystem = options.enqueueSystem;
+    this.recordsEnabled = options.completedWaitpointRecordsEnabled ?? (() => false);
     this.coordinator = new LegacyPostgresWaitpointCoordinator({
       runStore: this.$.runStore,
       prisma: this.$.prisma,
@@ -759,7 +774,8 @@ export class WaitpointSystem {
    * The record set for one resume, or undefined when no blocking waitpoint carries a store-format
    * id.
    *
-   * Gated on id FORMAT, not residency. The two are not the same during a migration: a
+   * Gated on the record set being reachable at all, and only then on id FORMAT rather than
+   * residency. Format and residency are not the same during a migration: a
    * store-format id can still be served by the Postgres arm, exactly as run-ops ids were for
    * runs. Whichever arm owns it answers, so the gate only decides whether to ask at all.
    *
@@ -778,10 +794,18 @@ export class WaitpointSystem {
     runId: string,
     blockingWaitpoints: RunBlockEdge[]
   ): Promise<CompletedWaitpointRecord[] | undefined> {
-    // `.some` before the dedup, so the gate allocates nothing in the case that is universal
-    // today and stays common through a partial rollout: no blocking waitpoint is store-format.
-    // Building the mapped array, the filtered array and the Set first meant three allocations
-    // per resume -- for a 1000-wide batch fan-in too -- to discover there was nothing to ask for.
+    // O(1) first, and unconditionally first: a run whose snapshots cannot hold a record set has
+    // nothing to build, and deciding that by walking its blocking waitpoints made every resume
+    // for every organisation pay a scan proportional to its fan-in to reach the same answer.
+    // Defaults to never, so today this returns here for everyone.
+    if (!this.recordsEnabled(runId)) {
+      return undefined;
+    }
+
+    // Only then the id-format scan, which is what keeps a MIXED cycle working once records are
+    // enabled: an organisation mid-rollout holds waitpoints minted either side of the flip, and
+    // the format is the only thing that says which half each id belongs to. `.some` before the
+    // dedup so an enabled run holding no store-format id still allocates nothing.
     if (!blockingWaitpoints.some((b) => parseWaitpointId(b.waitpoint.id).format === "b32hexW")) {
       return undefined;
     }

--- a/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
@@ -495,7 +495,6 @@ export class WaitpointSystem {
         blockingWaitpoints
       );
 
-
       // 3. Get the run (run-ops scalars) + resolve its environment via the control-plane resolver,
       // so the run-ops DB can split without a cross-provider join.
       const run = await this.$.runStore.findRun(

--- a/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
@@ -32,11 +32,17 @@ export type WaitpointSystemOptions = {
    * derived here: the answer is per-organisation, since it follows the snapshot store's own
    * rollout, and the store keeps that state private to itself.
    *
+   * Takes the organisation id, not just the run id. The decision is organisation-scoped, and an
+   * opaque run id cannot answer it without a lookup -- which would put a read back on the path
+   * this gate exists to keep free. Both call sites already hold it on the snapshot they are
+   * transitioning from, so it costs nothing to pass. The run id rides along for logging and for
+   * any future per-run override.
+   *
    * Defaults to never. A record set is only reachable through the snapshot store, so until the
    * ticket that wires that store supplies this predicate there is no run for which one could
    * exist, and no resume does any of this work.
    */
-  completedWaitpointRecordsEnabled?: (runId: string) => boolean;
+  completedWaitpointRecordsEnabled?: (args: { runId: string; organizationId: string }) => boolean;
 };
 
 type WaitpointContinuationWaitpoint = Pick<Waitpoint, "id" | "type" | "completedAfter" | "status">;
@@ -60,7 +66,7 @@ export class WaitpointSystem {
   private readonly executionSnapshotSystem: ExecutionSnapshotSystem;
   private readonly enqueueSystem: EnqueueSystem;
   private readonly coordinator: WaitpointCoordinator;
-  private readonly recordsEnabled: (runId: string) => boolean;
+  private readonly recordsEnabled: (args: { runId: string; organizationId: string }) => boolean;
 
   constructor(private readonly options: WaitpointSystemOptions) {
     this.$ = options.resources;
@@ -627,6 +633,7 @@ export class WaitpointSystem {
           // appending, and they must not pay an envelope read to do it.
           const completedWaitpointRecords = await this.#completedWaitpointRecordsFor(
             runId,
+            snapshot.organizationId,
             blockingWaitpoints
           );
 
@@ -700,6 +707,7 @@ export class WaitpointSystem {
 
           const completedWaitpointRecords = await this.#completedWaitpointRecordsFor(
             runId,
+            snapshot.organizationId,
             blockingWaitpoints
           );
 
@@ -792,13 +800,14 @@ export class WaitpointSystem {
    */
   async #completedWaitpointRecordsFor(
     runId: string,
+    organizationId: string,
     blockingWaitpoints: RunBlockEdge[]
   ): Promise<CompletedWaitpointRecord[] | undefined> {
     // O(1) first, and unconditionally first: a run whose snapshots cannot hold a record set has
     // nothing to build, and deciding that by walking its blocking waitpoints made every resume
     // for every organisation pay a scan proportional to its fan-in to reach the same answer.
     // Defaults to never, so today this returns here for everyone.
-    if (!this.recordsEnabled(runId)) {
+    if (!this.recordsEnabled({ runId, organizationId })) {
       return undefined;
     }
 

--- a/internal-packages/run-engine/src/engine/tests/completedWaitpointRecordsGate.test.ts
+++ b/internal-packages/run-engine/src/engine/tests/completedWaitpointRecordsGate.test.ts
@@ -34,7 +34,7 @@ vi.setConfig({ testTimeout: 60_000 });
 function engineWith(
   prisma: never,
   redisOptions: never,
-  completedWaitpointRecordsEnabled?: (args: { runId: string; organizationId: string }) => boolean
+  completedWaitpointRecordsEnabled?: (runId: string, organizationId: string) => boolean
 ) {
   return new RunEngine({
     prisma,
@@ -65,8 +65,8 @@ describe("the completed-waitpoint records gate", () => {
     "is consulted exactly once per resume, with the run's organisation",
     async ({ prisma, redisOptions }) => {
       const consulted: { runId: string; organizationId: string }[] = [];
-      const engine = engineWith(prisma as never, redisOptions as never, (args) => {
-        consulted.push(args);
+      const engine = engineWith(prisma as never, redisOptions as never, (runId, organizationId) => {
+        consulted.push({ runId, organizationId });
         return false;
       });
 

--- a/internal-packages/run-engine/src/engine/tests/completedWaitpointRecordsGate.test.ts
+++ b/internal-packages/run-engine/src/engine/tests/completedWaitpointRecordsGate.test.ts
@@ -1,0 +1,189 @@
+// The O(1) gate in front of the completed-waitpoint record build.
+//
+// Deciding whether to build a record set by scanning a run's blocking waitpoints made every
+// resume, for every organisation, pay work proportional to its fan-in to reach the same answer:
+// no. The predicate moves that decision in front of the scan, and defaults to never.
+import { containerTest } from "@internal/testcontainers";
+import { trace } from "@internal/tracing";
+import { expect } from "vitest";
+import { RunEngine } from "../index.js";
+import { setTimeout } from "node:timers/promises";
+import { setupAuthenticatedEnvironment, setupBackgroundWorker } from "./setup.js";
+
+// The trigger has to reach the queue, and the completion resumes the run out of band, so both
+// need settling before the assertions read state back.
+const SETTLE_MS = 500;
+
+async function waitForResume(
+  engine: RunEngine,
+  runId: string
+): Promise<{ completedWaitpointIds: string[] }> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const data = await engine.getRunExecutionData({ runId });
+    const ids = data?.completedWaitpoints?.map((w) => w.id) ?? [];
+    if (ids.length > 0) {
+      return { completedWaitpointIds: ids };
+    }
+    await setTimeout(100);
+  }
+  return { completedWaitpointIds: [] };
+}
+
+vi.setConfig({ testTimeout: 60_000 });
+
+function engineWith(
+  prisma: never,
+  redisOptions: never,
+  completedWaitpointRecordsEnabled?: (runId: string) => boolean
+) {
+  return new RunEngine({
+    prisma,
+    worker: { redis: redisOptions, workers: 1, tasksPerWorker: 10, pollIntervalMs: 100 },
+    queue: { redis: redisOptions },
+    runLock: { redis: redisOptions },
+    machines: {
+      defaultMachine: "small-1x",
+      machines: {
+        "small-1x": { name: "small-1x" as const, cpu: 0.5, memory: 0.5, centsPerMs: 0.0001 },
+      },
+      baseCostInCents: 0.0001,
+    },
+    tracer: trace.getTracer("test", "0.0.0"),
+    ...(completedWaitpointRecordsEnabled && { completedWaitpointRecordsEnabled }),
+  });
+}
+
+describe("the completed-waitpoint records gate", () => {
+  containerTest(
+    "is consulted once per resume, and the resume is unaffected",
+    async ({ prisma, redisOptions }) => {
+      const consulted: string[] = [];
+      const engine = engineWith(prisma as never, redisOptions as never, (runId) => {
+        consulted.push(runId);
+        return false;
+      });
+
+      try {
+        const env = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+        const taskIdentifier = "test-task";
+        await setupBackgroundWorker(engine, env, taskIdentifier);
+
+        const run = await engine.trigger(
+          {
+            number: 1,
+            friendlyId: "run_gate1",
+            environment: env,
+            taskIdentifier,
+            payload: "{}",
+            payloadType: "application/json",
+            context: {},
+            traceContext: {},
+            traceId: "t12345",
+            spanId: "s12345",
+            workerQueue: "main",
+            queue: `task/${taskIdentifier}`,
+            isTest: false,
+            tags: [],
+          },
+          prisma
+        );
+
+        await setTimeout(SETTLE_MS);
+        const dequeued = await engine.dequeueFromWorkerQueue({
+          consumerId: "test_12345",
+          workerQueue: "main",
+        });
+        const attempt = await engine.startRunAttempt({
+          runId: dequeued[0]!.run.id,
+          snapshotId: dequeued[0]!.snapshot.id,
+        });
+
+        // Block on a manual waitpoint, then release it: the release is what resumes the run and
+        // reaches the gate.
+        const waitpoint = await engine.createManualWaitpoint({
+          environmentId: env.id,
+          projectId: env.projectId,
+        });
+        await engine.blockRunWithWaitpoint({
+          runId: run.id,
+          waitpoints: [waitpoint.waitpoint.id],
+          projectId: env.project.id,
+          organizationId: env.organization.id,
+        });
+
+        await engine.completeWaitpoint({ id: waitpoint.waitpoint.id });
+
+        const { completedWaitpointIds } = await waitForResume(engine, run.id);
+
+        // The run resumed, because a disabled gate only skips the record build...
+        expect(completedWaitpointIds).toContain(waitpoint.waitpoint.id);
+        // ...and the gate was consulted for it, which is what puts it in the resume path.
+        expect(consulted).toContain(run.id);
+        expect(attempt.run.id).toBe(run.id);
+      } finally {
+        await engine.quit();
+      }
+    }
+  );
+
+  containerTest("defaults to never, so no resume consults it", async ({ prisma, redisOptions }) => {
+    // No predicate supplied, which is every deployment until the store that consumes a record set
+    // is wired. The default has to be a constant false rather than a scan, or the cost this gate
+    // exists to remove comes straight back for everyone.
+    const engine = engineWith(prisma as never, redisOptions as never);
+
+    try {
+      const env = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+      const taskIdentifier = "test-task";
+      await setupBackgroundWorker(engine, env, taskIdentifier);
+
+      const run = await engine.trigger(
+        {
+          number: 1,
+          friendlyId: "run_gate2",
+          environment: env,
+          taskIdentifier,
+          payload: "{}",
+          payloadType: "application/json",
+          context: {},
+          traceContext: {},
+          traceId: "t22345",
+          spanId: "s22345",
+          workerQueue: "main",
+          queue: `task/${taskIdentifier}`,
+          isTest: false,
+          tags: [],
+        },
+        prisma
+      );
+
+      await setTimeout(SETTLE_MS);
+      const dequeued = await engine.dequeueFromWorkerQueue({
+        consumerId: "test_22345",
+        workerQueue: "main",
+      });
+      await engine.startRunAttempt({
+        runId: dequeued[0]!.run.id,
+        snapshotId: dequeued[0]!.snapshot.id,
+      });
+
+      const waitpoint = await engine.createManualWaitpoint({
+        environmentId: env.id,
+        projectId: env.projectId,
+      });
+      await engine.blockRunWithWaitpoint({
+        runId: run.id,
+        waitpoints: [waitpoint.waitpoint.id],
+        projectId: env.project.id,
+        organizationId: env.organization.id,
+      });
+
+      await engine.completeWaitpoint({ id: waitpoint.waitpoint.id });
+
+      const { completedWaitpointIds } = await waitForResume(engine, run.id);
+      expect(completedWaitpointIds).toContain(waitpoint.waitpoint.id);
+    } finally {
+      await engine.quit();
+    }
+  });
+});

--- a/internal-packages/run-engine/src/engine/tests/completedWaitpointRecordsGate.test.ts
+++ b/internal-packages/run-engine/src/engine/tests/completedWaitpointRecordsGate.test.ts
@@ -34,7 +34,7 @@ vi.setConfig({ testTimeout: 60_000 });
 function engineWith(
   prisma: never,
   redisOptions: never,
-  completedWaitpointRecordsEnabled?: (runId: string) => boolean
+  completedWaitpointRecordsEnabled?: (args: { runId: string; organizationId: string }) => boolean
 ) {
   return new RunEngine({
     prisma,
@@ -54,12 +54,19 @@ function engineWith(
 }
 
 describe("the completed-waitpoint records gate", () => {
+  // Asserts what is observable: that the predicate is consulted exactly once per resume, with
+  // the right organisation, and that a false answer leaves the resume itself untouched.
+  //
+  // It does NOT assert that the call happens BEFORE the id scan. That ordering is not observable
+  // from outside: `parseWaitpointId` is a pure function on ids the caller already holds, so a scan
+  // leaves no trace, and proving the negative would need it stubbed -- which this repo does not do.
+  // The ordering is held by the code instead: the predicate is the first statement in the method.
   containerTest(
-    "is consulted once per resume, and the resume is unaffected",
+    "is consulted exactly once per resume, with the run's organisation",
     async ({ prisma, redisOptions }) => {
-      const consulted: string[] = [];
-      const engine = engineWith(prisma as never, redisOptions as never, (runId) => {
-        consulted.push(runId);
+      const consulted: { runId: string; organizationId: string }[] = [];
+      const engine = engineWith(prisma as never, redisOptions as never, (args) => {
+        consulted.push(args);
         return false;
       });
 
@@ -98,27 +105,43 @@ describe("the completed-waitpoint records gate", () => {
           snapshotId: dequeued[0]!.snapshot.id,
         });
 
-        // Block on a manual waitpoint, then release it: the release is what resumes the run and
-        // reaches the gate.
-        const waitpoint = await engine.createManualWaitpoint({
-          environmentId: env.id,
-          projectId: env.projectId,
-        });
+        // THREE waitpoints, not one. With a single blocker a gate consulted once per waitpoint
+        // is indistinguishable from one consulted once per resume, so a one-waitpoint run cannot
+        // hold the "exactly once" property this test exists for.
+        const waitpoints = [];
+        for (let i = 0; i < 3; i++) {
+          const created = await engine.createManualWaitpoint({
+            environmentId: env.id,
+            projectId: env.projectId,
+          });
+          waitpoints.push(created.waitpoint.id);
+        }
+
         await engine.blockRunWithWaitpoint({
           runId: run.id,
-          waitpoints: [waitpoint.waitpoint.id],
+          waitpoints,
           projectId: env.project.id,
           organizationId: env.organization.id,
         });
 
-        await engine.completeWaitpoint({ id: waitpoint.waitpoint.id });
+        // The LAST completion is the one that unblocks the run and reaches the gate.
+        for (const id of waitpoints) {
+          await engine.completeWaitpoint({ id });
+        }
 
         const { completedWaitpointIds } = await waitForResume(engine, run.id);
 
-        // The run resumed, because a disabled gate only skips the record build...
-        expect(completedWaitpointIds).toContain(waitpoint.waitpoint.id);
-        // ...and the gate was consulted for it, which is what puts it in the resume path.
-        expect(consulted).toContain(run.id);
+        // The run resumed, because a disabled gate only skips the record build.
+        expect(completedWaitpointIds).toEqual(expect.arrayContaining(waitpoints));
+
+        // Exactly one consultation for this run, not merely at least one: a gate called per
+        // waitpoint, or twice per resume, would satisfy a containment check.
+        const forThisRun = consulted.filter((c) => c.runId === run.id);
+        expect(forThisRun).toHaveLength(1);
+
+        // And it carries the organisation the decision is keyed on, which is the whole reason the
+        // predicate takes more than a run id.
+        expect(forThisRun[0]?.organizationId).toBe(env.organization.id);
         expect(attempt.run.id).toBe(run.id);
       } finally {
         await engine.quit();

--- a/internal-packages/run-engine/src/engine/types.ts
+++ b/internal-packages/run-engine/src/engine/types.ts
@@ -77,6 +77,14 @@ export type RunEngineOptions = {
   billing?: {
     getCurrentPlan: (orgId: string) => Promise<BillingPlan>;
   };
+  /**
+   * Whether a run's snapshots can hold a completed-waitpoint record set. Must be O(1): it is
+   * consulted on every resume, ahead of any work proportional to the run's fan-in.
+   *
+   * Per-run rather than global because the answer follows the snapshot store's own
+   * per-organisation rollout. Omitted means never, so no resume builds a record set.
+   */
+  completedWaitpointRecordsEnabled?: (runId: string) => boolean;
   queue: {
     redis: RedisOptions;
     shardCount?: number;

--- a/internal-packages/run-engine/src/engine/types.ts
+++ b/internal-packages/run-engine/src/engine/types.ts
@@ -85,9 +85,11 @@ export type RunEngineOptions = {
    * run id rides along for logging and for any future per-run override; resolving the
    * organisation from it would put a read back on the path this gate keeps free.
    *
+   * Positional arguments, so the disabled path allocates nothing at all.
+   *
    * Omitted means never, so no resume builds a record set.
    */
-  completedWaitpointRecordsEnabled?: (args: { runId: string; organizationId: string }) => boolean;
+  completedWaitpointRecordsEnabled?: (runId: string, organizationId: string) => boolean;
   queue: {
     redis: RedisOptions;
     shardCount?: number;

--- a/internal-packages/run-engine/src/engine/types.ts
+++ b/internal-packages/run-engine/src/engine/types.ts
@@ -81,10 +81,13 @@ export type RunEngineOptions = {
    * Whether a run's snapshots can hold a completed-waitpoint record set. Must be O(1): it is
    * consulted on every resume, ahead of any work proportional to the run's fan-in.
    *
-   * Per-run rather than global because the answer follows the snapshot store's own
-   * per-organisation rollout. Omitted means never, so no resume builds a record set.
+   * Organisation-scoped, because that is what the snapshot store's own rollout is keyed on. The
+   * run id rides along for logging and for any future per-run override; resolving the
+   * organisation from it would put a read back on the path this gate keeps free.
+   *
+   * Omitted means never, so no resume builds a record set.
    */
-  completedWaitpointRecordsEnabled?: (runId: string) => boolean;
+  completedWaitpointRecordsEnabled?: (args: { runId: string; organizationId: string }) => boolean;
   queue: {
     redis: RedisOptions;
     shardCount?: number;

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointEquivalence.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointEquivalence.test.ts
@@ -1,0 +1,330 @@
+// The resolver must produce what the executor already consumes, so the oracle is the
+// existing hydration and not a hand-written literal. A literal cannot catch a drift in
+// enhanceExecutionSnapshotWithWaitpoints itself; this can.
+import type { Waitpoint } from "@trigger.dev/database";
+import { describe, expect, it } from "vitest";
+import { enhanceExecutionSnapshotWithWaitpoints } from "../systems/executionSnapshotSystem.js";
+import { buildCompletedWaitpointRecords } from "./completedWaitpointRecords.js";
+import { createCompletedWaitpointResolver } from "./completedWaitpointResolver.js";
+import type { CompletionEnvelopeSource } from "./types.js";
+
+const COMPLETED_AT = new Date("2026-08-25T00:00:00.000Z");
+const RUN_ID = "run_0123456789abcdefghijklm";
+const CHILD_RUN_ID = "run_zyxwvutsrqponmlkjihgfe";
+const BATCH_ID = "batch_0123456789abcdefghijk";
+
+/**
+ * One waitpoint, in both shapes, from one description. Keeping them in one factory is what
+ * makes the comparison meaningful: a field added to only one shape shows up as a diff.
+ */
+function pair(overrides: {
+  id: string;
+  type: Waitpoint["type"];
+  output?: string | null;
+  outputType?: string;
+  outputIsError?: boolean;
+  completedByTaskRunId?: string | null;
+  completedByBatchId?: string | null;
+  completedAfter?: Date | null;
+  idempotencyKey?: string;
+  userProvidedIdempotencyKey?: boolean;
+  inactiveIdempotencyKey?: string | null;
+}): { row: Waitpoint; source: CompletionEnvelopeSource } {
+  const outputType = overrides.outputType ?? "application/json";
+  const outputIsError = overrides.outputIsError ?? false;
+  const output = overrides.output ?? null;
+  const isRef = outputType === "application/store";
+
+  const row = {
+    id: overrides.id,
+    friendlyId: `waitpoint_${overrides.id}`,
+    type: overrides.type,
+    status: "COMPLETED",
+    completedAt: COMPLETED_AT,
+    output,
+    outputType,
+    outputIsError,
+    completedByTaskRunId: overrides.completedByTaskRunId ?? null,
+    completedByBatchId: overrides.completedByBatchId ?? null,
+    completedAfter: overrides.completedAfter ?? null,
+    idempotencyKey: overrides.idempotencyKey ?? "internal",
+    userProvidedIdempotencyKey: overrides.userProvidedIdempotencyKey ?? false,
+    inactiveIdempotencyKey: overrides.inactiveIdempotencyKey ?? null,
+  } as unknown as Waitpoint;
+
+  const source: CompletionEnvelopeSource = {
+    id: overrides.id,
+    friendlyId: `waitpoint_${overrides.id}`,
+    type: overrides.type,
+    completedAt: COMPLETED_AT,
+    outputType,
+    outputIsError,
+    ...(output !== null ? (isRef ? { outputRef: output } : { output }) : {}),
+    ...(overrides.completedByTaskRunId && {
+      completedByTaskRunId: overrides.completedByTaskRunId,
+    }),
+    ...(overrides.completedByBatchId && { completedByBatchId: overrides.completedByBatchId }),
+    ...(overrides.completedAfter && { completedAfter: overrides.completedAfter }),
+    ...(overrides.userProvidedIdempotencyKey &&
+    !overrides.inactiveIdempotencyKey &&
+    overrides.idempotencyKey
+      ? { idempotencyKey: overrides.idempotencyKey }
+      : {}),
+  };
+
+  return { row, source };
+}
+
+function snapshot(batchId: string | null) {
+  return { id: "snap_1", runId: RUN_ID, batchId } as never;
+}
+
+function sortEntries<T extends { id: string; index?: number }>(entries: T[]): T[] {
+  return [...entries].sort((a, b) => a.id.localeCompare(b.id) || (a.index ?? -1) - (b.index ?? -1));
+}
+
+/**
+ * Run one description through both paths and assert the results match.
+ *
+ * `deriveFromRun` is the one case where the two paths cannot be identical by construction:
+ * the row carries the value and the record carries a marker. Feeding the row's own output
+ * back as the run's output is what makes them comparable, which is exactly the claim the
+ * variant makes — that TaskRun.output holds the same string.
+ */
+async function bothPaths(
+  pairs: ReturnType<typeof pair>[],
+  order: string[],
+  batchId: string | null = null
+) {
+  const outputsByRunId = new Map<string, string>();
+  for (const { row } of pairs) {
+    if (row.completedByTaskRunId && row.output !== null) {
+      outputsByRunId.set(row.completedByTaskRunId, row.output);
+    }
+  }
+
+  const expected = enhanceExecutionSnapshotWithWaitpoints(
+    snapshot(batchId),
+    pairs.map((p) => p.row),
+    order
+  ).completedWaitpoints;
+
+  const actual = await createCompletedWaitpointResolver({
+    readRunOutput: async (taskRunId) => outputsByRunId.get(taskRunId),
+  })({
+    runId: RUN_ID,
+    ...(batchId ? { batchId } : {}),
+    pointer: { cycleSeq: 1, count: order.length },
+    order,
+    records: buildCompletedWaitpointRecords(pairs.map((p) => p.source)),
+  });
+
+  return { expected: sortEntries(expected), actual: sortEntries(actual) };
+}
+
+describe("the resolver reproduces the existing hydration", () => {
+  it("for a single MANUAL waitpoint with an inline output", async () => {
+    const { expected, actual } = await bothPaths(
+      [pair({ id: "wp_manual", type: "MANUAL", output: '{"token":1}' })],
+      []
+    );
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("for a MANUAL waitpoint with a user-provided idempotency key", async () => {
+    const { expected, actual } = await bothPaths(
+      [
+        pair({
+          id: "wp_manual",
+          type: "MANUAL",
+          output: '{"token":1}',
+          idempotencyKey: "user-key",
+          userProvidedIdempotencyKey: true,
+        }),
+      ],
+      []
+    );
+
+    expect(actual).toEqual(expected);
+    expect(actual[0]?.idempotencyKey).toBe("user-key");
+  });
+
+  it("for an idempotency key the user provided but that went inactive", async () => {
+    const { expected, actual } = await bothPaths(
+      [
+        pair({
+          id: "wp_manual",
+          type: "MANUAL",
+          output: '{"token":1}',
+          idempotencyKey: "user-key",
+          userProvidedIdempotencyKey: true,
+          inactiveIdempotencyKey: "old",
+        }),
+      ],
+      []
+    );
+
+    expect(actual).toEqual(expected);
+    expect(actual[0]?.idempotencyKey).toBeUndefined();
+  });
+
+  it("for a DATETIME waitpoint", async () => {
+    const { expected, actual } = await bothPaths(
+      [
+        pair({
+          id: "wp_datetime",
+          type: "DATETIME",
+          completedAfter: new Date("2026-08-26T00:00:00.000Z"),
+        }),
+      ],
+      []
+    );
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("for a RUN waitpoint outside a batch", async () => {
+    const { expected, actual } = await bothPaths(
+      [
+        pair({
+          id: "wp_run",
+          type: "RUN",
+          output: '{"ok":true}',
+          completedByTaskRunId: CHILD_RUN_ID,
+        }),
+      ],
+      []
+    );
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("for a RUN waitpoint read under a batch", async () => {
+    const { expected, actual } = await bothPaths(
+      [
+        pair({
+          id: "wp_run",
+          type: "RUN",
+          output: '{"ok":true}',
+          completedByTaskRunId: CHILD_RUN_ID,
+        }),
+      ],
+      ["wp_run"],
+      BATCH_ID
+    );
+
+    expect(actual).toEqual(expected);
+    expect(actual[0]?.completedByTaskRun?.batch?.id).toBe(BATCH_ID);
+  });
+
+  it("for a RUN waitpoint whose output is an error", async () => {
+    const { expected, actual } = await bothPaths(
+      [
+        pair({
+          id: "wp_run",
+          type: "RUN",
+          output: '{"message":"boom"}',
+          outputIsError: true,
+          completedByTaskRunId: CHILD_RUN_ID,
+        }),
+      ],
+      []
+    );
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("for a BATCH waitpoint", async () => {
+    const { expected, actual } = await bothPaths(
+      [pair({ id: "wp_batch", type: "BATCH", completedByBatchId: BATCH_ID })],
+      []
+    );
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("for an already-offloaded output", async () => {
+    const { expected, actual } = await bothPaths(
+      [
+        pair({
+          id: "wp_manual",
+          type: "MANUAL",
+          output: "store-key-1",
+          outputType: "application/store",
+        }),
+      ],
+      []
+    );
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("for one run present at two batch indexes", async () => {
+    const { expected, actual } = await bothPaths(
+      [
+        pair({
+          id: "wp_run",
+          type: "RUN",
+          output: '{"ok":true}',
+          completedByTaskRunId: CHILD_RUN_ID,
+        }),
+      ],
+      ["wp_run", "wp_run"],
+      BATCH_ID
+    );
+
+    expect(actual).toEqual(expected);
+    expect(actual.map((w) => w.index)).toEqual([0, 1]);
+  });
+
+  it("for an index-less waitpoint sitting beside indexed ones", async () => {
+    const { expected, actual } = await bothPaths(
+      [
+        pair({ id: "wp_indexless", type: "MANUAL", output: '{"token":1}' }),
+        pair({
+          id: "wp_run",
+          type: "RUN",
+          output: '{"ok":true}',
+          completedByTaskRunId: CHILD_RUN_ID,
+        }),
+      ],
+      ["wp_run"],
+      BATCH_ID
+    );
+
+    expect(actual).toEqual(expected);
+    expect(actual.find((w) => w.id === "wp_indexless")?.index).toBeUndefined();
+  });
+
+  it("for every type at once, under a batch", async () => {
+    const { expected, actual } = await bothPaths(
+      [
+        pair({
+          id: "wp_run",
+          type: "RUN",
+          output: '{"ok":true}',
+          completedByTaskRunId: CHILD_RUN_ID,
+        }),
+        pair({ id: "wp_batch", type: "BATCH", completedByBatchId: BATCH_ID }),
+        pair({
+          id: "wp_datetime",
+          type: "DATETIME",
+          completedAfter: new Date("2026-08-26T00:00:00.000Z"),
+        }),
+        pair({
+          id: "wp_manual",
+          type: "MANUAL",
+          output: '{"token":1}',
+          idempotencyKey: "user-key",
+          userProvidedIdempotencyKey: true,
+        }),
+      ],
+      ["wp_run", "wp_batch", "wp_datetime"],
+      BATCH_ID
+    );
+
+    expect(actual).toEqual(expected);
+    expect(actual).toHaveLength(4);
+  });
+});

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointEquivalence.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointEquivalence.test.ts
@@ -1,17 +1,22 @@
 // The resolver must produce what the executor already consumes, so the oracle is the
 // existing hydration and not a hand-written literal. A literal cannot catch a drift in
 // enhanceExecutionSnapshotWithWaitpoints itself; this can.
-import type { Waitpoint } from "@trigger.dev/database";
-import { describe, expect, it } from "vitest";
+import { postgresTest } from "@internal/testcontainers";
+import { PostgresRunStore } from "@internal/run-store";
+import type { PrismaClient, Waitpoint } from "@trigger.dev/database";
+import { describe, expect } from "vitest";
+import { seedChildRunWithOutput } from "./testFixtures/childRun.js";
 import { enhanceExecutionSnapshotWithWaitpoints } from "../systems/executionSnapshotSystem.js";
 import { buildCompletedWaitpointRecords } from "./completedWaitpointRecords.js";
-import { createCompletedWaitpointResolver } from "./completedWaitpointResolver.js";
+import {
+  createCompletedWaitpointResolver,
+  createRunOutputReader,
+} from "./completedWaitpointResolver.js";
 import { envelopeSourceFromWaitpointRow } from "./completionEnvelopeSource.js";
 import type { CompletionEnvelopeSource } from "./types.js";
 
 const COMPLETED_AT = new Date("2026-08-25T00:00:00.000Z");
 const RUN_ID = "run_0123456789abcdefghijklm";
-const CHILD_RUN_ID = "run_zyxwvutsrqponmlkjihgfe";
 const BATCH_ID = "batch_0123456789abcdefghijk";
 
 /**
@@ -70,25 +75,21 @@ function sortEntries<T extends { id: string; index?: number }>(entries: T[]): T[
  * variant makes — that TaskRun.output holds the same string.
  */
 async function bothPaths(
+  prisma: PrismaClient,
   pairs: ReturnType<typeof pair>[],
   order: string[],
   batchId: string | null = null
 ) {
-  const outputsByRunId = new Map<string, string>();
-  for (const { row } of pairs) {
-    if (row.completedByTaskRunId && row.output !== null) {
-      outputsByRunId.set(row.completedByTaskRunId, row.output);
-    }
-  }
-
   const expected = enhanceExecutionSnapshotWithWaitpoints(
     snapshot(batchId),
     pairs.map((p) => p.row),
     order
   ).completedWaitpoints;
 
+  const runStore = new PostgresRunStore({ prisma, readOnlyPrisma: prisma });
+
   const actual = await createCompletedWaitpointResolver({
-    readRunOutput: async (taskRunId) => outputsByRunId.get(taskRunId),
+    readRunOutput: createRunOutputReader(runStore),
   })({
     runId: RUN_ID,
     ...(batchId ? { batchId } : {}),
@@ -102,8 +103,9 @@ async function bothPaths(
 }
 
 describe("the resolver reproduces the existing hydration", () => {
-  it("for a single MANUAL waitpoint with an inline output", async () => {
+  postgresTest("for a single MANUAL waitpoint with an inline output", async ({ prisma }) => {
     const { expected, actual } = await bothPaths(
+      prisma,
       [pair({ id: "wp_manual", type: "MANUAL", output: '{"token":1}' })],
       []
     );
@@ -111,45 +113,54 @@ describe("the resolver reproduces the existing hydration", () => {
     expect(actual).toEqual(expected);
   });
 
-  it("for a MANUAL waitpoint with a user-provided idempotency key", async () => {
+  postgresTest(
+    "for a MANUAL waitpoint with a user-provided idempotency key",
+    async ({ prisma }) => {
+      const { expected, actual } = await bothPaths(
+        prisma,
+        [
+          pair({
+            id: "wp_manual",
+            type: "MANUAL",
+            output: '{"token":1}',
+            idempotencyKey: "user-key",
+            userProvidedIdempotencyKey: true,
+          }),
+        ],
+        []
+      );
+
+      expect(actual).toEqual(expected);
+      expect(actual[0]?.idempotencyKey).toBe("user-key");
+    }
+  );
+
+  postgresTest(
+    "for an idempotency key the user provided but that went inactive",
+    async ({ prisma }) => {
+      const { expected, actual } = await bothPaths(
+        prisma,
+        [
+          pair({
+            id: "wp_manual",
+            type: "MANUAL",
+            output: '{"token":1}',
+            idempotencyKey: "user-key",
+            userProvidedIdempotencyKey: true,
+            inactiveIdempotencyKey: "old",
+          }),
+        ],
+        []
+      );
+
+      expect(actual).toEqual(expected);
+      expect(actual[0]?.idempotencyKey).toBeUndefined();
+    }
+  );
+
+  postgresTest("for a DATETIME waitpoint", async ({ prisma }) => {
     const { expected, actual } = await bothPaths(
-      [
-        pair({
-          id: "wp_manual",
-          type: "MANUAL",
-          output: '{"token":1}',
-          idempotencyKey: "user-key",
-          userProvidedIdempotencyKey: true,
-        }),
-      ],
-      []
-    );
-
-    expect(actual).toEqual(expected);
-    expect(actual[0]?.idempotencyKey).toBe("user-key");
-  });
-
-  it("for an idempotency key the user provided but that went inactive", async () => {
-    const { expected, actual } = await bothPaths(
-      [
-        pair({
-          id: "wp_manual",
-          type: "MANUAL",
-          output: '{"token":1}',
-          idempotencyKey: "user-key",
-          userProvidedIdempotencyKey: true,
-          inactiveIdempotencyKey: "old",
-        }),
-      ],
-      []
-    );
-
-    expect(actual).toEqual(expected);
-    expect(actual[0]?.idempotencyKey).toBeUndefined();
-  });
-
-  it("for a DATETIME waitpoint", async () => {
-    const { expected, actual } = await bothPaths(
+      prisma,
       [
         pair({
           id: "wp_datetime",
@@ -163,14 +174,16 @@ describe("the resolver reproduces the existing hydration", () => {
     expect(actual).toEqual(expected);
   });
 
-  it("for a RUN waitpoint outside a batch", async () => {
+  postgresTest("for a RUN waitpoint outside a batch", async ({ prisma }) => {
+    const childRunId = await seedChildRunWithOutput(prisma, '{"ok":true}');
     const { expected, actual } = await bothPaths(
+      prisma,
       [
         pair({
           id: "wp_run",
           type: "RUN",
           output: '{"ok":true}',
-          completedByTaskRunId: CHILD_RUN_ID,
+          completedByTaskRunId: childRunId,
         }),
       ],
       []
@@ -179,14 +192,16 @@ describe("the resolver reproduces the existing hydration", () => {
     expect(actual).toEqual(expected);
   });
 
-  it("for a RUN waitpoint read under a batch", async () => {
+  postgresTest("for a RUN waitpoint read under a batch", async ({ prisma }) => {
+    const childRunId = await seedChildRunWithOutput(prisma, '{"ok":true}');
     const { expected, actual } = await bothPaths(
+      prisma,
       [
         pair({
           id: "wp_run",
           type: "RUN",
           output: '{"ok":true}',
-          completedByTaskRunId: CHILD_RUN_ID,
+          completedByTaskRunId: childRunId,
         }),
       ],
       ["wp_run"],
@@ -197,15 +212,17 @@ describe("the resolver reproduces the existing hydration", () => {
     expect(actual[0]?.completedByTaskRun?.batch?.id).toBe(BATCH_ID);
   });
 
-  it("for a RUN waitpoint whose output is an error", async () => {
+  postgresTest("for a RUN waitpoint whose output is an error", async ({ prisma }) => {
+    const childRunId = await seedChildRunWithOutput(prisma, '{"message":"boom"}');
     const { expected, actual } = await bothPaths(
+      prisma,
       [
         pair({
           id: "wp_run",
           type: "RUN",
           output: '{"message":"boom"}',
           outputIsError: true,
-          completedByTaskRunId: CHILD_RUN_ID,
+          completedByTaskRunId: childRunId,
         }),
       ],
       []
@@ -214,8 +231,9 @@ describe("the resolver reproduces the existing hydration", () => {
     expect(actual).toEqual(expected);
   });
 
-  it("for a BATCH waitpoint", async () => {
+  postgresTest("for a BATCH waitpoint", async ({ prisma }) => {
     const { expected, actual } = await bothPaths(
+      prisma,
       [pair({ id: "wp_batch", type: "BATCH", completedByBatchId: BATCH_ID })],
       []
     );
@@ -223,8 +241,9 @@ describe("the resolver reproduces the existing hydration", () => {
     expect(actual).toEqual(expected);
   });
 
-  it("for an already-offloaded output", async () => {
+  postgresTest("for an already-offloaded output", async ({ prisma }) => {
     const { expected, actual } = await bothPaths(
+      prisma,
       [
         pair({
           id: "wp_manual",
@@ -241,15 +260,17 @@ describe("the resolver reproduces the existing hydration", () => {
 
   // The case the suite was blind to, and the one the frozen reference orders the other way. The
   // oracle emits the ref string; so does this, by a different branch.
-  it("for an offloaded RUN success", async () => {
+  postgresTest("for an offloaded RUN success", async ({ prisma }) => {
+    const childRunId = await seedChildRunWithOutput(prisma, "s3://bucket/key");
     const { expected, actual } = await bothPaths(
+      prisma,
       [
         pair({
           id: "wp_run_ref",
           type: "RUN",
           output: "s3://bucket/key",
           outputType: "application/store",
-          completedByTaskRunId: CHILD_RUN_ID,
+          completedByTaskRunId: childRunId,
         }),
       ],
       []
@@ -259,14 +280,16 @@ describe("the resolver reproduces the existing hydration", () => {
     expect(actual[0]?.output).toBe("s3://bucket/key");
   });
 
-  it("for one run present at two batch indexes", async () => {
+  postgresTest("for one run present at two batch indexes", async ({ prisma }) => {
+    const childRunId = await seedChildRunWithOutput(prisma, '{"ok":true}');
     const { expected, actual } = await bothPaths(
+      prisma,
       [
         pair({
           id: "wp_run",
           type: "RUN",
           output: '{"ok":true}',
-          completedByTaskRunId: CHILD_RUN_ID,
+          completedByTaskRunId: childRunId,
         }),
       ],
       ["wp_run", "wp_run"],
@@ -277,15 +300,19 @@ describe("the resolver reproduces the existing hydration", () => {
     expect(actual.map((w) => w.index)).toEqual([0, 1]);
   });
 
-  it("for an index-less waitpoint sitting beside indexed ones", async () => {
+  postgresTest("for an index-less waitpoint sitting beside indexed ones", async ({ prisma }) => {
+    // Seeded to match the RUN row's own output, which is the parity premise: TaskRun.output
+    // holds the same string the waitpoint carried.
+    const childRunId = await seedChildRunWithOutput(prisma, '{"ok":true}');
     const { expected, actual } = await bothPaths(
+      prisma,
       [
         pair({ id: "wp_indexless", type: "MANUAL", output: '{"token":1}' }),
         pair({
           id: "wp_run",
           type: "RUN",
           output: '{"ok":true}',
-          completedByTaskRunId: CHILD_RUN_ID,
+          completedByTaskRunId: childRunId,
         }),
       ],
       ["wp_run"],
@@ -300,8 +327,9 @@ describe("the resolver reproduces the existing hydration", () => {
   // an output, but the executor never reads it (sharedRuntimeManager.resolveWaitpoint
   // early-returns on type). Pinned so that if that early return ever goes away, this fails and
   // says why, instead of the output silently being missing at resume.
-  it("deliberately drops a BATCH output, unlike the oracle", async () => {
+  postgresTest("deliberately drops a BATCH output, unlike the oracle", async ({ prisma }) => {
     const { expected, actual } = await bothPaths(
+      prisma,
       [
         pair({
           id: "wp_batch",
@@ -319,14 +347,16 @@ describe("the resolver reproduces the existing hydration", () => {
     expect(actual[0]?.outputIsError).toBe(true);
   });
 
-  it("for every type at once, under a batch", async () => {
+  postgresTest("for every type at once, under a batch", async ({ prisma }) => {
+    const childRunId = await seedChildRunWithOutput(prisma, '{"ok":true}');
     const { expected, actual } = await bothPaths(
+      prisma,
       [
         pair({
           id: "wp_run",
           type: "RUN",
           output: '{"ok":true}',
-          completedByTaskRunId: CHILD_RUN_ID,
+          completedByTaskRunId: childRunId,
         }),
         pair({ id: "wp_batch", type: "BATCH", completedByBatchId: BATCH_ID }),
         pair({

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointEquivalence.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointEquivalence.test.ts
@@ -89,7 +89,7 @@ async function bothPaths(
   const runStore = new PostgresRunStore({ prisma, readOnlyPrisma: prisma });
 
   const actual = await createCompletedWaitpointResolver({
-    readRunOutputs: createRunOutputsReader(runStore),
+    readRunOutputs: createRunOutputsReader(runStore, prisma),
   })({
     runId: RUN_ID,
     ...(batchId ? { batchId } : {}),
@@ -230,6 +230,29 @@ describe("the resolver reproduces the existing hydration", () => {
       '{"child":"a"}',
     ]);
     expect(actual.find((w) => w.id === "wp_run_b")?.output).toBe('{"child":"b"}');
+  });
+
+  // A child that returned nothing. The oracle emits `output: w.output ?? undefined`, i.e. resumes
+  // with no output; an earlier revision marked this derivable, read a null TaskRun.output and
+  // refused the resume outright. Comparing against the oracle is what makes that a failure rather
+  // than a design choice, so the case belongs here and not only in the unit suite.
+  postgresTest("for a RUN waitpoint whose child returned no output", async ({ prisma }) => {
+    const childRunId = await seedChildRunWithOutput(prisma, null);
+    const { expected, actual } = await bothPaths(
+      prisma,
+      [
+        pair({
+          id: "wp_run_void",
+          type: "RUN",
+          output: null,
+          completedByTaskRunId: childRunId,
+        }),
+      ],
+      ["wp_run_void"]
+    );
+
+    expect(actual).toEqual(expected);
+    expect(actual[0]?.output).toBeUndefined();
   });
 
   postgresTest("for a RUN waitpoint read under a batch", async ({ prisma }) => {

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointEquivalence.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointEquivalence.test.ts
@@ -10,7 +10,7 @@ import { enhanceExecutionSnapshotWithWaitpoints } from "../systems/executionSnap
 import { buildCompletedWaitpointRecords } from "./completedWaitpointRecords.js";
 import {
   createCompletedWaitpointResolver,
-  createRunOutputReader,
+  createRunOutputsReader,
 } from "./completedWaitpointResolver.js";
 import { envelopeSourceFromWaitpointRow } from "./completionEnvelopeSource.js";
 import type { CompletionEnvelopeSource } from "./types.js";
@@ -89,7 +89,7 @@ async function bothPaths(
   const runStore = new PostgresRunStore({ prisma, readOnlyPrisma: prisma });
 
   const actual = await createCompletedWaitpointResolver({
-    readRunOutput: createRunOutputReader(runStore),
+    readRunOutputs: createRunOutputsReader(runStore),
   })({
     runId: RUN_ID,
     ...(batchId ? { batchId } : {}),

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointEquivalence.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointEquivalence.test.ts
@@ -5,7 +5,7 @@ import { postgresTest } from "@internal/testcontainers";
 import { PostgresRunStore } from "@internal/run-store";
 import type { PrismaClient, Waitpoint } from "@trigger.dev/database";
 import { describe, expect } from "vitest";
-import { seedChildRunWithOutput } from "./testFixtures/childRun.js";
+import { seedChildRunsWithOutputs, seedChildRunWithOutput } from "./testFixtures/childRun.js";
 import { enhanceExecutionSnapshotWithWaitpoints } from "../systems/executionSnapshotSystem.js";
 import { buildCompletedWaitpointRecords } from "./completedWaitpointRecords.js";
 import {
@@ -190,6 +190,46 @@ describe("the resolver reproduces the existing hydration", () => {
     );
 
     expect(actual).toEqual(expected);
+  });
+
+  // Two deferring records in ONE cycle, which is the shape a batch fan-in produces and the one
+  // the batched read introduced. Every other case here defers at most once, so a mis-keyed map
+  // or a swapped output would compare equal against the oracle in all of them.
+  //
+  // The outputs differ deliberately, and one run sits at two interleaved positions, so a swap
+  // between the two runs and a lost second position both show up as a diff.
+  postgresTest("for two RUN waitpoints deferring to different runs", async ({ prisma }) => {
+    const [runA, runB] = await seedChildRunsWithOutputs(prisma, ['{"child":"a"}', '{"child":"b"}']);
+
+    const { expected, actual } = await bothPaths(
+      prisma,
+      [
+        pair({
+          id: "wp_run_a",
+          type: "RUN",
+          output: '{"child":"a"}',
+          completedByTaskRunId: runA,
+        }),
+        pair({
+          id: "wp_run_b",
+          type: "RUN",
+          output: '{"child":"b"}',
+          completedByTaskRunId: runB,
+        }),
+      ],
+      ["wp_run_a", "wp_run_b", "wp_run_a"],
+      BATCH_ID
+    );
+
+    expect(actual).toEqual(expected);
+    // Stated as well as compared: the oracle agreeing is the assertion, but a reader should not
+    // have to run it to see that three entries come back and each output landed on its own id.
+    expect(actual).toHaveLength(3);
+    expect(actual.filter((w) => w.id === "wp_run_a").map((w) => w.output)).toEqual([
+      '{"child":"a"}',
+      '{"child":"a"}',
+    ]);
+    expect(actual.find((w) => w.id === "wp_run_b")?.output).toBe('{"child":"b"}');
   });
 
   postgresTest("for a RUN waitpoint read under a batch", async ({ prisma }) => {

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointEquivalence.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointEquivalence.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import { enhanceExecutionSnapshotWithWaitpoints } from "../systems/executionSnapshotSystem.js";
 import { buildCompletedWaitpointRecords } from "./completedWaitpointRecords.js";
 import { createCompletedWaitpointResolver } from "./completedWaitpointResolver.js";
+import { envelopeSourceFromWaitpointRow } from "./completionEnvelopeSource.js";
 import type { CompletionEnvelopeSource } from "./types.js";
 
 const COMPLETED_AT = new Date("2026-08-25T00:00:00.000Z");
@@ -30,20 +31,15 @@ function pair(overrides: {
   userProvidedIdempotencyKey?: boolean;
   inactiveIdempotencyKey?: string | null;
 }): { row: Waitpoint; source: CompletionEnvelopeSource } {
-  const outputType = overrides.outputType ?? "application/json";
-  const outputIsError = overrides.outputIsError ?? false;
-  const output = overrides.output ?? null;
-  const isRef = outputType === "application/store";
-
   const row = {
     id: overrides.id,
     friendlyId: `waitpoint_${overrides.id}`,
     type: overrides.type,
     status: "COMPLETED",
     completedAt: COMPLETED_AT,
-    output,
-    outputType,
-    outputIsError,
+    output: overrides.output ?? null,
+    outputType: overrides.outputType ?? "application/json",
+    outputIsError: overrides.outputIsError ?? false,
     completedByTaskRunId: overrides.completedByTaskRunId ?? null,
     completedByBatchId: overrides.completedByBatchId ?? null,
     completedAfter: overrides.completedAfter ?? null,
@@ -52,27 +48,9 @@ function pair(overrides: {
     inactiveIdempotencyKey: overrides.inactiveIdempotencyKey ?? null,
   } as unknown as Waitpoint;
 
-  const source: CompletionEnvelopeSource = {
-    id: overrides.id,
-    friendlyId: `waitpoint_${overrides.id}`,
-    type: overrides.type,
-    completedAt: COMPLETED_AT,
-    outputType,
-    outputIsError,
-    ...(output !== null ? (isRef ? { outputRef: output } : { output }) : {}),
-    ...(overrides.completedByTaskRunId && {
-      completedByTaskRunId: overrides.completedByTaskRunId,
-    }),
-    ...(overrides.completedByBatchId && { completedByBatchId: overrides.completedByBatchId }),
-    ...(overrides.completedAfter && { completedAfter: overrides.completedAfter }),
-    ...(overrides.userProvidedIdempotencyKey &&
-    !overrides.inactiveIdempotencyKey &&
-    overrides.idempotencyKey
-      ? { idempotencyKey: overrides.idempotencyKey }
-      : {}),
-  };
-
-  return { row, source };
+  // Through the SHARED mapper the legacy arm uses. A hand-rolled copy here would make a bug in
+  // that arm invisible to every case below, because the oracle chain would never touch it.
+  return { row, source: envelopeSourceFromWaitpointRow(row) };
 }
 
 function snapshot(batchId: string | null) {
@@ -116,6 +94,7 @@ async function bothPaths(
     ...(batchId ? { batchId } : {}),
     pointer: { cycleSeq: 1, count: order.length },
     order,
+    distinctIds: [...new Set(pairs.map((p) => p.row.id))],
     records: buildCompletedWaitpointRecords(pairs.map((p) => p.source)),
   });
 
@@ -295,6 +274,29 @@ describe("the resolver reproduces the existing hydration", () => {
 
     expect(actual).toEqual(expected);
     expect(actual.find((w) => w.id === "wp_indexless")?.index).toBeUndefined();
+  });
+
+  // The ONE intentional divergence from the oracle. A BATCH waitpoint really is completed with
+  // an output, but the executor never reads it (sharedRuntimeManager.resolveWaitpoint
+  // early-returns on type). Pinned so that if that early return ever goes away, this fails and
+  // says why, instead of the output silently being missing at resume.
+  it("deliberately drops a BATCH output, unlike the oracle", async () => {
+    const { expected, actual } = await bothPaths(
+      [
+        pair({
+          id: "wp_batch",
+          type: "BATCH",
+          completedByBatchId: BATCH_ID,
+          output: '{"message":"batch expired"}',
+          outputIsError: true,
+        }),
+      ],
+      []
+    );
+
+    expect(expected[0]?.output).toBe('{"message":"batch expired"}');
+    expect(actual[0]?.output).toBeUndefined();
+    expect(actual[0]?.outputIsError).toBe(true);
   });
 
   it("for every type at once, under a batch", async () => {

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointEquivalence.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointEquivalence.test.ts
@@ -236,6 +236,29 @@ describe("the resolver reproduces the existing hydration", () => {
   // with no output; an earlier revision marked this derivable, read a null TaskRun.output and
   // refused the resume outright. Comparing against the oracle is what makes that a failure rather
   // than a design choice, so the case belongs here and not only in the unit suite.
+  // An orphan: the completing run is gone, so onDelete: SetNull cleared the back-reference while
+  // the waitpoint kept its output. The record must stay inline -- derivable would send the
+  // resolver to a run that no longer exists -- and the entry must omit completedByTaskRun, which
+  // only the oracle comparison pins.
+  postgresTest("for an orphaned RUN waitpoint that kept its output", async ({ prisma }) => {
+    const { expected, actual } = await bothPaths(
+      prisma,
+      [
+        pair({
+          id: "wp_run_orphan",
+          type: "RUN",
+          output: '{"orphan":true}',
+          completedByTaskRunId: null,
+        }),
+      ],
+      ["wp_run_orphan"]
+    );
+
+    expect(actual).toEqual(expected);
+    expect(actual[0]?.output).toBe('{"orphan":true}');
+    expect(actual[0]?.completedByTaskRun).toBeUndefined();
+  });
+
   postgresTest("for a RUN waitpoint whose child returned no output", async ({ prisma }) => {
     const childRunId = await seedChildRunWithOutput(prisma, null);
     const { expected, actual } = await bothPaths(

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointEquivalence.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointEquivalence.test.ts
@@ -239,6 +239,26 @@ describe("the resolver reproduces the existing hydration", () => {
     expect(actual).toEqual(expected);
   });
 
+  // The case the suite was blind to, and the one the frozen reference orders the other way. The
+  // oracle emits the ref string; so does this, by a different branch.
+  it("for an offloaded RUN success", async () => {
+    const { expected, actual } = await bothPaths(
+      [
+        pair({
+          id: "wp_run_ref",
+          type: "RUN",
+          output: "s3://bucket/key",
+          outputType: "application/store",
+          completedByTaskRunId: CHILD_RUN_ID,
+        }),
+      ],
+      []
+    );
+
+    expect(actual).toEqual(expected);
+    expect(actual[0]?.output).toBe("s3://bucket/key");
+  });
+
   it("for one run present at two batch indexes", async () => {
     const { expected, actual } = await bothPaths(
       [

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointRecords.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointRecords.test.ts
@@ -107,6 +107,27 @@ describe("buildCompletedWaitpointRecords", () => {
       expect(record?.output).toEqual({ deriveFromRun: true });
     });
 
+    // A task that returns nothing completes its waitpoint with NO output, so there is nothing to
+    // derive. Marking it derivable made the resolver read a null TaskRun.output and refuse the
+    // resume as a lost output -- for every triggerAndWait on a void task. The hydration this
+    // replaces resumes cleanly with no output, so the record must carry none, not a marker.
+    it("does not defer a RUN whose output is absent", () => {
+      const [record] = buildCompletedWaitpointRecords([
+        source({ type: "RUN", completedByTaskRunId: "run_1", output: undefined }),
+      ]);
+
+      expect(record?.output).toBeNull();
+    });
+
+    // An empty string is a value, so it IS derivable: TaskRun.output holds it verbatim.
+    it("defers a RUN whose output is an empty string", () => {
+      const [record] = buildCompletedWaitpointRecords([
+        source({ type: "RUN", completedByTaskRunId: "run_1", output: "" }),
+      ]);
+
+      expect(record?.output).toEqual({ deriveFromRun: true });
+    });
+
     // TaskRun.error is jsonb and does not round-trip to the same string, so a RUN error can
     // never be re-read from the run row.
     it("keeps a RUN error inline", () => {

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointRecords.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointRecords.test.ts
@@ -83,6 +83,22 @@ describe("buildCompletedWaitpointRecords", () => {
       expect(record?.output).toEqual({ ref: "store-key-1" });
     });
 
+    // Deliberately a ref, not deriveFromRun, and the opposite of the reference implementation in
+    // completedWaitpointFreeze.test.ts. Byte-identical either way, and this route stays
+    // resolvable when the completing run row is gone.
+    it("routes an offloaded RUN success down the ref branch", () => {
+      const [record] = buildCompletedWaitpointRecords([
+        source({
+          type: "RUN",
+          outputRef: "s3://bucket/key",
+          outputType: "application/store",
+          completedByTaskRunId: "run_1",
+        }),
+      ]);
+
+      expect(record?.output).toEqual({ ref: "s3://bucket/key" });
+    });
+
     it("marks a plain RUN output as derivable from the run", () => {
       const [record] = buildCompletedWaitpointRecords([
         source({ type: "RUN", output: '{"ok":true}', completedByTaskRunId: "run_1" }),

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointRecords.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointRecords.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { buildCompletedWaitpointRecords } from "./completedWaitpointRecords.js";
+import type { CompletionEnvelopeSource } from "./types.js";
+
+const COMPLETED_AT = new Date("2026-08-25T00:00:00.000Z");
+
+function source(overrides: Partial<CompletionEnvelopeSource> = {}): CompletionEnvelopeSource {
+  return {
+    id: "wp_1",
+    friendlyId: "waitpoint_wp_1",
+    type: "MANUAL",
+    completedAt: COMPLETED_AT,
+    outputType: "application/json",
+    outputIsError: false,
+    ...overrides,
+  };
+}
+
+describe("buildCompletedWaitpointRecords", () => {
+  it("emits one record per distinct id", () => {
+    const records = buildCompletedWaitpointRecords([source(), source()]);
+
+    expect(records).toHaveLength(1);
+  });
+
+  it("emits one record for each of several distinct ids", () => {
+    const records = buildCompletedWaitpointRecords([
+      source({ id: "wp_1" }),
+      source({ id: "wp_2" }),
+    ]);
+
+    expect(records.map((r) => r.id)).toEqual(["wp_1", "wp_2"]);
+  });
+
+  it("writes completedAt as an ISO string", () => {
+    const [record] = buildCompletedWaitpointRecords([source()]);
+
+    expect(record?.completedAt).toBe("2026-08-25T00:00:00.000Z");
+  });
+
+  it("omits every absent optional field rather than writing undefined", () => {
+    const [record] = buildCompletedWaitpointRecords([source()]);
+
+    expect("completedByTaskRunId" in record!).toBe(false);
+    expect("completedByBatchId" in record!).toBe(false);
+    expect("completedAfter" in record!).toBe(false);
+    expect("idempotencyKey" in record!).toBe(false);
+  });
+
+  it("carries the fields the executor shape needs", () => {
+    const [record] = buildCompletedWaitpointRecords([
+      source({
+        completedAfter: new Date("2026-08-26T00:00:00.000Z"),
+        idempotencyKey: "user-key",
+      }),
+    ]);
+
+    expect(record).toMatchObject({
+      id: "wp_1",
+      friendlyId: "waitpoint_wp_1",
+      type: "MANUAL",
+      outputType: "application/json",
+      outputIsError: false,
+      completedAfter: "2026-08-26T00:00:00.000Z",
+      idempotencyKey: "user-key",
+    });
+  });
+
+  describe("the output variant", () => {
+    it("keeps an already-offloaded value as a ref", () => {
+      const [record] = buildCompletedWaitpointRecords([
+        source({ outputRef: "store-key-1", outputType: "application/store" }),
+      ]);
+
+      expect(record?.output).toEqual({ ref: "store-key-1" });
+    });
+
+    it("prefers a ref over an inline value when both are somehow present", () => {
+      const [record] = buildCompletedWaitpointRecords([
+        source({ output: '{"ok":true}', outputRef: "store-key-1" }),
+      ]);
+
+      expect(record?.output).toEqual({ ref: "store-key-1" });
+    });
+
+    it("marks a plain RUN output as derivable from the run", () => {
+      const [record] = buildCompletedWaitpointRecords([
+        source({ type: "RUN", output: '{"ok":true}', completedByTaskRunId: "run_1" }),
+      ]);
+
+      expect(record?.output).toEqual({ deriveFromRun: true });
+    });
+
+    // TaskRun.error is jsonb and does not round-trip to the same string, so a RUN error can
+    // never be re-read from the run row.
+    it("keeps a RUN error inline", () => {
+      const [record] = buildCompletedWaitpointRecords([
+        source({
+          type: "RUN",
+          output: '{"message":"boom"}',
+          outputIsError: true,
+          completedByTaskRunId: "run_1",
+        }),
+      ]);
+
+      expect(record?.output).toEqual({ inline: '{"message":"boom"}' });
+    });
+
+    // The back-reference is onDelete: SetNull, so an orphaned RUN waitpoint has no run row
+    // left to derive from.
+    it("keeps an orphaned RUN inline", () => {
+      const [record] = buildCompletedWaitpointRecords([
+        source({ type: "RUN", output: '{"ok":true}' }),
+      ]);
+
+      expect(record?.output).toEqual({ inline: '{"ok":true}' });
+    });
+
+    it("omits a BATCH output, because the runtime discards it at source", () => {
+      const [record] = buildCompletedWaitpointRecords([
+        source({ type: "BATCH", completedByBatchId: "batch_1", output: '{"ignored":true}' }),
+      ]);
+
+      expect(record?.output).toBeNull();
+    });
+
+    it("keeps a MANUAL output inline", () => {
+      const [record] = buildCompletedWaitpointRecords([source({ output: '{"token":1}' })]);
+
+      expect(record?.output).toEqual({ inline: '{"token":1}' });
+    });
+
+    it("keeps a DATETIME output inline", () => {
+      const [record] = buildCompletedWaitpointRecords([
+        source({ type: "DATETIME", output: '{"at":1}' }),
+      ]);
+
+      expect(record?.output).toEqual({ inline: '{"at":1}' });
+    });
+
+    it("writes null when there is no output at all", () => {
+      const [record] = buildCompletedWaitpointRecords([source()]);
+
+      expect(record?.output).toBeNull();
+    });
+
+    it("keeps an empty-string output inline, because empty is a value and not an absence", () => {
+      const [record] = buildCompletedWaitpointRecords([source({ output: "" })]);
+
+      expect(record?.output).toEqual({ inline: "" });
+    });
+  });
+
+  it("returns an empty set for no sources", () => {
+    expect(buildCompletedWaitpointRecords([])).toEqual([]);
+  });
+});

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointRecords.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointRecords.ts
@@ -50,7 +50,10 @@ function chooseOutput(source: CompletionEnvelopeSource): CompletedWaitpointRecor
     return { deriveFromRun: true };
   }
 
-  // The runtime discards a batch output at source, so there is nothing to carry.
+  // Deliberately dropped, and this is the one place the record set does NOT reproduce the row.
+  // A BATCH waitpoint IS completed with an output (see batchSystem), but the executor ignores
+  // it: sharedRuntimeManager.resolveWaitpoint early-returns for type === "BATCH" and never
+  // reads the body. Carrying it would put bytes in the cycle key that nothing can observe.
   if (source.type === "BATCH") {
     return null;
   }

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointRecords.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointRecords.ts
@@ -38,6 +38,13 @@ export function buildCompletedWaitpointRecords(
 }
 
 function chooseOutput(source: CompletionEnvelopeSource): CompletedWaitpointRecordOutput {
+  // Ref BEFORE the RUN branch, which is the opposite order to the reference implementation in
+  // completedWaitpointFreeze.test.ts. Both are byte-identical at read time, by that reference's
+  // own reasoning: an offloaded RUN success has the same ref string in TaskRun.output. This
+  // order is preferred because it needs no Postgres read to recover a string already in hand,
+  // and because a deriveFromRun record whose run row is later deleted now refuses rather than
+  // resolving empty — so routing an offloaded RUN success down the ref branch keeps it
+  // resolvable when that row is gone.
   if (source.outputRef !== undefined) {
     return { ref: source.outputRef };
   }

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointRecords.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointRecords.ts
@@ -49,11 +49,21 @@ function chooseOutput(source: CompletionEnvelopeSource): CompletedWaitpointRecor
     return { ref: source.outputRef };
   }
 
-  // A plain RUN output is re-readable from TaskRun.output verbatim. Two RUN cases are not,
-  // and both must stay inline: an ERROR, because TaskRun.error is jsonb and does not
-  // round-trip to the same string, and an ORPHAN, because the back-reference is
-  // onDelete: SetNull so the completing row may be gone.
-  if (source.type === "RUN" && !source.outputIsError && source.completedByTaskRunId) {
+  // A plain RUN output is re-readable from TaskRun.output verbatim. Three RUN cases are not.
+  // An ERROR, because TaskRun.error is jsonb and does not round-trip to the same string. An
+  // ORPHAN, because the back-reference is onDelete: SetNull so the completing row may be gone.
+  // And an ABSENT output, which is the case that has to be checked here rather than left to the
+  // read: a task that returns nothing completes its waitpoint with no output at all, and there
+  // is then nothing to derive. Marking it derivable makes the resolver read a null TaskRun.output
+  // and refuse the resume as a lost output, where the hydration this replaces resumes cleanly
+  // with no output (`output: w.output ?? undefined`). A waitpoint that DID carry an output whose
+  // run row has since gone still refuses, which is what the refusal is for.
+  if (
+    source.type === "RUN" &&
+    !source.outputIsError &&
+    source.output !== undefined &&
+    source.completedByTaskRunId
+  ) {
     return { deriveFromRun: true };
   }
 

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointRecords.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointRecords.ts
@@ -1,0 +1,60 @@
+import type { CompletedWaitpointRecord, CompletedWaitpointRecordOutput } from "@internal/run-store";
+import type { CompletionEnvelopeSource } from "./types.js";
+
+/**
+ * Turn sourced envelope fields into the frozen record set that rides one wait cycle's key.
+ *
+ * One record per DISTINCT id. The cycle's ordered id list carries multiplicity, and the
+ * resolver expands one record into one entry per position of its id. That list holds only
+ * batch-indexed ids, because its positions ARE the indexes, so this set — not the list — is
+ * authoritative for membership.
+ */
+export function buildCompletedWaitpointRecords(
+  sources: CompletionEnvelopeSource[]
+): CompletedWaitpointRecord[] {
+  const byId = new Map<string, CompletedWaitpointRecord>();
+
+  for (const source of sources) {
+    if (byId.has(source.id)) {
+      continue;
+    }
+
+    byId.set(source.id, {
+      id: source.id,
+      friendlyId: source.friendlyId,
+      type: source.type,
+      completedAt: source.completedAt.toISOString(),
+      outputType: source.outputType,
+      outputIsError: source.outputIsError,
+      output: chooseOutput(source),
+      ...(source.completedByTaskRunId && { completedByTaskRunId: source.completedByTaskRunId }),
+      ...(source.completedByBatchId && { completedByBatchId: source.completedByBatchId }),
+      ...(source.completedAfter && { completedAfter: source.completedAfter.toISOString() }),
+      ...(source.idempotencyKey && { idempotencyKey: source.idempotencyKey }),
+    });
+  }
+
+  return [...byId.values()];
+}
+
+function chooseOutput(source: CompletionEnvelopeSource): CompletedWaitpointRecordOutput {
+  if (source.outputRef !== undefined) {
+    return { ref: source.outputRef };
+  }
+
+  // A plain RUN output is re-readable from TaskRun.output verbatim. Two RUN cases are not,
+  // and both must stay inline: an ERROR, because TaskRun.error is jsonb and does not
+  // round-trip to the same string, and an ORPHAN, because the back-reference is
+  // onDelete: SetNull so the completing row may be gone.
+  if (source.type === "RUN" && !source.outputIsError && source.completedByTaskRunId) {
+    return { deriveFromRun: true };
+  }
+
+  // The runtime discards a batch output at source, so there is nothing to carry.
+  if (source.type === "BATCH") {
+    return null;
+  }
+
+  // An empty string is a value, not an absence, so this checks undefined only.
+  return source.output === undefined ? null : { inline: source.output };
+}

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.runOutput.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.runOutput.test.ts
@@ -30,7 +30,9 @@ function deriveRecord(completedByTaskRunId: string): CompletedWaitpointRecord {
 
 function resolverFor(prisma: PrismaClient) {
   const runStore = new PostgresRunStore({ prisma, readOnlyPrisma: prisma });
-  return createCompletedWaitpointResolver({ readRunOutputs: createRunOutputsReader(runStore) });
+  return createCompletedWaitpointResolver({
+    readRunOutputs: createRunOutputsReader(runStore, prisma),
+  });
 }
 
 /**
@@ -42,7 +44,7 @@ function resolverFor(prisma: PrismaClient) {
  */
 function countingResolver(prisma: PrismaClient) {
   const runStore = new PostgresRunStore({ prisma, readOnlyPrisma: prisma });
-  const read = createRunOutputsReader(runStore);
+  const read = createRunOutputsReader(runStore, prisma);
   const batches: string[][] = [];
 
   return {
@@ -106,7 +108,14 @@ describe("the deriveFromRun branch", () => {
     expect(failure.reason).toBe("lost-run-output");
   });
 
-  postgresTest("refuses when the run exists with no output", async ({ prisma }) => {
+  // A record that DEFERS to a run whose output is gone still refuses -- that is the case the
+  // refusal exists for, and the record only defers when the waitpoint carried an output.
+  //
+  // This is deliberately reached by hand-building a derive record for an output-less run, a shape
+  // chooseOutput no longer produces. An earlier revision produced it for every non-error RUN
+  // waitpoint, which refused the resume of any task that returns nothing; the test below pins
+  // that case, and this one keeps the refusal itself honest.
+  postgresTest("refuses when a derive record's run output is gone", async ({ prisma }) => {
     const runId = await seedChildRunWithOutput(prisma, null);
 
     const failure = await resolverFor(prisma)({

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.runOutput.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.runOutput.test.ts
@@ -10,10 +10,10 @@ import type { PrismaClient } from "@trigger.dev/database";
 import { describe, expect } from "vitest";
 import {
   createCompletedWaitpointResolver,
-  createRunOutputReader,
+  createRunOutputsReader,
   UnresolvableWaitpointId,
 } from "./completedWaitpointResolver.js";
-import { seedChildRunWithOutput } from "./testFixtures/childRun.js";
+import { seedChildRunsWithOutputs, seedChildRunWithOutput } from "./testFixtures/childRun.js";
 
 function deriveRecord(completedByTaskRunId: string): CompletedWaitpointRecord {
   return {
@@ -30,7 +30,30 @@ function deriveRecord(completedByTaskRunId: string): CompletedWaitpointRecord {
 
 function resolverFor(prisma: PrismaClient) {
   const runStore = new PostgresRunStore({ prisma, readOnlyPrisma: prisma });
-  return createCompletedWaitpointResolver({ readRunOutput: createRunOutputReader(runStore) });
+  return createCompletedWaitpointResolver({ readRunOutputs: createRunOutputsReader(runStore) });
+}
+
+/**
+ * A resolver that records the id set of every batched read and DELEGATES to the real reader, so
+ * the Postgres read still happens.
+ *
+ * Wrapping the collaborator rather than replacing it is deliberate: the assertion is about how
+ * many reads occur and what they ask for, and neither is observable from the resolved output.
+ */
+function countingResolver(prisma: PrismaClient) {
+  const runStore = new PostgresRunStore({ prisma, readOnlyPrisma: prisma });
+  const read = createRunOutputsReader(runStore);
+  const batches: string[][] = [];
+
+  return {
+    batches,
+    resolve: createCompletedWaitpointResolver({
+      readRunOutputs: async (ids) => {
+        batches.push(ids);
+        return read(ids);
+      },
+    }),
+  };
 }
 
 describe("the deriveFromRun branch", () => {
@@ -102,19 +125,9 @@ describe("the deriveFromRun branch", () => {
   // query per index.
   postgresTest("reads the run once for a record at several indexes", async ({ prisma }) => {
     const runId = await seedChildRunWithOutput(prisma, '{"value":42}');
-    const runStore = new PostgresRunStore({ prisma, readOnlyPrisma: prisma });
-    const reads: string[] = [];
-    const reader = createRunOutputReader(runStore);
+    const { resolve, batches } = countingResolver(prisma);
 
-    // Counts calls and DELEGATES to the real reader, so the Postgres read still happens. This
-    // wraps the collaborator rather than replacing it: the assertion is about how many reads
-    // occur, which is not observable from the resolved output alone.
-    const result = await createCompletedWaitpointResolver({
-      readRunOutput: async (id) => {
-        reads.push(id);
-        return reader(id);
-      },
-    })({
+    const result = await resolve({
       runId: "run_parent",
       pointer: { cycleSeq: 1, count: 2 },
       order: ["wp_run", "wp_run"],
@@ -123,7 +136,67 @@ describe("the deriveFromRun branch", () => {
     });
 
     expect(result).toHaveLength(2);
-    expect(reads).toEqual([runId]);
+    expect(batches).toEqual([[runId]]);
+  });
+
+  // The shape a batch fan-in produces. Every deferring record resolves in ONE read, not one
+  // read each: a per-record read put a serial round trip per child on the resume path, which is
+  // the cost the record set exists to remove.
+  postgresTest("reads every deferred run in one batch", async ({ prisma }) => {
+    const runIds = await seedChildRunsWithOutputs(
+      prisma,
+      Array.from({ length: 12 }, (_, i) => `{"value":${i}}`)
+    );
+    const { resolve, batches } = countingResolver(prisma);
+
+    const records = runIds.map((runId, i) => ({
+      ...deriveRecord(runId),
+      id: `wp_run_${i}`,
+      friendlyId: `waitpoint_wp_run_${i}`,
+    }));
+
+    const result = await resolve({
+      runId: "run_parent",
+      pointer: { cycleSeq: 1, count: records.length },
+      order: records.map((r) => r.id),
+      distinctIds: records.map((r) => r.id),
+      records,
+    });
+
+    expect(result).toHaveLength(12);
+    // One batch, holding every distinct run id.
+    expect(batches).toHaveLength(1);
+    expect(batches[0]?.slice().sort()).toEqual(runIds.slice().sort());
+    // And each output landed on its own waitpoint.
+    for (const [i, runId] of runIds.entries()) {
+      const entry = result.find((w) => w.id === `wp_run_${i}`);
+      expect(entry?.output).toBe(`{"value":${i}}`);
+      expect(runId).toBeTruthy();
+    }
+  });
+
+  // A cycle that defers nothing reads nothing, so an all-inline resume pays no Postgres round
+  // trip at all.
+  postgresTest("reads nothing when no record defers", async ({ prisma }) => {
+    const { resolve, batches } = countingResolver(prisma);
+
+    const result = await resolve({
+      runId: "run_parent",
+      pointer: { cycleSeq: 1, count: 0 },
+      order: [],
+      distinctIds: ["wp_inline"],
+      records: [
+        {
+          ...deriveRecord("run_unused"),
+          id: "wp_inline",
+          friendlyId: "waitpoint_wp_inline",
+          output: { inline: '{"ok":true}' },
+        },
+      ],
+    });
+
+    expect(result[0]?.output).toBe('{"ok":true}');
+    expect(batches).toEqual([]);
   });
 
   postgresTest("throws when a derive record arrives with no reader wired", async ({ prisma }) => {

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.runOutput.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.runOutput.test.ts
@@ -4,7 +4,7 @@
 // by a pure test: the claim is that TaskRun.output holds the same string the waitpoint carried,
 // and only a real row can settle that. The pure suite covers everything that does not read.
 import { postgresTest } from "@internal/testcontainers";
-import { PostgresRunStore } from "@internal/run-store";
+import { markReadReplicaClient, PostgresRunStore } from "@internal/run-store";
 import type { CompletedWaitpointRecord } from "@internal/run-store";
 import type { PrismaClient } from "@trigger.dev/database";
 import { describe, expect } from "vitest";
@@ -246,6 +246,31 @@ describe("the deriveFromRun branch", () => {
 
     expect(result[0]?.output).toBe('{"ok":true}');
     expect(batches).toEqual([]);
+  });
+
+  // The required-writer rule is a runtime check because it cannot be a type one: ReadClient admits
+  // a writer and a replica, and they are structurally identical apart from the brand.
+  postgresTest("refuses to be built with a replica client", async ({ prisma }) => {
+    const runStore = new PostgresRunStore({ prisma, readOnlyPrisma: prisma });
+    const replica = markReadReplicaClient({ ...prisma });
+
+    expect(() => createRunOutputsReader(runStore, replica as never)).toThrow(/needs a writer/);
+  });
+
+  // The one place the design could fail OPEN instead of loud: a derive marker with no run to
+  // derive from would otherwise resolve the waitpoint with no output and no error.
+  postgresTest("throws on a derive record carrying no run id", async ({ prisma }) => {
+    const { id: _drop, ...rest } = deriveRecord("run_unused");
+
+    await expect(
+      resolverFor(prisma)({
+        runId: "run_parent",
+        pointer: { cycleSeq: 1, count: 0 },
+        order: [],
+        distinctIds: ["wp_run"],
+        records: [{ ...rest, id: "wp_run", completedByTaskRunId: undefined }],
+      })
+    ).rejects.toThrow(/carries no run id/);
   });
 
   postgresTest("throws when a derive record arrives with no reader wired", async ({ prisma }) => {

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.runOutput.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.runOutput.test.ts
@@ -175,6 +175,46 @@ describe("the deriveFromRun branch", () => {
     }
   });
 
+  // An empty string is a VALUE, not an absence. The reader's `row.output !== null` is what keeps
+  // it: narrowed to a truthy test it would report the run as output-less and throw
+  // lost-run-output on a run that completed perfectly well. Nothing else pins that, and
+  // `chooseOutput` already treats empty as a value on the write side.
+  postgresTest("keeps an empty-string output rather than refusing", async ({ prisma }) => {
+    const runId = await seedChildRunWithOutput(prisma, "");
+
+    const [entry] = await resolverFor(prisma)({
+      runId: "run_parent",
+      pointer: { cycleSeq: 1, count: 0 },
+      order: [],
+      distinctIds: ["wp_run"],
+      records: [deriveRecord(runId)],
+    });
+
+    expect(entry?.output).toBe("");
+  });
+
+  // Two waitpoints completed by the SAME run. One id in one batch, and both entries carry it:
+  // the dedup must not cost the second waitpoint its output.
+  postgresTest("reads a shared run once and hydrates both waitpoints", async ({ prisma }) => {
+    const runId = await seedChildRunWithOutput(prisma, '{"shared":true}');
+    const { resolve, batches } = countingResolver(prisma);
+
+    const result = await resolve({
+      runId: "run_parent",
+      pointer: { cycleSeq: 1, count: 2 },
+      order: ["wp_first", "wp_second"],
+      distinctIds: ["wp_first", "wp_second"],
+      records: [
+        { ...deriveRecord(runId), id: "wp_first", friendlyId: "waitpoint_wp_first" },
+        { ...deriveRecord(runId), id: "wp_second", friendlyId: "waitpoint_wp_second" },
+      ],
+    });
+
+    expect(batches).toEqual([[runId]]);
+    expect(result).toHaveLength(2);
+    expect(result.map((w) => w.output)).toEqual(['{"shared":true}', '{"shared":true}']);
+  });
+
   // A cycle that defers nothing reads nothing, so an all-inline resume pays no Postgres round
   // trip at all.
   postgresTest("reads nothing when no record defers", async ({ prisma }) => {

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.runOutput.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.runOutput.test.ts
@@ -1,0 +1,142 @@
+// The deriveFromRun branch, against a real TaskRun row.
+//
+// This branch is the resolver's only Postgres read, so it is the one part that cannot be proved
+// by a pure test: the claim is that TaskRun.output holds the same string the waitpoint carried,
+// and only a real row can settle that. The pure suite covers everything that does not read.
+import { postgresTest } from "@internal/testcontainers";
+import { PostgresRunStore } from "@internal/run-store";
+import type { CompletedWaitpointRecord } from "@internal/run-store";
+import type { PrismaClient } from "@trigger.dev/database";
+import { describe, expect } from "vitest";
+import {
+  createCompletedWaitpointResolver,
+  createRunOutputReader,
+  UnresolvableWaitpointId,
+} from "./completedWaitpointResolver.js";
+import { seedChildRunWithOutput } from "./testFixtures/childRun.js";
+
+function deriveRecord(completedByTaskRunId: string): CompletedWaitpointRecord {
+  return {
+    id: "wp_run",
+    friendlyId: "waitpoint_wp_run",
+    type: "RUN",
+    completedAt: "2026-08-26T00:00:00.000Z",
+    outputType: "application/json",
+    outputIsError: false,
+    output: { deriveFromRun: true },
+    completedByTaskRunId,
+  };
+}
+
+function resolverFor(prisma: PrismaClient) {
+  const runStore = new PostgresRunStore({ prisma, readOnlyPrisma: prisma });
+  return createCompletedWaitpointResolver({ readRunOutput: createRunOutputReader(runStore) });
+}
+
+describe("the deriveFromRun branch", () => {
+  postgresTest("reads the completing run's output verbatim", async ({ prisma }) => {
+    const stored = '{"value":42,"nested":{"a":[1,2,3]}}';
+    const runId = await seedChildRunWithOutput(prisma, stored);
+
+    const [entry] = await resolverFor(prisma)({
+      runId: "run_parent",
+      pointer: { cycleSeq: 1, count: 0 },
+      order: [],
+      distinctIds: ["wp_run"],
+      records: [deriveRecord(runId)],
+    });
+
+    // Byte-identical, which is the whole premise of the variant.
+    expect(entry?.output).toBe(stored);
+  });
+
+  postgresTest("carries an offloaded ref through unchanged", async ({ prisma }) => {
+    const runId = await seedChildRunWithOutput(prisma, "s3://bucket/key");
+
+    const [entry] = await resolverFor(prisma)({
+      runId: "run_parent",
+      pointer: { cycleSeq: 1, count: 0 },
+      order: [],
+      distinctIds: ["wp_run"],
+      records: [deriveRecord(runId)],
+    });
+
+    expect(entry?.output).toBe("s3://bucket/key");
+  });
+
+  // The run row disappearing between the record write and the read. Postgres does not lose the
+  // value on the legacy path, so resolving empty here would resolve a triggerAndWait with
+  // silently wrong data.
+  postgresTest("refuses when the completing run is gone", async ({ prisma }) => {
+    const runId = await seedChildRunWithOutput(prisma, '{"value":42}');
+    await prisma.taskRun.delete({ where: { id: runId } });
+
+    const failure = await resolverFor(prisma)({
+      runId: "run_parent",
+      pointer: { cycleSeq: 1, count: 0 },
+      order: [],
+      distinctIds: ["wp_run"],
+      records: [deriveRecord(runId)],
+    }).catch((caught: unknown) => caught as UnresolvableWaitpointId);
+
+    expect(failure).toBeInstanceOf(UnresolvableWaitpointId);
+    expect(failure.reason).toBe("lost-run-output");
+  });
+
+  postgresTest("refuses when the run exists with no output", async ({ prisma }) => {
+    const runId = await seedChildRunWithOutput(prisma, null);
+
+    const failure = await resolverFor(prisma)({
+      runId: "run_parent",
+      pointer: { cycleSeq: 1, count: 0 },
+      order: [],
+      distinctIds: ["wp_run"],
+      records: [deriveRecord(runId)],
+    }).catch((caught: unknown) => caught as UnresolvableWaitpointId);
+
+    expect(failure).toBeInstanceOf(UnresolvableWaitpointId);
+    expect(failure.reason).toBe("lost-run-output");
+  });
+
+  // One read per record, not one per position, so a run at several batch indexes does not pay a
+  // query per index.
+  postgresTest("reads the run once for a record at several indexes", async ({ prisma }) => {
+    const runId = await seedChildRunWithOutput(prisma, '{"value":42}');
+    const runStore = new PostgresRunStore({ prisma, readOnlyPrisma: prisma });
+    const reads: string[] = [];
+    const reader = createRunOutputReader(runStore);
+
+    // Counts calls and DELEGATES to the real reader, so the Postgres read still happens. This
+    // wraps the collaborator rather than replacing it: the assertion is about how many reads
+    // occur, which is not observable from the resolved output alone.
+    const result = await createCompletedWaitpointResolver({
+      readRunOutput: async (id) => {
+        reads.push(id);
+        return reader(id);
+      },
+    })({
+      runId: "run_parent",
+      pointer: { cycleSeq: 1, count: 2 },
+      order: ["wp_run", "wp_run"],
+      distinctIds: ["wp_run"],
+      records: [deriveRecord(runId)],
+    });
+
+    expect(result).toHaveLength(2);
+    expect(reads).toEqual([runId]);
+  });
+
+  postgresTest("throws when a derive record arrives with no reader wired", async ({ prisma }) => {
+    const runId = await seedChildRunWithOutput(prisma, '{"value":42}');
+
+    await expect(
+      createCompletedWaitpointResolver({})({
+        runId: "run_parent",
+        pointer: { cycleSeq: 1, count: 0 },
+        order: [],
+        distinctIds: ["wp_run"],
+        records: [deriveRecord(runId)],
+      })
+    ).rejects.toThrow(/no run-output reader/);
+  });
+});

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.test.ts
@@ -20,17 +20,18 @@ function record(overrides: Partial<CompletedWaitpointRecord> = {}): CompletedWai
   };
 }
 
-const noRunOutput = { readRunOutput: async () => undefined };
-
 type CaseArgs = Omit<ResolveArgs, "distinctIds"> & { distinctIds?: string[] };
 
 /**
+ * Built with NO run-output reader, deliberately. Every case here carries inline, ref or null
+ * output, so none reaches the branch that reads Postgres.
+ *
  * Fills `distinctIds` from the records when a case does not name it, because most cases are
  * about the expansion rather than the membership. The coverage-check cases set it explicitly,
  * since there it IS the subject.
  */
-function resolver(readRunOutput?: (taskRunId: string) => Promise<string | undefined>) {
-  const resolve = createCompletedWaitpointResolver(readRunOutput ? { readRunOutput } : noRunOutput);
+function resolver() {
+  const resolve = createCompletedWaitpointResolver({});
   return (over: CaseArgs) =>
     resolve({ ...over, distinctIds: over.distinctIds ?? over.records.map((r) => r.id) });
 }
@@ -210,55 +211,10 @@ describe("the output hydration", () => {
     expect(entry?.output).toBe("store-key-1");
   });
 
-  it("reads a deriveFromRun output from the run", async () => {
-    const [entry] = await resolver(async (id) =>
-      id === "run_child" ? '{"derived":true}' : undefined
-    )({
-      runId: "run_1",
-      pointer: CYCLE,
-      order: [],
-      records: [
-        record({ type: "RUN", completedByTaskRunId: "run_child", output: { deriveFromRun: true } }),
-      ],
-    });
-
-    expect(entry?.output).toBe('{"derived":true}');
-  });
-
-  // Postgres does not lose this: the back-reference nulls on delete but Waitpoint.output stays,
-  // so the legacy path still emits it. Resolving to undefined would resolve the parent's
-  // triggerAndWait successfully with no output, which is silent wrong data.
-  it("refuses when the run row it defers to is gone", async () => {
-    const failure = await resolver()({
-      runId: "run_1",
-      pointer: CYCLE,
-      order: [],
-      records: [
-        record({ type: "RUN", completedByTaskRunId: "run_gone", output: { deriveFromRun: true } }),
-      ],
-    }).catch((caught: unknown) => caught as UnresolvableWaitpointId);
-
-    expect(failure).toBeInstanceOf(UnresolvableWaitpointId);
-    expect(failure.reason).toBe("lost-run-output");
-  });
-
-  it("reads the run once for a record that expands to several entries", async () => {
-    const reads: string[] = [];
-    const result = await resolver(async (id) => {
-      reads.push(id);
-      return '{"derived":true}';
-    })({
-      runId: "run_1",
-      pointer: { cycleSeq: 1, count: 2 },
-      order: ["wp_1", "wp_1"],
-      records: [
-        record({ type: "RUN", completedByTaskRunId: "run_child", output: { deriveFromRun: true } }),
-      ],
-    });
-
-    expect(result).toHaveLength(2);
-    expect(reads).toEqual(["run_child"]);
-  });
+  // The deriveFromRun branch is the resolver's only Postgres read, so its cases live in
+  // completedWaitpointResolver.runOutput.test.ts against a real TaskRun row: the found output,
+  // the deleted row, the output-less row, the one-read-per-record property, and the unwired
+  // reader. Faking the read here would assert only that the fake was called.
 
   it("leaves the output undefined when the record carries none", async () => {
     const [entry] = await resolver()({

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.test.ts
@@ -1,0 +1,332 @@
+import type { CompletedWaitpointRecord } from "@internal/run-store";
+import { BatchId, RunId } from "@trigger.dev/core/v3/isomorphic";
+import { describe, expect, it } from "vitest";
+import {
+  createCompletedWaitpointResolver,
+  UnresolvableWaitpointId,
+} from "./completedWaitpointResolver.js";
+
+function record(overrides: Partial<CompletedWaitpointRecord> = {}): CompletedWaitpointRecord {
+  return {
+    id: "wp_1",
+    friendlyId: "waitpoint_wp_1",
+    type: "MANUAL",
+    completedAt: "2026-08-25T00:00:00.000Z",
+    outputType: "application/json",
+    outputIsError: false,
+    output: { inline: '{"ok":true}' },
+    ...overrides,
+  };
+}
+
+const noRunOutput = { readRunOutput: async () => undefined };
+
+function resolver(readRunOutput?: (taskRunId: string) => Promise<string | undefined>) {
+  return createCompletedWaitpointResolver(readRunOutput ? { readRunOutput } : noRunOutput);
+}
+
+const CYCLE = { cycleSeq: 1, count: 0 };
+
+describe("the index expansion", () => {
+  it("emits one entry per position of the id in the order", async () => {
+    const result = await resolver()({
+      runId: "run_1",
+      pointer: { cycleSeq: 1, count: 2 },
+      order: ["wp_1", "wp_1"],
+      records: [record()],
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result.map((w) => w.index)).toEqual([0, 1]);
+  });
+
+  it("gives a run at two batch indexes its two real positions", async () => {
+    const result = await resolver()({
+      runId: "run_1",
+      pointer: { cycleSeq: 1, count: 3 },
+      order: ["wp_other", "wp_1", "wp_1"],
+      records: [record(), record({ id: "wp_other", friendlyId: "waitpoint_wp_other" })],
+    });
+
+    expect(result.filter((w) => w.id === "wp_1").map((w) => w.index)).toEqual([1, 2]);
+  });
+
+  // Every wait.for, every single triggerAndWait and every token has no batch index, so it
+  // is absent from the order. Dropping it here loses the run's results on resume.
+  it("keeps a record with no position, with an undefined index", async () => {
+    const result = await resolver()({
+      runId: "run_1",
+      pointer: CYCLE,
+      order: [],
+      records: [record()],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.index).toBeUndefined();
+  });
+
+  it("keeps an index-less record alongside an indexed one", async () => {
+    const result = await resolver()({
+      runId: "run_1",
+      pointer: { cycleSeq: 1, count: 1 },
+      order: ["wp_indexed"],
+      records: [record(), record({ id: "wp_indexed", friendlyId: "waitpoint_wp_indexed" })],
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result.find((w) => w.id === "wp_1")?.index).toBeUndefined();
+    expect(result.find((w) => w.id === "wp_indexed")?.index).toBe(0);
+  });
+});
+
+describe("the executor shape", () => {
+  it("reproduces the scalar fields", async () => {
+    const [entry] = await resolver()({
+      runId: "run_1",
+      pointer: CYCLE,
+      order: [],
+      records: [record({ idempotencyKey: "user-key" })],
+    });
+
+    expect(entry).toMatchObject({
+      id: "wp_1",
+      friendlyId: "waitpoint_wp_1",
+      type: "MANUAL",
+      completedAt: new Date("2026-08-25T00:00:00.000Z"),
+      idempotencyKey: "user-key",
+      output: '{"ok":true}',
+      outputType: "application/json",
+      outputIsError: false,
+    });
+  });
+
+  it("builds completedByTaskRun for a RUN record", async () => {
+    const childRunId = RunId.fromFriendlyId(RunId.generate().friendlyId);
+
+    const [entry] = await resolver()({
+      runId: "run_1",
+      pointer: CYCLE,
+      order: [],
+      records: [record({ type: "RUN", completedByTaskRunId: childRunId, output: null })],
+    });
+
+    expect(entry?.completedByTaskRun).toEqual({
+      id: childRunId,
+      friendlyId: RunId.toFriendlyId(childRunId),
+    });
+  });
+
+  // The cycle is minted once, but a later entry in the resume chain can be read under a
+  // different batch. The batch shown must be the reading entry's, never the minting one's.
+  it("takes batch{} from the reading entry's batchId", async () => {
+    const childRunId = RunId.fromFriendlyId(RunId.generate().friendlyId);
+    const batchId = BatchId.fromFriendlyId(BatchId.generate().friendlyId);
+
+    const [entry] = await resolver()({
+      runId: "run_1",
+      batchId,
+      pointer: CYCLE,
+      order: [],
+      records: [record({ type: "RUN", completedByTaskRunId: childRunId, output: null })],
+    });
+
+    expect(entry?.completedByTaskRun?.batch).toEqual({
+      id: batchId,
+      friendlyId: BatchId.toFriendlyId(batchId),
+    });
+  });
+
+  it("omits batch{} when the reading entry has no batch", async () => {
+    const childRunId = RunId.fromFriendlyId(RunId.generate().friendlyId);
+
+    const [entry] = await resolver()({
+      runId: "run_1",
+      pointer: CYCLE,
+      order: [],
+      records: [record({ type: "RUN", completedByTaskRunId: childRunId, output: null })],
+    });
+
+    expect(entry?.completedByTaskRun?.batch).toBeUndefined();
+  });
+
+  it("builds completedByBatch for a BATCH record", async () => {
+    const batchId = BatchId.fromFriendlyId(BatchId.generate().friendlyId);
+
+    const [entry] = await resolver()({
+      runId: "run_1",
+      pointer: CYCLE,
+      order: [],
+      records: [record({ type: "BATCH", completedByBatchId: batchId, output: null })],
+    });
+
+    expect(entry?.completedByBatch).toEqual({
+      id: batchId,
+      friendlyId: BatchId.toFriendlyId(batchId),
+    });
+  });
+
+  it("carries completedAfter as a Date", async () => {
+    const [entry] = await resolver()({
+      runId: "run_1",
+      pointer: CYCLE,
+      order: [],
+      records: [record({ type: "DATETIME", completedAfter: "2026-08-26T00:00:00.000Z" })],
+    });
+
+    expect(entry?.completedAfter).toEqual(new Date("2026-08-26T00:00:00.000Z"));
+  });
+});
+
+describe("the output hydration", () => {
+  it("returns an inline value as-is", async () => {
+    const [entry] = await resolver()({
+      runId: "run_1",
+      pointer: CYCLE,
+      order: [],
+      records: [record({ output: { inline: '{"v":1}' } })],
+    });
+
+    expect(entry?.output).toBe('{"v":1}');
+  });
+
+  it("returns a ref as the output, so the executor resolves it the existing way", async () => {
+    const [entry] = await resolver()({
+      runId: "run_1",
+      pointer: CYCLE,
+      order: [],
+      records: [record({ output: { ref: "store-key-1" }, outputType: "application/store" })],
+    });
+
+    expect(entry?.output).toBe("store-key-1");
+  });
+
+  it("reads a deriveFromRun output from the run", async () => {
+    const [entry] = await resolver(async (id) =>
+      id === "run_child" ? '{"derived":true}' : undefined
+    )({
+      runId: "run_1",
+      pointer: CYCLE,
+      order: [],
+      records: [
+        record({ type: "RUN", completedByTaskRunId: "run_child", output: { deriveFromRun: true } }),
+      ],
+    });
+
+    expect(entry?.output).toBe('{"derived":true}');
+  });
+
+  it("leaves the output undefined when the run row is gone", async () => {
+    const [entry] = await resolver()({
+      runId: "run_1",
+      pointer: CYCLE,
+      order: [],
+      records: [
+        record({ type: "RUN", completedByTaskRunId: "run_gone", output: { deriveFromRun: true } }),
+      ],
+    });
+
+    expect(entry?.output).toBeUndefined();
+  });
+
+  it("reads the run once for a record that expands to several entries", async () => {
+    const reads: string[] = [];
+    const result = await resolver(async (id) => {
+      reads.push(id);
+      return '{"derived":true}';
+    })({
+      runId: "run_1",
+      pointer: { cycleSeq: 1, count: 2 },
+      order: ["wp_1", "wp_1"],
+      records: [
+        record({ type: "RUN", completedByTaskRunId: "run_child", output: { deriveFromRun: true } }),
+      ],
+    });
+
+    expect(result).toHaveLength(2);
+    expect(reads).toEqual(["run_child"]);
+  });
+
+  it("leaves the output undefined when the record carries none", async () => {
+    const [entry] = await resolver()({
+      runId: "run_1",
+      pointer: CYCLE,
+      order: [],
+      records: [record({ output: null })],
+    });
+
+    expect(entry?.output).toBeUndefined();
+  });
+});
+
+// The id classifier is total and never throws: an unrecognised shape classifies as legacy,
+// finds no row, and would otherwise vanish from the resumed run's completed set with no
+// error. These are the tests that make that impossible.
+describe("the coverage check", () => {
+  it("throws when the order names an id no half resolved", async () => {
+    await expect(
+      resolver()({
+        runId: "run_1",
+        pointer: { cycleSeq: 1, count: 1 },
+        order: ["wp_missing"],
+        records: [record()],
+      })
+    ).rejects.toThrow(UnresolvableWaitpointId);
+  });
+
+  it("names the offending id and the reason", async () => {
+    const error = await resolver()({
+      runId: "run_1",
+      pointer: { cycleSeq: 1, count: 1 },
+      order: ["wp_missing"],
+      records: [record()],
+    }).catch((caught: unknown) => caught as UnresolvableWaitpointId);
+
+    expect(error.waitpointId).toBe("wp_missing");
+    expect(error.reason).toBe("no-source");
+  });
+
+  it("accepts an ordered id that the caller resolved from a row", async () => {
+    const result = await resolver()({
+      runId: "run_1",
+      pointer: { cycleSeq: 1, count: 1 },
+      order: ["wp_legacy"],
+      records: [record()],
+      resolvedElsewhere: ["wp_legacy"],
+    });
+
+    expect(result.map((w) => w.id)).toEqual(["wp_1"]);
+  });
+
+  it("throws when both halves claim the same id", async () => {
+    const error = await resolver()({
+      runId: "run_1",
+      pointer: CYCLE,
+      order: [],
+      records: [record()],
+      resolvedElsewhere: ["wp_1"],
+    }).catch((caught: unknown) => caught as UnresolvableWaitpointId);
+
+    expect(error).toBeInstanceOf(UnresolvableWaitpointId);
+    expect(error.waitpointId).toBe("wp_1");
+    expect(error.reason).toBe("two-sources");
+  });
+
+  it("returns only its own half, leaving the legacy half to the caller", async () => {
+    const result = await resolver()({
+      runId: "run_1",
+      pointer: { cycleSeq: 1, count: 2 },
+      order: ["wp_legacy", "wp_1"],
+      records: [record()],
+      resolvedElsewhere: ["wp_legacy"],
+    });
+
+    expect(result.map((w) => w.id)).toEqual(["wp_1"]);
+    expect(result[0]?.index).toBe(1);
+  });
+
+  it("resolves an empty cycle to nothing", async () => {
+    await expect(
+      resolver()({ runId: "run_1", pointer: CYCLE, order: [], records: [] })
+    ).resolves.toEqual([]);
+  });
+});

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   createCompletedWaitpointResolver,
   UnresolvableWaitpointId,
+  type ResolveArgs,
 } from "./completedWaitpointResolver.js";
 
 function record(overrides: Partial<CompletedWaitpointRecord> = {}): CompletedWaitpointRecord {
@@ -21,8 +22,17 @@ function record(overrides: Partial<CompletedWaitpointRecord> = {}): CompletedWai
 
 const noRunOutput = { readRunOutput: async () => undefined };
 
+type CaseArgs = Omit<ResolveArgs, "distinctIds"> & { distinctIds?: string[] };
+
+/**
+ * Fills `distinctIds` from the records when a case does not name it, because most cases are
+ * about the expansion rather than the membership. The coverage-check cases set it explicitly,
+ * since there it IS the subject.
+ */
 function resolver(readRunOutput?: (taskRunId: string) => Promise<string | undefined>) {
-  return createCompletedWaitpointResolver(readRunOutput ? { readRunOutput } : noRunOutput);
+  const resolve = createCompletedWaitpointResolver(readRunOutput ? { readRunOutput } : noRunOutput);
+  return (over: CaseArgs) =>
+    resolve({ ...over, distinctIds: over.distinctIds ?? over.records.map((r) => r.id) });
 }
 
 const CYCLE = { cycleSeq: 1, count: 0 };
@@ -215,17 +225,21 @@ describe("the output hydration", () => {
     expect(entry?.output).toBe('{"derived":true}');
   });
 
-  it("leaves the output undefined when the run row is gone", async () => {
-    const [entry] = await resolver()({
+  // Postgres does not lose this: the back-reference nulls on delete but Waitpoint.output stays,
+  // so the legacy path still emits it. Resolving to undefined would resolve the parent's
+  // triggerAndWait successfully with no output, which is silent wrong data.
+  it("refuses when the run row it defers to is gone", async () => {
+    const failure = await resolver()({
       runId: "run_1",
       pointer: CYCLE,
       order: [],
       records: [
         record({ type: "RUN", completedByTaskRunId: "run_gone", output: { deriveFromRun: true } }),
       ],
-    });
+    }).catch((caught: unknown) => caught as UnresolvableWaitpointId);
 
-    expect(entry?.output).toBeUndefined();
+    expect(failure).toBeInstanceOf(UnresolvableWaitpointId);
+    expect(failure.reason).toBe("lost-run-output");
   });
 
   it("reads the run once for a record that expands to several entries", async () => {
@@ -322,6 +336,36 @@ describe("the coverage check", () => {
 
     expect(result.map((w) => w.id)).toEqual(["wp_1"]);
     expect(result[0]?.index).toBe(1);
+  });
+
+  // The check must run over the whole membership. An index-less wait is absent from `order` by
+  // construction, so an order-scoped check returns [] here and the run resumes having silently
+  // lost its result.
+  it("throws when an index-less id in the membership has no record", async () => {
+    const failure = await resolver()({
+      runId: "run_1",
+      pointer: CYCLE,
+      order: [],
+      distinctIds: ["wp_indexless"],
+      records: [],
+    }).catch((caught: unknown) => caught as UnresolvableWaitpointId);
+
+    expect(failure).toBeInstanceOf(UnresolvableWaitpointId);
+    expect(failure.waitpointId).toBe("wp_indexless");
+    expect(failure.reason).toBe("no-source");
+  });
+
+  it("accepts an index-less id the caller resolved from a row", async () => {
+    const result = await resolver()({
+      runId: "run_1",
+      pointer: CYCLE,
+      order: [],
+      distinctIds: ["wp_legacy"],
+      records: [],
+      resolvedElsewhere: ["wp_legacy"],
+    });
+
+    expect(result).toEqual([]);
   });
 
   it("resolves an empty cycle to nothing", async () => {

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.ts
@@ -1,0 +1,149 @@
+import type { CompletedWaitpointRecord, ResolveCompletedWaitpointsArgs } from "@internal/run-store";
+import { BatchId, RunId } from "@trigger.dev/core/v3/isomorphic";
+import type { CompletedWaitpoint } from "@trigger.dev/core/v3/schemas";
+
+/**
+ * A waitpoint id that no half of a snapshot can account for, or that both halves claim.
+ *
+ * This exists because the id classifier is total and never throws: an unrecognised shape
+ * classifies as legacy, finds no row, and would otherwise disappear from the resumed run's
+ * completed set with no error at all.
+ */
+export class UnresolvableWaitpointId extends Error {
+  readonly waitpointId: string;
+  readonly reason: "no-source" | "two-sources";
+
+  constructor(waitpointId: string, reason: "no-source" | "two-sources") {
+    super(
+      reason === "no-source"
+        ? `Waitpoint ${waitpointId} has neither a cycle record nor a fetched row. Refusing to resume without it.`
+        : `Waitpoint ${waitpointId} resolved twice, from a cycle record and from a fetched row.`
+    );
+    this.name = "UnresolvableWaitpointId";
+    this.waitpointId = waitpointId;
+    this.reason = reason;
+  }
+}
+
+export type CompletedWaitpointResolverDeps = {
+  /** Reads TaskRun.output. Returns undefined when the row is gone. */
+  readRunOutput(taskRunId: string): Promise<string | undefined>;
+};
+
+export type ResolveArgs = ResolveCompletedWaitpointsArgs & {
+  /** Ids the caller resolved from Postgres rows. Read by the coverage check only. */
+  resolvedElsewhere?: string[];
+};
+
+/**
+ * Rebuild `CompletedWaitpoint[]` from one wait cycle's records.
+ *
+ * Field-for-field equivalent to `enhanceExecutionSnapshotWithWaitpoints`, which is what the
+ * executor already consumes. It iterates the RECORDS, not the order: the order holds only
+ * batch-indexed ids, so iterating it would silently drop every index-less wait.
+ *
+ * Returns the store-resident half only. A mixed snapshot's legacy half arrives as Postgres
+ * rows and is expanded by the existing path, and the caller concatenates. Both halves read
+ * their index from the same order, so the positions agree with no coordination.
+ */
+export function createCompletedWaitpointResolver(deps: CompletedWaitpointResolverDeps) {
+  return async function resolveCompletedWaitpoints(
+    args: ResolveArgs
+  ): Promise<CompletedWaitpoint[]> {
+    const recordIds = new Set(args.records.map((record) => record.id));
+    const resolvedElsewhere = new Set(args.resolvedElsewhere ?? []);
+
+    for (const id of resolvedElsewhere) {
+      if (recordIds.has(id)) {
+        throw new UnresolvableWaitpointId(id, "two-sources");
+      }
+    }
+
+    for (const id of args.order) {
+      if (!recordIds.has(id) && !resolvedElsewhere.has(id)) {
+        throw new UnresolvableWaitpointId(id, "no-source");
+      }
+    }
+
+    const out: CompletedWaitpoint[] = [];
+
+    for (const record of args.records) {
+      const indexes = positionsOf(record.id, args.order);
+      // Hydrated once per record, not once per position, so a run at several batch indexes
+      // costs one read rather than one per index.
+      const output = await hydrateOutput(record, deps);
+
+      for (const index of indexes) {
+        out.push({
+          id: record.id,
+          index,
+          friendlyId: record.friendlyId,
+          type: record.type,
+          completedAt: new Date(record.completedAt),
+          ...(record.idempotencyKey && { idempotencyKey: record.idempotencyKey }),
+          ...(record.completedByTaskRunId && {
+            completedByTaskRun: {
+              id: record.completedByTaskRunId,
+              friendlyId: RunId.toFriendlyId(record.completedByTaskRunId),
+              // The reading entry's batch, never the entry that minted the cycle.
+              ...(args.batchId && {
+                batch: { id: args.batchId, friendlyId: BatchId.toFriendlyId(args.batchId) },
+              }),
+            },
+          }),
+          ...(record.completedAfter && { completedAfter: new Date(record.completedAfter) }),
+          ...(record.completedByBatchId && {
+            completedByBatch: {
+              id: record.completedByBatchId,
+              friendlyId: BatchId.toFriendlyId(record.completedByBatchId),
+            },
+          }),
+          ...(output !== undefined && { output }),
+          outputType: record.outputType,
+          outputIsError: record.outputIsError,
+        });
+      }
+    }
+
+    return out;
+  };
+}
+
+// An id with no position yields one entry with an undefined index, matching what the
+// existing hydration does for a wait that carried no batch index.
+function positionsOf(waitpointId: string, order: string[]): (number | undefined)[] {
+  const indexes: (number | undefined)[] = [];
+
+  for (let i = 0; i < order.length; i++) {
+    if (order[i] === waitpointId) {
+      indexes.push(i);
+    }
+  }
+
+  return indexes.length === 0 ? [undefined] : indexes;
+}
+
+async function hydrateOutput(
+  record: CompletedWaitpointRecord,
+  deps: CompletedWaitpointResolverDeps
+): Promise<string | undefined> {
+  if (record.output === null) {
+    return undefined;
+  }
+
+  if ("inline" in record.output) {
+    return record.output.inline;
+  }
+
+  // A ref is handed back as the output verbatim: the executor already resolves an
+  // application/store output the same way it does for a Postgres-served snapshot.
+  if ("ref" in record.output) {
+    return record.output.ref;
+  }
+
+  if (!record.completedByTaskRunId) {
+    return undefined;
+  }
+
+  return deps.readRunOutput(record.completedByTaskRunId);
+}

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.ts
@@ -1,6 +1,5 @@
 import type {
   CompletedWaitpointRecord,
-  ReadClient,
   ResolveCompletedWaitpointsArgs,
   RunStore,
 } from "@internal/run-store";
@@ -64,17 +63,23 @@ const RUN_OUTPUT_CHUNK_SIZE = 100;
  * `findRunsByIds` is the store's own grouped replacement for `Promise.all(ids.map(findRun))`,
  * and it forces `id` into the projection so the map keys correctly even though this select
  * names only `output`.
+ *
+ * Takes no read client on purpose. The router reads the owning store's REPLICA when no client is
+ * passed, and forces its PRIMARY for any client that is not replica-branded -- so accepting one
+ * would let a caller put a wide `TaskRun.output` read on the writer by reflex. This read does not
+ * need read-your-writes: the child run committed its output before it completed the waitpoint that
+ * unblocked this parent, so replica lag cannot hide it. That is the opposite of the envelope read
+ * in the legacy arm, which reads a waitpoint completed moments earlier and must use the writer.
  */
 export function createRunOutputsReader(
-  runStore: Pick<RunStore, "findRunsByIds">,
-  client?: ReadClient
+  runStore: Pick<RunStore, "findRunsByIds">
 ): (taskRunIds: string[]) => Promise<Map<string, string>> {
   return async (taskRunIds) => {
     const outputs = new Map<string, string>();
 
     for (let i = 0; i < taskRunIds.length; i += RUN_OUTPUT_CHUNK_SIZE) {
       const chunk = taskRunIds.slice(i, i + RUN_OUTPUT_CHUNK_SIZE);
-      const rows = await runStore.findRunsByIds(chunk, { select: { output: true } }, client);
+      const rows = await runStore.findRunsByIds(chunk, { select: { output: true } });
 
       for (const [id, row] of rows) {
         // A row present with a null output is the same absence as a missing row: either way the
@@ -218,27 +223,34 @@ async function readDeferredOutputs(
   deps: CompletedWaitpointResolverDeps
 ): Promise<Map<string, string>> {
   const runIds = new Set<string>();
-  let deferring: CompletedWaitpointRecord | undefined;
+  let read: NonNullable<CompletedWaitpointResolverDeps["readRunOutputs"]> | undefined;
 
   for (const record of records) {
     const runId = deferredRunIdOf(record);
-    if (runId !== undefined) {
-      runIds.add(runId);
-      deferring ??= record;
+    if (runId === undefined) {
+      continue;
     }
+
+    // Checked here rather than after the pass, so the message names a record that really does
+    // defer rather than whichever one happened to be first. A missing reader is a wiring fault,
+    // so every deferring record is equally implicated and the first is as informative as any.
+    if (!deps.readRunOutputs) {
+      throw new Error(
+        `Waitpoint ${record.id} defers its output to run ${runId}, but the resolver was built with no run-output reader.`
+      );
+    }
+
+    read = deps.readRunOutputs;
+    runIds.add(runId);
   }
 
-  if (runIds.size === 0) {
+  // Set exactly when a record deferred, so this is the same condition as an empty `runIds` --
+  // and unlike `runIds.size`, it carries the reader with it.
+  if (read === undefined) {
     return new Map();
   }
 
-  if (!deps.readRunOutputs) {
-    throw new Error(
-      `Waitpoint ${deferring?.id} defers its output to run ${deferring?.completedByTaskRunId}, but the resolver was built with no run-output reader.`
-    );
-  }
-
-  return deps.readRunOutputs([...runIds]);
+  return read([...runIds]);
 }
 
 // The run a record defers its output to, or undefined when it carries its own output or has

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.ts
@@ -1,5 +1,6 @@
 import type {
   CompletedWaitpointRecord,
+  ReadClient,
   ResolveCompletedWaitpointsArgs,
   RunStore,
 } from "@internal/run-store";
@@ -64,22 +65,29 @@ const RUN_OUTPUT_CHUNK_SIZE = 100;
  * and it forces `id` into the projection so the map keys correctly even though this select
  * names only `output`.
  *
- * Takes no read client on purpose. The router reads the owning store's REPLICA when no client is
- * passed, and forces its PRIMARY for any client that is not replica-branded -- so accepting one
- * would let a caller put a wide `TaskRun.output` read on the writer by reflex. This read does not
- * need read-your-writes: the child run committed its output before it completed the waitpoint that
- * unblocked this parent, so replica lag cannot hide it. That is the opposite of the envelope read
- * in the legacy arm, which reads a waitpoint completed moments earlier and must use the writer.
+ * The client is REQUIRED, and must be the writer, because this read needs read-your-writes.
+ *
+ * It is tempting to argue the replica is safe here: the child commits its output before it
+ * completes the waitpoint that unblocks this parent, so the write happens first. That ordering is
+ * real but it does not help, because the READER can observe the completion by another route --
+ * from Redis, or from the primary -- while the run-output replica still trails. The output then
+ * reads null and the resolver refuses the resume as a lost output. A hard refusal is a far worse
+ * outcome than a read on the writer, and this read is bounded and projected to one column.
+ *
+ * The router turns any client that is not replica-branded into the owning store's primary, and
+ * turns NO client into its replica -- so an optional parameter would silently reintroduce the lag
+ * window every time a caller omitted it. Hence required.
  */
 export function createRunOutputsReader(
-  runStore: Pick<RunStore, "findRunsByIds">
+  runStore: Pick<RunStore, "findRunsByIds">,
+  client: ReadClient
 ): (taskRunIds: string[]) => Promise<Map<string, string>> {
   return async (taskRunIds) => {
     const outputs = new Map<string, string>();
 
     for (let i = 0; i < taskRunIds.length; i += RUN_OUTPUT_CHUNK_SIZE) {
       const chunk = taskRunIds.slice(i, i + RUN_OUTPUT_CHUNK_SIZE);
-      const rows = await runStore.findRunsByIds(chunk, { select: { output: true } });
+      const rows = await runStore.findRunsByIds(chunk, { select: { output: true } }, client);
 
       for (const [id, row] of rows) {
         // A row present with a null output is the same absence as a missing row: either way the

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.ts
@@ -1,4 +1,9 @@
-import type { CompletedWaitpointRecord, ResolveCompletedWaitpointsArgs } from "@internal/run-store";
+import type {
+  CompletedWaitpointRecord,
+  ReadClient,
+  ResolveCompletedWaitpointsArgs,
+  RunStore,
+} from "@internal/run-store";
 import { BatchId, RunId } from "@trigger.dev/core/v3/isomorphic";
 import type { CompletedWaitpoint } from "@trigger.dev/core/v3/schemas";
 
@@ -33,9 +38,29 @@ export class UnresolvableWaitpointId extends Error {
 }
 
 export type CompletedWaitpointResolverDeps = {
-  /** Reads TaskRun.output. Returns undefined when the row is gone. */
-  readRunOutput(taskRunId: string): Promise<string | undefined>;
+  /**
+   * Reads TaskRun.output. Returns undefined when the row is gone.
+   *
+   * Optional, because most cycles carry no `deriveFromRun` record and therefore never need it.
+   * A cycle that DOES carry one without a reader is a wiring error, not a data condition, so it
+   * throws rather than resolving empty.
+   */
+  readRunOutput?(taskRunId: string): Promise<string | undefined>;
 };
+
+/**
+ * The production reader: TaskRun.output for the completing run, through the store so the read
+ * routes to the run's owning database.
+ */
+export function createRunOutputReader(
+  runStore: Pick<RunStore, "findRun">,
+  client?: ReadClient
+): (taskRunId: string) => Promise<string | undefined> {
+  return async (taskRunId) => {
+    const run = await runStore.findRun({ id: taskRunId }, { select: { output: true } }, client);
+    return run?.output ?? undefined;
+  };
+}
 
 export type ResolveArgs = ResolveCompletedWaitpointsArgs & {
   /** Ids the caller resolved from Postgres rows. Read by the coverage check only. */
@@ -153,6 +178,12 @@ async function hydrateOutput(
 
   if (!record.completedByTaskRunId) {
     return undefined;
+  }
+
+  if (!deps.readRunOutput) {
+    throw new Error(
+      `Waitpoint ${record.id} defers its output to run ${record.completedByTaskRunId}, but the resolver was built with no run-output reader.`
+    );
   }
 
   // Postgres does not lose this: the back-reference nulls on delete but Waitpoint.output stays,

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.ts
@@ -1,3 +1,4 @@
+import { isReadReplicaClient } from "@internal/run-store";
 import type {
   CompletedWaitpointRecord,
   ReadClient,
@@ -76,12 +77,29 @@ const RUN_OUTPUT_CHUNK_SIZE = 100;
  *
  * The router turns any client that is not replica-branded into the owning store's primary, and
  * turns NO client into its replica -- so an optional parameter would silently reintroduce the lag
- * window every time a caller omitted it. Hence required.
+ * window every time a caller omitted it. Hence required, and hence checked: `ReadClient` admits
+ * both a writer and a replica, and the two are structurally identical, separable only by the
+ * runtime brand. A caller passing `readOnlyPrisma` would type-check and quietly reinstate the
+ * window, so the constraint has to be asserted rather than documented. Constructed once at wiring
+ * time, so the assertion costs nothing per read.
+ *
+ * The premise this read rests on: `TaskRun.output` still holds what the waitpoint was completed
+ * with. `completeAttemptSuccess` writes the run's output and the waitpoint's completion from the
+ * same values, and nothing overwrites a completed run's output afterwards. If that ever stops
+ * being true, a deferred record resolves the NEWER value while the legacy path would emit the
+ * frozen one -- and unlike a lost output, that divergence is silent.
  */
 export function createRunOutputsReader(
   runStore: Pick<RunStore, "findRunsByIds">,
   client: ReadClient
 ): (taskRunIds: string[]) => Promise<Map<string, string>> {
+  if (isReadReplicaClient(client)) {
+    throw new Error(
+      "createRunOutputsReader needs a writer: a replica can trail the child's committed output " +
+        "and the resolver would refuse the resume as a lost output."
+    );
+  }
+
   return async (taskRunIds) => {
     const outputs = new Map<string, string>();
 
@@ -293,6 +311,17 @@ function hydrateOutput(
   // application/store output the same way it does for a Postgres-served snapshot.
   if ("ref" in record.output) {
     return record.output.ref;
+  }
+
+  // A record marked deriveFromRun with no run to derive from. Unreachable from today's
+  // chooseOutput, which requires the id before it marks anything derivable -- but this is the one
+  // spot where the design could fail OPEN rather than loud, resolving the waitpoint with no output
+  // at all, and a reordering of those conjuncts is all it would take. Treated as the build fault
+  // it would be, like a record arriving with no reader wired.
+  if (record.output !== null && "deriveFromRun" in record.output && !record.completedByTaskRunId) {
+    throw new Error(
+      `Waitpoint ${record.id} defers its output to its completing run, but carries no run id.`
+    );
   }
 
   const runId = deferredRunIdOf(record);

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.ts
@@ -39,26 +39,54 @@ export class UnresolvableWaitpointId extends Error {
 
 export type CompletedWaitpointResolverDeps = {
   /**
-   * Reads TaskRun.output. Returns undefined when the row is gone.
+   * Reads TaskRun.output for a SET of completing runs, keyed by run id.
+   *
+   * Plural on purpose. A batch parent resumes on every child at once, so a per-id reader made
+   * the resolver do one round trip per child -- 500 of them, in series, for a 500-wide fan-in,
+   * where the path this replaces did one chunked read. An id absent from the returned map is an
+   * absent output, which the caller refuses rather than resolving empty.
    *
    * Optional, because most cycles carry no `deriveFromRun` record and therefore never need it.
    * A cycle that DOES carry one without a reader is a wiring error, not a data condition, so it
    * throws rather than resolving empty.
    */
-  readRunOutput?(taskRunId: string): Promise<string | undefined>;
+  readRunOutputs?(taskRunIds: string[]): Promise<Map<string, string>>;
 };
 
+// Bounds one read, for the reason the envelope and waitpoint reads share: a run output can be
+// 100KB+, so a wide fan-in read whole can exceed Node's string conversion limits.
+const RUN_OUTPUT_CHUNK_SIZE = 100;
+
 /**
- * The production reader: TaskRun.output for the completing run, through the store so the read
+ * The production reader: TaskRun.output for the completing runs, through the store so each read
  * routes to the run's owning database.
+ *
+ * `findRunsByIds` is the store's own grouped replacement for `Promise.all(ids.map(findRun))`,
+ * and it forces `id` into the projection so the map keys correctly even though this select
+ * names only `output`.
  */
-export function createRunOutputReader(
-  runStore: Pick<RunStore, "findRun">,
+export function createRunOutputsReader(
+  runStore: Pick<RunStore, "findRunsByIds">,
   client?: ReadClient
-): (taskRunId: string) => Promise<string | undefined> {
-  return async (taskRunId) => {
-    const run = await runStore.findRun({ id: taskRunId }, { select: { output: true } }, client);
-    return run?.output ?? undefined;
+): (taskRunIds: string[]) => Promise<Map<string, string>> {
+  return async (taskRunIds) => {
+    const outputs = new Map<string, string>();
+
+    for (let i = 0; i < taskRunIds.length; i += RUN_OUTPUT_CHUNK_SIZE) {
+      const chunk = taskRunIds.slice(i, i + RUN_OUTPUT_CHUNK_SIZE);
+      const rows = await runStore.findRunsByIds(chunk, { select: { output: true } }, client);
+
+      for (const [id, row] of rows) {
+        // A row present with a null output is the same absence as a missing row: either way the
+        // value the waitpoint deferred is gone. Omitting it here keeps one absence rule, so the
+        // caller's refusal covers both.
+        if (row.output !== null) {
+          outputs.set(id, row.output);
+        }
+      }
+    }
+
+    return outputs;
   };
 }
 
@@ -100,13 +128,23 @@ export function createCompletedWaitpointResolver(deps: CompletedWaitpointResolve
       }
     }
 
+    // Every deferred output in ONE read, before the emit loop. Reading inside the loop meant a
+    // round trip per record, in series, which is the shape a batch fan-in punishes hardest: the
+    // wide wait this feature exists to make cheap is exactly the wide wait that paid most.
+    const runOutputs = await readDeferredOutputs(args.records, deps);
+
+    // Positions once, not once per record. `positionsOf` scanned the whole order for every
+    // record, so the emit loop was O(records x order) -- a million comparisons for a 1000-wide
+    // wait, growing with the same input as above.
+    const positions = positionsById(args.order);
+
     const out: CompletedWaitpoint[] = [];
 
     for (const record of args.records) {
-      const indexes = positionsOf(record.id, args.order);
+      const indexes = positions.get(record.id) ?? [undefined];
       // Hydrated once per record, not once per position, so a run at several batch indexes
-      // costs one read rather than one per index.
-      const output = await hydrateOutput(record, deps);
+      // resolves from one map entry rather than one per index.
+      const output = hydrateOutput(record, runOutputs);
 
       for (const index of indexes) {
         out.push({
@@ -144,24 +182,85 @@ export function createCompletedWaitpointResolver(deps: CompletedWaitpointResolve
   };
 }
 
-// An id with no position yields one entry with an undefined index, matching what the
-// existing hydration does for a wait that carried no batch index.
-function positionsOf(waitpointId: string, order: string[]): (number | undefined)[] {
-  const indexes: (number | undefined)[] = [];
+// Every id's positions in the order, built in one pass.
+//
+// An id ABSENT from this map has no position, and the caller emits it once with an undefined
+// index -- matching what the existing hydration does for a wait that carried no batch index.
+// Absence is how that case is carried, so this never stores an [undefined] entry itself.
+function positionsById(order: string[]): Map<string, number[]> {
+  const positions = new Map<string, number[]>();
 
   for (let i = 0; i < order.length; i++) {
-    if (order[i] === waitpointId) {
-      indexes.push(i);
+    const id = order[i];
+    if (id === undefined) {
+      continue;
+    }
+
+    const existing = positions.get(id);
+    if (existing) {
+      existing.push(i);
+    } else {
+      positions.set(id, [i]);
     }
   }
 
-  return indexes.length === 0 ? [undefined] : indexes;
+  return positions;
 }
 
-async function hydrateOutput(
-  record: CompletedWaitpointRecord,
+/**
+ * The output of every run a record defers to, in one batched read.
+ *
+ * Returns an empty map when no record defers, which is the common case: a cycle carrying only
+ * inline values, refs and BATCH records reads nothing at all.
+ */
+async function readDeferredOutputs(
+  records: CompletedWaitpointRecord[],
   deps: CompletedWaitpointResolverDeps
-): Promise<string | undefined> {
+): Promise<Map<string, string>> {
+  const runIds = new Set<string>();
+  let deferring: CompletedWaitpointRecord | undefined;
+
+  for (const record of records) {
+    const runId = deferredRunIdOf(record);
+    if (runId !== undefined) {
+      runIds.add(runId);
+      deferring ??= record;
+    }
+  }
+
+  if (runIds.size === 0) {
+    return new Map();
+  }
+
+  if (!deps.readRunOutputs) {
+    throw new Error(
+      `Waitpoint ${deferring?.id} defers its output to run ${deferring?.completedByTaskRunId}, but the resolver was built with no run-output reader.`
+    );
+  }
+
+  return deps.readRunOutputs([...runIds]);
+}
+
+// The run a record defers its output to, or undefined when it carries its own output or has
+// nothing to defer to. This is the single definition of "needs a run read", so the pre-pass and
+// the hydration cannot disagree about which records those are.
+function deferredRunIdOf(record: CompletedWaitpointRecord): string | undefined {
+  if (record.output === null) {
+    return undefined;
+  }
+
+  if ("inline" in record.output || "ref" in record.output) {
+    return undefined;
+  }
+
+  return record.completedByTaskRunId ?? undefined;
+}
+
+// Synchronous: every read this needs already happened in readDeferredOutputs.
+function hydrateOutput(
+  record: CompletedWaitpointRecord,
+  runOutputs: Map<string, string>
+): string | undefined {
   if (record.output === null) {
     return undefined;
   }
@@ -176,20 +275,15 @@ async function hydrateOutput(
     return record.output.ref;
   }
 
-  if (!record.completedByTaskRunId) {
+  const runId = deferredRunIdOf(record);
+  if (runId === undefined) {
     return undefined;
-  }
-
-  if (!deps.readRunOutput) {
-    throw new Error(
-      `Waitpoint ${record.id} defers its output to run ${record.completedByTaskRunId}, but the resolver was built with no run-output reader.`
-    );
   }
 
   // Postgres does not lose this: the back-reference nulls on delete but Waitpoint.output stays,
   // so the legacy path still emits it. Returning undefined here instead would resolve the
   // parent's triggerAndWait successfully with no output, which is silent wrong data.
-  const output = await deps.readRunOutput(record.completedByTaskRunId);
+  const output = runOutputs.get(runId);
   if (output === undefined) {
     throw new UnresolvableWaitpointId(record.id, "lost-run-output");
   }

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointResolver.ts
@@ -9,16 +9,23 @@ import type { CompletedWaitpoint } from "@trigger.dev/core/v3/schemas";
  * classifies as legacy, finds no row, and would otherwise disappear from the resumed run's
  * completed set with no error at all.
  */
+export type UnresolvableReason = "no-source" | "two-sources" | "lost-run-output";
+
+const MESSAGES: Record<UnresolvableReason, (id: string) => string> = {
+  "no-source": (id) =>
+    `Waitpoint ${id} has neither a cycle record nor a fetched row. Refusing to resume without it.`,
+  "two-sources": (id) =>
+    `Waitpoint ${id} resolved twice, from a cycle record and from a fetched row.`,
+  "lost-run-output": (id) =>
+    `Waitpoint ${id} defers its output to its completing run, and that run's output is gone. Refusing to resume with an empty output.`,
+};
+
 export class UnresolvableWaitpointId extends Error {
   readonly waitpointId: string;
-  readonly reason: "no-source" | "two-sources";
+  readonly reason: UnresolvableReason;
 
-  constructor(waitpointId: string, reason: "no-source" | "two-sources") {
-    super(
-      reason === "no-source"
-        ? `Waitpoint ${waitpointId} has neither a cycle record nor a fetched row. Refusing to resume without it.`
-        : `Waitpoint ${waitpointId} resolved twice, from a cycle record and from a fetched row.`
-    );
+  constructor(waitpointId: string, reason: UnresolvableReason) {
+    super(MESSAGES[reason](waitpointId));
     this.name = "UnresolvableWaitpointId";
     this.waitpointId = waitpointId;
     this.reason = reason;
@@ -59,7 +66,10 @@ export function createCompletedWaitpointResolver(deps: CompletedWaitpointResolve
       }
     }
 
-    for (const id of args.order) {
+    // Over the WHOLE membership, not `order`. The order omits every index-less wait, so a
+    // check scoped to it cannot see an index-less id whose record is missing — which is the
+    // exact loss this resolver exists to make impossible.
+    for (const id of new Set([...args.distinctIds, ...args.order])) {
       if (!recordIds.has(id) && !resolvedElsewhere.has(id)) {
         throw new UnresolvableWaitpointId(id, "no-source");
       }
@@ -145,5 +155,13 @@ async function hydrateOutput(
     return undefined;
   }
 
-  return deps.readRunOutput(record.completedByTaskRunId);
+  // Postgres does not lose this: the back-reference nulls on delete but Waitpoint.output stays,
+  // so the legacy path still emits it. Returning undefined here instead would resolve the
+  // parent's triggerAndWait successfully with no output, which is silent wrong data.
+  const output = await deps.readRunOutput(record.completedByTaskRunId);
+  if (output === undefined) {
+    throw new UnresolvableWaitpointId(record.id, "lost-run-output");
+  }
+
+  return output;
 }

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointRoundTrip.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointRoundTrip.test.ts
@@ -1,0 +1,372 @@
+// The seam: a record set written into a real cycle key, read back out, and resolved.
+//
+// The two halves were covered separately and the join between them was not, so an envelope built
+// in a shape the resolver does not expect survives both suites and fails only here. Envelopes come
+// from real Postgres rows through the legacy arm; the oracle is the existing hydration over the
+// same rows.
+//
+// The records field is read with a probe because the read API for it does not exist yet -- that
+// hydration belongs to the snapshot-store lane. Everything either side of that read is production
+// code.
+import { createRedisClient } from "@internal/redis";
+import { PostgresRunStore, RedisSnapshotStore, type SnapshotEntryInput } from "@internal/run-store";
+import { Logger } from "@trigger.dev/core/logger";
+import { generateInternalId, generateWaitpointId } from "@trigger.dev/core/v3/isomorphic";
+import type { PrismaClient, Waitpoint } from "@trigger.dev/database";
+import { containerTest } from "@internal/testcontainers";
+import { describe, expect } from "vitest";
+import { enhanceExecutionSnapshotWithWaitpoints } from "../systems/executionSnapshotSystem.js";
+import { setupAuthenticatedEnvironment } from "../tests/setup.js";
+import { buildCompletedWaitpointRecords } from "./completedWaitpointRecords.js";
+import {
+  createCompletedWaitpointResolver,
+  createRunOutputsReader,
+  UnresolvableWaitpointId,
+} from "./completedWaitpointResolver.js";
+import { LegacyPostgresWaitpointCoordinator } from "./legacyPostgresCoordinator.js";
+
+const COMPLETED_TTL_MS = 72 * 60 * 60 * 1000;
+
+type Env = Awaited<ReturnType<typeof setupAuthenticatedEnvironment>>;
+
+function entryFor(runId: string, env: Env): SnapshotEntryInput {
+  return {
+    id: generateInternalId(),
+    engine: "V2",
+    executionStatus: "EXECUTING_WITH_WAITPOINTS",
+    description: "Run resumed",
+    runId,
+    runStatus: "EXECUTING",
+    createdAt: new Date().toISOString(),
+    environmentId: env.id,
+    environmentType: env.type,
+    projectId: env.project.id,
+    organizationId: env.organization.id,
+  };
+}
+
+// `id` omitted gives Prisma's cuid default, i.e. the legacy format; a minted id gives the store
+// format. Both halves of a mixed snapshot come from here so they cannot drift apart.
+async function seedWaitpoint(
+  prisma: PrismaClient,
+  env: Env,
+  fields: {
+    id?: string;
+    output?: string | null;
+    outputType?: string;
+    completedByTaskRunId?: string;
+  }
+): Promise<Waitpoint> {
+  const key = `idem_${generateInternalId().slice(-16)}`;
+  return prisma.waitpoint.create({
+    data: {
+      ...(fields.id ? { id: fields.id } : {}),
+      friendlyId: `waitpoint_${key}`,
+      type: fields.completedByTaskRunId ? "RUN" : "MANUAL",
+      status: "COMPLETED",
+      completedAt: new Date(),
+      idempotencyKey: key,
+      userProvidedIdempotencyKey: false,
+      output: fields.output ?? null,
+      outputType: fields.outputType ?? "application/json",
+      ...(fields.completedByTaskRunId && { completedByTaskRunId: fields.completedByTaskRunId }),
+      projectId: env.project.id,
+      environmentId: env.id,
+    },
+  });
+}
+
+async function seedCompletedRun(prisma: PrismaClient, env: Env, output: string): Promise<string> {
+  const suffix = generateInternalId().slice(-12);
+  const run = await prisma.taskRun.create({
+    data: {
+      engine: "V2",
+      status: "COMPLETED_SUCCESSFULLY",
+      friendlyId: `run_child${suffix}`,
+      runtimeEnvironmentId: env.id,
+      environmentType: env.type,
+      organizationId: env.organization.id,
+      projectId: env.project.id,
+      taskIdentifier: "child-task",
+      payload: "{}",
+      payloadType: "application/json",
+      traceContext: {},
+      traceId: `trace_${suffix}`,
+      spanId: `span_${suffix}`,
+      queue: "task/child-task",
+      isTest: false,
+      taskEventStore: "taskEvent",
+      depth: 1,
+      output,
+      outputType: "application/json",
+    },
+    select: { id: true },
+  });
+  return run.id;
+}
+
+type Harness = {
+  runId: string;
+  store: RedisSnapshotStore;
+  probe: ReturnType<typeof createRedisClient>;
+  coordinator: LegacyPostgresWaitpointCoordinator;
+  resolve: ReturnType<typeof createCompletedWaitpointResolver>;
+  runStore: PostgresRunStore;
+};
+
+function harness(prisma: PrismaClient, redisOptions: never): Harness {
+  const runStore = new PostgresRunStore({ prisma, readOnlyPrisma: prisma });
+  return {
+    runId: generateInternalId(),
+    store: new RedisSnapshotStore({ redisOptions, completedTtlMs: COMPLETED_TTL_MS }),
+    probe: createRedisClient(redisOptions, { onError: () => {} }),
+    coordinator: new LegacyPostgresWaitpointCoordinator({
+      runStore: runStore as never,
+      prisma,
+      logger: new Logger("roundtrip", "error"),
+    }),
+    resolve: createCompletedWaitpointResolver({
+      readRunOutputs: createRunOutputsReader(runStore),
+    }),
+    runStore,
+  };
+}
+
+// Envelopes from rows, records into the cycle key, id lists back out through the store's read,
+// then resolve. Returns the resolver's answer beside the oracle's for the same rows.
+async function roundTrip(
+  h: Harness,
+  env: Env,
+  rows: Waitpoint[],
+  order: string[],
+  storeFormatIds: string[]
+) {
+  const refs = rows.map((row) => {
+    const index = order.indexOf(row.id);
+    return index === -1 ? { id: row.id } : { id: row.id, index };
+  });
+  // Every position, not just the first: a run at two batch indexes must keep both.
+  const withRepeats = order.flatMap((id, index) =>
+    refs.some((r) => r.id === id) ? [{ id, index }] : []
+  );
+  const completedWaitpoints = [
+    ...withRepeats,
+    ...refs.filter((r) => r.index === undefined).map((r) => ({ id: r.id })),
+  ];
+
+  // Production envelope build, over real rows, through the arm the engine actually constructs.
+  const sources = await h.coordinator.readCompletionEnvelopes({
+    runId: h.runId,
+    waitpointIds: storeFormatIds,
+  });
+  const records = buildCompletedWaitpointRecords(sources);
+
+  const appended = await h.store.append({
+    entry: entryFor(h.runId, env),
+    kind: "birth",
+    isTerminal: false,
+    cycle: { kind: "new", completedWaitpoints, records },
+  });
+  expect(appended.outcome).toBe("written");
+
+  // Back out through the store's own read, not through the objects we just wrote.
+  const read = await h.store.getLatest(h.runId);
+  expect(read?.cycle).toBeDefined();
+  expect(read?.danglingCycle).toBeFalsy();
+
+  const raw = await h.probe.hget(`snap:{${h.runId}}:wp:${read!.cycle!.cycleSeq}`, "records");
+  const storedRecords = raw ? JSON.parse(raw) : [];
+
+  const legacyIds = rows.map((r) => r.id).filter((id) => !storeFormatIds.includes(id));
+
+  const actual = await h.resolve({
+    runId: h.runId,
+    pointer: read!.cycle!,
+    order: read!.completedWaitpointIds?.order ?? [],
+    distinctIds: read!.completedWaitpointIds?.distinctIds ?? [],
+    records: storedRecords,
+    ...(legacyIds.length > 0 && { resolvedElsewhere: legacyIds }),
+  });
+
+  const oracle = enhanceExecutionSnapshotWithWaitpoints(
+    { id: generateInternalId(), runId: h.runId, batchId: null } as never,
+    rows,
+    order
+  ).completedWaitpoints;
+
+  const sort = <T extends { id: string; index?: number }>(xs: T[]) =>
+    [...xs].sort((a, b) => a.id.localeCompare(b.id) || (a.index ?? -1) - (b.index ?? -1));
+
+  return {
+    actual: sort(actual),
+    // The resolver returns its own half only; the legacy half stays with the caller.
+    expected: sort(oracle.filter((w) => storeFormatIds.includes(w.id))),
+    storedRecords,
+    read,
+  };
+}
+
+describe("a record set round-trips through the cycle key", () => {
+  containerTest("for an inline MANUAL output", async ({ prisma, redisOptions }) => {
+    const h = harness(prisma as never, redisOptions as never);
+    try {
+      const env = await setupAuthenticatedEnvironment(prisma as never, "PRODUCTION");
+      const row = await seedWaitpoint(prisma as never, env, {
+        id: generateWaitpointId("MANUAL"),
+        output: '{"token":1}',
+      });
+
+      const { actual, expected, storedRecords } = await roundTrip(
+        h,
+        env,
+        [row],
+        [row.id],
+        [row.id]
+      );
+
+      expect(storedRecords).toHaveLength(1);
+      expect(actual).toEqual(expected);
+      expect(actual[0]?.output).toBe('{"token":1}');
+    } finally {
+      await Promise.all([h.store.quit(), h.probe.quit().catch(() => {})]);
+    }
+  });
+
+  // deriveFromRun is the one place the written record and the resolved entry legitimately
+  // differ, so it has to survive the real round trip.
+  containerTest("for a RUN output derived from the run row", async ({ prisma, redisOptions }) => {
+    const h = harness(prisma as never, redisOptions as never);
+    try {
+      const env = await setupAuthenticatedEnvironment(prisma as never, "PRODUCTION");
+      const childRunId = await seedCompletedRun(prisma as never, env, '{"child":true}');
+      const row = await seedWaitpoint(prisma as never, env, {
+        id: generateWaitpointId("RUN"),
+        output: '{"child":true}',
+        completedByTaskRunId: childRunId,
+      });
+
+      const { actual, expected, storedRecords } = await roundTrip(
+        h,
+        env,
+        [row],
+        [row.id],
+        [row.id]
+      );
+
+      // The record carries a marker, not the value.
+      expect(storedRecords[0]?.output).toEqual({ deriveFromRun: true });
+      // And the resolved entry carries the value, byte-identical to the oracle's.
+      expect(actual).toEqual(expected);
+      expect(actual[0]?.output).toBe('{"child":true}');
+    } finally {
+      await Promise.all([h.store.quit(), h.probe.quit().catch(() => {})]);
+    }
+  });
+
+  // Both halves read their index from the same order, so the positions agree with no
+  // coordination between them.
+  containerTest(
+    "for a mixed legacy and store-format snapshot",
+    async ({ prisma, redisOptions }) => {
+      const h = harness(prisma as never, redisOptions as never);
+      try {
+        const env = await setupAuthenticatedEnvironment(prisma as never, "PRODUCTION");
+        const storeRow = await seedWaitpoint(prisma as never, env, {
+          id: generateWaitpointId("MANUAL"),
+          output: '{"store":true}',
+        });
+        // No id: Prisma's cuid default, which is the legacy format.
+        const legacyRow = await seedWaitpoint(prisma as never, env, { output: '{"legacy":true}' });
+
+        const order = [legacyRow.id, storeRow.id];
+        const { actual, expected, read } = await roundTrip(h, env, [storeRow, legacyRow], order, [
+          storeRow.id,
+        ]);
+
+        // The store read carries BOTH ids, because the cycle records the whole membership...
+        expect(read?.completedWaitpointIds?.order).toEqual(order);
+        // ...but the resolver answers for its half only, at its real position.
+        expect(actual).toEqual(expected);
+        expect(actual).toHaveLength(1);
+        expect(actual[0]?.id).toBe(storeRow.id);
+        expect(actual[0]?.index).toBe(1);
+      } finally {
+        await Promise.all([h.store.quit(), h.probe.quit().catch(() => {})]);
+      }
+    }
+  );
+
+  // Repeats live in the order, never in the record set, so this pins that the round trip does
+  // not collapse them.
+  containerTest("for one waitpoint at two batch indexes", async ({ prisma, redisOptions }) => {
+    const h = harness(prisma as never, redisOptions as never);
+    try {
+      const env = await setupAuthenticatedEnvironment(prisma as never, "PRODUCTION");
+      const row = await seedWaitpoint(prisma as never, env, {
+        id: generateWaitpointId("RUN"),
+        output: '{"twice":true}',
+      });
+
+      const { actual, expected, storedRecords } = await roundTrip(
+        h,
+        env,
+        [row],
+        [row.id, row.id],
+        [row.id]
+      );
+
+      expect(storedRecords).toHaveLength(1);
+      expect(actual).toEqual(expected);
+      expect(actual.map((w) => w.index)).toEqual([0, 1]);
+    } finally {
+      await Promise.all([h.store.quit(), h.probe.quit().catch(() => {})]);
+    }
+  });
+
+  // Losing the records while the id list survives is the shape an eviction leaves behind.
+  containerTest("and refuses when a member id has no record", async ({ prisma, redisOptions }) => {
+    const h = harness(prisma as never, redisOptions as never);
+    try {
+      const env = await setupAuthenticatedEnvironment(prisma as never, "PRODUCTION");
+      const row = await seedWaitpoint(prisma as never, env, {
+        id: generateWaitpointId("MANUAL"),
+        output: '{"lost":true}',
+      });
+
+      const sources = await h.coordinator.readCompletionEnvelopes({
+        runId: h.runId,
+        waitpointIds: [row.id],
+      });
+      await h.store.append({
+        entry: entryFor(h.runId, env),
+        kind: "birth",
+        isTerminal: false,
+        cycle: {
+          kind: "new",
+          completedWaitpoints: [{ id: row.id, index: 0 }],
+          records: buildCompletedWaitpointRecords(sources),
+        },
+      });
+
+      const read = await h.store.getLatest(h.runId);
+      // The records field alone is lost; the id list survives.
+      await h.probe.hdel(`snap:{${h.runId}}:wp:${read!.cycle!.cycleSeq}`, "records");
+
+      const failure = await h
+        .resolve({
+          runId: h.runId,
+          pointer: read!.cycle!,
+          order: read!.completedWaitpointIds?.order ?? [],
+          distinctIds: read!.completedWaitpointIds?.distinctIds ?? [],
+          records: [],
+        })
+        .catch((caught: unknown) => caught as UnresolvableWaitpointId);
+
+      expect(failure).toBeInstanceOf(UnresolvableWaitpointId);
+      expect(failure.waitpointId).toBe(row.id);
+      expect(failure.reason).toBe("no-source");
+    } finally {
+      await Promise.all([h.store.quit(), h.probe.quit().catch(() => {})]);
+    }
+  });
+});

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointRoundTrip.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completedWaitpointRoundTrip.test.ts
@@ -126,7 +126,7 @@ function harness(prisma: PrismaClient, redisOptions: never): Harness {
       logger: new Logger("roundtrip", "error"),
     }),
     resolve: createCompletedWaitpointResolver({
-      readRunOutputs: createRunOutputsReader(runStore),
+      readRunOutputs: createRunOutputsReader(runStore, prisma),
     }),
     runStore,
   };

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completionEnvelopeSource.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completionEnvelopeSource.test.ts
@@ -1,0 +1,128 @@
+// The row-to-source mapping the legacy arm depends on. It had no direct coverage: the
+// equivalence suite reaches the same code through its `pair()` factory, which proves the
+// mapping is self-consistent with the record build but never states what the mapping IS.
+import type { Waitpoint } from "@trigger.dev/database";
+import { describe, expect, it } from "vitest";
+import { envelopeSourceFromWaitpointRow } from "./completionEnvelopeSource.js";
+
+const COMPLETED_AT = new Date("2026-08-25T00:00:00.000Z");
+
+function row(overrides: Partial<Waitpoint> = {}): Waitpoint {
+  return {
+    id: "wp_1",
+    friendlyId: "waitpoint_wp_1",
+    type: "MANUAL",
+    status: "COMPLETED",
+    completedAt: COMPLETED_AT,
+    output: null,
+    outputType: "application/json",
+    outputIsError: false,
+    completedByTaskRunId: null,
+    completedByBatchId: null,
+    completedAfter: null,
+    idempotencyKey: "internal",
+    userProvidedIdempotencyKey: false,
+    inactiveIdempotencyKey: null,
+    ...overrides,
+  } as unknown as Waitpoint;
+}
+
+describe("envelopeSourceFromWaitpointRow", () => {
+  it("carries the scalar fields through", () => {
+    expect(envelopeSourceFromWaitpointRow(row())).toMatchObject({
+      id: "wp_1",
+      friendlyId: "waitpoint_wp_1",
+      type: "MANUAL",
+      completedAt: COMPLETED_AT,
+      outputType: "application/json",
+      outputIsError: false,
+    });
+  });
+
+  it("treats a plain output as an inline value", () => {
+    const source = envelopeSourceFromWaitpointRow(row({ output: '{"ok":true}' }));
+
+    expect(source.output).toBe('{"ok":true}');
+    expect(source.outputRef).toBeUndefined();
+  });
+
+  // The type names it, not the shape. A store reference is an opaque string like any other, so
+  // reading the string alone cannot tell the two apart.
+  it("treats an application/store output as a reference", () => {
+    const source = envelopeSourceFromWaitpointRow(
+      row({ output: "store-key-1", outputType: "application/store" })
+    );
+
+    expect(source.outputRef).toBe("store-key-1");
+    expect(source.output).toBeUndefined();
+  });
+
+  it("keeps an empty-string output, because empty is a value", () => {
+    expect(envelopeSourceFromWaitpointRow(row({ output: "" })).output).toBe("");
+  });
+
+  it("omits an absent output entirely", () => {
+    const source = envelopeSourceFromWaitpointRow(row());
+
+    expect("output" in source).toBe(false);
+    expect("outputRef" in source).toBe(false);
+  });
+
+  describe("the idempotency key", () => {
+    it("is carried when the user provided it and it is still active", () => {
+      const source = envelopeSourceFromWaitpointRow(
+        row({ idempotencyKey: "user-key", userProvidedIdempotencyKey: true })
+      );
+
+      expect(source.idempotencyKey).toBe("user-key");
+    });
+
+    it("is suppressed when the user did not provide it", () => {
+      const source = envelopeSourceFromWaitpointRow(
+        row({ idempotencyKey: "internal-key", userProvidedIdempotencyKey: false })
+      );
+
+      expect(source.idempotencyKey).toBeUndefined();
+    });
+
+    it("is suppressed once it goes inactive", () => {
+      const source = envelopeSourceFromWaitpointRow(
+        row({
+          idempotencyKey: "user-key",
+          userProvidedIdempotencyKey: true,
+          inactiveIdempotencyKey: "rotated",
+        })
+      );
+
+      expect(source.idempotencyKey).toBeUndefined();
+    });
+  });
+
+  it("carries the RUN and BATCH back-references", () => {
+    expect(
+      envelopeSourceFromWaitpointRow(row({ type: "RUN", completedByTaskRunId: "run_child" }))
+        .completedByTaskRunId
+    ).toBe("run_child");
+
+    expect(
+      envelopeSourceFromWaitpointRow(row({ type: "BATCH", completedByBatchId: "batch_1" }))
+        .completedByBatchId
+    ).toBe("batch_1");
+  });
+
+  it("carries completedAfter", () => {
+    const completedAfter = new Date("2026-08-26T00:00:00.000Z");
+
+    expect(
+      envelopeSourceFromWaitpointRow(row({ type: "DATETIME", completedAfter })).completedAfter
+    ).toEqual(completedAfter);
+  });
+
+  // A row read at COMPLETED always has this set. The fallback exists so the shape stays total
+  // rather than emitting an invalid Date, matching what the snapshot hydration does.
+  it("falls back to a real date when completedAt is null", () => {
+    expect(envelopeSourceFromWaitpointRow(row({ completedAt: null })).completedAt).toBeInstanceOf(
+      Date
+    );
+  });
+});

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completionEnvelopeSource.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completionEnvelopeSource.test.ts
@@ -98,6 +98,16 @@ describe("envelopeSourceFromWaitpointRow", () => {
     });
   });
 
+  // The mapper itself is status-blind by design: the legacy arm filters to COMPLETED before
+  // calling it, so both arms omit a pending waitpoint rather than describing one. This states
+  // that the mapper is not where that decision lives.
+  it("does not itself inspect status", () => {
+    const source = envelopeSourceFromWaitpointRow(row({ status: "PENDING", completedAt: null }));
+
+    expect(source.id).toBe("wp_1");
+    expect(source.completedAt).toBeInstanceOf(Date);
+  });
+
   it("carries the RUN and BATCH back-references", () => {
     expect(
       envelopeSourceFromWaitpointRow(row({ type: "RUN", completedByTaskRunId: "run_child" }))

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/completionEnvelopeSource.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/completionEnvelopeSource.ts
@@ -1,0 +1,53 @@
+import type { Waitpoint } from "@trigger.dev/database";
+import type { CompletionEnvelopeSource } from "./types.js";
+
+/**
+ * Map a waitpoint row onto the arm-independent envelope source.
+ *
+ * Shared so the legacy arm and the equivalence suite cannot drift: if the suite hand-rolled its
+ * own copy, a bug in the arm would be invisible to every test that compares against the oracle.
+ */
+export function envelopeSourceFromWaitpointRow(
+  row: Pick<
+    Waitpoint,
+    | "id"
+    | "friendlyId"
+    | "type"
+    | "completedAt"
+    | "output"
+    | "outputType"
+    | "outputIsError"
+    | "completedByTaskRunId"
+    | "completedByBatchId"
+    | "completedAfter"
+    | "idempotencyKey"
+    | "userProvidedIdempotencyKey"
+    | "inactiveIdempotencyKey"
+  >
+): CompletionEnvelopeSource {
+  // An already-offloaded value is named by its type, not by its shape, so the type is what
+  // decides whether the string is a payload or a reference to one.
+  const isRef = row.outputType === "application/store";
+
+  return {
+    id: row.id,
+    friendlyId: row.friendlyId,
+    type: row.type,
+    // A completed waitpoint always has this. The fallback keeps the shape total rather than
+    // emitting an invalid Date, and mirrors the fallback the snapshot hydration already applies.
+    completedAt: row.completedAt ?? new Date(),
+    outputType: row.outputType,
+    outputIsError: row.outputIsError,
+    ...(row.output !== null && row.output !== undefined
+      ? isRef
+        ? { outputRef: row.output }
+        : { output: row.output }
+      : {}),
+    ...(row.completedByTaskRunId && { completedByTaskRunId: row.completedByTaskRunId }),
+    ...(row.completedByBatchId && { completedByBatchId: row.completedByBatchId }),
+    ...(row.completedAfter && { completedAfter: row.completedAfter }),
+    ...(row.userProvidedIdempotencyKey && !row.inactiveIdempotencyKey && row.idempotencyKey
+      ? { idempotencyKey: row.idempotencyKey }
+      : {}),
+  };
+}

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/legacyPostgresCoordinator.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/legacyPostgresCoordinator.ts
@@ -16,6 +16,8 @@ import type {
   CreateWaitpointResult,
   RegisterBlocksLocklessParams,
   RegisterBlocksParams,
+  CompletionEnvelopeSource,
+  ReadCompletionEnvelopesParams,
   RunBlockEdge,
   WaitpointCoordinator,
 } from "./types.js";
@@ -80,6 +82,73 @@ export class LegacyPostgresWaitpointCoordinator implements WaitpointCoordinator 
       },
       this.prisma
     );
+  }
+
+  /**
+   * Source the envelope fields from the waitpoint rows.
+   *
+   * `runId` is unused here and that is correct: a routing store needs it to pick the owning
+   * database, a single store does not. It stays in the signature so both arms share one
+   * shape and the caller never branches.
+   *
+   * A row whose `outputType` is already a store reference carries `outputRef`, so the
+   * record build never re-offloads a value that object storage already holds.
+   */
+  async readCompletionEnvelopes({
+    waitpointIds,
+  }: ReadCompletionEnvelopesParams): Promise<CompletionEnvelopeSource[]> {
+    if (waitpointIds.length === 0) {
+      return [];
+    }
+
+    const rows = await this.runStore.findManyWaitpoints(
+      {
+        where: { id: { in: boundedIn(waitpointIds) } },
+        select: {
+          id: true,
+          friendlyId: true,
+          type: true,
+          completedAt: true,
+          output: true,
+          outputType: true,
+          outputIsError: true,
+          completedByTaskRunId: true,
+          completedByBatchId: true,
+          completedAfter: true,
+          idempotencyKey: true,
+          userProvidedIdempotencyKey: true,
+          inactiveIdempotencyKey: true,
+        },
+      },
+      this.prisma
+    );
+
+    return rows.map((row) => {
+      const isRef = row.outputType === "application/store";
+
+      return {
+        id: row.id,
+        friendlyId: row.friendlyId,
+        type: row.type,
+        // A completed waitpoint always has this set. The fallback keeps the shape total
+        // rather than emitting an invalid Date, and mirrors the same fallback the snapshot
+        // hydration already applies.
+        completedAt: row.completedAt ?? new Date(),
+        outputType: row.outputType,
+        outputIsError: row.outputIsError,
+        ...(row.output !== null && row.output !== undefined
+          ? isRef
+            ? { outputRef: row.output }
+            : { output: row.output }
+          : {}),
+        ...(row.completedByTaskRunId && { completedByTaskRunId: row.completedByTaskRunId }),
+        ...(row.completedByBatchId && { completedByBatchId: row.completedByBatchId }),
+        ...(row.completedAfter && { completedAfter: row.completedAfter }),
+        ...(row.userProvidedIdempotencyKey && !row.inactiveIdempotencyKey && row.idempotencyKey
+          ? { idempotencyKey: row.idempotencyKey }
+          : {}),
+      };
+    });
   }
 
   async registerBlocks({

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/legacyPostgresCoordinator.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/legacyPostgresCoordinator.ts
@@ -6,6 +6,8 @@ import type { PrismaClient, Waitpoint } from "@trigger.dev/database";
 import { boundedIn, Prisma } from "@trigger.dev/database";
 import { nanoid } from "nanoid";
 import { UnclassifiableWaitpointId } from "../errors.js";
+import { fetchWaitpointsInChunks } from "../systems/executionSnapshotSystem.js";
+import { envelopeSourceFromWaitpointRow } from "./completionEnvelopeSource.js";
 import type {
   AssociatedWaitpointData,
   ClearRunBlockStateParams,
@@ -87,68 +89,25 @@ export class LegacyPostgresWaitpointCoordinator implements WaitpointCoordinator 
   /**
    * Source the envelope fields from the waitpoint rows.
    *
-   * `runId` is unused here and that is correct: a routing store needs it to pick the owning
-   * database, a single store does not. It stays in the signature so both arms share one
-   * shape and the caller never branches.
+   * `runId` is the routing hint, not decoration: the routing store takes it as the third
+   * argument and reads the run's own store, falling back only for the rare cross-tree token.
+   * Omitting it fans every read out across every run-ops database, once per resume.
    *
-   * A row whose `outputType` is already a store reference carries `outputRef`, so the
-   * record build never re-offloads a value that object storage already holds.
+   * Chunked for the same reason the snapshot hydration chunks: a waitpoint output can be
+   * 100KB+, and a large fan-in read whole can exceed Node's string limits. `boundedIn` pads
+   * for plan-cache stability, it does not bound the set.
    */
   async readCompletionEnvelopes({
+    runId,
     waitpointIds,
   }: ReadCompletionEnvelopesParams): Promise<CompletionEnvelopeSource[]> {
     if (waitpointIds.length === 0) {
       return [];
     }
 
-    const rows = await this.runStore.findManyWaitpoints(
-      {
-        where: { id: { in: boundedIn(waitpointIds) } },
-        select: {
-          id: true,
-          friendlyId: true,
-          type: true,
-          completedAt: true,
-          output: true,
-          outputType: true,
-          outputIsError: true,
-          completedByTaskRunId: true,
-          completedByBatchId: true,
-          completedAfter: true,
-          idempotencyKey: true,
-          userProvidedIdempotencyKey: true,
-          inactiveIdempotencyKey: true,
-        },
-      },
-      this.prisma
-    );
+    const rows = await fetchWaitpointsInChunks(this.prisma, waitpointIds, this.runStore, runId);
 
-    return rows.map((row) => {
-      const isRef = row.outputType === "application/store";
-
-      return {
-        id: row.id,
-        friendlyId: row.friendlyId,
-        type: row.type,
-        // A completed waitpoint always has this set. The fallback keeps the shape total
-        // rather than emitting an invalid Date, and mirrors the same fallback the snapshot
-        // hydration already applies.
-        completedAt: row.completedAt ?? new Date(),
-        outputType: row.outputType,
-        outputIsError: row.outputIsError,
-        ...(row.output !== null && row.output !== undefined
-          ? isRef
-            ? { outputRef: row.output }
-            : { output: row.output }
-          : {}),
-        ...(row.completedByTaskRunId && { completedByTaskRunId: row.completedByTaskRunId }),
-        ...(row.completedByBatchId && { completedByBatchId: row.completedByBatchId }),
-        ...(row.completedAfter && { completedAfter: row.completedAfter }),
-        ...(row.userProvidedIdempotencyKey && !row.inactiveIdempotencyKey && row.idempotencyKey
-          ? { idempotencyKey: row.idempotencyKey }
-          : {}),
-      };
-    });
+    return rows.map(envelopeSourceFromWaitpointRow);
   }
 
   async registerBlocks({

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/legacyPostgresCoordinator.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/legacyPostgresCoordinator.ts
@@ -6,7 +6,7 @@ import type { PrismaClient, Waitpoint } from "@trigger.dev/database";
 import { boundedIn, Prisma } from "@trigger.dev/database";
 import { nanoid } from "nanoid";
 import { UnclassifiableWaitpointId } from "../errors.js";
-import { fetchWaitpointsInChunks } from "../systems/executionSnapshotSystem.js";
+import { fetchWaitpointEnvelopeRowsInChunks } from "../systems/executionSnapshotSystem.js";
 import { envelopeSourceFromWaitpointRow } from "./completionEnvelopeSource.js";
 import type {
   AssociatedWaitpointData,
@@ -96,6 +96,10 @@ export class LegacyPostgresWaitpointCoordinator implements WaitpointCoordinator 
    * Chunked for the same reason the snapshot hydration chunks: a waitpoint output can be
    * 100KB+, and a large fan-in read whole can exceed Node's string limits. `boundedIn` pads
    * for plan-cache stability, it does not bound the set.
+   *
+   * Projected to the columns the envelope is built from. This read lands on the writer, inside
+   * the run lock, and the hydration reads the same rows again afterwards for a store-format
+   * resume that Postgres still serves -- so it takes no more than it uses.
    */
   async readCompletionEnvelopes({
     runId,
@@ -105,7 +109,12 @@ export class LegacyPostgresWaitpointCoordinator implements WaitpointCoordinator 
       return [];
     }
 
-    const rows = await fetchWaitpointsInChunks(this.prisma, waitpointIds, this.runStore, runId);
+    const rows = await fetchWaitpointEnvelopeRowsInChunks(
+      this.prisma,
+      waitpointIds,
+      this.runStore,
+      runId
+    );
 
     // COMPLETED only, so both arms honour one omission contract. The store arm cannot return a
     // pending waitpoint because a pending one has no completion to read; this arm reads rows by

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/legacyPostgresCoordinator.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/legacyPostgresCoordinator.ts
@@ -107,7 +107,12 @@ export class LegacyPostgresWaitpointCoordinator implements WaitpointCoordinator 
 
     const rows = await fetchWaitpointsInChunks(this.prisma, waitpointIds, this.runStore, runId);
 
-    return rows.map(envelopeSourceFromWaitpointRow);
+    // COMPLETED only, so both arms honour one omission contract. The store arm cannot return a
+    // pending waitpoint because a pending one has no completion to read; this arm reads rows by
+    // id and would otherwise hand back an envelope with completedAt defaulted to now. The
+    // resolver's coverage check reads an omission as "fail loud", so the two arms disagreeing
+    // here would turn a pending waitpoint into a resumable one.
+    return rows.filter((row) => row.status === "COMPLETED").map(envelopeSourceFromWaitpointRow);
   }
 
   async registerBlocks({

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/storeCoordinator.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/storeCoordinator.test.ts
@@ -1973,3 +1973,53 @@ describe("readCompletionEnvelopes", () => {
     }
   });
 });
+
+// The read is chunked so a large fan-in cannot burst. This asserts correctness ACROSS the chunk
+// boundary, which is where an off-by-one in the slice would show: a count either side of 100.
+describe("readCompletionEnvelopes chunking", () => {
+  redisTest("returns every envelope across a chunk boundary", async ({ redisOptions }) => {
+    const store = coordinator(redisOptions);
+    try {
+      const ids = Array.from({ length: 250 }, (_, i) => `w_chunk_${i}`);
+      for (const id of ids) {
+        await store.createIfAbsent({ record: record(id), status: "PENDING" });
+        await store.complete({ waitpointId: id, completion: completion() });
+      }
+
+      const envelopes = await store.readCompletionEnvelopes({
+        runId: "run_chunked",
+        waitpointIds: ids,
+      });
+
+      expect(envelopes).toHaveLength(250);
+      expect(new Set(envelopes.map((e) => e.id)).size).toBe(250);
+    } finally {
+      await store.quit();
+    }
+  });
+
+  redisTest("omits only the incomplete ones in a mixed chunked read", async ({ redisOptions }) => {
+    const store = coordinator(redisOptions);
+    try {
+      const ids = Array.from({ length: 150 }, (_, i) => `w_mix_${i}`);
+      for (const [i, id] of ids.entries()) {
+        await store.createIfAbsent({ record: record(id), status: "PENDING" });
+        // Leave every third pending, including ids either side of the chunk boundary.
+        if (i % 3 !== 0) {
+          await store.complete({ waitpointId: id, completion: completion() });
+        }
+      }
+
+      const envelopes = await store.readCompletionEnvelopes({
+        runId: "run_chunked",
+        waitpointIds: ids,
+      });
+
+      const expected = ids.filter((_, i) => i % 3 !== 0).length;
+      expect(envelopes).toHaveLength(expected);
+      expect(envelopes.every((e) => e.id.startsWith("w_mix_"))).toBe(true);
+    } finally {
+      await store.quit();
+    }
+  });
+});

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/storeCoordinator.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/storeCoordinator.test.ts
@@ -1871,31 +1871,32 @@ describe("readCompletionEnvelopes", () => {
     }
   });
 
-  redisTest("carries an offloaded value as a ref, not as an inline value", async ({
-    redisOptions,
-  }) => {
-    const store = coordinator(redisOptions);
-    try {
-      await store.createIfAbsent({ record: record("w_ref"), status: "PENDING" });
-      await store.complete({
-        waitpointId: "w_ref",
-        completion: completion({
-          outputType: "application/store",
-          output: { ref: "store-key-1" },
-        }),
-      });
+  redisTest(
+    "carries an offloaded value as a ref, not as an inline value",
+    async ({ redisOptions }) => {
+      const store = coordinator(redisOptions);
+      try {
+        await store.createIfAbsent({ record: record("w_ref"), status: "PENDING" });
+        await store.complete({
+          waitpointId: "w_ref",
+          completion: completion({
+            outputType: "application/store",
+            output: { ref: "store-key-1" },
+          }),
+        });
 
-      const [envelope] = await store.readCompletionEnvelopes({
-        runId: "run_env",
-        waitpointIds: ["w_ref"],
-      });
+        const [envelope] = await store.readCompletionEnvelopes({
+          runId: "run_env",
+          waitpointIds: ["w_ref"],
+        });
 
-      expect(envelope?.outputRef).toBe("store-key-1");
-      expect(envelope?.output).toBeUndefined();
-    } finally {
-      await store.quit();
+        expect(envelope?.outputRef).toBe("store-key-1");
+        expect(envelope?.output).toBeUndefined();
+      } finally {
+        await store.quit();
+      }
     }
-  });
+  );
 
   // The omission is the contract. A pending waitpoint has no envelope, and defaulting one
   // here would hand the resolver a record it must not have. The caller's coverage check is

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/storeCoordinator.test.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/storeCoordinator.test.ts
@@ -1835,3 +1835,140 @@ describe("genuine concurrency", () => {
     }
   );
 });
+
+describe("readCompletionEnvelopes", () => {
+  redisTest("returns the completion and the immutable half together", async ({ redisOptions }) => {
+    const store = coordinator(redisOptions);
+    try {
+      await store.createIfAbsent({
+        record: record("w_env", {
+          idempotencyKey: "user-key",
+          userProvidedIdempotencyKey: true,
+        }),
+        status: "PENDING",
+      });
+      await store.complete({ waitpointId: "w_env", completion: completion() });
+
+      const envelopes = await store.readCompletionEnvelopes({
+        runId: "run_env",
+        waitpointIds: ["w_env"],
+      });
+
+      expect(envelopes).toEqual([
+        {
+          id: "w_env",
+          friendlyId: "waitpoint_w_env",
+          type: "MANUAL",
+          completedAt: new Date(NOW),
+          outputType: "application/json",
+          outputIsError: false,
+          output: '{"ok":true}',
+          idempotencyKey: "user-key",
+        },
+      ]);
+    } finally {
+      await store.quit();
+    }
+  });
+
+  redisTest("carries an offloaded value as a ref, not as an inline value", async ({
+    redisOptions,
+  }) => {
+    const store = coordinator(redisOptions);
+    try {
+      await store.createIfAbsent({ record: record("w_ref"), status: "PENDING" });
+      await store.complete({
+        waitpointId: "w_ref",
+        completion: completion({
+          outputType: "application/store",
+          output: { ref: "store-key-1" },
+        }),
+      });
+
+      const [envelope] = await store.readCompletionEnvelopes({
+        runId: "run_env",
+        waitpointIds: ["w_ref"],
+      });
+
+      expect(envelope?.outputRef).toBe("store-key-1");
+      expect(envelope?.output).toBeUndefined();
+    } finally {
+      await store.quit();
+    }
+  });
+
+  // The omission is the contract. A pending waitpoint has no envelope, and defaulting one
+  // here would hand the resolver a record it must not have. The caller's coverage check is
+  // what turns the gap into a loud failure.
+  redisTest("omits a waitpoint that is not completed", async ({ redisOptions }) => {
+    const store = coordinator(redisOptions);
+    try {
+      await store.createIfAbsent({ record: record("w_pending"), status: "PENDING" });
+
+      const envelopes = await store.readCompletionEnvelopes({
+        runId: "run_env",
+        waitpointIds: ["w_pending"],
+      });
+
+      expect(envelopes).toEqual([]);
+    } finally {
+      await store.quit();
+    }
+  });
+
+  redisTest("omits an id that has no record at all", async ({ redisOptions }) => {
+    const store = coordinator(redisOptions);
+    try {
+      const envelopes = await store.readCompletionEnvelopes({
+        runId: "run_env",
+        waitpointIds: ["w_absent"],
+      });
+
+      expect(envelopes).toEqual([]);
+    } finally {
+      await store.quit();
+    }
+  });
+
+  redisTest("suppresses an idempotency key the user did not provide", async ({ redisOptions }) => {
+    const store = coordinator(redisOptions);
+    try {
+      await store.createIfAbsent({
+        record: record("w_internal", {
+          idempotencyKey: "internal-key",
+          userProvidedIdempotencyKey: false,
+        }),
+        status: "PENDING",
+      });
+      await store.complete({ waitpointId: "w_internal", completion: completion() });
+
+      const [envelope] = await store.readCompletionEnvelopes({
+        runId: "run_env",
+        waitpointIds: ["w_internal"],
+      });
+
+      expect(envelope?.idempotencyKey).toBeUndefined();
+    } finally {
+      await store.quit();
+    }
+  });
+
+  redisTest("reads many ids in one pass", async ({ redisOptions }) => {
+    const store = coordinator(redisOptions);
+    try {
+      for (const id of ["w_m1", "w_m2", "w_m3"]) {
+        await store.createIfAbsent({ record: record(id), status: "PENDING" });
+        await store.complete({ waitpointId: id, completion: completion() });
+      }
+
+      const envelopes = await store.readCompletionEnvelopes({
+        runId: "run_env",
+        waitpointIds: ["w_m1", "w_m2", "w_m3"],
+      });
+
+      expect(envelopes.map((e) => e.id).sort()).toEqual(["w_m1", "w_m2", "w_m3"]);
+    } finally {
+      await store.quit();
+    }
+  });
+});

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/storeCoordinator.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/storeCoordinator.ts
@@ -10,6 +10,7 @@ import {
   watcherField,
 } from "./keys.js";
 import { registerWaitpointCommands } from "./scripts.js";
+import type { CompletionEnvelopeSource, ReadCompletionEnvelopesParams } from "./types.js";
 
 /** The values written into a record's `status` field. Uppercase, and never a token. */
 export type WaitpointStatus = "PENDING" | "COMPLETED";
@@ -506,6 +507,62 @@ export class WaitpointStoreCoordinator {
   }
 
   /**
+   * Source the envelope fields for a run's COMPLETED waitpoints.
+   *
+   * Reads `wp:{id}` and nothing else. Both halves live under that one key — `r` holds the
+   * immutable record, `c` holds the completion — so this needs no run-scoped key and no
+   * script. One HMGET per id, pipelined: each command touches a single key, so nothing can
+   * span two cluster slots and there is no #call guard to route through.
+   *
+   * The run's delivered hash carries the same envelope, but `wp:{id}` is the record of
+   * origin, and reading it keeps this independent of whether the run's edges were already
+   * reconciled.
+   *
+   * An id with no record, or a record with no completion, is OMITTED rather than defaulted.
+   * The omission is the contract: the caller's coverage check turns a gap into a loud
+   * failure, which a defaulted envelope would hide.
+   */
+  async readCompletionEnvelopes({
+    waitpointIds,
+  }: ReadCompletionEnvelopesParams): Promise<CompletionEnvelopeSource[]> {
+    if (waitpointIds.length === 0) {
+      return [];
+    }
+
+    const pipeline = this.redis.pipeline();
+    for (const id of waitpointIds) {
+      pipeline.hmget(waitpointKeys(id).record, "r", "c");
+    }
+    const replies = await pipeline.exec();
+
+    const out: CompletionEnvelopeSource[] = [];
+
+    for (let i = 0; i < waitpointIds.length; i++) {
+      const id = waitpointIds[i]!;
+      const reply = replies?.[i];
+
+      // A pipelined command reports its own error in slot 0. Surface it rather than reading
+      // slot 1, because an errored command's value is not a result.
+      const error = reply?.[0];
+      if (error) {
+        throw error;
+      }
+
+      const fields = reply?.[1] as (string | null)[] | undefined;
+      const record = parseJson<WaitpointRecordInput>(fields?.[0] ?? undefined);
+      const completion = parseJson<WaitpointCompletion>(fields?.[1] ?? undefined);
+
+      if (!record || !completion) {
+        continue;
+      }
+
+      out.push(toEnvelopeSource(id, record, completion));
+    }
+
+    return out;
+  }
+
+  /**
    * Drain one cycle's edges, or clear the run entirely when no edge ids are given.
    *
    * The selective form RECONCILES: any pending or delivered entry that no surviving edge
@@ -535,4 +592,38 @@ export class WaitpointStoreCoordinator {
 
     return { outcome: reply[0] as "cleared" | "drained" };
   }
+}
+
+/**
+ * Map the store's two halves onto the arm-independent source shape.
+ *
+ * The idempotency key is suppressed unless the user provided it, matching the rule the
+ * snapshot hydration applies today. The store never sets an inactive flag, so
+ * `userProvidedIdempotencyKey` alone decides it here.
+ */
+function toEnvelopeSource(
+  id: string,
+  record: WaitpointRecordInput,
+  completion: WaitpointCompletion
+): CompletionEnvelopeSource {
+  const output = completion.output;
+  const inline = output && "inline" in output ? output.inline : undefined;
+  const ref = output && "ref" in output ? output.ref : undefined;
+
+  return {
+    id,
+    friendlyId: record.friendlyId,
+    type: record.type,
+    completedAt: new Date(completion.completedAt),
+    outputType: completion.outputType,
+    outputIsError: completion.outputIsError,
+    ...(inline !== undefined && { output: inline }),
+    ...(ref !== undefined && { outputRef: ref }),
+    ...(record.completedByTaskRunId && { completedByTaskRunId: record.completedByTaskRunId }),
+    ...(record.completedByBatchId && { completedByBatchId: record.completedByBatchId }),
+    ...(record.completedAfter && { completedAfter: new Date(record.completedAfter) }),
+    ...(record.userProvidedIdempotencyKey && record.idempotencyKey
+      ? { idempotencyKey: record.idempotencyKey }
+      : {}),
+  };
 }

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/storeCoordinator.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/storeCoordinator.ts
@@ -163,6 +163,12 @@ function parseJson<T>(raw: string | undefined): T | undefined {
   return raw ? (JSON.parse(raw) as T) : undefined;
 }
 
+/**
+ * How many envelope reads run concurrently. Matches the chunk the snapshot hydration uses for the
+ * same shape of read, so a large fan-in bounds Redis client pressure instead of bursting.
+ */
+const ENVELOPE_READ_CHUNK_SIZE = 100;
+
 export class WaitpointStoreCoordinator {
   private readonly redis: Redis;
   private readonly logger: Logger;
@@ -527,9 +533,18 @@ export class WaitpointStoreCoordinator {
       return [];
     }
 
-    const halves = await Promise.all(
-      waitpointIds.map((id) => this.redis.hmget(waitpointKeys(id).record, "r", "c"))
-    );
+    // Chunked, not one Promise.all over the whole set. A 1000-item batch fan-in would otherwise
+    // launch 1000 concurrent HMGETs at once, and the burst is the cost even though each command
+    // is small. The bound mirrors the snapshot hydration's own WAITPOINT_CHUNK_SIZE, and stays
+    // per-command so nothing can span two cluster slots.
+    const halves: (string | null)[][] = [];
+    for (let i = 0; i < waitpointIds.length; i += ENVELOPE_READ_CHUNK_SIZE) {
+      const chunk = waitpointIds.slice(i, i + ENVELOPE_READ_CHUNK_SIZE);
+      const settled = await Promise.all(
+        chunk.map((id) => this.redis.hmget(waitpointKeys(id).record, "r", "c"))
+      );
+      halves.push(...settled);
+    }
 
     const out: CompletionEnvelopeSource[] = [];
 

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/storeCoordinator.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/storeCoordinator.ts
@@ -510,17 +510,15 @@ export class WaitpointStoreCoordinator {
    * Source the envelope fields for a run's COMPLETED waitpoints.
    *
    * Reads `wp:{id}` and nothing else. Both halves live under that one key — `r` holds the
-   * immutable record, `c` holds the completion — so this needs no run-scoped key and no
-   * script. One HMGET per id, pipelined: each command touches a single key, so nothing can
-   * span two cluster slots and there is no #call guard to route through.
+   * immutable record, `c` holds the completion — so this needs no run-scoped key.
    *
-   * The run's delivered hash carries the same envelope, but `wp:{id}` is the record of
-   * origin, and reading it keeps this independent of whether the run's edges were already
-   * reconciled.
+   * One command per id, issued concurrently rather than as a pipeline. Each id is its own hash
+   * tag, so N ids are N cluster slots: a pipeline spanning them is rejected outright under
+   * cluster mode, and a single-node test server would never surface that.
    *
    * An id with no record, or a record with no completion, is OMITTED rather than defaulted.
-   * The omission is the contract: the caller's coverage check turns a gap into a loud
-   * failure, which a defaulted envelope would hide.
+   * The omission is the contract: the caller's coverage check turns a gap into a loud failure,
+   * which a defaulted envelope would hide.
    */
   async readCompletionEnvelopes({
     waitpointIds,
@@ -529,26 +527,15 @@ export class WaitpointStoreCoordinator {
       return [];
     }
 
-    const pipeline = this.redis.pipeline();
-    for (const id of waitpointIds) {
-      pipeline.hmget(waitpointKeys(id).record, "r", "c");
-    }
-    const replies = await pipeline.exec();
+    const halves = await Promise.all(
+      waitpointIds.map((id) => this.redis.hmget(waitpointKeys(id).record, "r", "c"))
+    );
 
     const out: CompletionEnvelopeSource[] = [];
 
     for (let i = 0; i < waitpointIds.length; i++) {
       const id = waitpointIds[i]!;
-      const reply = replies?.[i];
-
-      // A pipelined command reports its own error in slot 0. Surface it rather than reading
-      // slot 1, because an errored command's value is not a result.
-      const error = reply?.[0];
-      if (error) {
-        throw error;
-      }
-
-      const fields = reply?.[1] as (string | null)[] | undefined;
+      const fields = halves[i];
       const record = parseJson<WaitpointRecordInput>(fields?.[0] ?? undefined);
       const completion = parseJson<WaitpointCompletion>(fields?.[1] ?? undefined);
 

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/testFixtures/childRun.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/testFixtures/childRun.ts
@@ -2,42 +2,64 @@ import type { PrismaClient } from "@trigger.dev/database";
 import { setupAuthenticatedEnvironment } from "../../tests/setup.js";
 
 /**
- * A completed child run holding `output`, for the deriveFromRun branch.
+ * Completed child runs holding `output`, for the deriveFromRun branch.
  *
  * The branch's premise is that TaskRun.output holds the same string the waitpoint carried, so a
- * test that asserts it needs a real row rather than a stand-in for one.
+ * test that asserts it needs real rows rather than stand-ins for them.
+ *
+ * All the runs share ONE environment, because `setupAuthenticatedEnvironment` hardcodes the
+ * organization slug and the column is unique: calling it once per run fails on the second.
  */
+export async function seedChildRunsWithOutputs(
+  prisma: PrismaClient,
+  outputs: (string | null)[],
+  outputType = "application/json"
+): Promise<string[]> {
+  const env = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+  const envSuffix = env.id.slice(-10);
+  const ids: string[] = [];
+
+  for (const [i, output] of outputs.entries()) {
+    // Unique per run, not per environment: friendlyId is a unique column and every run here
+    // shares the one environment.
+    const suffix = `${envSuffix}${i}`;
+
+    const run = await prisma.taskRun.create({
+      data: {
+        engine: "V2",
+        status: "COMPLETED_SUCCESSFULLY",
+        friendlyId: `run_child${suffix}`,
+        runtimeEnvironmentId: env.id,
+        environmentType: env.type,
+        organizationId: env.organization.id,
+        projectId: env.project.id,
+        taskIdentifier: "child-task",
+        payload: "{}",
+        payloadType: "application/json",
+        traceContext: {},
+        traceId: `trace_${suffix}`,
+        spanId: `span_${suffix}`,
+        queue: "task/child-task",
+        isTest: false,
+        taskEventStore: "taskEvent",
+        depth: 1,
+        ...(output !== null && { output, outputType }),
+      },
+      select: { id: true },
+    });
+
+    ids.push(run.id);
+  }
+
+  return ids;
+}
+
+/** One child run, for the cases that only need one. */
 export async function seedChildRunWithOutput(
   prisma: PrismaClient,
   output: string | null,
   outputType = "application/json"
 ): Promise<string> {
-  const env = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
-  const suffix = env.id.slice(-10);
-
-  const run = await prisma.taskRun.create({
-    data: {
-      engine: "V2",
-      status: "COMPLETED_SUCCESSFULLY",
-      friendlyId: `run_child${suffix}`,
-      runtimeEnvironmentId: env.id,
-      environmentType: env.type,
-      organizationId: env.organization.id,
-      projectId: env.project.id,
-      taskIdentifier: "child-task",
-      payload: "{}",
-      payloadType: "application/json",
-      traceContext: {},
-      traceId: `trace_${suffix}`,
-      spanId: `span_${suffix}`,
-      queue: "task/child-task",
-      isTest: false,
-      taskEventStore: "taskEvent",
-      depth: 1,
-      ...(output !== null && { output, outputType }),
-    },
-    select: { id: true },
-  });
-
-  return run.id;
+  const [id] = await seedChildRunsWithOutputs(prisma, [output], outputType);
+  return id!;
 }

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/testFixtures/childRun.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/testFixtures/childRun.ts
@@ -1,0 +1,43 @@
+import type { PrismaClient } from "@trigger.dev/database";
+import { setupAuthenticatedEnvironment } from "../../tests/setup.js";
+
+/**
+ * A completed child run holding `output`, for the deriveFromRun branch.
+ *
+ * The branch's premise is that TaskRun.output holds the same string the waitpoint carried, so a
+ * test that asserts it needs a real row rather than a stand-in for one.
+ */
+export async function seedChildRunWithOutput(
+  prisma: PrismaClient,
+  output: string | null,
+  outputType = "application/json"
+): Promise<string> {
+  const env = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+  const suffix = env.id.slice(-10);
+
+  const run = await prisma.taskRun.create({
+    data: {
+      engine: "V2",
+      status: "COMPLETED_SUCCESSFULLY",
+      friendlyId: `run_child${suffix}`,
+      runtimeEnvironmentId: env.id,
+      environmentType: env.type,
+      organizationId: env.organization.id,
+      projectId: env.project.id,
+      taskIdentifier: "child-task",
+      payload: "{}",
+      payloadType: "application/json",
+      traceContext: {},
+      traceId: `trace_${suffix}`,
+      spanId: `span_${suffix}`,
+      queue: "task/child-task",
+      isTest: false,
+      taskEventStore: "taskEvent",
+      depth: 1,
+      ...(output !== null && { output, outputType }),
+    },
+    select: { id: true },
+  });
+
+  return run.id;
+}

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/types.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/types.ts
@@ -16,6 +16,9 @@ import type { PrismaClientOrTransaction, Waitpoint } from "@trigger.dev/database
 export type WaitpointCoordinator = {
   clearRunBlockState(params: ClearRunBlockStateParams): Promise<{ count: number }>;
   readRunBlockState(runId: string): Promise<RunBlockEdge[]>;
+  readCompletionEnvelopes(
+    params: ReadCompletionEnvelopesParams
+  ): Promise<CompletionEnvelopeSource[]>;
   registerBlocks(params: RegisterBlocksParams): Promise<{ pendingCount: number }>;
   registerBlocksLockless(params: RegisterBlocksLocklessParams): Promise<void>;
   complete(params: CompleteParams): Promise<CompleteResult>;
@@ -29,6 +32,38 @@ export type WaitpointCoordinator = {
     runId: string;
     data: AssociatedWaitpointData;
   }): Promise<Waitpoint>;
+};
+
+export type ReadCompletionEnvelopesParams = {
+  runId: string;
+  /** The DISTINCT completed waitpoint ids to source. Result order is not meaningful. */
+  waitpointIds: string[];
+};
+
+/**
+ * One completed waitpoint's fields, sourced from whichever arm owns it.
+ *
+ * Deliberately NOT the frozen record type. This is the raw material; the record build
+ * decides which output variant a record carries. Both arms return this same shape, so the
+ * record build never branches on residency, which is what makes a mixed wait work.
+ *
+ * `output` is the literal stored value. `outputRef` is set instead when the value was
+ * already offloaded to object storage. At most one of the two is set.
+ */
+export type CompletionEnvelopeSource = {
+  id: string;
+  friendlyId: string;
+  type: "RUN" | "BATCH" | "DATETIME" | "MANUAL";
+  completedAt: Date;
+  outputType: string;
+  outputIsError: boolean;
+  output?: string;
+  outputRef?: string;
+  completedByTaskRunId?: string;
+  completedByBatchId?: string;
+  completedAfter?: Date;
+  /** Already resolved by the arm: userProvidedIdempotencyKey && !inactiveIdempotencyKey. */
+  idempotencyKey?: string;
 };
 
 export type ClearRunBlockStateParams = {

--- a/internal-packages/run-engine/src/engine/waitpointCoordinator/types.ts
+++ b/internal-packages/run-engine/src/engine/waitpointCoordinator/types.ts
@@ -17,6 +17,9 @@ import type { ShardKey } from "@trigger.dev/core/v3/isomorphic";
 export type WaitpointCoordinator = {
   clearRunBlockState(params: ClearRunBlockStateParams): Promise<{ count: number }>;
   readRunBlockState(runId: string): Promise<RunBlockEdge[]>;
+  readCompletionEnvelopes(
+    params: ReadCompletionEnvelopesParams
+  ): Promise<CompletionEnvelopeSource[]>;
   registerBlocks(params: RegisterBlocksParams): Promise<{ pendingCount: number }>;
   registerBlocksLockless(params: RegisterBlocksLocklessParams): Promise<void>;
   complete(params: CompleteParams): Promise<CompleteResult>;
@@ -32,6 +35,38 @@ export type WaitpointCoordinator = {
     runId: string;
     data: AssociatedWaitpointData;
   }): Promise<Waitpoint>;
+};
+
+export type ReadCompletionEnvelopesParams = {
+  runId: string;
+  /** The DISTINCT completed waitpoint ids to source. Result order is not meaningful. */
+  waitpointIds: string[];
+};
+
+/**
+ * One completed waitpoint's fields, sourced from whichever arm owns it.
+ *
+ * Deliberately NOT the frozen record type. This is the raw material; the record build
+ * decides which output variant a record carries. Both arms return this same shape, so the
+ * record build never branches on residency, which is what makes a mixed wait work.
+ *
+ * `output` is the literal stored value. `outputRef` is set instead when the value was
+ * already offloaded to object storage. At most one of the two is set.
+ */
+export type CompletionEnvelopeSource = {
+  id: string;
+  friendlyId: string;
+  type: "RUN" | "BATCH" | "DATETIME" | "MANUAL";
+  completedAt: Date;
+  outputType: string;
+  outputIsError: boolean;
+  output?: string;
+  outputRef?: string;
+  completedByTaskRunId?: string;
+  completedByBatchId?: string;
+  completedAfter?: Date;
+  /** Already resolved by the arm: userProvidedIdempotencyKey && !inactiveIdempotencyKey. */
+  idempotencyKey?: string;
 };
 
 export type ClearRunBlockStateParams = {

--- a/internal-packages/run-store/src/redisSnapshotStore.recordsOnCarryRefusal.test.ts
+++ b/internal-packages/run-store/src/redisSnapshotStore.recordsOnCarryRefusal.test.ts
@@ -1,0 +1,132 @@
+// A refused carry-forward mints a replacement cycle inside the same call. That replacement must
+// carry the records, not just the ids: the resolver's coverage check requires every distinct id to
+// resolve through exactly one half, so a cycle holding ids with no records makes a legitimate
+// resume fail loud.
+import { createRedisClient } from "@internal/redis";
+import { redisTest } from "@internal/testcontainers";
+import { describe, expect } from "vitest";
+import {
+  RedisSnapshotStore,
+  type CompletedWaitpointRecord,
+  type SnapshotEntryInput,
+} from "./redisSnapshotStore.js";
+
+function entry(over: Partial<SnapshotEntryInput> = {}): SnapshotEntryInput {
+  return {
+    id: "snap_1",
+    engine: "V2",
+    executionStatus: "RUN_CREATED",
+    description: "created",
+    runId: "run_1",
+    runStatus: "PENDING",
+    createdAt: "2026-08-21T00:00:00.000Z",
+    environmentId: "env_1",
+    environmentType: "PRODUCTION",
+    projectId: "proj_1",
+    organizationId: "org_1",
+    ...over,
+  };
+}
+
+function record(id: string, output: string): CompletedWaitpointRecord {
+  return {
+    id,
+    friendlyId: `waitpoint_${id}`,
+    type: "MANUAL",
+    completedAt: "2026-08-25T00:00:00.000Z",
+    outputType: "application/json",
+    outputIsError: false,
+    output: { inline: output },
+  };
+}
+
+async function recordsAt(
+  raw: ReturnType<typeof createRedisClient>,
+  cycleSeq: number
+): Promise<CompletedWaitpointRecord[] | undefined> {
+  const stored = await raw.hget(`snap:{run_1}:wp:${cycleSeq}`, "records");
+  return stored ? (JSON.parse(stored) as CompletedWaitpointRecord[]) : undefined;
+}
+
+describe("a refused carry-forward", () => {
+  redisTest("mints a replacement that carries the records", async ({ redisOptions }) => {
+    const store = new RedisSnapshotStore({ redisOptions, completedTtlMs: 60_000 });
+    const raw = createRedisClient(redisOptions, { onError: () => {} });
+    try {
+      await store.append({
+        entry: entry({ id: "snap_1" }),
+        kind: "birth",
+        isTerminal: false,
+        cycle: {
+          kind: "new",
+          completedWaitpoints: [{ id: "w_a", index: 0 }],
+          records: [record("w_a", "first")],
+        },
+      });
+
+      // Lose everything except the cycle key, as under maxmemory eviction. The carried pointer is
+      // now untrustworthy, so the store refuses it.
+      await raw.del("snap:{run_1}:e", "snap:{run_1}:idx", "snap:{run_1}:cur", "snap:{run_1}:seq");
+
+      const carried = await store.append({
+        entry: entry({ id: "snap_2" }),
+        kind: "birth",
+        isTerminal: false,
+        cycle: {
+          kind: "carryForward",
+          cycleSeq: 1,
+          completedWaitpoints: [{ id: "w_b", index: 0 }],
+          records: [record("w_b", "second")],
+        },
+      });
+
+      expect(carried).toMatchObject({ outcome: "written", cycleMismatch: true });
+
+      // The replacement holds the CARRIED records, not the dead incarnation's.
+      const read = await store.getLatest("run_1");
+      const mintedSeq = read?.cycle?.cycleSeq;
+      expect(mintedSeq).toBeDefined();
+
+      const records = await recordsAt(raw, mintedSeq!);
+      expect(records).toHaveLength(1);
+      expect(records?.[0]?.id).toBe("w_b");
+      expect(records?.[0]?.output).toEqual({ inline: "second" });
+    } finally {
+      await Promise.all([store.quit(), raw.quit().catch(() => {})]);
+    }
+  });
+
+  // Without refs there is nothing to mint from, so the entry is written with no pointer. That is
+  // the older behaviour and it stays: no pointer is safe, a pointer with no records is not.
+  redisTest("writes no pointer when the caller carried no refs", async ({ redisOptions }) => {
+    const store = new RedisSnapshotStore({ redisOptions, completedTtlMs: 60_000 });
+    const raw = createRedisClient(redisOptions, { onError: () => {} });
+    try {
+      await store.append({
+        entry: entry({ id: "snap_1" }),
+        kind: "birth",
+        isTerminal: false,
+        cycle: {
+          kind: "new",
+          completedWaitpoints: [{ id: "w_a", index: 0 }],
+          records: [record("w_a", "first")],
+        },
+      });
+
+      await raw.del("snap:{run_1}:e", "snap:{run_1}:idx", "snap:{run_1}:cur", "snap:{run_1}:seq");
+
+      const carried = await store.append({
+        entry: entry({ id: "snap_2" }),
+        kind: "birth",
+        isTerminal: false,
+        cycle: { kind: "carryForward", cycleSeq: 1 },
+      });
+
+      expect(carried).toMatchObject({ outcome: "written", cycleMismatch: true });
+      const read = await store.getLatest("run_1");
+      expect(read?.cycle).toBeUndefined();
+    } finally {
+      await Promise.all([store.quit(), raw.quit().catch(() => {})]);
+    }
+  });
+});

--- a/internal-packages/run-store/src/redisSnapshotStore.recordsOnCarryRefusal.test.ts
+++ b/internal-packages/run-store/src/redisSnapshotStore.recordsOnCarryRefusal.test.ts
@@ -96,6 +96,54 @@ describe("a refused carry-forward", () => {
     }
   });
 
+  // The reachable production shape. Every copy-forward append (dequeue, checkpoint, attempt)
+  // re-passes the same refs and carries no records of its own, so this is the case a refusal
+  // actually meets. Before the decorator read the surviving cycle's records, this minted a
+  // replacement holding ids with no records, permanently.
+  redisTest("keeps the records when the caller carried refs but none", async ({ redisOptions }) => {
+    const store = new RedisSnapshotStore({ redisOptions, completedTtlMs: 60_000 });
+    const raw = createRedisClient(redisOptions, { onError: () => {} });
+    try {
+      await store.append({
+        entry: entry({ id: "snap_1" }),
+        kind: "birth",
+        isTerminal: false,
+        cycle: {
+          kind: "new",
+          completedWaitpoints: [{ id: "w_a", index: 0 }],
+          records: [record("w_a", "first")],
+        },
+      });
+
+      // What the decorator now does for a records-less carry: read the surviving cycle's
+      // records and carry those into the refusal branch.
+      const carried = await store.getCycleRecords("run_1", 1);
+      expect(carried).toHaveLength(1);
+
+      await raw.del("snap:{run_1}:e", "snap:{run_1}:idx", "snap:{run_1}:cur", "snap:{run_1}:seq");
+
+      await store.append({
+        entry: entry({ id: "snap_2" }),
+        kind: "birth",
+        isTerminal: false,
+        cycle: {
+          kind: "carryForward",
+          cycleSeq: 1,
+          completedWaitpoints: [{ id: "w_a", index: 0 }],
+          records: carried,
+        },
+      });
+
+      const read = await store.getLatest("run_1");
+      const records = await recordsAt(raw, read!.cycle!.cycleSeq);
+
+      expect(records).toHaveLength(1);
+      expect(records?.[0]?.id).toBe("w_a");
+    } finally {
+      await Promise.all([store.quit(), raw.quit().catch(() => {})]);
+    }
+  });
+
   // Without refs there is nothing to mint from, so the entry is written with no pointer. That is
   // the older behaviour and it stays: no pointer is safe, a pointer with no records is not.
   redisTest("writes no pointer when the caller carried no refs", async ({ redisOptions }) => {

--- a/internal-packages/run-store/src/redisSnapshotStore.recordsOnCarryRefusal.test.ts
+++ b/internal-packages/run-store/src/redisSnapshotStore.recordsOnCarryRefusal.test.ts
@@ -97,9 +97,9 @@ describe("a refused carry-forward", () => {
   });
 
   // The reachable production shape. Every copy-forward append (dequeue, checkpoint, attempt)
-  // re-passes the same refs and carries no records of its own, so this is the case a refusal
-  // actually meets. Before the decorator read the surviving cycle's records, this minted a
-  // replacement holding ids with no records, permanently.
+  // re-passes the same refs and carries NO records of its own, and no longer pre-reads them: the
+  // append script sources the record set from the cycle it is replacing. So a refusal preserves
+  // the records without the caller having paid a read on every copy-forward that did not refuse.
   redisTest("keeps the records when the caller carried refs but none", async ({ redisOptions }) => {
     const store = new RedisSnapshotStore({ redisOptions, completedTtlMs: 60_000 });
     const raw = createRedisClient(redisOptions, { onError: () => {} });
@@ -115,34 +115,84 @@ describe("a refused carry-forward", () => {
         },
       });
 
-      // What the decorator now does for a records-less carry: read the surviving cycle's
-      // records and carry those into the refusal branch.
-      const carried = await store.getCycleRecords("run_1", 1);
-      expect(carried).toHaveLength(1);
-
+      // Lose the four core keys, keeping the cycle key. This is the shape that makes the store
+      // refuse the pointer: the seq counter is behind cycleSeqIn while wp:1 still lives.
       await raw.del("snap:{run_1}:e", "snap:{run_1}:idx", "snap:{run_1}:cur", "snap:{run_1}:seq");
 
-      await store.append({
+      const carried = await store.append({
         entry: entry({ id: "snap_2" }),
         kind: "birth",
         isTerminal: false,
+        // No `records`, exactly as a copy-forward append passes it.
         cycle: {
           kind: "carryForward",
           cycleSeq: 1,
           completedWaitpoints: [{ id: "w_a", index: 0 }],
-          records: carried,
         },
       });
 
+      expect(carried).toMatchObject({ outcome: "written", cycleMismatch: true });
+
+      // The replacement holds the records the refused cycle held, copied inside the script.
       const read = await store.getLatest("run_1");
       const records = await recordsAt(raw, read!.cycle!.cycleSeq);
 
       expect(records).toHaveLength(1);
       expect(records?.[0]?.id).toBe("w_a");
+      expect(records?.[0]?.output).toEqual({ inline: "first" });
     } finally {
       await Promise.all([store.quit(), raw.quit().catch(() => {})]);
     }
   });
+
+  // The other half of the refusal: the cycle key itself is gone, so there are no records anywhere
+  // and the replacement legitimately holds none. It must not inherit a stale set from a re-minted
+  // cycleSeq whose key survived.
+  redisTest(
+    "mints a records-less replacement when the cycle key is gone",
+    async ({ redisOptions }) => {
+      const store = new RedisSnapshotStore({ redisOptions, completedTtlMs: 60_000 });
+      const raw = createRedisClient(redisOptions, { onError: () => {} });
+      try {
+        await store.append({
+          entry: entry({ id: "snap_1" }),
+          kind: "birth",
+          isTerminal: false,
+          cycle: {
+            kind: "new",
+            completedWaitpoints: [{ id: "w_a", index: 0 }],
+            records: [record("w_a", "first")],
+          },
+        });
+
+        await raw.del(
+          "snap:{run_1}:e",
+          "snap:{run_1}:idx",
+          "snap:{run_1}:cur",
+          "snap:{run_1}:seq",
+          "snap:{run_1}:wp:1"
+        );
+
+        const carried = await store.append({
+          entry: entry({ id: "snap_2" }),
+          kind: "birth",
+          isTerminal: false,
+          cycle: {
+            kind: "carryForward",
+            cycleSeq: 1,
+            completedWaitpoints: [{ id: "w_b", index: 0 }],
+          },
+        });
+
+        expect(carried).toMatchObject({ outcome: "written", cycleMismatch: true });
+
+        const read = await store.getLatest("run_1");
+        expect(await recordsAt(raw, read!.cycle!.cycleSeq)).toBeUndefined();
+      } finally {
+        await Promise.all([store.quit(), raw.quit().catch(() => {})]);
+      }
+    }
+  );
 
   // Without refs there is nothing to mint from, so the entry is written with no pointer. That is
   // the older behaviour and it stays: no pointer is safe, a pointer with no records is not.

--- a/internal-packages/run-store/src/redisSnapshotStore.test.ts
+++ b/internal-packages/run-store/src/redisSnapshotStore.test.ts
@@ -4,9 +4,7 @@ import { expect, describe, vi } from "vitest";
 import { redisTest, slotOf } from "@internal/testcontainers";
 import { createRedisClient } from "@internal/redis";
 import { Logger } from "@trigger.dev/core/logger";
-import { generateWaitpointId } from "@trigger.dev/core/v3/isomorphic";
 import {
-  mayHoldRecords,
   snapshotKeys,
   deriveOrder,
   isValidFor,
@@ -23,46 +21,6 @@ describe("snapshotKeys", () => {
     expect(k.idx).toBe("snap:{run_abc123}:idx");
     expect(k.cur).toBe("snap:{run_abc123}:cur");
     expect(k.seq).toBe("snap:{run_abc123}:seq");
-  });
-});
-
-describe("mayHoldRecords", () => {
-  it("is false for an empty set", () => {
-    expect(mayHoldRecords([])).toBe(false);
-  });
-
-  it("is false when every id is legacy", () => {
-    expect(mayHoldRecords([{ id: "w_cuid_a", index: 0 }, { id: "w_cuid_b" }])).toBe(false);
-  });
-
-  it("is true when one id is store-format", () => {
-    expect(mayHoldRecords([{ id: generateWaitpointId("MANUAL"), index: 0 }])).toBe(true);
-  });
-
-  // The mixed case is the one a per-organisation rollout produces: a run holding waitpoints
-  // minted either side of the flip. One store-format id is enough to require the read.
-  it("is true when a store-format id sits among legacy ones", () => {
-    expect(
-      mayHoldRecords([
-        { id: "w_cuid_a", index: 0 },
-        { id: generateWaitpointId("MANUAL"), index: 1 },
-        { id: "w_cuid_c" },
-      ])
-    ).toBe(true);
-  });
-
-  it("reads the id, not the index, so an index-less store id still counts", () => {
-    expect(mayHoldRecords([{ id: generateWaitpointId("DATETIME") }])).toBe(true);
-  });
-
-  it("counts every store waitpoint type", () => {
-    for (const t of ["RUN", "BATCH", "DATETIME", "MANUAL"] as const) {
-      expect(mayHoldRecords([{ id: generateWaitpointId(t) }])).toBe(true);
-    }
-  });
-
-  it("is false for a foreign prefix that is not a waitpoint id", () => {
-    expect(mayHoldRecords([{ id: "run_0123456789abcdefghijklm" }])).toBe(false);
   });
 });
 

--- a/internal-packages/run-store/src/redisSnapshotStore.test.ts
+++ b/internal-packages/run-store/src/redisSnapshotStore.test.ts
@@ -4,7 +4,9 @@ import { expect, describe, vi } from "vitest";
 import { redisTest, slotOf } from "@internal/testcontainers";
 import { createRedisClient } from "@internal/redis";
 import { Logger } from "@trigger.dev/core/logger";
+import { generateWaitpointId } from "@trigger.dev/core/v3/isomorphic";
 import {
+  mayHoldRecords,
   snapshotKeys,
   deriveOrder,
   isValidFor,
@@ -21,6 +23,46 @@ describe("snapshotKeys", () => {
     expect(k.idx).toBe("snap:{run_abc123}:idx");
     expect(k.cur).toBe("snap:{run_abc123}:cur");
     expect(k.seq).toBe("snap:{run_abc123}:seq");
+  });
+});
+
+describe("mayHoldRecords", () => {
+  it("is false for an empty set", () => {
+    expect(mayHoldRecords([])).toBe(false);
+  });
+
+  it("is false when every id is legacy", () => {
+    expect(mayHoldRecords([{ id: "w_cuid_a", index: 0 }, { id: "w_cuid_b" }])).toBe(false);
+  });
+
+  it("is true when one id is store-format", () => {
+    expect(mayHoldRecords([{ id: generateWaitpointId("MANUAL"), index: 0 }])).toBe(true);
+  });
+
+  // The mixed case is the one a per-organisation rollout produces: a run holding waitpoints
+  // minted either side of the flip. One store-format id is enough to require the read.
+  it("is true when a store-format id sits among legacy ones", () => {
+    expect(
+      mayHoldRecords([
+        { id: "w_cuid_a", index: 0 },
+        { id: generateWaitpointId("MANUAL"), index: 1 },
+        { id: "w_cuid_c" },
+      ])
+    ).toBe(true);
+  });
+
+  it("reads the id, not the index, so an index-less store id still counts", () => {
+    expect(mayHoldRecords([{ id: generateWaitpointId("DATETIME") }])).toBe(true);
+  });
+
+  it("counts every store waitpoint type", () => {
+    for (const t of ["RUN", "BATCH", "DATETIME", "MANUAL"] as const) {
+      expect(mayHoldRecords([{ id: generateWaitpointId(t) }])).toBe(true);
+    }
+  });
+
+  it("is false for a foreign prefix that is not a waitpoint id", () => {
+    expect(mayHoldRecords([{ id: "run_0123456789abcdefghijklm" }])).toBe(false);
   });
 });
 

--- a/internal-packages/run-store/src/redisSnapshotStore.ts
+++ b/internal-packages/run-store/src/redisSnapshotStore.ts
@@ -310,6 +310,21 @@ export class RedisSnapshotStore {
           records?: CompletedWaitpointRecord[];
         }
       | {
+          /**
+           * Mint a cycle, and if the caller has no records, inherit the current cycle's when its
+           * id set is identical.
+           *
+           * For the one caller that cannot tell whether this id set continues the previous cycle:
+           * a head probe that FAILED. It must not carry a pointer it could not verify, and it
+           * cannot read the records it would need to mint a complete replacement. Minting without
+           * them would leave ids that resolve from nothing, so the comparison and the copy happen
+           * here, atomically, where the previous cycle can still be read.
+           */
+          kind: "newInherit";
+          completedWaitpoints: CompletedWaitpointRef[];
+          records?: CompletedWaitpointRecord[];
+        }
+      | {
           kind: "carryForward";
           cycleSeq: number;
           /**
@@ -341,9 +356,9 @@ export class RedisSnapshotStore {
       let distinctJson = "";
       let records = "";
       let orderCount = "0";
-      if (args.cycle?.kind === "new") {
+      if (args.cycle?.kind === "new" || args.cycle?.kind === "newInherit") {
         const order = deriveOrder(args.cycle.completedWaitpoints);
-        cycleMode = "new";
+        cycleMode = args.cycle.kind === "newInherit" ? "newInherit" : "new";
         orderJson = JSON.stringify(order);
         distinctJson = JSON.stringify(deriveDistinctIds(args.cycle.completedWaitpoints));
         records = args.cycle.records ? JSON.stringify(args.cycle.records) : "";
@@ -810,6 +825,24 @@ export class RedisSnapshotStore {
 
         if cycleMode == 'new' then
           cycleSeq = mintCycle(records)
+        elseif cycleMode == 'newInherit' then
+          -- The caller's head probe failed, so it knows neither whether this id set continues the
+          -- previous cycle nor what records that cycle holds. Minting fresh is the safe direction,
+          -- but minting with NO records leaves ids that resolve from nothing, and the next resume
+          -- refuses the whole cycle rather than losing a result quietly. So inherit them here.
+          --
+          -- Guarded on the distinct set being IDENTICAL, which is the same test the caller would
+          -- have made had its probe succeeded. A differing set is a genuinely new wait and must
+          -- start with the caller's own records, even when that is none. Read before mintCycle,
+          -- because mintCycle advances the counter this reads.
+          local inherited = records
+          if inherited == '' then
+            local prev = tonumber(redis.call('HGET', seqKey, 'c') or '0')
+            if prev > 0 and redis.call('HGET', wpKey(prev), 'distinct') == distinctJson then
+              inherited = redis.call('HGET', wpKey(prev), 'records') or ''
+            end
+          end
+          cycleSeq = mintCycle(inherited)
         elseif cycleMode == 'carry' then
           -- Attach the CARRIED pointer only if this incarnation actually minted that cycle. seq can
           -- be evicted while a wp:<n> key survives, so a bare key-exists check would adopt a dead

--- a/internal-packages/run-store/src/redisSnapshotStore.ts
+++ b/internal-packages/run-store/src/redisSnapshotStore.ts
@@ -6,6 +6,7 @@ import {
   type Result,
 } from "@internal/redis";
 import { Logger } from "@trigger.dev/core/logger";
+import { parseWaitpointId } from "@trigger.dev/core/v3/isomorphic";
 import type { CompletedWaitpoint } from "@trigger.dev/core/v3/schemas";
 
 export type SnapshotKeys = { e: string; idx: string; cur: string; seq: string };
@@ -46,6 +47,22 @@ export function deriveOrder(completedWaitpoints: CompletedWaitpointRef[]): strin
  */
 export function deriveDistinctIds(completedWaitpoints: CompletedWaitpointRef[]): string[] {
   return [...new Set(completedWaitpoints.map((w) => w.id))];
+}
+
+/**
+ * Whether a cycle carrying these ids could hold a record set.
+ *
+ * A record set is written for store-format waitpoint ids and nothing else, so a cycle whose ids
+ * are all legacy has none, and a read for one could only ever return nothing. Callers use this to
+ * skip that read, which keeps a deployment holding no store-format waitpoint at zero extra round
+ * trips on the resume path.
+ *
+ * This is the one place this module looks INSIDE a waitpoint id rather than treating the record
+ * set as opaque. It is named and exported rather than inlined so the cost decision it drives is
+ * testable on its own.
+ */
+export function mayHoldRecords(completedWaitpoints: CompletedWaitpointRef[]): boolean {
+  return completedWaitpoints.some((w) => parseWaitpointId(w.id).format === "b32hexW");
 }
 
 // isValid is derived, never stored, so the entry JSON stays byte-identical to the caller's document.

--- a/internal-packages/run-store/src/redisSnapshotStore.ts
+++ b/internal-packages/run-store/src/redisSnapshotStore.ts
@@ -6,7 +6,6 @@ import {
   type Result,
 } from "@internal/redis";
 import { Logger } from "@trigger.dev/core/logger";
-import { parseWaitpointId } from "@trigger.dev/core/v3/isomorphic";
 import type { CompletedWaitpoint } from "@trigger.dev/core/v3/schemas";
 
 export type SnapshotKeys = { e: string; idx: string; cur: string; seq: string };
@@ -16,12 +15,6 @@ export type SnapshotKeys = { e: string; idx: string; cur: string; seq: string };
 export function snapshotKeys(runId: string): SnapshotKeys {
   const base = `snap:{${runId}}`;
   return { e: `${base}:e`, idx: `${base}:idx`, cur: `${base}:cur`, seq: `${base}:seq` };
-}
-
-// The per-cycle key. Shares the {runId} tag with the four core keys, and the append scripts
-// derive the same name in Lua from KEYS[1]; this is its only TypeScript-side spelling.
-export function cycleKey(runId: string, cycleSeq: number): string {
-  return `snap:{${runId}}:wp:${cycleSeq}`;
 }
 
 export type CompletedWaitpointRef = { id: string; index?: number };
@@ -47,22 +40,6 @@ export function deriveOrder(completedWaitpoints: CompletedWaitpointRef[]): strin
  */
 export function deriveDistinctIds(completedWaitpoints: CompletedWaitpointRef[]): string[] {
   return [...new Set(completedWaitpoints.map((w) => w.id))];
-}
-
-/**
- * Whether a cycle carrying these ids could hold a record set.
- *
- * A record set is written for store-format waitpoint ids and nothing else, so a cycle whose ids
- * are all legacy has none, and a read for one could only ever return nothing. Callers use this to
- * skip that read, which keeps a deployment holding no store-format waitpoint at zero extra round
- * trips on the resume path.
- *
- * This is the one place this module looks INSIDE a waitpoint id rather than treating the record
- * set as opaque. It is named and exported rather than inlined so the cost decision it drives is
- * testable on its own.
- */
-export function mayHoldRecords(completedWaitpoints: CompletedWaitpointRef[]): boolean {
-  return completedWaitpoints.some((w) => parseWaitpointId(w.id).format === "b32hexW");
 }
 
 // isValid is derived, never stored, so the entry JSON stays byte-identical to the caller's document.
@@ -463,6 +440,11 @@ export class RedisSnapshotStore {
     }
     if (orderJson !== "") {
       // The whole wp:<cycleSeq> key, not just its order field: records dominates it once populated.
+      //
+      // `records` is what the CALLER sent, so this under-reports one case: a refused carry-forward,
+      // where the script copies the record set from the cycle it replaces and the client never sees
+      // it. Sizing that exactly would cost the read this path exists to avoid, and the copied set
+      // was already measured when the cycle it came from was minted.
       const cycleBytes = Buffer.byteLength(orderJson, "utf8") + Buffer.byteLength(records, "utf8");
       this.metrics?.recordCycleKeyBytes(cycleBytes);
       if (this.highWater.cycleKeyBytes !== undefined && cycleBytes > this.highWater.cycleKeyBytes) {
@@ -522,25 +504,6 @@ export class RedisSnapshotStore {
         return { present: false, distinctIds: [], order: [] };
       }
       return decodeWaitpointIds(reply[0] === "1", reply[1] ?? "", reply[2] ?? "");
-    });
-  }
-
-  /**
-   * The record set a cycle already holds, if any.
-   *
-   * Read on one path only: a copy-forward append that carries no records of its own. A
-   * copy-forward legitimately has none, because it only points at a cycle that was already
-   * minted. But the append script can REFUSE an untrustworthy pointer and mint a replacement
-   * from the carried refs, and a replacement minted with no records holds ids that nothing can
-   * resolve. So the caller reads the surviving cycle's records and carries those.
-   */
-  async getCycleRecords(
-    runId: string,
-    cycleSeq: number
-  ): Promise<CompletedWaitpointRecord[] | undefined> {
-    return this.#timed("getCycleRecords", async () => {
-      const raw = await this.redis.hget(cycleKey(runId, cycleSeq), "records");
-      return raw ? (JSON.parse(raw) as CompletedWaitpointRecord[]) : undefined;
     });
   }
 
@@ -828,11 +791,14 @@ export class RedisSnapshotStore {
 
         -- The STORE mints cycleSeq, so the sequence is dense by construction and the terminal
         -- PEXPIRE loop from 1..c is correct.
-        local function mintCycle()
+        -- Takes the record set rather than closing over ARGV, because the two mint sites source it
+        -- differently: a 'new' cycle uses what the caller sent, and the refusal path below reads it
+        -- from the cycle it is replacing.
+        local function mintCycle(recordsJson)
           local minted = redis.call('HINCRBY', seqKey, 'c', 1)
           redis.call('HSET', wpKey(minted), 'order', orderJson, 'count', orderCount, 'distinct', distinctJson)
-          if records ~= '' then
-            redis.call('HSET', wpKey(minted), 'records', records)
+          if recordsJson ~= '' then
+            redis.call('HSET', wpKey(minted), 'records', recordsJson)
           else
             -- A new cycle owns the whole key: a lost seq counter can re-mint a cycleSeq whose key
             -- still holds another cycle's records, and order/count stay mutually consistent so the
@@ -843,7 +809,7 @@ export class RedisSnapshotStore {
         end
 
         if cycleMode == 'new' then
-          cycleSeq = mintCycle()
+          cycleSeq = mintCycle(records)
         elseif cycleMode == 'carry' then
           -- Attach the CARRIED pointer only if this incarnation actually minted that cycle. seq can
           -- be evicted while a wp:<n> key survives, so a bare key-exists check would adopt a dead
@@ -860,7 +826,22 @@ export class RedisSnapshotStore {
             -- Only possible when the caller carried the refs. With none there is nothing to mint
             -- from, and the entry is written with no pointer, which is the older behaviour.
             if distinctJson ~= '' then
-              cycleSeq = mintCycle()
+              -- Source the records HERE, not from the caller. A copy-forward append holds none of
+              -- its own, and having the caller pre-read them meant one HGET plus a parse on EVERY
+              -- copy-forward -- attempt start, dequeue, checkpoint -- to serve a branch that needs
+              -- eviction to reach. Reading in the branch that uses them costs nothing on the common
+              -- path, keeps the blob inside Redis, and is atomic with the mint, so no reader can
+              -- observe a replacement cycle whose ids have no records.
+              --
+              -- The surviving cycle key is the source. It is readable in exactly the case that
+              -- matters: 'minted < cycleSeqIn' means the seq counter was lost while wp:<n> lived.
+              -- When the cycle key itself is gone ('not c') the records are gone with it and there
+              -- is nothing to carry, which is what the caller's read also found.
+              local carried = records
+              if carried == '' then
+                carried = redis.call('HGET', wpKey(cycleSeqIn), 'records') or ''
+              end
+              cycleSeq = mintCycle(carried)
             end
           else
             cycleSeq = cycleSeqIn

--- a/internal-packages/run-store/src/redisSnapshotStore.ts
+++ b/internal-packages/run-store/src/redisSnapshotStore.ts
@@ -456,10 +456,10 @@ export class RedisSnapshotStore {
     if (orderJson !== "") {
       // The whole wp:<cycleSeq> key, not just its order field: records dominates it once populated.
       //
-      // `records` is what the CALLER sent, so this under-reports one case: a refused carry-forward,
-      // where the script copies the record set from the cycle it replaces and the client never sees
-      // it. Sizing that exactly would cost the read this path exists to avoid, and the copied set
-      // was already measured when the cycle it came from was minted.
+      // `records` is what the CALLER sent, so this under-reports the two cases where the script
+      // sources the set itself and the client never sees it: a refused carry-forward, and a mint
+      // after a failed probe that inherits. Sizing either exactly would cost the read those paths
+      // exist to avoid, and the set was already measured when the cycle it came from was minted.
       const cycleBytes = Buffer.byteLength(orderJson, "utf8") + Buffer.byteLength(records, "utf8");
       this.metrics?.recordCycleKeyBytes(cycleBytes);
       if (this.highWater.cycleKeyBytes !== undefined && cycleBytes > this.highWater.cycleKeyBytes) {
@@ -806,6 +806,32 @@ export class RedisSnapshotStore {
 
         -- The STORE mints cycleSeq, so the sequence is dense by construction and the terminal
         -- PEXPIRE loop from 1..c is correct.
+        -- Set equality, NOT string equality.
+        --
+        -- Both sides come from deriveDistinctIds over a Postgres read with no ORDER BY -- the
+        -- resume reads the run's block edges, the copy-forward reads the snapshot's waitpoint
+        -- rows -- so the same set of ids arrives in an arbitrary order on each append. Comparing
+        -- the serialised arrays would therefore disagree for almost every wait holding two or
+        -- more waitpoints, which is the batch fan-in this inherit exists to protect.
+        --
+        -- Both arrays are already deduped by construction, so equal length plus membership one
+        -- way is set equality. This matches the decorator's own sameSet, which is deliberately
+        -- order-insensitive for the same reason.
+        local function sameDistinctSet(stored, incoming)
+          if not stored or stored == '' or incoming == '' then return false end
+          if stored == incoming then return true end
+          local ok, left = pcall(cjson.decode, stored)
+          if not ok or type(left) ~= 'table' then return false end
+          local right = cjson.decode(incoming)
+          if #left ~= #right then return false end
+          local seen = {}
+          for i = 1, #left do seen[left[i]] = true end
+          for i = 1, #right do
+            if not seen[right[i]] then return false end
+          end
+          return true
+        end
+
         -- Takes the record set rather than closing over ARGV, because the two mint sites source it
         -- differently: a 'new' cycle uses what the caller sent, and the refusal path below reads it
         -- from the cycle it is replacing.
@@ -831,14 +857,18 @@ export class RedisSnapshotStore {
           -- but minting with NO records leaves ids that resolve from nothing, and the next resume
           -- refuses the whole cycle rather than losing a result quietly. So inherit them here.
           --
-          -- Guarded on the distinct set being IDENTICAL, which is the same test the caller would
-          -- have made had its probe succeeded. A differing set is a genuinely new wait and must
-          -- start with the caller's own records, even when that is none. Read before mintCycle,
-          -- because mintCycle advances the counter this reads.
+          -- Guarded on the distinct SET matching, which is sufficient and is deliberately weaker
+          -- than the carry test the decorator applies on a successful probe. That test also
+          -- requires the order to match, because a pointer hands the reader the previous cycle's
+          -- order; this mints a fresh cycle from the caller's OWN order, so only the records have
+          -- to be right, and records are keyed by waitpoint id. A differing set is a genuinely new
+          -- wait and must start with the caller's own records, even when that is none.
+          --
+          -- Read before mintCycle, because mintCycle advances the counter this reads.
           local inherited = records
           if inherited == '' then
             local prev = tonumber(redis.call('HGET', seqKey, 'c') or '0')
-            if prev > 0 and redis.call('HGET', wpKey(prev), 'distinct') == distinctJson then
+            if prev > 0 and sameDistinctSet(redis.call('HGET', wpKey(prev), 'distinct'), distinctJson) then
               inherited = redis.call('HGET', wpKey(prev), 'records') or ''
             end
           end

--- a/internal-packages/run-store/src/redisSnapshotStore.ts
+++ b/internal-packages/run-store/src/redisSnapshotStore.ts
@@ -17,6 +17,12 @@ export function snapshotKeys(runId: string): SnapshotKeys {
   return { e: `${base}:e`, idx: `${base}:idx`, cur: `${base}:cur`, seq: `${base}:seq` };
 }
 
+// The per-cycle key. Shares the {runId} tag with the four core keys, and the append scripts
+// derive the same name in Lua from KEYS[1]; this is its only TypeScript-side spelling.
+export function cycleKey(runId: string, cycleSeq: number): string {
+  return `snap:{${runId}}:wp:${cycleSeq}`;
+}
+
 export type CompletedWaitpointRef = { id: string; index?: number };
 
 // Reproduces PostgresRunStore.#createExecutionSnapshot's completedWaitpointOrder derivation exactly:
@@ -117,6 +123,12 @@ export type ResolveCompletedWaitpointsArgs = {
   pointer: CompletedWaitpointsPointer;
   /** Index oracle only. A SUBSET of the record ids. Repeats preserved. */
   order: string[];
+  /**
+   * Every id the cycle recorded, deduped, including the ids with no batch index. This is the
+   * membership the resolver's coverage check runs over: `order` omits every index-less wait,
+   * so a check scoped to it cannot see an id whose record is missing.
+   */
+  distinctIds: string[];
   /** The authoritative, complete set. Iterate this, never `order`. */
   records: CompletedWaitpointRecord[];
 };
@@ -493,6 +505,25 @@ export class RedisSnapshotStore {
         return { present: false, distinctIds: [], order: [] };
       }
       return decodeWaitpointIds(reply[0] === "1", reply[1] ?? "", reply[2] ?? "");
+    });
+  }
+
+  /**
+   * The record set a cycle already holds, if any.
+   *
+   * Read on one path only: a copy-forward append that carries no records of its own. A
+   * copy-forward legitimately has none, because it only points at a cycle that was already
+   * minted. But the append script can REFUSE an untrustworthy pointer and mint a replacement
+   * from the carried refs, and a replacement minted with no records holds ids that nothing can
+   * resolve. So the caller reads the surviving cycle's records and carries those.
+   */
+  async getCycleRecords(
+    runId: string,
+    cycleSeq: number
+  ): Promise<CompletedWaitpointRecord[] | undefined> {
+    return this.#timed("getCycleRecords", async () => {
+      const raw = await this.redis.hget(cycleKey(runId, cycleSeq), "records");
+      return raw ? (JSON.parse(raw) as CompletedWaitpointRecord[]) : undefined;
     });
   }
 

--- a/internal-packages/run-store/src/taskRunExecutionSnapshotStore.ts
+++ b/internal-packages/run-store/src/taskRunExecutionSnapshotStore.ts
@@ -597,7 +597,7 @@ export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
     records?: CompletedWaitpointRecord[]
   ): Promise<
     | {
-        kind: "new";
+        kind: "new" | "newInherit";
         completedWaitpoints: CompletedWaitpointRef[];
         records?: CompletedWaitpointRecord[];
       }
@@ -645,7 +645,15 @@ export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
       // A failed probe must not lose the waitpoints. Minting a fresh cycle is the safe direction:
       // it costs one duplicated record set, where a wrong carryForward would point at another
       // cycle's ids.
+      //
+      // `newInherit` rather than `new`, because a copy-forward caller carries no records of its
+      // own: the probe is what would have found the previous cycle to read them from. Minting
+      // plain `new` here writes ids with no records, and the next resume then refuses the cycle
+      // outright -- a probe failure that recovers turns into a run that cannot resume. The script
+      // inherits them instead, and only when the id set is identical.
       this.logger.warn("snapshot cycle probe failed, minting a new cycle", { runId, error });
+
+      return { kind: "newInherit", completedWaitpoints, ...(records && { records }) };
     }
 
     return { kind: "new", completedWaitpoints, ...(records && { records }) };

--- a/internal-packages/run-store/src/taskRunExecutionSnapshotStore.ts
+++ b/internal-packages/run-store/src/taskRunExecutionSnapshotStore.ts
@@ -12,7 +12,7 @@
 // Each order is chosen so the crash state is the harmless one. A lost cross-store write is never
 // recovered by a transaction or an outbox: recovery is always the existing stall-and-repair job.
 import { Logger } from "@trigger.dev/core/logger";
-import { generateInternalId, parseWaitpointId } from "@trigger.dev/core/v3/isomorphic";
+import { generateInternalId } from "@trigger.dev/core/v3/isomorphic";
 import { DelegatingRunStore } from "./delegatingRunStore.js";
 import type {
   CompletedWaitpointRecord,
@@ -21,7 +21,7 @@ import type {
   SnapshotEntryInput,
   SnapshotRead,
 } from "./redisSnapshotStore.js";
-import { deriveDistinctIds, deriveOrder } from "./redisSnapshotStore.js";
+import { deriveDistinctIds, deriveOrder, mayHoldRecords } from "./redisSnapshotStore.js";
 import {
   entryFromCompletion,
   entryFromCreateExecutionSnapshot,
@@ -630,22 +630,13 @@ export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
         // cycle already minted. But the script may refuse the pointer and mint a replacement
         // from these refs, and a replacement minted with no records holds ids that nothing
         // resolves. So carry the surviving cycle's records for that branch.
-        // Read only when a record could exist. A record set is written for store-format waitpoint
-        // ids and nothing else, so a cycle whose ids are all legacy has none, and the read could
-        // only ever return nothing. Gating on the id keeps a deployment with no store-format
-        // waitpoint at zero extra round trips, and confines the cost to the organisations that
-        // actually hold them.
-        //
-        // This is the one place the snapshot store looks INSIDE a waitpoint id rather than
-        // treating the record set as opaque. It buys a per-append round trip on the resume path,
-        // which is worth the narrower layering.
-        const mayHaveRecords = completedWaitpoints.some(
-          (w) => parseWaitpointId(w.id).format === "b32hexW"
-        );
-
+        // Read only when a record could exist: see mayHoldRecords. A legacy-only cycle has none,
+        // so the read would return nothing and the round trip is pure cost.
         const carried =
           records ??
-          (mayHaveRecords ? await this.#recordsForCycle(runId, head.cycle.cycleSeq) : undefined);
+          (mayHoldRecords(completedWaitpoints)
+            ? await this.#recordsForCycle(runId, head.cycle.cycleSeq)
+            : undefined);
 
         return {
           kind: "carryForward",

--- a/internal-packages/run-store/src/taskRunExecutionSnapshotStore.ts
+++ b/internal-packages/run-store/src/taskRunExecutionSnapshotStore.ts
@@ -21,7 +21,7 @@ import type {
   SnapshotEntryInput,
   SnapshotRead,
 } from "./redisSnapshotStore.js";
-import { deriveDistinctIds, deriveOrder, mayHoldRecords } from "./redisSnapshotStore.js";
+import { deriveDistinctIds, deriveOrder } from "./redisSnapshotStore.js";
 import {
   entryFromCompletion,
   entryFromCreateExecutionSnapshot,
@@ -579,14 +579,17 @@ export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
    * the pointer model exists to remove. So an unchanged id set carries the previous cycleSeq
    * forward and writes no key.
    *
-   * The extra read only happens for an append that actually carries waitpoints, which is the resume
-   * path rather than the hot path.
+   * Resolving a cycle adds no read of its own. The id-set comparison reuses the head this method
+   * already probes, and the refusal path's record set is sourced inside the append script, in the
+   * branch that uses it. An earlier revision pre-read that set here, which put one HGET and a
+   * parse of the whole blob on every copy-forward append -- attempt start, dequeue, checkpoint --
+   * to serve a branch that needs eviction to reach. Those are the hot paths; the resume path is
+   * the one that supplies `records` and never read at all.
    *
-   * `records` rides every arm that can mint. A carryForward normally writes no key, but the
-   * store may refuse the pointer and mint a replacement inside the same call, and that
-   * replacement needs the records or the resolver's coverage check rejects the cycle later.
-   * A legacy-only wait supplies none at all, which is what keeps a Postgres-resident resume
-   * byte-identical to before.
+   * `records` rides the mint arms only. A carryForward passes none: it points at a cycle already
+   * minted, and if the store refuses that pointer and mints a replacement inside the same call,
+   * the script reads the record set off the cycle it is replacing. A legacy-only wait supplies
+   * none anywhere, which is what keeps a Postgres-resident resume byte-identical to before.
    */
   async #resolveCycle(
     runId: string,
@@ -626,23 +629,16 @@ export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
         sameOrder(previousIds.order, order) &&
         sameSet(previousIds.distinctIds, distinct)
       ) {
-        // A copy-forward carries no records of its own, and does not need any: it points at a
-        // cycle already minted. But the script may refuse the pointer and mint a replacement
-        // from these refs, and a replacement minted with no records holds ids that nothing
-        // resolves. So carry the surviving cycle's records for that branch.
-        // Read only when a record could exist: see mayHoldRecords. A legacy-only cycle has none,
-        // so the read would return nothing and the round trip is pure cost.
-        const carried =
-          records ??
-          (mayHoldRecords(completedWaitpoints)
-            ? await this.#recordsForCycle(runId, head.cycle.cycleSeq)
-            : undefined);
-
+        // A copy-forward carries no records of its own, and needs none: it points at a cycle
+        // already minted. The script can still refuse that pointer and mint a replacement from
+        // these refs, and a replacement minted with no records holds ids nothing resolves -- so
+        // the script sources the record set from the cycle it replaces, atomically with the mint.
+        // Doing it there rather than here is what keeps every copy-forward append read-free.
         return {
           kind: "carryForward",
           cycleSeq: head.cycle.cycleSeq,
           completedWaitpoints,
-          ...(carried && { records: carried }),
+          ...(records && { records }),
         };
       }
     } catch (error) {
@@ -653,25 +649,6 @@ export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
     }
 
     return { kind: "new", completedWaitpoints, ...(records && { records }) };
-  }
-
-  // Never fatal. Failing to read the records only loses the refusal branch's ability to mint a
-  // complete replacement, which is where it started; a throw here would fail an append that
-  // would otherwise have succeeded.
-  async #recordsForCycle(
-    runId: string,
-    cycleSeq: number
-  ): Promise<CompletedWaitpointRecord[] | undefined> {
-    try {
-      return await this.redis.getCycleRecords(runId, cycleSeq);
-    } catch (error) {
-      this.logger.warn("reading a cycle's records failed, carrying none", {
-        runId,
-        cycleSeq,
-        error,
-      });
-      return undefined;
-    }
   }
 
   /**

--- a/internal-packages/run-store/src/taskRunExecutionSnapshotStore.ts
+++ b/internal-packages/run-store/src/taskRunExecutionSnapshotStore.ts
@@ -586,6 +586,10 @@ export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
    * to serve a branch that needs eviction to reach. Those are the hot paths; the resume path is
    * the one that supplies `records` and never read at all.
    *
+   * Three arms: `new` mints from the caller's own records, `newInherit` mints after a probe that
+   * FAILED and lets the script inherit the previous cycle's records when the id set matches, and
+   * `carryForward` points at a cycle already minted.
+   *
    * `records` rides the mint arms only. A carryForward passes none: it points at a cycle already
    * minted, and if the store refuses that pointer and mints a replacement inside the same call,
    * the script reads the record set off the cycle it is replacing. A legacy-only wait supplies

--- a/internal-packages/run-store/src/taskRunExecutionSnapshotStore.ts
+++ b/internal-packages/run-store/src/taskRunExecutionSnapshotStore.ts
@@ -15,6 +15,7 @@ import { Logger } from "@trigger.dev/core/logger";
 import { generateInternalId } from "@trigger.dev/core/v3/isomorphic";
 import { DelegatingRunStore } from "./delegatingRunStore.js";
 import type {
+  CompletedWaitpointRecord,
   CompletedWaitpointRef,
   RedisSnapshotStore,
   SnapshotEntryInput,
@@ -114,6 +115,7 @@ export type StagedAppend = {
    */
   expectedCur?: string;
   completedWaitpoints?: CompletedWaitpointRef[];
+  completedWaitpointRecords?: CompletedWaitpointRecord[];
 };
 
 export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
@@ -177,7 +179,8 @@ export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
         "runInTransaction",
         item.entry,
         item.expectedCur,
-        item.completedWaitpoints
+        item.completedWaitpoints,
+        item.completedWaitpointRecords
       );
     }
 
@@ -420,7 +423,8 @@ export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
       "createExecutionSnapshot",
       entryFromCreateExecutionSnapshot(ctx, input),
       input.previousSnapshotId,
-      input.completedWaitpoints
+      input.completedWaitpoints,
+      input.completedWaitpointRecords
     );
     return created;
   }
@@ -503,7 +507,8 @@ export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
     site: string,
     entry: SnapshotEntryInput,
     expectedCur?: string,
-    completedWaitpoints?: CompletedWaitpointRef[]
+    completedWaitpoints?: CompletedWaitpointRef[],
+    completedWaitpointRecords?: CompletedWaitpointRecord[]
   ): Promise<void> {
     if (this.staging) {
       // Inside a transaction the append cannot run until the Postgres side commits, or a rollback
@@ -512,6 +517,7 @@ export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
         entry,
         ...(expectedCur !== undefined && { expectedCur }),
         ...(completedWaitpoints && { completedWaitpoints }),
+        ...(completedWaitpointRecords && { completedWaitpointRecords }),
       });
       return;
     }
@@ -523,7 +529,11 @@ export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
           snapshotId: entry.id,
         });
 
-        const cycle = await this.#resolveCycle(entry.runId, completedWaitpoints);
+        const cycle = await this.#resolveCycle(
+          entry.runId,
+          completedWaitpoints,
+          completedWaitpointRecords
+        );
 
         const result = await this.redis.append({
           entry,
@@ -572,15 +582,28 @@ export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
    * The extra read only happens for an append that actually carries waitpoints, which is the resume
    * path rather than the hot path.
    *
-   * `records` is deliberately left unset. The record envelope belongs to the waitpoint lane and
-   * ships empty in this build, so dual-write never re-versions the entry when it arrives.
+   * `records` rides every arm that can mint. A carryForward normally writes no key, but the
+   * store may refuse the pointer and mint a replacement inside the same call, and that
+   * replacement needs the records or the resolver's coverage check rejects the cycle later.
+   * A legacy-only wait supplies none at all, which is what keeps a Postgres-resident resume
+   * byte-identical to before.
    */
   async #resolveCycle(
     runId: string,
-    completedWaitpoints?: CompletedWaitpointRef[]
+    completedWaitpoints?: CompletedWaitpointRef[],
+    records?: CompletedWaitpointRecord[]
   ): Promise<
-    | { kind: "new"; completedWaitpoints: CompletedWaitpointRef[] }
-    | { kind: "carryForward"; cycleSeq: number; completedWaitpoints: CompletedWaitpointRef[] }
+    | {
+        kind: "new";
+        completedWaitpoints: CompletedWaitpointRef[];
+        records?: CompletedWaitpointRecord[];
+      }
+    | {
+        kind: "carryForward";
+        cycleSeq: number;
+        completedWaitpoints: CompletedWaitpointRef[];
+        records?: CompletedWaitpointRecord[];
+      }
     | undefined
   > {
     if (!completedWaitpoints || completedWaitpoints.length === 0) {
@@ -607,6 +630,7 @@ export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
           kind: "carryForward",
           cycleSeq: head.cycle.cycleSeq,
           completedWaitpoints,
+          ...(records && { records }),
         };
       }
     } catch (error) {
@@ -616,7 +640,7 @@ export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
       this.logger.warn("snapshot cycle probe failed, minting a new cycle", { runId, error });
     }
 
-    return { kind: "new", completedWaitpoints };
+    return { kind: "new", completedWaitpoints, ...(records && { records }) };
   }
 
   /**

--- a/internal-packages/run-store/src/taskRunExecutionSnapshotStore.ts
+++ b/internal-packages/run-store/src/taskRunExecutionSnapshotStore.ts
@@ -12,7 +12,7 @@
 // Each order is chosen so the crash state is the harmless one. A lost cross-store write is never
 // recovered by a transaction or an outbox: recovery is always the existing stall-and-repair job.
 import { Logger } from "@trigger.dev/core/logger";
-import { generateInternalId } from "@trigger.dev/core/v3/isomorphic";
+import { generateInternalId, parseWaitpointId } from "@trigger.dev/core/v3/isomorphic";
 import { DelegatingRunStore } from "./delegatingRunStore.js";
 import type {
   CompletedWaitpointRecord,
@@ -630,7 +630,22 @@ export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
         // cycle already minted. But the script may refuse the pointer and mint a replacement
         // from these refs, and a replacement minted with no records holds ids that nothing
         // resolves. So carry the surviving cycle's records for that branch.
-        const carried = records ?? (await this.#recordsForCycle(runId, head.cycle.cycleSeq));
+        // Read only when a record could exist. A record set is written for store-format waitpoint
+        // ids and nothing else, so a cycle whose ids are all legacy has none, and the read could
+        // only ever return nothing. Gating on the id keeps a deployment with no store-format
+        // waitpoint at zero extra round trips, and confines the cost to the organisations that
+        // actually hold them.
+        //
+        // This is the one place the snapshot store looks INSIDE a waitpoint id rather than
+        // treating the record set as opaque. It buys a per-append round trip on the resume path,
+        // which is worth the narrower layering.
+        const mayHaveRecords = completedWaitpoints.some(
+          (w) => parseWaitpointId(w.id).format === "b32hexW"
+        );
+
+        const carried =
+          records ??
+          (mayHaveRecords ? await this.#recordsForCycle(runId, head.cycle.cycleSeq) : undefined);
 
         return {
           kind: "carryForward",

--- a/internal-packages/run-store/src/taskRunExecutionSnapshotStore.ts
+++ b/internal-packages/run-store/src/taskRunExecutionSnapshotStore.ts
@@ -626,11 +626,17 @@ export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
         sameOrder(previousIds.order, order) &&
         sameSet(previousIds.distinctIds, distinct)
       ) {
+        // A copy-forward carries no records of its own, and does not need any: it points at a
+        // cycle already minted. But the script may refuse the pointer and mint a replacement
+        // from these refs, and a replacement minted with no records holds ids that nothing
+        // resolves. So carry the surviving cycle's records for that branch.
+        const carried = records ?? (await this.#recordsForCycle(runId, head.cycle.cycleSeq));
+
         return {
           kind: "carryForward",
           cycleSeq: head.cycle.cycleSeq,
           completedWaitpoints,
-          ...(records && { records }),
+          ...(carried && { records: carried }),
         };
       }
     } catch (error) {
@@ -641,6 +647,25 @@ export class TaskRunExecutionSnapshotStore extends DelegatingRunStore {
     }
 
     return { kind: "new", completedWaitpoints, ...(records && { records }) };
+  }
+
+  // Never fatal. Failing to read the records only loses the refusal branch's ability to mint a
+  // complete replacement, which is where it started; a throw here would fail an append that
+  // would otherwise have succeeded.
+  async #recordsForCycle(
+    runId: string,
+    cycleSeq: number
+  ): Promise<CompletedWaitpointRecord[] | undefined> {
+    try {
+      return await this.redis.getCycleRecords(runId, cycleSeq);
+    } catch (error) {
+      this.logger.warn("reading a cycle's records failed, carrying none", {
+        runId,
+        cycleSeq,
+        error,
+      });
+      return undefined;
+    }
   }
 
   /**

--- a/internal-packages/run-store/src/taskRunExecutionSnapshotStore.waitpointRecords.test.ts
+++ b/internal-packages/run-store/src/taskRunExecutionSnapshotStore.waitpointRecords.test.ts
@@ -289,8 +289,40 @@ describe("a failed cycle probe", () => {
     return () => void (redis.getLatest = original);
   }
 
+  async function seedStoreWaitpoint(
+    prisma: never,
+    env: SnapshotFixtureEnv,
+    id: string
+  ): Promise<void> {
+    await (
+      prisma as unknown as { waitpoint: { create: (a: unknown) => Promise<unknown> } }
+    ).waitpoint.create({
+      data: {
+        id,
+        friendlyId: `waitpoint_${id}`,
+        type: "MANUAL",
+        status: "COMPLETED",
+        completedAt: new Date(),
+        idempotencyKey: `idem_${id.slice(-12)}`,
+        userProvidedIdempotencyKey: false,
+        projectId: env.projectId,
+        environmentId: env.id,
+      },
+    });
+  }
+
+  // TWO waitpoints, and the copy-forward re-passes them in the OPPOSITE order.
+  //
+  // That is not a contrived permutation: both id lists are derived from Postgres reads with no
+  // ORDER BY -- the resume reads the run's block edges, the copy-forward reads the snapshot's
+  // waitpoint rows -- so an arbitrary order on each append is the normal case. A guard comparing
+  // the serialised id arrays would miss here and mint a record-less cycle, which is the very
+  // state this path exists to prevent, for every wait holding more than one waitpoint.
+  //
+  // A single-id version of this test passes whether the guard compares sets or strings, so it
+  // cannot hold the property on its own.
   containerTest(
-    "inherits the records when the id set is unchanged",
+    "inherits the records when the id set is unchanged but reordered",
     async ({ prisma, redisOptions }) => {
       const { decorated, redis } = build(prisma as never, redisOptions as never);
       const probe = createRedisClient(redisOptions, { onError: () => {} });
@@ -298,32 +330,33 @@ describe("a failed cycle probe", () => {
       try {
         const env = await seedSnapshotEnvironment(prisma);
         const runId = await seedRun(decorated, redis, env);
-        const storeId = generateWaitpointId("MANUAL");
-        await prisma.waitpoint.create({
-          data: {
-            id: storeId,
-            friendlyId: `waitpoint_${storeId}`,
-            type: "MANUAL",
-            status: "COMPLETED",
-            completedAt: new Date(),
-            idempotencyKey: `idem_${storeId.slice(-12)}`,
-            userProvidedIdempotencyKey: false,
-            projectId: env.projectId,
-            environmentId: env.id,
-          },
-        });
-        const waitpoints = [{ id: storeId, index: 0 }];
+        const first = generateWaitpointId("MANUAL");
+        const second = generateWaitpointId("MANUAL");
+        await seedStoreWaitpoint(prisma as never, env, first);
+        await seedStoreWaitpoint(prisma as never, env, second);
 
         // The resume, which supplies the records and mints cycle 1.
         await decorated.createExecutionSnapshot(
-          resumeInput(runId, env, waitpoints, [record(storeId)])
+          resumeInput(
+            runId,
+            env,
+            [
+              { id: first, index: 0 },
+              { id: second, index: 1 },
+            ],
+            [record(first), record(second)]
+          )
         );
 
-        // The copy-forward that follows it, with the probe broken. It carries the same refs and
-        // no records of its own, exactly as attempt-start and dequeue do.
+        // The copy-forward: same ids, same indexes, arbitrary order, no records of its own.
         const restore = breakNextProbe(redis);
         try {
-          await decorated.createExecutionSnapshot(resumeInput(runId, env, waitpoints));
+          await decorated.createExecutionSnapshot(
+            resumeInput(runId, env, [
+              { id: second, index: 1 },
+              { id: first, index: 0 },
+            ])
+          );
         } finally {
           restore();
         }
@@ -332,10 +365,9 @@ describe("a failed cycle probe", () => {
         const cycleKeys = await probe.keys(`snap:{${runId}}:wp:*`);
         expect(cycleKeys.length).toBe(2);
 
-        // ...but it still holds the records, so the cycle stays resolvable.
+        // ...holding BOTH records, so the cycle stays resolvable.
         const records = await recordsAtHead(redis, probe, runId);
-        expect(records).toHaveLength(1);
-        expect(records?.[0]?.id).toBe(storeId);
+        expect(records?.map((r) => r.id).sort()).toEqual([first, second].sort());
       } finally {
         await Promise.all([redis.quit(), probe.quit().catch(() => {})]);
       }

--- a/internal-packages/run-store/src/taskRunExecutionSnapshotStore.waitpointRecords.test.ts
+++ b/internal-packages/run-store/src/taskRunExecutionSnapshotStore.waitpointRecords.test.ts
@@ -252,6 +252,127 @@ describe("the completed-waitpoint record set", () => {
   );
 });
 
+// A cycle-probe failure must not mint an unresolvable cycle.
+//
+// The probe is how a copy-forward append discovers that its id set continues the previous cycle.
+// When it throws, the append still has to write, and minting fresh is the safe direction -- but a
+// copy-forward carries no records of its own, so a plain mint writes ids that resolve from
+// nothing. The next resume then refuses the whole cycle: one transient probe failure would leave
+// a run permanently unable to resume, with the join rows still sitting in Postgres.
+//
+// Reachable with Redis healthy: getLatest JSON-parses the entry payload, so one corrupt entry
+// does it.
+describe("a failed cycle probe", () => {
+  async function recordsAtHead(
+    redis: RedisSnapshotStore,
+    probe: ReturnType<typeof createRedisClient>,
+    runId: string
+  ): Promise<CompletedWaitpointRecord[] | undefined> {
+    const head = await redis.getLatest(runId);
+    const cycleSeq = head?.cycle?.cycleSeq;
+    if (cycleSeq === undefined) return undefined;
+    const raw = await probe.hget(`snap:{${runId}}:wp:${cycleSeq}`, "records");
+    return raw ? (JSON.parse(raw) as CompletedWaitpointRecord[]) : undefined;
+  }
+
+  // Fails the NEXT probe only, so the append that follows it still runs against a healthy store.
+  function breakNextProbe(redis: RedisSnapshotStore) {
+    const original = redis.getLatest.bind(redis);
+    let broken = true;
+    redis.getLatest = async (runId: string, opts?: { environmentId?: string }) => {
+      if (broken) {
+        broken = false;
+        throw new Error("probe failed");
+      }
+      return original(runId, opts);
+    };
+    return () => void (redis.getLatest = original);
+  }
+
+  containerTest(
+    "inherits the records when the id set is unchanged",
+    async ({ prisma, redisOptions }) => {
+      const { decorated, redis } = build(prisma as never, redisOptions as never);
+      const probe = createRedisClient(redisOptions, { onError: () => {} });
+
+      try {
+        const env = await seedSnapshotEnvironment(prisma);
+        const runId = await seedRun(decorated, redis, env);
+        const storeId = generateWaitpointId("MANUAL");
+        await prisma.waitpoint.create({
+          data: {
+            id: storeId,
+            friendlyId: `waitpoint_${storeId}`,
+            type: "MANUAL",
+            status: "COMPLETED",
+            completedAt: new Date(),
+            idempotencyKey: `idem_${storeId.slice(-12)}`,
+            userProvidedIdempotencyKey: false,
+            projectId: env.projectId,
+            environmentId: env.id,
+          },
+        });
+        const waitpoints = [{ id: storeId, index: 0 }];
+
+        // The resume, which supplies the records and mints cycle 1.
+        await decorated.createExecutionSnapshot(
+          resumeInput(runId, env, waitpoints, [record(storeId)])
+        );
+
+        // The copy-forward that follows it, with the probe broken. It carries the same refs and
+        // no records of its own, exactly as attempt-start and dequeue do.
+        const restore = breakNextProbe(redis);
+        try {
+          await decorated.createExecutionSnapshot(resumeInput(runId, env, waitpoints));
+        } finally {
+          restore();
+        }
+
+        // A fresh cycle, because an unverified pointer must not be carried...
+        const cycleKeys = await probe.keys(`snap:{${runId}}:wp:*`);
+        expect(cycleKeys.length).toBe(2);
+
+        // ...but it still holds the records, so the cycle stays resolvable.
+        const records = await recordsAtHead(redis, probe, runId);
+        expect(records).toHaveLength(1);
+        expect(records?.[0]?.id).toBe(storeId);
+      } finally {
+        await Promise.all([redis.quit(), probe.quit().catch(() => {})]);
+      }
+    }
+  );
+
+  // The other direction: a genuinely NEW wait must not inherit the previous cycle's records, or
+  // the resolver would hand the run a result belonging to a waitpoint it is not waiting on.
+  containerTest("inherits nothing when the id set differs", async ({ prisma, redisOptions }) => {
+    const { decorated, redis } = build(prisma as never, redisOptions as never);
+    const probe = createRedisClient(redisOptions, { onError: () => {} });
+
+    try {
+      const env = await seedSnapshotEnvironment(prisma);
+      const runId = await seedRun(decorated, redis, env);
+      const [first, second] = await seedSnapshotWaitpoints(prisma, env, 2);
+
+      await decorated.createExecutionSnapshot(
+        resumeInput(runId, env, [{ id: first!, index: 0 }], [record(first!)])
+      );
+
+      const restore = breakNextProbe(redis);
+      try {
+        await decorated.createExecutionSnapshot(
+          resumeInput(runId, env, [{ id: second!, index: 0 }])
+        );
+      } finally {
+        restore();
+      }
+
+      expect(await recordsAtHead(redis, probe, runId)).toBeUndefined();
+    } finally {
+      await Promise.all([redis.quit(), probe.quit().catch(() => {})]);
+    }
+  });
+});
+
 // A copy-forward append reads NO cycle key, whatever the ids look like.
 //
 // The record set a refusal needs is sourced inside the append script now, so the decorator does

--- a/internal-packages/run-store/src/taskRunExecutionSnapshotStore.waitpointRecords.test.ts
+++ b/internal-packages/run-store/src/taskRunExecutionSnapshotStore.waitpointRecords.test.ts
@@ -1,0 +1,226 @@
+// The record set's journey from a caller's input to the wait cycle's key.
+//
+// The raw store already pins that a records array round-trips through the cycle hash. What is
+// untested without this file is the decorator leg: that `completedWaitpointRecords` on a
+// snapshot input reaches `cycle.records`, that a mint carries it, and that a copy-forward and
+// a legacy-only wait carry none — which is what keeps a Postgres-resident resume unchanged.
+import { createRedisClient } from "@internal/redis";
+import { containerTest } from "@internal/testcontainers";
+import { generateInternalId } from "@trigger.dev/core/v3/isomorphic";
+import { describe, expect } from "vitest";
+import { PostgresRunStore } from "./PostgresRunStore.js";
+import { RedisSnapshotStore, type CompletedWaitpointRecord } from "./redisSnapshotStore.js";
+import { entryFromCreateRun } from "./snapshotEntry.js";
+import { TaskRunExecutionSnapshotStore } from "./taskRunExecutionSnapshotStore.js";
+import {
+  buildCreateRunData,
+  seedSnapshotEnvironment,
+  seedSnapshotWaitpoints,
+  type SnapshotFixtureEnv,
+} from "./testFixtures/snapshotIdFixture.js";
+import type { RunStore } from "./types.js";
+
+const COMPLETED_TTL_MS = 72 * 60 * 60 * 1000;
+
+function build(prisma: never, redisOptions: never) {
+  const redis = new RedisSnapshotStore({ redisOptions, completedTtlMs: COMPLETED_TTL_MS });
+  const decorated = new TaskRunExecutionSnapshotStore(
+    new PostgresRunStore({ prisma, readOnlyPrisma: prisma }) as unknown as RunStore,
+    {
+      store: redis,
+      mode: "redis-read",
+      readPercent: 100,
+      metrics: {
+        recordWrite: () => {},
+        recordAppendFailed: () => {},
+        recordRead: () => {},
+      },
+    }
+  );
+  return { decorated, redis };
+}
+
+async function seedRun(
+  decorated: TaskRunExecutionSnapshotStore,
+  redis: RedisSnapshotStore,
+  env: SnapshotFixtureEnv
+): Promise<string> {
+  const runId = generateInternalId();
+  const snapshot = {
+    id: generateInternalId(),
+    engine: "V2" as const,
+    executionStatus: "RUN_CREATED" as const,
+    description: "Run was created",
+    runStatus: "PENDING" as const,
+    environmentId: env.id,
+    environmentType: env.type,
+    projectId: env.projectId,
+    organizationId: env.organizationId,
+  };
+  await redis.append({
+    entry: entryFromCreateRun({ id: snapshot.id, runId, createdAt: new Date() }, snapshot),
+    kind: "birth",
+    isTerminal: false,
+  });
+  await decorated.createRun({ data: buildCreateRunData(runId, env), snapshot });
+  return runId;
+}
+
+function resumeInput(
+  runId: string,
+  env: SnapshotFixtureEnv,
+  completedWaitpoints: { id: string; index?: number }[],
+  completedWaitpointRecords?: CompletedWaitpointRecord[]
+) {
+  return {
+    id: generateInternalId(),
+    run: { id: runId, status: "EXECUTING" as const, attemptNumber: 1 },
+    snapshot: { executionStatus: "EXECUTING" as const, description: "Run resumed" },
+    completedWaitpoints,
+    ...(completedWaitpointRecords && { completedWaitpointRecords }),
+    environmentId: env.id,
+    environmentType: env.type,
+    projectId: env.projectId,
+    organizationId: env.organizationId,
+  };
+}
+
+function record(id: string, overrides: Partial<CompletedWaitpointRecord> = {}) {
+  return {
+    id,
+    friendlyId: `waitpoint_${id}`,
+    type: "MANUAL" as const,
+    completedAt: "2026-08-25T00:00:00.000Z",
+    outputType: "application/json",
+    outputIsError: false,
+    output: { inline: '{"ok":true}' },
+    ...overrides,
+  } satisfies CompletedWaitpointRecord;
+}
+
+async function readRecords(
+  probe: ReturnType<typeof createRedisClient>,
+  runId: string
+): Promise<CompletedWaitpointRecord[] | undefined> {
+  const [cycleKey] = await probe.keys(`snap:{${runId}}:wp:*`);
+  if (!cycleKey) return undefined;
+  const raw = await probe.hget(cycleKey, "records");
+  return raw ? (JSON.parse(raw) as CompletedWaitpointRecord[]) : undefined;
+}
+
+describe("the completed-waitpoint record set", () => {
+  containerTest("a mint writes the records the caller supplied", async ({
+    prisma,
+    redisOptions,
+  }) => {
+    const { decorated, redis } = build(prisma as never, redisOptions as never);
+    const probe = createRedisClient(redisOptions, { onError: () => {} });
+    try {
+      const env = await seedSnapshotEnvironment(prisma);
+      const runId = await seedRun(decorated, redis, env);
+      const [wpA, wpB] = await seedSnapshotWaitpoints(prisma, env, 2);
+
+      await decorated.createExecutionSnapshot(
+        resumeInput(
+          runId,
+          env,
+          [
+            { id: wpA!, index: 0 },
+            { id: wpB!, index: 1 },
+          ],
+          [record(wpA!), record(wpB!)]
+        )
+      );
+
+      const records = await readRecords(probe, runId);
+
+      expect(records).toHaveLength(2);
+      expect(records?.map((r) => r.id).sort()).toEqual([wpA, wpB].sort());
+      expect(records?.[0]?.output).toEqual({ inline: '{"ok":true}' });
+    } finally {
+      await Promise.all([redis.quit(), probe.quit().catch(() => {})]);
+    }
+  });
+
+  // The inertness guarantee. A wait with no store-resident half supplies no records, and the
+  // cycle key must then hold none — a Postgres-resident resume is unchanged.
+  containerTest("a mint with no records supplied writes none", async ({
+    prisma,
+    redisOptions,
+  }) => {
+    const { decorated, redis } = build(prisma as never, redisOptions as never);
+    const probe = createRedisClient(redisOptions, { onError: () => {} });
+    try {
+      const env = await seedSnapshotEnvironment(prisma);
+      const runId = await seedRun(decorated, redis, env);
+      const [wpA] = await seedSnapshotWaitpoints(prisma, env, 1);
+
+      await decorated.createExecutionSnapshot(resumeInput(runId, env, [{ id: wpA!, index: 0 }]));
+
+      expect(await readRecords(probe, runId)).toBeUndefined();
+    } finally {
+      await Promise.all([redis.quit(), probe.quit().catch(() => {})]);
+    }
+  });
+
+  // One record set per wait cycle, not one per entry in the resume chain. That is the write
+  // amplification the pointer model exists to remove.
+  containerTest("a copy-forward writes no second record set", async ({ prisma, redisOptions }) => {
+    const { decorated, redis } = build(prisma as never, redisOptions as never);
+    const probe = createRedisClient(redisOptions, { onError: () => {} });
+    try {
+      const env = await seedSnapshotEnvironment(prisma);
+      const runId = await seedRun(decorated, redis, env);
+      const [wpA] = await seedSnapshotWaitpoints(prisma, env, 1);
+
+      const waitpoints = [{ id: wpA!, index: 0 }];
+      await decorated.createExecutionSnapshot(
+        resumeInput(runId, env, waitpoints, [record(wpA!)])
+      );
+      await decorated.createExecutionSnapshot(
+        resumeInput(runId, env, waitpoints, [record(wpA!)])
+      );
+
+      const cycleKeys = await probe.keys(`snap:{${runId}}:wp:*`);
+
+      expect(cycleKeys).toHaveLength(1);
+      expect(await readRecords(probe, runId)).toHaveLength(1);
+    } finally {
+      await Promise.all([redis.quit(), probe.quit().catch(() => {})]);
+    }
+  });
+
+  containerTest("a record set survives beside a repeat-preserving order", async ({
+    prisma,
+    redisOptions,
+  }) => {
+    const { decorated, redis } = build(prisma as never, redisOptions as never);
+    const probe = createRedisClient(redisOptions, { onError: () => {} });
+    try {
+      const env = await seedSnapshotEnvironment(prisma);
+      const runId = await seedRun(decorated, redis, env);
+      const [wpA] = await seedSnapshotWaitpoints(prisma, env, 1);
+
+      const created = await decorated.createExecutionSnapshot(
+        resumeInput(
+          runId,
+          env,
+          [
+            { id: wpA!, index: 0 },
+            { id: wpA!, index: 1 },
+          ],
+          [record(wpA!)]
+        )
+      );
+
+      const ids = await redis.getSnapshotWaitpointIds(runId, created.id);
+
+      // One record, two positions. The record set carries membership, the order carries
+      // multiplicity.
+      expect(await readRecords(probe, runId)).toHaveLength(1);
+      expect(ids.order).toEqual([wpA, wpA]);
+    } finally {
+      await Promise.all([redis.quit(), probe.quit().catch(() => {})]);
+    }
+  });
+});

--- a/internal-packages/run-store/src/taskRunExecutionSnapshotStore.waitpointRecords.test.ts
+++ b/internal-packages/run-store/src/taskRunExecutionSnapshotStore.waitpointRecords.test.ts
@@ -183,6 +183,36 @@ describe("the completed-waitpoint record set", () => {
     }
   });
 
+  // The shape every copy-forward append actually has: same id set, no records of its own. The
+  // cycle's records must survive it untouched.
+  containerTest(
+    "a records-less copy-forward does not clobber the records",
+    async ({ prisma, redisOptions }) => {
+      const { decorated, redis } = build(prisma as never, redisOptions as never);
+      const probe = createRedisClient(redisOptions, { onError: () => {} });
+      try {
+        const env = await seedSnapshotEnvironment(prisma);
+        const runId = await seedRun(decorated, redis, env);
+        const [wpA] = await seedSnapshotWaitpoints(prisma, env, 1);
+        const waitpoints = [{ id: wpA!, index: 0 }];
+
+        await decorated.createExecutionSnapshot(
+          resumeInput(runId, env, waitpoints, [record(wpA!)])
+        );
+        // No records this time, exactly as dequeue/checkpoint/attempt appends do.
+        await decorated.createExecutionSnapshot(resumeInput(runId, env, waitpoints));
+
+        const records = await readRecords(probe, runId);
+
+        expect(await probe.keys(`snap:{${runId}}:wp:*`)).toHaveLength(1);
+        expect(records).toHaveLength(1);
+        expect(records?.[0]?.id).toBe(wpA);
+      } finally {
+        await Promise.all([redis.quit(), probe.quit().catch(() => {})]);
+      }
+    }
+  );
+
   containerTest(
     "a record set survives beside a repeat-preserving order",
     async ({ prisma, redisOptions }) => {

--- a/internal-packages/run-store/src/taskRunExecutionSnapshotStore.waitpointRecords.test.ts
+++ b/internal-packages/run-store/src/taskRunExecutionSnapshotStore.waitpointRecords.test.ts
@@ -6,7 +6,11 @@
 // a legacy-only wait carry none — which is what keeps a Postgres-resident resume unchanged.
 import { createRedisClient } from "@internal/redis";
 import { containerTest } from "@internal/testcontainers";
-import { generateInternalId } from "@trigger.dev/core/v3/isomorphic";
+import {
+  generateInternalId,
+  generateWaitpointId,
+  parseWaitpointId,
+} from "@trigger.dev/core/v3/isomorphic";
 import { describe, expect } from "vitest";
 import { PostgresRunStore } from "./PostgresRunStore.js";
 import { RedisSnapshotStore, type CompletedWaitpointRecord } from "./redisSnapshotStore.js";
@@ -243,6 +247,86 @@ describe("the completed-waitpoint record set", () => {
         expect(ids.order).toEqual([wpA, wpA]);
       } finally {
         await Promise.all([redis.quit(), probe.quit().catch(() => {})]);
+      }
+    }
+  );
+});
+
+// The records read is gated on id shape, so a deployment holding no store-format waitpoint pays
+// no extra round trip on the resume path. These count the reads rather than infer them: the cost
+// is the whole point of the gate, and it is not visible in the resulting entry.
+describe("the records read is gated on waitpoint id shape", () => {
+  containerTest(
+    "a legacy-only carry-forward performs NO getCycleRecords read",
+    async ({ prisma, redisOptions }) => {
+      const { decorated, redis } = build(prisma as never, redisOptions as never);
+      const reads: number[] = [];
+      const original = redis.getCycleRecords.bind(redis);
+      redis.getCycleRecords = async (runId: string, cycleSeq: number) => {
+        reads.push(cycleSeq);
+        return original(runId, cycleSeq);
+      };
+
+      try {
+        const env = await seedSnapshotEnvironment(prisma);
+        const runId = await seedRun(decorated, redis, env);
+        const [wpA] = await seedSnapshotWaitpoints(prisma, env, 1);
+        const waitpoints = [{ id: wpA!, index: 0 }];
+
+        // Two appends with the same id set: the second carries the first's cycle forward.
+        await decorated.createExecutionSnapshot(resumeInput(runId, env, waitpoints));
+        await decorated.createExecutionSnapshot(resumeInput(runId, env, waitpoints));
+
+        // The fixture mints cuid waitpoints, so no id is store-format and no record can exist.
+        expect(wpA && parseWaitpointId(wpA).format).toBe("legacy");
+        expect(reads).toEqual([]);
+      } finally {
+        redis.getCycleRecords = original;
+        await redis.quit();
+      }
+    }
+  );
+
+  containerTest(
+    "a store-format id in the cycle DOES perform the read",
+    async ({ prisma, redisOptions }) => {
+      const { decorated, redis } = build(prisma as never, redisOptions as never);
+      const reads: number[] = [];
+      const original = redis.getCycleRecords.bind(redis);
+      redis.getCycleRecords = async (runId: string, cycleSeq: number) => {
+        reads.push(cycleSeq);
+        return original(runId, cycleSeq);
+      };
+
+      try {
+        const env = await seedSnapshotEnvironment(prisma);
+        const runId = await seedRun(decorated, redis, env);
+        // A real row, but with a store-format id rather than the fixture's cuid. The delegate
+        // still writes the completed-waitpoint join, so the row has to exist.
+        const storeId = generateWaitpointId("MANUAL");
+        await prisma.waitpoint.create({
+          data: {
+            id: storeId,
+            friendlyId: `waitpoint_${storeId}`,
+            type: "MANUAL",
+            status: "COMPLETED",
+            completedAt: new Date(),
+            idempotencyKey: `idem_${storeId.slice(-12)}`,
+            userProvidedIdempotencyKey: false,
+            projectId: env.projectId,
+            environmentId: env.id,
+          },
+        });
+        const waitpoints = [{ id: storeId, index: 0 }];
+
+        await decorated.createExecutionSnapshot(resumeInput(runId, env, waitpoints));
+        await decorated.createExecutionSnapshot(resumeInput(runId, env, waitpoints));
+
+        expect(parseWaitpointId(storeId).format).toBe("b32hexW");
+        expect(reads.length).toBeGreaterThan(0);
+      } finally {
+        redis.getCycleRecords = original;
+        await redis.quit();
       }
     }
   );

--- a/internal-packages/run-store/src/taskRunExecutionSnapshotStore.waitpointRecords.test.ts
+++ b/internal-packages/run-store/src/taskRunExecutionSnapshotStore.waitpointRecords.test.ts
@@ -252,82 +252,96 @@ describe("the completed-waitpoint record set", () => {
   );
 });
 
-// The records read is gated on id shape, so a deployment holding no store-format waitpoint pays
-// no extra round trip on the resume path. These count the reads rather than infer them: the cost
-// is the whole point of the gate, and it is not visible in the resulting entry.
-describe("the records read is gated on waitpoint id shape", () => {
-  containerTest(
-    "a legacy-only carry-forward performs NO getCycleRecords read",
-    async ({ prisma, redisOptions }) => {
-      const { decorated, redis } = build(prisma as never, redisOptions as never);
-      const reads: number[] = [];
-      const original = redis.getCycleRecords.bind(redis);
-      redis.getCycleRecords = async (runId: string, cycleSeq: number) => {
-        reads.push(cycleSeq);
-        return original(runId, cycleSeq);
-      };
-
-      try {
-        const env = await seedSnapshotEnvironment(prisma);
-        const runId = await seedRun(decorated, redis, env);
-        const [wpA] = await seedSnapshotWaitpoints(prisma, env, 1);
-        const waitpoints = [{ id: wpA!, index: 0 }];
-
-        // Two appends with the same id set: the second carries the first's cycle forward.
-        await decorated.createExecutionSnapshot(resumeInput(runId, env, waitpoints));
-        await decorated.createExecutionSnapshot(resumeInput(runId, env, waitpoints));
-
-        // The fixture mints cuid waitpoints, so no id is store-format and no record can exist.
-        expect(wpA && parseWaitpointId(wpA).format).toBe("legacy");
-        expect(reads).toEqual([]);
-      } finally {
-        redis.getCycleRecords = original;
-        await redis.quit();
+// A copy-forward append reads NO cycle key, whatever the ids look like.
+//
+// The record set a refusal needs is sourced inside the append script now, so the decorator does
+// not pre-read it. That matters because copy-forward appends are the hot paths -- attempt start,
+// dequeue, checkpoint -- while the refusal they were preparing for needs eviction to reach. These
+// count the reads rather than infer them: the absence of the round trip is the whole point, and it
+// is not visible in the resulting entry.
+//
+// The store-format case is the one that used to pay: it performed the read on every copy-forward.
+describe("a copy-forward append reads no cycle key", () => {
+  function countCycleReads(redis: RedisSnapshotStore) {
+    const client = (redis as unknown as { redis: Record<string, (...a: never[]) => unknown> })
+      .redis;
+    const original = client.hget.bind(client);
+    const reads: string[] = [];
+    client.hget = (...args: never[]) => {
+      const key = args[0];
+      if (typeof key === "string" && key.includes(":wp:")) {
+        reads.push(key);
       }
+      return original(...args);
+    };
+    return { reads, restore: () => void (client.hget = original) };
+  }
+
+  containerTest("with a legacy-only id set", async ({ prisma, redisOptions }) => {
+    const { decorated, redis } = build(prisma as never, redisOptions as never);
+    const { reads, restore } = countCycleReads(redis);
+
+    try {
+      const env = await seedSnapshotEnvironment(prisma);
+      const runId = await seedRun(decorated, redis, env);
+      const [wpA] = await seedSnapshotWaitpoints(prisma, env, 1);
+      const waitpoints = [{ id: wpA!, index: 0 }];
+
+      // Two appends with the same id set: the second carries the first's cycle forward.
+      await decorated.createExecutionSnapshot(resumeInput(runId, env, waitpoints));
+      await decorated.createExecutionSnapshot(resumeInput(runId, env, waitpoints));
+
+      expect(wpA && parseWaitpointId(wpA).format).toBe("legacy");
+      expect(reads).toEqual([]);
+    } finally {
+      restore();
+      await redis.quit();
     }
-  );
+  });
 
-  containerTest(
-    "a store-format id in the cycle DOES perform the read",
-    async ({ prisma, redisOptions }) => {
-      const { decorated, redis } = build(prisma as never, redisOptions as never);
-      const reads: number[] = [];
-      const original = redis.getCycleRecords.bind(redis);
-      redis.getCycleRecords = async (runId: string, cycleSeq: number) => {
-        reads.push(cycleSeq);
-        return original(runId, cycleSeq);
-      };
+  containerTest("with a store-format id in the cycle", async ({ prisma, redisOptions }) => {
+    const { decorated, redis } = build(prisma as never, redisOptions as never);
+    const { reads, restore } = countCycleReads(redis);
 
+    try {
+      const env = await seedSnapshotEnvironment(prisma);
+      const runId = await seedRun(decorated, redis, env);
+      // A real row, but with a store-format id rather than the fixture's cuid. The delegate
+      // still writes the completed-waitpoint join, so the row has to exist.
+      const storeId = generateWaitpointId("MANUAL");
+      await prisma.waitpoint.create({
+        data: {
+          id: storeId,
+          friendlyId: `waitpoint_${storeId}`,
+          type: "MANUAL",
+          status: "COMPLETED",
+          completedAt: new Date(),
+          idempotencyKey: `idem_${storeId.slice(-12)}`,
+          userProvidedIdempotencyKey: false,
+          projectId: env.projectId,
+          environmentId: env.id,
+        },
+      });
+      const waitpoints = [{ id: storeId, index: 0 }];
+
+      await decorated.createExecutionSnapshot(
+        resumeInput(runId, env, waitpoints, [record(storeId)])
+      );
+      await decorated.createExecutionSnapshot(resumeInput(runId, env, waitpoints));
+
+      expect(parseWaitpointId(storeId).format).toBe("b32hexW");
+      expect(reads).toEqual([]);
+
+      // And the records the mint wrote are still there, untouched by the copy-forward.
+      const probe = createRedisClient(redisOptions, { onError: () => {} });
       try {
-        const env = await seedSnapshotEnvironment(prisma);
-        const runId = await seedRun(decorated, redis, env);
-        // A real row, but with a store-format id rather than the fixture's cuid. The delegate
-        // still writes the completed-waitpoint join, so the row has to exist.
-        const storeId = generateWaitpointId("MANUAL");
-        await prisma.waitpoint.create({
-          data: {
-            id: storeId,
-            friendlyId: `waitpoint_${storeId}`,
-            type: "MANUAL",
-            status: "COMPLETED",
-            completedAt: new Date(),
-            idempotencyKey: `idem_${storeId.slice(-12)}`,
-            userProvidedIdempotencyKey: false,
-            projectId: env.projectId,
-            environmentId: env.id,
-          },
-        });
-        const waitpoints = [{ id: storeId, index: 0 }];
-
-        await decorated.createExecutionSnapshot(resumeInput(runId, env, waitpoints));
-        await decorated.createExecutionSnapshot(resumeInput(runId, env, waitpoints));
-
-        expect(parseWaitpointId(storeId).format).toBe("b32hexW");
-        expect(reads.length).toBeGreaterThan(0);
+        expect(await readRecords(probe, runId)).toHaveLength(1);
       } finally {
-        redis.getCycleRecords = original;
-        await redis.quit();
+        await probe.quit().catch(() => {});
       }
+    } finally {
+      restore();
+      await redis.quit();
     }
-  );
+  });
 });

--- a/internal-packages/run-store/src/taskRunExecutionSnapshotStore.waitpointRecords.test.ts
+++ b/internal-packages/run-store/src/taskRunExecutionSnapshotStore.waitpointRecords.test.ts
@@ -109,45 +109,42 @@ async function readRecords(
 }
 
 describe("the completed-waitpoint record set", () => {
-  containerTest("a mint writes the records the caller supplied", async ({
-    prisma,
-    redisOptions,
-  }) => {
-    const { decorated, redis } = build(prisma as never, redisOptions as never);
-    const probe = createRedisClient(redisOptions, { onError: () => {} });
-    try {
-      const env = await seedSnapshotEnvironment(prisma);
-      const runId = await seedRun(decorated, redis, env);
-      const [wpA, wpB] = await seedSnapshotWaitpoints(prisma, env, 2);
+  containerTest(
+    "a mint writes the records the caller supplied",
+    async ({ prisma, redisOptions }) => {
+      const { decorated, redis } = build(prisma as never, redisOptions as never);
+      const probe = createRedisClient(redisOptions, { onError: () => {} });
+      try {
+        const env = await seedSnapshotEnvironment(prisma);
+        const runId = await seedRun(decorated, redis, env);
+        const [wpA, wpB] = await seedSnapshotWaitpoints(prisma, env, 2);
 
-      await decorated.createExecutionSnapshot(
-        resumeInput(
-          runId,
-          env,
-          [
-            { id: wpA!, index: 0 },
-            { id: wpB!, index: 1 },
-          ],
-          [record(wpA!), record(wpB!)]
-        )
-      );
+        await decorated.createExecutionSnapshot(
+          resumeInput(
+            runId,
+            env,
+            [
+              { id: wpA!, index: 0 },
+              { id: wpB!, index: 1 },
+            ],
+            [record(wpA!), record(wpB!)]
+          )
+        );
 
-      const records = await readRecords(probe, runId);
+        const records = await readRecords(probe, runId);
 
-      expect(records).toHaveLength(2);
-      expect(records?.map((r) => r.id).sort()).toEqual([wpA, wpB].sort());
-      expect(records?.[0]?.output).toEqual({ inline: '{"ok":true}' });
-    } finally {
-      await Promise.all([redis.quit(), probe.quit().catch(() => {})]);
+        expect(records).toHaveLength(2);
+        expect(records?.map((r) => r.id).sort()).toEqual([wpA, wpB].sort());
+        expect(records?.[0]?.output).toEqual({ inline: '{"ok":true}' });
+      } finally {
+        await Promise.all([redis.quit(), probe.quit().catch(() => {})]);
+      }
     }
-  });
+  );
 
   // The inertness guarantee. A wait with no store-resident half supplies no records, and the
   // cycle key must then hold none — a Postgres-resident resume is unchanged.
-  containerTest("a mint with no records supplied writes none", async ({
-    prisma,
-    redisOptions,
-  }) => {
+  containerTest("a mint with no records supplied writes none", async ({ prisma, redisOptions }) => {
     const { decorated, redis } = build(prisma as never, redisOptions as never);
     const probe = createRedisClient(redisOptions, { onError: () => {} });
     try {
@@ -174,12 +171,8 @@ describe("the completed-waitpoint record set", () => {
       const [wpA] = await seedSnapshotWaitpoints(prisma, env, 1);
 
       const waitpoints = [{ id: wpA!, index: 0 }];
-      await decorated.createExecutionSnapshot(
-        resumeInput(runId, env, waitpoints, [record(wpA!)])
-      );
-      await decorated.createExecutionSnapshot(
-        resumeInput(runId, env, waitpoints, [record(wpA!)])
-      );
+      await decorated.createExecutionSnapshot(resumeInput(runId, env, waitpoints, [record(wpA!)]));
+      await decorated.createExecutionSnapshot(resumeInput(runId, env, waitpoints, [record(wpA!)]));
 
       const cycleKeys = await probe.keys(`snap:{${runId}}:wp:*`);
 
@@ -190,37 +183,37 @@ describe("the completed-waitpoint record set", () => {
     }
   });
 
-  containerTest("a record set survives beside a repeat-preserving order", async ({
-    prisma,
-    redisOptions,
-  }) => {
-    const { decorated, redis } = build(prisma as never, redisOptions as never);
-    const probe = createRedisClient(redisOptions, { onError: () => {} });
-    try {
-      const env = await seedSnapshotEnvironment(prisma);
-      const runId = await seedRun(decorated, redis, env);
-      const [wpA] = await seedSnapshotWaitpoints(prisma, env, 1);
+  containerTest(
+    "a record set survives beside a repeat-preserving order",
+    async ({ prisma, redisOptions }) => {
+      const { decorated, redis } = build(prisma as never, redisOptions as never);
+      const probe = createRedisClient(redisOptions, { onError: () => {} });
+      try {
+        const env = await seedSnapshotEnvironment(prisma);
+        const runId = await seedRun(decorated, redis, env);
+        const [wpA] = await seedSnapshotWaitpoints(prisma, env, 1);
 
-      const created = await decorated.createExecutionSnapshot(
-        resumeInput(
-          runId,
-          env,
-          [
-            { id: wpA!, index: 0 },
-            { id: wpA!, index: 1 },
-          ],
-          [record(wpA!)]
-        )
-      );
+        const created = await decorated.createExecutionSnapshot(
+          resumeInput(
+            runId,
+            env,
+            [
+              { id: wpA!, index: 0 },
+              { id: wpA!, index: 1 },
+            ],
+            [record(wpA!)]
+          )
+        );
 
-      const ids = await redis.getSnapshotWaitpointIds(runId, created.id);
+        const ids = await redis.getSnapshotWaitpointIds(runId, created.id);
 
-      // One record, two positions. The record set carries membership, the order carries
-      // multiplicity.
-      expect(await readRecords(probe, runId)).toHaveLength(1);
-      expect(ids.order).toEqual([wpA, wpA]);
-    } finally {
-      await Promise.all([redis.quit(), probe.quit().catch(() => {})]);
+        // One record, two positions. The record set carries membership, the order carries
+        // multiplicity.
+        expect(await readRecords(probe, runId)).toHaveLength(1);
+        expect(ids.order).toEqual([wpA, wpA]);
+      } finally {
+        await Promise.all([redis.quit(), probe.quit().catch(() => {})]);
+      }
     }
-  });
+  );
 });

--- a/internal-packages/run-store/src/types.ts
+++ b/internal-packages/run-store/src/types.ts
@@ -13,6 +13,7 @@ import type {
 } from "@trigger.dev/database";
 import type { TaskRunError } from "@trigger.dev/core/v3/schemas";
 import type { Residency } from "@trigger.dev/core/v3/isomorphic";
+import type { CompletedWaitpointRecord } from "./redisSnapshotStore.js";
 
 /**
  * Client accepted by the read methods. Reads route through the replica by
@@ -352,6 +353,10 @@ export type CreateExecutionSnapshotInput = {
   workerId?: string;
   runnerId?: string;
   completedWaitpoints?: { id: string; index?: number }[];
+  /** One envelope per DISTINCT completed waitpoint id. Owned by the waitpoint lane; the
+   *  snapshot store only carries it into the wait cycle's key. Absent for a legacy-only
+   *  wait, which is what keeps a Postgres-resident resume unchanged. */
+  completedWaitpointRecords?: CompletedWaitpointRecord[];
   error?: string;
 };
 

--- a/internal-packages/run-store/src/types.ts
+++ b/internal-packages/run-store/src/types.ts
@@ -13,6 +13,7 @@ import type {
 } from "@trigger.dev/database";
 import type { TaskRunError } from "@trigger.dev/core/v3/schemas";
 import type { Residency, ShardKey } from "@trigger.dev/core/v3/isomorphic";
+import type { CompletedWaitpointRecord } from "./redisSnapshotStore.js";
 
 /**
  * Client accepted by the read methods. Reads route through the replica by
@@ -352,6 +353,10 @@ export type CreateExecutionSnapshotInput = {
   workerId?: string;
   runnerId?: string;
   completedWaitpoints?: { id: string; index?: number }[];
+  /** One envelope per DISTINCT completed waitpoint id. Owned by the waitpoint lane; the
+   *  snapshot store only carries it into the wait cycle's key. Absent for a legacy-only
+   *  wait, which is what keeps a Postgres-resident resume unchanged. */
+  completedWaitpointRecords?: CompletedWaitpointRecord[];
   error?: string;
 };
 


### PR DESCRIPTION
Defines the completed-waitpoint record shape, writes it at the resume appends, and rebuilds `CompletedWaitpoint[]` from it at read time.

The record set lives in an immutable per-cycle Redis key: an ordered waitpoint id list plus one envelope per **distinct** id. A waitpoint's output is never copied through the snapshot chain — a record carries an inline value, a reference to an already-offloaded one, or a marker saying the value is re-readable from the completing run.

## What is here

- **The envelope**, byte-compatible with `enhanceExecutionSnapshotWithWaitpoints`, which is what the executor consumes today. A differential suite compares the two over real rows rather than against a literal, so a drift in either side shows up as a diff.
- **The resume-time write**, at both appending branches of `continueRunIfUnblocked`.
- **The read-time resolver**, which iterates the records rather than the order — the order holds only batch-indexed ids, so iterating it would silently drop every index-less wait.
- **Mixed-snapshot support**: a snapshot holding legacy and store-format ids resolves both halves, each reading its index from the same order.
- **Fail-loud**: an id that no half accounts for, or that both claim, refuses rather than resuming short.

## Merge test

Merged alone, nothing is observable.

The record build sits behind an O(1) predicate that defaults to never, so no resume reaches it. Nothing consumes a record set either: the resolver has no production caller and is not exported from the package index. The wiring is a later ticket.

The append script is modified, and organisations already on the snapshot store execute it. Those changes are behaviour-preserving for the paths they take: the `new` and healthy carry-forward branches are byte-identical to `main`, and the new branch needs a failed head probe to reach.

## Performance

No added I/O on any production path at any dial setting. A record set is read only where one can exist, and never on a copy-forward append — the append script sources it from the cycle it replaces, in the one branch that needs it, atomically with the mint.

## Testing

Roughly 190 automated tests. The ones worth knowing about:

- a **differential** suite against the existing hydration, over real waitpoint rows;
- a **round-trip** through a real cycle key: envelopes from Postgres rows, written through the real store, id lists read back through the store's read API, then resolved and compared with the oracle;
- an exhaustive walk of the reachable output state space, which is where every defect on this branch turned out to live.

Mutation-verified at a dozen points, including that emptying the envelope build fails four of the five round-trip cases.

## Handoff to the wiring ticket

Two things this PR cannot supply and the next one must:

1. A **Postgres fallback when the resolver throws.** `findLatestExecutionSnapshot` falls back on a miss and on a dangling cycle, but a throw propagates. Unhandled, one unresolvable cycle makes a run's execution data unreadable rather than merely unresumable, while Postgres still holds the join rows.
2. The **records-enabled predicate**, and the store coordinator arm. Store-format minting should follow the snapshot store rather than lead it: the engine gate keys on id format, so the first store-format mint is what starts the cost, not the first store flip.
