### PR TITLE
fix(webapp): project integrations page — Staging gating, unreachable code, and follow-ups

### DIFF
--- a/.server-changes/vercel-staging-gating.md
+++ b/.server-changes/vercel-staging-gating.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+The Staging branch setting now shows an upgrade prompt on plans that don't include a Staging environment, instead of looking editable and then silently doing nothing when saved.

--- a/apps/webapp/app/components/integrations/VercelBuildSettings.tsx
+++ b/apps/webapp/app/components/integrations/VercelBuildSettings.tsx
@@ -49,7 +49,6 @@ type BuildSettingsFieldsProps = {
    * the pin status is unknown — distinct from "not set". */
   currentTriggerVersionFetchFailed?: boolean;
   /** Hide the section-level master toggles for "Pull env vars" and "Discover new env vars". */
-  hideSectionToggles?: boolean;
   showAtomicDeployments?: boolean;
   layout?: "settings" | "card";
 };
@@ -68,7 +67,6 @@ export function BuildSettingsFields({
   onAutoPromoteChange,
   currentTriggerVersion,
   currentTriggerVersionFetchFailed,
-  hideSectionToggles,
   showAtomicDeployments = true,
   layout = "card",
 }: BuildSettingsFieldsProps) {
@@ -222,7 +220,7 @@ export function BuildSettingsFields({
           <div className="mb-2">
             <div className="flex items-center justify-between">
               <Label>Pull env vars before build</Label>
-              {!hideSectionToggles && availableEnvSlugs.length > 1 && (
+              {availableEnvSlugs.length > 1 && (
                 <Switch
                   variant="small"
                   checked={
@@ -292,7 +290,7 @@ export function BuildSettingsFields({
           <div className="mb-2">
             <div className="flex items-center justify-between">
               <Label>Discover new env vars</Label>
-              {!hideSectionToggles && availableEnvSlugs.length > 1 && (
+              {availableEnvSlugs.length > 1 && (
                 <Switch
                   variant="small"
                   checked={

--- a/apps/webapp/app/components/integrations/VercelOnboardingModal.tsx
+++ b/apps/webapp/app/components/integrations/VercelOnboardingModal.tsx
@@ -4,7 +4,7 @@ import {
   ChevronDownIcon,
   ChevronUpIcon,
 } from "@heroicons/react/20/solid";
-import { useFetcher, useNavigation, useSearchParams } from "@remix-run/react";
+import { useFetcher, useSearchParams } from "@remix-run/react";
 import { useTypedFetcher } from "remix-typedjson";
 import { Dialog, DialogContent, DialogHeader } from "~/components/primitives/Dialog";
 import { Button, LinkButton } from "~/components/primitives/Buttons";
@@ -34,13 +34,11 @@ import {
   type EnvSlug,
   ALL_ENV_SLUGS,
   shouldSyncEnvVarForAnyEnvironment,
-  getAvailableEnvSlugs,
   getAvailableEnvSlugsForBuildSettings,
 } from "~/v3/vercel/vercelProjectIntegrationSchema";
 import { type VercelCustomEnvironment } from "~/models/vercelIntegration.server";
 import { type VercelOnboardingData } from "~/presenters/v3/VercelSettingsPresenter.server";
 import {
-  vercelAppInstallPath,
   v3ProjectSettingsIntegrationsPath,
   githubAppInstallPath,
   vercelResourcePath,
@@ -78,7 +76,6 @@ function formatVercelTargets(targets: string[]): string {
 
 type OnboardingState =
   | "idle"
-  | "installing"
   | "loading-projects"
   | "project-selection"
   | "loading-env-mapping"
@@ -119,11 +116,9 @@ export function VercelOnboardingModal({
   vercelManageAccessUrl?: string;
 }) {
   const { capture, startSessionRecording } = usePostHogTracking();
-  const navigation = useNavigation();
   const fetcher = useTypedFetcher<typeof loader>();
   const envMappingFetcher = useFetcher();
   const completeOnboardingFetcher = useFetcher();
-  const { Form: _CompleteOnboardingForm } = completeOnboardingFetcher;
   const [searchParams] = useSearchParams();
   const origin = searchParams.get("origin");
   const fromMarketplaceContext = origin === "marketplace";
@@ -132,7 +127,6 @@ export function VercelOnboardingModal({
     () => onboardingData?.availableProjects ?? [],
     [onboardingData?.availableProjects]
   );
-  const _hasProjectSelected = onboardingData?.hasProjectSelected ?? false;
   const customEnvironments = useMemo(
     () => onboardingData?.customEnvironments ?? [],
     [onboardingData?.customEnvironments]
@@ -226,10 +220,6 @@ export function VercelOnboardingModal({
     environmentId: string;
     displayName: string;
   } | null>(null);
-  const _availableEnvSlugsForOnboarding = getAvailableEnvSlugs(
-    hasStagingEnvironment,
-    hasPreviewEnvironment
-  );
   const availableEnvSlugsForOnboardingBuildSettings = getAvailableEnvSlugsForBuildSettings(
     hasStagingEnvironment,
     hasPreviewEnvironment
@@ -377,7 +367,6 @@ export function VercelOnboardingModal({
         }
         break;
 
-      case "installing":
       case "project-selection":
       case "env-mapping":
       case "env-var-sync":
@@ -460,8 +449,6 @@ export function VercelOnboardingModal({
   );
 
   const overlappingEnvVarsCount = enabledEnvVars.filter((v) => existingVars[v.key]).length;
-
-  const _isSubmitting = navigation.state === "submitting" || navigation.state === "loading";
 
   const actionUrl = vercelResourcePath(organizationSlug, projectSlug, environmentSlug);
 
@@ -636,19 +623,6 @@ export function VercelOnboardingModal({
     gitHubAppInstallations.length,
   ]);
 
-  const _handleFinishOnboarding = useCallback(
-    (e: React.FormEvent<HTMLFormElement>) => {
-      e.preventDefault();
-      const form = e.currentTarget;
-      const formData = new FormData(form);
-      completeOnboardingFetcher.submit(formData, {
-        method: "post",
-        action: actionUrl,
-      });
-    },
-    [completeOnboardingFetcher, actionUrl]
-  );
-
   useEffect(() => {
     if (
       completeOnboardingFetcher.data &&
@@ -701,13 +675,6 @@ export function VercelOnboardingModal({
   }, [state, onClose, trackOnboarding, isGitHubConnectedForOnboarding]);
 
   useEffect(() => {
-    if (state === "installing") {
-      const installUrl = vercelAppInstallPath(organizationSlug, projectSlug);
-      window.location.href = installUrl;
-    }
-  }, [state, organizationSlug, projectSlug]);
-
-  useEffect(() => {
     if (
       envMappingFetcher.data &&
       typeof envMappingFetcher.data === "object" &&
@@ -751,7 +718,6 @@ export function VercelOnboardingModal({
     state === "loading-projects" ||
     state === "loading-env-mapping" ||
     state === "loading-env-vars" ||
-    state === "installing" ||
     (state === "idle" && !onboardingData);
 
   if (isLoadingState) {
@@ -760,9 +726,7 @@ export function VercelOnboardingModal({
         open={isOpen}
         onOpenChange={(open) => {
           if (!open && !fromMarketplaceContext) {
-            if ((state as string) !== "completed") {
-              trackOnboarding("vercel onboarding abandoned");
-            }
+            trackOnboarding("vercel onboarding abandoned");
             onClose();
           }
         }}
@@ -787,12 +751,7 @@ export function VercelOnboardingModal({
                   </Button>
                 )}
                 {vercelManageAccessUrl && (
-                  <LinkButton
-                    to={vercelManageAccessUrl}
-                    target="_blank"
-                    rel="noreferrer noopener"
-                    variant="tertiary/small"
-                  >
+                  <LinkButton to={vercelManageAccessUrl} target="_blank" variant="tertiary/small">
                     Manage access on Vercel
                   </LinkButton>
                 )}

--- a/apps/webapp/app/components/integrations/VercelOnboardingModal.tsx
+++ b/apps/webapp/app/components/integrations/VercelOnboardingModal.tsx
@@ -99,6 +99,7 @@ export function VercelOnboardingModal({
   hasStagingEnvironment,
   hasPreviewEnvironment,
   hasOrgIntegration,
+  onboardingDataUnavailable = false,
   nextUrl,
   onDataReload,
   vercelManageAccessUrl,
@@ -112,6 +113,7 @@ export function VercelOnboardingModal({
   hasStagingEnvironment: boolean;
   hasPreviewEnvironment: boolean;
   hasOrgIntegration: boolean;
+  onboardingDataUnavailable?: boolean;
   nextUrl?: string;
   onDataReload?: (vercelStagingEnvironment?: string) => void;
   vercelManageAccessUrl?: string;
@@ -772,9 +774,35 @@ export function VercelOnboardingModal({
               <span>Set up Vercel Integration</span>
             </div>
           </DialogHeader>
-          <div className="flex items-center justify-center py-8">
-            <Spinner color="blue" className="size-6" />
-          </div>
+          {onboardingDataUnavailable ? (
+            <div className="flex flex-col items-start gap-3 py-4">
+              <Paragraph variant="small">
+                We couldn't load your Vercel projects. The integration may have been removed or lost
+                access to this organization on Vercel.
+              </Paragraph>
+              <div className="flex items-center gap-2">
+                {onDataReload && (
+                  <Button variant="secondary/small" onClick={() => onDataReload()}>
+                    Try again
+                  </Button>
+                )}
+                {vercelManageAccessUrl && (
+                  <LinkButton
+                    to={vercelManageAccessUrl}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    variant="tertiary/small"
+                  >
+                    Manage access on Vercel
+                  </LinkButton>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="flex items-center justify-center py-8">
+              <Spinner color="blue" className="size-6" />
+            </div>
+          )}
         </DialogContent>
       </Dialog>
     );

--- a/apps/webapp/app/presenters/v3/GitHubSettingsPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/GitHubSettingsPresenter.server.ts
@@ -115,7 +115,8 @@ export class GitHubSettingsPresenter extends BasePresenter {
           },
           where: {
             projectId: projectId,
-            slug: "preview",
+            type: "PREVIEW",
+            parentEnvironmentId: null,
           },
         }),
         (error) => ({
@@ -132,7 +133,8 @@ export class GitHubSettingsPresenter extends BasePresenter {
           },
           where: {
             projectId: projectId,
-            slug: "stg",
+            type: "STAGING",
+            parentEnvironmentId: null,
           },
         }),
         (error) => ({

--- a/apps/webapp/app/presenters/v3/GitHubSettingsPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/GitHubSettingsPresenter.server.ts
@@ -19,6 +19,7 @@ export class GitHubSettingsPresenter extends BasePresenter {
         connectedRepository: undefined,
         installations: undefined,
         isPreviewEnvironmentEnabled: undefined,
+        isStagingEnvironmentEnabled: undefined,
       });
     }
 
@@ -123,15 +124,41 @@ export class GitHubSettingsPresenter extends BasePresenter {
         })
       ).map((previewEnvironment) => previewEnvironment !== null);
 
+    const isStagingEnvironmentEnabled = () =>
+      fromPromise(
+        (this._replica as PrismaClient).runtimeEnvironment.findFirst({
+          select: {
+            id: true,
+          },
+          where: {
+            projectId: projectId,
+            slug: "stg",
+          },
+        }),
+        (error) => ({
+          type: "other" as const,
+          cause: error,
+        })
+      ).map((stagingEnvironment) => stagingEnvironment !== null);
+
     return ResultAsync.combine([
       isPreviewEnvironmentEnabled(),
+      isStagingEnvironmentEnabled(),
       findConnectedGithubRepository(),
       listGithubAppInstallations(),
-    ]).map(([isPreviewEnvironmentEnabled, connectedGithubRepository, githubAppInstallations]) => ({
-      enabled: true,
-      connectedRepository: connectedGithubRepository,
-      installations: githubAppInstallations,
-      isPreviewEnvironmentEnabled,
-    }));
+    ]).map(
+      ([
+        isPreviewEnvironmentEnabled,
+        isStagingEnvironmentEnabled,
+        connectedGithubRepository,
+        githubAppInstallations,
+      ]) => ({
+        enabled: true,
+        connectedRepository: connectedGithubRepository,
+        installations: githubAppInstallations,
+        isPreviewEnvironmentEnabled,
+        isStagingEnvironmentEnabled,
+      })
+    );
   }
 }

--- a/apps/webapp/app/presenters/v3/VercelSettingsPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/VercelSettingsPresenter.server.ts
@@ -182,6 +182,7 @@ export class VercelSettingsPresenter extends BasePresenter {
           where: {
             projectId,
             type: "STAGING",
+            parentEnvironmentId: null,
           },
         }),
         (error) => ({
@@ -199,6 +200,7 @@ export class VercelSettingsPresenter extends BasePresenter {
           where: {
             projectId,
             type: "PREVIEW",
+            parentEnvironmentId: null,
           },
         }),
         (error) => ({

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
@@ -223,6 +223,8 @@ export default function IntegrationsSettingsPage() {
   const loadVercelOnboarding = vercelFetcher.load;
   const onboardingData = vercelFetcher.data?.onboardingData ?? null;
   const hasVercelFetcherData = vercelFetcher.data !== undefined;
+  const onboardingDataUnavailable =
+    hasVercelFetcherData && vercelFetcher.state === "idle" && onboardingData === null;
   const vercelOnboardingPath = `${vercelResourcePath(
     organization.slug,
     project.slug,
@@ -407,6 +409,7 @@ export default function IntegrationsSettingsPage() {
           hasStagingEnvironment={vercelFetcher.data?.hasStagingEnvironment ?? false}
           hasPreviewEnvironment={vercelFetcher.data?.hasPreviewEnvironment ?? false}
           hasOrgIntegration={vercelFetcher.data?.hasOrgIntegration ?? false}
+          onboardingDataUnavailable={onboardingDataUnavailable}
           nextUrl={nextUrl ?? undefined}
           vercelManageAccessUrl={vercelFetcher.data?.vercelManageAccessUrl}
           onDataReload={(vercelEnvironmentId) => {

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
@@ -375,24 +375,24 @@ export default function IntegrationsSettingsPage() {
                 />
               </SettingsSection>
             )}
-
-            <SettingsSection>
-              <SettingsHeader
-                title="Build settings"
-                description={
-                  <>
-                    Applies to deployments triggered from GitHub, and CLI deployments run with the{" "}
-                    <InlineCode variant="extra-small" className="whitespace-nowrap">
-                      --native-build-server
-                    </InlineCode>{" "}
-                    flag.
-                  </>
-                }
-              />
-              <BuildSettingsForm buildSettings={buildSettings ?? {}} />
-            </SettingsSection>
           </>
         )}
+
+        <SettingsSection>
+          <SettingsHeader
+            title="Build settings"
+            description={
+              <>
+                Applies to deployments triggered from GitHub, and CLI deployments run with the{" "}
+                <InlineCode variant="extra-small" className="whitespace-nowrap">
+                  --native-build-server
+                </InlineCode>{" "}
+                flag.
+              </>
+            }
+          />
+          <BuildSettingsForm buildSettings={buildSettings ?? {}} />
+        </SettingsSection>
       </SettingsContainer>
 
       {/* Vercel Onboarding Modal */}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
@@ -59,8 +59,9 @@ export const loader = dashboardLoader(
   async ({ params, user, ability }) => {
     const { projectParam, organizationSlug } = params;
 
+    const canManageBuildSettings = ability.can("write", { type: "github" });
     const canManageIntegrations =
-      ability.can("write", { type: "github" }) || ability.can("write", { type: "vercel" });
+      canManageBuildSettings || ability.can("write", { type: "vercel" });
 
     if (!canManageIntegrations) {
       throwPermissionDenied("With your current role, you can't manage integrations.");
@@ -102,6 +103,7 @@ export const loader = dashboardLoader(
       githubAppEnabled: gitHubApp.enabled,
       buildSettings,
       vercelIntegrationEnabled: OrgIntegrationRepository.isVercelSupported,
+      canManageBuildSettings,
     });
   }
 );
@@ -208,7 +210,7 @@ export const action = dashboardAction(
 );
 
 export default function IntegrationsSettingsPage() {
-  const { githubAppEnabled, buildSettings, vercelIntegrationEnabled } =
+  const { githubAppEnabled, buildSettings, vercelIntegrationEnabled, canManageBuildSettings } =
     useTypedLoaderData<typeof loader>();
   const project = useProject();
   const organization = useOrganization();
@@ -393,7 +395,10 @@ export default function IntegrationsSettingsPage() {
               </>
             }
           />
-          <BuildSettingsForm buildSettings={buildSettings ?? {}} />
+          <BuildSettingsForm
+            buildSettings={buildSettings ?? {}}
+            canManageBuildSettings={canManageBuildSettings}
+          />
         </SettingsSection>
       </SettingsContainer>
 
@@ -427,7 +432,13 @@ export default function IntegrationsSettingsPage() {
   );
 }
 
-function BuildSettingsForm({ buildSettings }: { buildSettings: BuildSettings }) {
+function BuildSettingsForm({
+  buildSettings,
+  canManageBuildSettings = true,
+}: {
+  buildSettings: BuildSettings;
+  canManageBuildSettings?: boolean;
+}) {
   const lastSubmission = useActionData() as any;
   const navigation = useNavigation();
 
@@ -575,7 +586,12 @@ function BuildSettingsForm({ buildSettings }: { buildSettings: BuildSettings }) 
           name="action"
           value="update-build-settings"
           variant="secondary/small"
-          disabled={isBuildSettingsLoading || !hasBuildSettingsChanges}
+          disabled={isBuildSettingsLoading || !hasBuildSettingsChanges || !canManageBuildSettings}
+          tooltip={
+            canManageBuildSettings
+              ? undefined
+              : "You don't have permission to manage build settings"
+          }
           LeadingIcon={isBuildSettingsLoading ? SpinnerWhite : undefined}
         >
           Save

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.github.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.github.tsx
@@ -779,6 +779,7 @@ function GitHubSettingsRows({
 export function ConnectedGitHubRepoForm({
   connectedGitHubRepo,
   previewEnvironmentEnabled,
+  stagingEnvironmentEnabled,
   organizationSlug,
   projectSlug,
   environmentSlug,
@@ -788,6 +789,7 @@ export function ConnectedGitHubRepoForm({
 }: {
   connectedGitHubRepo: ConnectedGitHubRepo;
   previewEnvironmentEnabled?: boolean;
+  stagingEnvironmentEnabled?: boolean;
   organizationSlug: string;
   projectSlug: string;
   environmentSlug: string;
@@ -956,24 +958,42 @@ export function ConnectedGitHubRepoForm({
 
         <SettingsRow
           action={
-            <Input
-              {...getInputProps(fields.stagingBranch, { type: "text" })}
-              defaultValue={connectedGitHubRepo.branchTracking?.staging?.branch}
-              placeholder="none"
-              variant="medium"
-              className="font-mono"
-              containerClassName="w-64"
-              icon={GitBranchIcon}
-              onChange={(e) => {
-                setGitSettingsValues((prev) => ({
-                  ...prev,
-                  stagingBranch: e.target.value,
-                }));
-              }}
-            />
+            stagingEnvironmentEnabled ? (
+              <Input
+                {...getInputProps(fields.stagingBranch, { type: "text" })}
+                defaultValue={connectedGitHubRepo.branchTracking?.staging?.branch}
+                placeholder="none"
+                variant="medium"
+                className="font-mono"
+                containerClassName="w-64"
+                icon={GitBranchIcon}
+                onChange={(e) => {
+                  setGitSettingsValues((prev) => ({
+                    ...prev,
+                    stagingBranch: e.target.value,
+                  }));
+                }}
+              />
+            ) : (
+              <LinkButton
+                to={billingPath}
+                variant="secondary/small"
+                LeadingIcon={ArrowUpCircleIcon}
+                leadingIconClassName="text-indigo-500"
+              >
+                Upgrade
+              </LinkButton>
+            )
           }
         >
-          <EnvironmentRowLabel type="STAGING" />
+          <EnvironmentRowLabel
+            type="STAGING"
+            description={
+              stagingEnvironmentEnabled
+                ? undefined
+                : "Upgrade your plan to enable a Staging environment"
+            }
+          />
         </SettingsRow>
 
         <SettingsRow
@@ -1122,6 +1142,7 @@ export function GitHubSettingsPanel({
         <ConnectedGitHubRepoForm
           connectedGitHubRepo={data.connectedRepository}
           previewEnvironmentEnabled={data.isPreviewEnvironmentEnabled}
+          stagingEnvironmentEnabled={data.isStagingEnvironmentEnabled}
           organizationSlug={organizationSlug}
           projectSlug={projectSlug}
           environmentSlug={environmentSlug}

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.vercel.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.vercel.tsx
@@ -822,9 +822,15 @@ function ConnectedVercelProjectForm({
     hasPreviewEnvironment
   );
 
+  const hasVercelCustomEnvironments = customEnvironments.length > 0;
+
   const disabledEnvSlugsForBuildSettings: Partial<Record<EnvSlug, string>> | undefined =
     hasStagingEnvironment && !configValues.vercelStagingEnvironment
-      ? { stg: "Set a Vercel environment for Staging first." }
+      ? {
+          stg: hasVercelCustomEnvironments
+            ? "Set a Vercel environment for Staging first."
+            : "Add a custom environment to this project in Vercel to use Staging.",
+        }
       : undefined;
 
   return (
@@ -935,60 +941,68 @@ function ConnectedVercelProjectForm({
           ref={clearTriggerVersionInputRef}
         />
 
-        {/* Staging environment mapping */}
-        {hasStagingEnvironment && customEnvironments && customEnvironments.length > 0 && (
+        {hasStagingEnvironment && (
           <SettingsRow
             title="Vercel environment for Staging"
             description="Required to enable the Staging options below."
             action={
-              <div data-unlock-target="staging-env">
-                <Select
-                  value={configValues.vercelStagingEnvironment?.environmentId || ""}
-                  setValue={(value) => {
-                    if (!Array.isArray(value)) {
-                      const env = customEnvironments?.find((e) => e.id === value);
-                      setConfigValues((prev) => {
-                        const next = {
-                          ...prev,
-                          vercelStagingEnvironment: env
-                            ? { environmentId: env.id, displayName: env.slug }
-                            : null,
-                        };
-                        // When clearing the staging mapping, strip "stg" from build settings
-                        if (!env) {
-                          next.pullEnvVarsBeforeBuild = prev.pullEnvVarsBeforeBuild.filter(
-                            (s) => s !== "stg"
-                          );
-                          next.discoverEnvVars = prev.discoverEnvVars.filter((s) => s !== "stg");
-                        }
-                        return next;
-                      });
+              !hasVercelCustomEnvironments ? (
+                <Paragraph variant="extra-small" className="w-64">
+                  This Vercel project has no custom environments. Add one in Vercel under Settings{" "}
+                  &rarr; Environments, then reload this page.
+                </Paragraph>
+              ) : (
+                <div data-unlock-target="staging-env">
+                  <Select
+                    value={configValues.vercelStagingEnvironment?.environmentId || ""}
+                    setValue={(value) => {
+                      if (!Array.isArray(value)) {
+                        const env = customEnvironments?.find((e) => e.id === value);
+                        setConfigValues((prev) => {
+                          const next = {
+                            ...prev,
+                            vercelStagingEnvironment: env
+                              ? { environmentId: env.id, displayName: env.slug }
+                              : null,
+                          };
+                          // When clearing the staging mapping, strip "stg" from build settings
+                          if (!env) {
+                            next.pullEnvVarsBeforeBuild = prev.pullEnvVarsBeforeBuild.filter(
+                              (s) => s !== "stg"
+                            );
+                            next.discoverEnvVars = prev.discoverEnvVars.filter((s) => s !== "stg");
+                          }
+                          return next;
+                        });
+                      }
+                    }}
+                    items={[{ id: "", slug: "None" }, ...customEnvironments]}
+                    variant="secondary/small"
+                    placeholder="Select environment"
+                    dropdownIcon
+                    text={
+                      configValues.vercelStagingEnvironment ? (
+                        <StagingEnvOption
+                          name={configValues.vercelStagingEnvironment.displayName}
+                        />
+                      ) : (
+                        "None"
+                      )
                     }
-                  }}
-                  items={[{ id: "", slug: "None" }, ...customEnvironments]}
-                  variant="secondary/small"
-                  placeholder="Select environment"
-                  dropdownIcon
-                  text={
-                    configValues.vercelStagingEnvironment ? (
-                      <StagingEnvOption name={configValues.vercelStagingEnvironment.displayName} />
-                    ) : (
-                      "None"
-                    )
-                  }
-                >
-                  {[
-                    <SelectItem key="" value="">
-                      <span className="text-text-bright">None</span>
-                    </SelectItem>,
-                    ...customEnvironments.map((env) => (
-                      <SelectItem key={env.id} value={env.id}>
-                        <StagingEnvOption name={env.slug} />
-                      </SelectItem>
-                    )),
-                  ]}
-                </Select>
-              </div>
+                  >
+                    {[
+                      <SelectItem key="" value="">
+                        <span className="text-text-bright">None</span>
+                      </SelectItem>,
+                      ...customEnvironments.map((env) => (
+                        <SelectItem key={env.id} value={env.id}>
+                          <StagingEnvOption name={env.slug} />
+                        </SelectItem>
+                      )),
+                    ]}
+                  </Select>
+                </div>
+              )
             }
           />
         )}

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.vercel.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.vercel.tsx
@@ -1,6 +1,6 @@
 import { getFormProps, useForm } from "@conform-to/react";
 import { parseWithZod } from "@conform-to/zod";
-import { CheckCircleIcon, ExclamationTriangleIcon } from "@heroicons/react/20/solid";
+import { CheckCircleIcon } from "@heroicons/react/20/solid";
 import { DialogClose } from "@radix-ui/react-dialog";
 import { Form, useActionData, useFetcher, useLocation, useNavigation } from "@remix-run/react";
 import { type LoaderFunctionArgs, json } from "@remix-run/server-runtime";
@@ -1207,42 +1207,15 @@ function VercelSettingsPanel({
   const { load } = fetcher;
   const _location = useLocation();
   const data = fetcher.data;
-  const [hasError, _setHasError] = useState(false);
   const [hasFetched, setHasFetched] = useState(false);
 
   useEffect(() => {
-    if (!data?.authInvalid && !hasError && !data && !hasFetched) {
+    if (!data && !hasFetched) {
       load(vercelResourcePath(organizationSlug, projectSlug, environmentSlug));
       // oxlint-disable-next-line react/set-state-in-effect -- This effect intentionally synchronizes route state after an external or lifecycle change.
       setHasFetched(true);
     }
-  }, [
-    organizationSlug,
-    projectSlug,
-    environmentSlug,
-    data?.authInvalid,
-    hasError,
-    data,
-    hasFetched,
-    load,
-  ]);
-
-  if (hasError) {
-    return (
-      <div className="rounded-sm border border-rose-500/40 bg-rose-500/10 p-4">
-        <div className="flex items-start gap-3">
-          <ExclamationTriangleIcon className="h-5 w-5 shrink-0 text-rose-500" />
-          <div>
-            <p className="font-medium text-rose-400">Failed to load Vercel settings</p>
-            <p className="mt-1 text-sm text-rose-300">
-              There was an error loading the Vercel integration settings. Please refresh the page to
-              try again.
-            </p>
-          </div>
-        </div>
-      </div>
-    );
-  }
+  }, [organizationSlug, projectSlug, environmentSlug, data, hasFetched, load]);
 
   if (fetcher.state === "loading" && !data) {
     return (
@@ -1258,40 +1231,30 @@ function VercelSettingsPanel({
   }
 
   const showGitHubWarning = data.connectedProject && !data.isGitHubConnected;
-  const showAuthInvalid = data.authInvalid || data.onboardingData?.authInvalid;
 
   if (data.connectedProject) {
     return (
       <>
-        {showAuthInvalid && (
-          <VercelAuthInvalidBanner
-            organizationSlug={organizationSlug}
-            projectSlug={projectSlug}
-            canManageVercel={data.canManageVercel}
-          />
-        )}
         {showGitHubWarning && <VercelGitHubWarning />}
-        {!showAuthInvalid && <VercelAppInstalledRow />}
-        {!showAuthInvalid && (
-          <ConnectedVercelProjectForm
-            connectedProject={data.connectedProject}
-            hasStagingEnvironment={data.hasStagingEnvironment}
-            hasPreviewEnvironment={data.hasPreviewEnvironment}
-            customEnvironments={data.customEnvironments}
-            autoAssignCustomDomains={data.autoAssignCustomDomains ?? null}
-            currentTriggerVersion={data.currentTriggerVersion ?? null}
-            currentTriggerVersionFetchFailed={data.currentTriggerVersionFetchFailed ?? false}
-            organizationSlug={organizationSlug}
-            projectSlug={projectSlug}
-            environmentSlug={environmentSlug}
-            canManageVercel={data.canManageVercel}
-          />
-        )}
+        <VercelAppInstalledRow />
+        <ConnectedVercelProjectForm
+          connectedProject={data.connectedProject}
+          hasStagingEnvironment={data.hasStagingEnvironment}
+          hasPreviewEnvironment={data.hasPreviewEnvironment}
+          customEnvironments={data.customEnvironments}
+          autoAssignCustomDomains={data.autoAssignCustomDomains ?? null}
+          currentTriggerVersion={data.currentTriggerVersion ?? null}
+          currentTriggerVersionFetchFailed={data.currentTriggerVersionFetchFailed ?? false}
+          organizationSlug={organizationSlug}
+          projectSlug={projectSlug}
+          environmentSlug={environmentSlug}
+          canManageVercel={data.canManageVercel}
+        />
       </>
     );
   }
 
-  if (showAuthInvalid) {
+  if (data.authInvalid) {
     return (
       <VercelAuthInvalidBanner
         organizationSlug={organizationSlug}

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.vercel.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.vercel.tsx
@@ -2,7 +2,7 @@ import { getFormProps, useForm } from "@conform-to/react";
 import { parseWithZod } from "@conform-to/zod";
 import { CheckCircleIcon } from "@heroicons/react/20/solid";
 import { DialogClose } from "@radix-ui/react-dialog";
-import { Form, useActionData, useFetcher, useLocation, useNavigation } from "@remix-run/react";
+import { Form, useActionData, useFetcher, useNavigation } from "@remix-run/react";
 import { type LoaderFunctionArgs, json } from "@remix-run/server-runtime";
 import { Result, fromPromise } from "neverthrow";
 import { useEffect, useRef, useState } from "react";
@@ -62,7 +62,6 @@ import {
   type SyncEnvVarsMapping,
   type VercelProjectIntegrationData,
   envSlugArrayField,
-  getAvailableEnvSlugs,
   getAvailableEnvSlugsForBuildSettings,
 } from "~/v3/vercel/vercelProjectIntegrationSchema";
 import { sanitizeVercelNextUrl } from "~/v3/vercel/vercelUrls.server";
@@ -596,7 +595,6 @@ function VercelLoadingIcon() {
 function VercelSettingsRows({
   organizationSlug,
   projectSlug,
-  environmentSlug: _environmentSlug,
   hasOrgIntegration,
   isGitHubConnected,
   onOpenModal,
@@ -605,7 +603,6 @@ function VercelSettingsRows({
 }: {
   organizationSlug: string;
   projectSlug: string;
-  environmentSlug: string;
   hasOrgIntegration: boolean;
   isGitHubConnected: boolean;
   onOpenModal?: () => void;
@@ -698,19 +695,6 @@ function VercelGitHubWarning() {
   );
 }
 
-function envSlugLabel(slug: EnvSlug): string {
-  switch (slug) {
-    case "prod":
-      return "Production";
-    case "stg":
-      return "Staging";
-    case "preview":
-      return "Preview";
-    case "dev":
-      return "Development";
-  }
-}
-
 function ConnectedVercelProjectForm({
   connectedProject,
   hasStagingEnvironment,
@@ -774,7 +758,7 @@ function ConnectedVercelProjectForm({
     stagingEnvChanged ||
     autoPromoteChanged;
 
-  const [configForm, _fields] = useForm({
+  const [configForm] = useForm({
     id: "update-vercel-config",
     lastResult: lastSubmission,
     shouldRevalidate: "onSubmit",
@@ -833,7 +817,6 @@ function ConnectedVercelProjectForm({
 
   const actionUrl = vercelResourcePath(organizationSlug, projectSlug, environmentSlug);
 
-  const availableEnvSlugs = getAvailableEnvSlugs(hasStagingEnvironment, hasPreviewEnvironment);
   const availableEnvSlugsForBuildSettings = getAvailableEnvSlugsForBuildSettings(
     hasStagingEnvironment,
     hasPreviewEnvironment
@@ -843,15 +826,6 @@ function ConnectedVercelProjectForm({
     hasStagingEnvironment && !configValues.vercelStagingEnvironment
       ? { stg: "Set a Vercel environment for Staging first." }
       : undefined;
-
-  const _formatSelectedEnvs = (
-    selected: EnvSlug[],
-    availableSlugs: EnvSlug[] = availableEnvSlugs
-  ): string => {
-    if (selected.length === 0) return "None selected";
-    if (selected.length === availableSlugs.length) return "All environments";
-    return selected.map(envSlugLabel).join(", ");
-  };
 
   return (
     <>
@@ -1041,7 +1015,6 @@ function ConnectedVercelProjectForm({
           }
           currentTriggerVersion={currentTriggerVersion}
           currentTriggerVersionFetchFailed={currentTriggerVersionFetchFailed}
-          hideSectionToggles
           layout="settings"
         />
 
@@ -1205,7 +1178,6 @@ function VercelSettingsPanel({
 }) {
   const fetcher = useTypedFetcher<typeof loader>();
   const { load } = fetcher;
-  const _location = useLocation();
   const data = fetcher.data;
   const [hasFetched, setHasFetched] = useState(false);
 
@@ -1268,7 +1240,6 @@ function VercelSettingsPanel({
     <VercelSettingsRows
       organizationSlug={organizationSlug}
       projectSlug={projectSlug}
-      environmentSlug={environmentSlug}
       hasOrgIntegration={data.hasOrgIntegration}
       isGitHubConnected={data.isGitHubConnected}
       onOpenModal={onOpenVercelModal}

--- a/apps/webapp/app/services/projectSettings.server.ts
+++ b/apps/webapp/app/services/projectSettings.server.ts
@@ -322,7 +322,8 @@ export class ProjectSettingsService {
         },
         where: {
           projectId: projectId,
-          slug: "preview",
+          type: "PREVIEW",
+          parentEnvironmentId: null,
         },
       }),
       (error) => ({
@@ -340,7 +341,8 @@ export class ProjectSettingsService {
         },
         where: {
           projectId: projectId,
-          slug: "stg",
+          type: "STAGING",
+          parentEnvironmentId: null,
         },
       }),
       (error) => ({

--- a/apps/webapp/app/services/projectSettings.server.ts
+++ b/apps/webapp/app/services/projectSettings.server.ts
@@ -234,20 +234,25 @@ export class ProjectSettingsService {
     return getExistingConnectedRepo()
       .andThen((connectedRepo) => {
         const installationId = Number(connectedRepo.repository.installation.appInstallationId);
+        const oldStagingBranch = connectedRepo.branchTracking?.staging?.branch;
 
-        return ResultAsync.combine([
-          validateProductionBranch({
-            installationId,
-            fullRepoName: connectedRepo.repository.fullName,
-            oldProductionBranch: connectedRepo.branchTracking?.prod?.branch,
-          }),
-          validateStagingBranch({
-            installationId,
-            fullRepoName: connectedRepo.repository.fullName,
-            oldStagingBranch: connectedRepo.branchTracking?.staging?.branch,
-          }),
-          this.isPreviewEnvironmentEnabled(projectId),
-        ]);
+        return this.isStagingEnvironmentEnabled(projectId).andThen((stagingEnvironmentEnabled) =>
+          ResultAsync.combine([
+            validateProductionBranch({
+              installationId,
+              fullRepoName: connectedRepo.repository.fullName,
+              oldProductionBranch: connectedRepo.branchTracking?.prod?.branch,
+            }),
+            stagingEnvironmentEnabled
+              ? validateStagingBranch({
+                  installationId,
+                  fullRepoName: connectedRepo.repository.fullName,
+                  oldStagingBranch,
+                })
+              : okAsync(oldStagingBranch),
+            this.isPreviewEnvironmentEnabled(projectId),
+          ])
+        );
       })
       .map(([productionBranch, stagingBranch, previewEnvironmentEnabled]) => ({
         productionBranch,
@@ -325,5 +330,23 @@ export class ProjectSettingsService {
         cause: error,
       })
     ).map((previewEnvironment) => previewEnvironment !== null);
+  }
+
+  private isStagingEnvironmentEnabled(projectId: string) {
+    return fromPromise(
+      this.#prismaClient.runtimeEnvironment.findFirst({
+        select: {
+          id: true,
+        },
+        where: {
+          projectId: projectId,
+          slug: "stg",
+        },
+      }),
+      (error) => ({
+        type: "other" as const,
+        cause: error,
+      })
+    ).map((stagingEnvironment) => stagingEnvironment !== null);
   }
 }

--- a/apps/webapp/app/services/vercelIntegration.server.ts
+++ b/apps/webapp/app/services/vercelIntegration.server.ts
@@ -20,6 +20,8 @@ import {
   VercelProjectIntegrationDataSchema,
   envTypeToSlug,
   createDefaultVercelIntegrationData,
+  getAvailableEnvSlugs,
+  restrictConfigToAvailableEnvSlugs,
   SKEW_PROTECTION_ENV_VAR_KEY,
 } from "~/v3/vercel/vercelProjectIntegrationSchema";
 
@@ -129,6 +131,17 @@ export class VercelIntegrationService {
       .filter((i): i is VercelProjectIntegrationWithProject => i !== null);
   }
 
+  async #getAvailableEnvSlugs(projectId: string): Promise<EnvSlug[]> {
+    const environments = await this.#prismaClient.runtimeEnvironment.findMany({
+      where: { projectId, type: { in: ["STAGING", "PREVIEW"] }, parentEnvironmentId: null },
+      select: { type: true },
+    });
+
+    const types = new Set(environments.map((environment) => environment.type));
+
+    return getAvailableEnvSlugs(types.has("STAGING"), types.has("PREVIEW"));
+  }
+
   async createVercelProjectIntegration(params: {
     organizationIntegrationId: string;
     projectId: string;
@@ -142,7 +155,8 @@ export class VercelIntegrationService {
       params.vercelProjectId,
       params.vercelProjectName,
       params.vercelTeamId,
-      params.vercelTeamSlug
+      params.vercelTeamSlug,
+      await this.#getAvailableEnvSlugs(params.projectId)
     );
 
     return this.#prismaClient.organizationProjectIntegration.create({
@@ -182,6 +196,8 @@ export class VercelIntegrationService {
         (slug) => slug,
         () => undefined
       );
+
+    const availableEnvSlugs = await this.#getAvailableEnvSlugs(params.projectId);
 
     // Use a serializable transaction to prevent duplicate project integrations
     // from concurrent selectVercelProject calls (read-then-write race condition).
@@ -236,7 +252,8 @@ export class VercelIntegrationService {
           params.vercelProjectId,
           params.vercelProjectName,
           teamId,
-          vercelTeamSlug
+          vercelTeamSlug,
+          availableEnvSlugs
         );
 
         const created = await tx.organizationProjectIntegration.create({
@@ -320,7 +337,10 @@ export class VercelIntegrationService {
 
     const updatedConfig = {
       ...existing.parsedIntegrationData.config,
-      ...configUpdates,
+      ...restrictConfigToAvailableEnvSlugs(
+        configUpdates,
+        await this.#getAvailableEnvSlugs(projectId)
+      ),
     };
 
     const updatedData: VercelProjectIntegrationData = {
@@ -578,14 +598,20 @@ export class VercelIntegrationService {
       prod: {},
       preview: {},
     };
+    const availableEnvSlugs = await this.#getAvailableEnvSlugs(projectId);
     const updatedData: VercelProjectIntegrationData = {
       ...existing.parsedIntegrationData,
       config: {
         ...existing.parsedIntegrationData.config,
-        pullEnvVarsBeforeBuild: params.pullEnvVarsBeforeBuild ?? null,
-        atomicBuilds: params.atomicBuilds ?? null,
-        discoverEnvVars: params.discoverEnvVars ?? null,
-        vercelStagingEnvironment: params.vercelStagingEnvironment ?? null,
+        ...restrictConfigToAvailableEnvSlugs(
+          {
+            pullEnvVarsBeforeBuild: params.pullEnvVarsBeforeBuild ?? null,
+            atomicBuilds: params.atomicBuilds ?? null,
+            discoverEnvVars: params.discoverEnvVars ?? null,
+            vercelStagingEnvironment: params.vercelStagingEnvironment ?? null,
+          },
+          availableEnvSlugs
+        ),
       },
       //This is intentionally not updated here, in case of resetting the onboarding it should not override the existing mapping with an empty one
       syncEnvVarsMapping: existing.parsedIntegrationData.syncEnvVarsMapping,
@@ -610,7 +636,7 @@ export class VercelIntegrationService {
         projectId,
         vercelProjectId: updatedData.vercelProjectId,
         teamId,
-        vercelStagingEnvironment: params.vercelStagingEnvironment,
+        vercelStagingEnvironment: updatedData.config.vercelStagingEnvironment,
         syncEnvVarsMapping,
         orgIntegration,
       });

--- a/apps/webapp/app/v3/vercel/vercelProjectIntegrationSchema.ts
+++ b/apps/webapp/app/v3/vercel/vercelProjectIntegrationSchema.ts
@@ -85,13 +85,16 @@ export function createDefaultVercelIntegrationData(
   vercelProjectId: string,
   vercelProjectName: string,
   vercelTeamId: string | null,
-  vercelTeamSlug?: string
+  vercelTeamSlug?: string,
+  availableEnvSlugs: EnvSlug[] = ALL_ENV_SLUGS
 ): VercelProjectIntegrationData {
+  const defaultOn = (["prod", "preview"] as EnvSlug[]).filter((s) => availableEnvSlugs.includes(s));
+
   return {
     config: {
       atomicBuilds: [],
-      pullEnvVarsBeforeBuild: ["prod", "preview"],
-      discoverEnvVars: ["prod", "preview"],
+      pullEnvVarsBeforeBuild: defaultOn,
+      discoverEnvVars: defaultOn,
       vercelStagingEnvironment: null,
       autoPromote: true,
     },
@@ -140,6 +143,26 @@ export function getAvailableEnvSlugs(
     if (s === "preview" && !hasPreviewEnvironment) return false;
     return true;
   });
+}
+
+export function restrictConfigToAvailableEnvSlugs(
+  config: Partial<VercelIntegrationConfig>,
+  availableEnvSlugs: EnvSlug[]
+): Partial<VercelIntegrationConfig> {
+  const restricted = { ...config };
+
+  for (const key of ["atomicBuilds", "pullEnvVarsBeforeBuild", "discoverEnvVars"] as const) {
+    const slugs = restricted[key];
+    if (slugs) {
+      restricted[key] = slugs.filter((slug) => availableEnvSlugs.includes(slug));
+    }
+  }
+
+  if ("vercelStagingEnvironment" in restricted && !availableEnvSlugs.includes("stg")) {
+    restricted.vercelStagingEnvironment = null;
+  }
+
+  return restricted;
 }
 
 export function getAvailableEnvSlugsForBuildSettings(

--- a/apps/webapp/test/vercelIntegrationConfig.test.ts
+++ b/apps/webapp/test/vercelIntegrationConfig.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import {
+  createDefaultVercelIntegrationData,
+  restrictConfigToAvailableEnvSlugs,
+} from "../app/v3/vercel/vercelProjectIntegrationSchema";
+
+const STAGING_ENV = { environmentId: "env_123", displayName: "Staging" };
+
+describe("restrictConfigToAvailableEnvSlugs", () => {
+  it("drops slugs the project has no environment for", () => {
+    const restricted = restrictConfigToAvailableEnvSlugs(
+      {
+        atomicBuilds: ["prod", "stg"],
+        pullEnvVarsBeforeBuild: ["prod", "preview"],
+        discoverEnvVars: ["dev", "stg", "preview"],
+      },
+      ["dev", "prod"]
+    );
+
+    expect(restricted.atomicBuilds).toEqual(["prod"]);
+    expect(restricted.pullEnvVarsBeforeBuild).toEqual(["prod"]);
+    expect(restricted.discoverEnvVars).toEqual(["dev"]);
+  });
+
+  it("keeps slugs the project does have", () => {
+    const restricted = restrictConfigToAvailableEnvSlugs(
+      { atomicBuilds: ["prod", "stg", "preview"] },
+      ["dev", "stg", "prod", "preview"]
+    );
+
+    expect(restricted.atomicBuilds).toEqual(["prod", "stg", "preview"]);
+  });
+
+  it("only touches keys present on the input", () => {
+    const restricted = restrictConfigToAvailableEnvSlugs({ atomicBuilds: ["stg"] }, ["prod"]);
+
+    expect(restricted).not.toHaveProperty("pullEnvVarsBeforeBuild");
+    expect(restricted).not.toHaveProperty("discoverEnvVars");
+    expect(restricted).not.toHaveProperty("vercelStagingEnvironment");
+  });
+
+  it("clears the staging environment mapping when staging is unavailable", () => {
+    const restricted = restrictConfigToAvailableEnvSlugs(
+      { vercelStagingEnvironment: STAGING_ENV },
+      ["dev", "prod", "preview"]
+    );
+
+    expect(restricted.vercelStagingEnvironment).toBeNull();
+  });
+
+  it("keeps the staging environment mapping when staging is available", () => {
+    const restricted = restrictConfigToAvailableEnvSlugs(
+      { vercelStagingEnvironment: STAGING_ENV },
+      ["dev", "stg", "prod"]
+    );
+
+    expect(restricted.vercelStagingEnvironment).toEqual(STAGING_ENV);
+  });
+
+  it("does not mutate the input", () => {
+    const config = { atomicBuilds: ["prod", "stg"] as const };
+    restrictConfigToAvailableEnvSlugs({ atomicBuilds: [...config.atomicBuilds] }, ["prod"]);
+
+    expect(config.atomicBuilds).toEqual(["prod", "stg"]);
+  });
+});
+
+describe("createDefaultVercelIntegrationData", () => {
+  it("does not enable preview for a project without a preview environment", () => {
+    const data = createDefaultVercelIntegrationData("prj_1", "My project", null, undefined, [
+      "dev",
+      "prod",
+    ]);
+
+    expect(data.config.pullEnvVarsBeforeBuild).toEqual(["prod"]);
+    expect(data.config.discoverEnvVars).toEqual(["prod"]);
+  });
+
+  it("enables preview when the project has a preview environment", () => {
+    const data = createDefaultVercelIntegrationData("prj_1", "My project", null, undefined, [
+      "dev",
+      "stg",
+      "prod",
+      "preview",
+    ]);
+
+    expect(data.config.pullEnvVarsBeforeBuild).toEqual(["prod", "preview"]);
+    expect(data.config.discoverEnvVars).toEqual(["prod", "preview"]);
+  });
+
+  it("never turns atomic builds on by default", () => {
+    const data = createDefaultVercelIntegrationData("prj_1", "My project", null, undefined, [
+      "dev",
+      "stg",
+      "prod",
+      "preview",
+    ]);
+
+    expect(data.config.atomicBuilds).toEqual([]);
+    expect(data.config.vercelStagingEnvironment).toBeNull();
+  });
+});


### PR DESCRIPTION
Three bugs on the project integrations page, one commit each for the two reported ones and four for the follow-ups found while fixing them.

## `chore`: remove unreachable code on the integrations page (TRI-12645)

Two notification panels in `VercelSettingsPanel` could never render:

1. The **"Failed to load Vercel settings"** panel was gated on a `hasError` state whose setter is never called anywhere, so it was permanently `false`.
2. The **"connection expired"** banner *inside* the `connectedProject` branch was unreachable: `VercelSettingsPresenter` only populates `connectedProject` on its success exit, which hardcodes `authInvalid: false`, while both `authInvalid: true` exits return `connectedProject: undefined`.

Removing them makes the surrounding `!showAuthInvalid` guards vacuous, and the `onboardingData?.authInvalid` disjunct redundant — the loader already folds onboarding auth state into `authInvalid` before it reaches the component.

**No behaviour change.** An org with a connected project and an expired token still gets the banner, from the branch below (untouched).

## `fix`: gate Staging settings on plans without a Staging environment (TRI-12646)

The ticket's premise was inverted, and I've corrected it there. In Git settings, **Preview** is the row that's correctly gated; **Staging** is the one with no gate at all:

- Preview swaps its switch for an Upgrade button, and `projectSettings.server.ts` neutralises a forged `previewDeploymentsEnabled=on`.
- Staging was a plain always-editable `Input`, and `validateStagingBranch` only checked the branch existed on GitHub. An org without a staging environment could type a tracking branch, hit Save, get a success toast, and have it silently do nothing.

Staging and Preview environments are created together for projects on a plan that includes them, so gating one and not the other was an oversight.

The Staging row now mirrors the Preview row. Server-side it ignores the submitted branch when there's no staging environment, but **preserves the stored branch rather than clearing it** — deliberately different from the Preview handling. Forcing a boolean off is harmless; forcing a *string* off would wipe a tracking branch the org had already configured the first time they saved after losing the environment.

The Vercel write path had the same gap: `update-config` / `complete-onboarding` / `update-env-mapping` never re-derived available env slugs server-side, so `["stg","preview"]` could be persisted for a project with neither environment, and `createDefaultVercelIntegrationData` turned preview on unconditionally. Both now filter against the project's actual environments, via a pure `restrictConfigToAvailableEnvSlugs` helper that only touches keys present on the input.

## `fix`: show build settings when the GitHub app is disabled (TRI-13488)

The page wrapped Git settings, the Vercel section **and** build settings in one `githubAppEnabled` guard, so with the GitHub app off it rendered an empty container.

The Vercel section genuinely depends on GitHub — it can't sync environment variables or link deployments without a connected repo — so it stays gated. Build settings don't: they also apply to CLI deploys run with `--native-build-server`, exactly as the section's own description states. They now render regardless.

## `fix`: stop the Vercel onboarding modal spinning forever (TRI-13488)

`computeInitialState` starts in `loading-projects` whenever the org has a Vercel integration but no onboarding data yet, and the effect that escapes it waits for `availableProjects !== undefined`. When `getOnboardingData` returns `null` — it does that on any thrown error, and when the org integration row is missing — nothing ever arrives.

The empty-array case self-resolves (`[] !== undefined`), so this is specifically the null case. The route can tell "still loading" from "loaded nothing" because its fetcher always requests `?vercelOnboarding=true`; it now passes that down and the modal explains the failure with a retry and a link to check the integration's access on Vercel.

## `fix`: match staging and preview environments consistently (TRI-13488)

The four places that ask "does this project have a staging / preview environment?" disagreed. `VercelSettingsPresenter` matched on type with no parent filter, so any preview *branch* row satisfied it — branches are `PREVIEW` rows too. `GitHubSettingsPresenter` and `ProjectSettingsService` matched on slug instead.

Slug is the weaker key: it's derived at creation time and legacy rows can carry something else, which is why `memberDevelopmentEnvironmentWhere` deliberately avoids it. All four now match on `type` plus `parentEnvironmentId: null`, which excludes branches without depending on the slug being canonical.

## `fix`: explain when no Vercel environment can be mapped to Staging (TRI-13488)

Reported while reviewing the branch. The Staging build settings show *"Set a Vercel environment for Staging first."* whenever the project has a staging environment and no mapping — but the control that sets the mapping only rendered when the Vercel project had at least one custom environment:

```
hint:     hasStagingEnvironment && !configValues.vercelStagingEnvironment
control:  hasStagingEnvironment && customEnvironments.length > 0
```

So a Vercel project with no custom environments, or one whose custom environments failed to fetch (the presenter swallows that error to `[]`), got an instruction with nothing to act on. Both conditions predate this PR.

The mapping row now always renders alongside the hint and explains what to do when there's nothing to choose from, and the build-settings hint says the same thing.

## `chore`: remove the remaining dead code (TRI-13488)

- The `"installing"` `OnboardingState` is unproducible — no `setState` call yields it — so its redirect effect, switch arm, `isLoadingState` conjunct and the `vercelAppInstallPath` import it was the only user of are all dead.
- `(state as string) !== "completed"` sits in a branch where TypeScript has already narrowed `"completed"` out; the cast is what let it compile.
- `hideSectionToggles` was only ever passed alongside `layout="settings"` but only read inside `layout="card"` blocks, so it could never take effect. Removed the prop entirely.
- Unused bindings and the helpers only they referenced: `envSlugLabel`, `_formatSelectedEnvs`, `_CompleteOnboardingForm`, `_handleFinishOnboarding`, and the rest.

No behaviour change in that commit.

## Not included

The three overlapping modal-open effects in `settings.integrations/route.tsx` are left alone — they're defensive against a close-then-reopen race, and untangling them is a behavioural risk with no user-visible payoff.

## Verification

`pnpm run typecheck --filter webapp`, `pnpm run lint` and `pnpm run knip` are clean. New `apps/webapp/test/vercelIntegrationConfig.test.ts` covers the slug restriction and the default-config seeding (both pure functions); 39 tests pass across it and the three existing Vercel/project-settings files.

The new `projectId` + `slug` query is served by the existing `@@unique([projectId, slug, orgMemberId])` prefix — same access pattern as the preview check it mirrors.

refs TRI-12645, TRI-12646, TRI-13488
