### PR TITLE
feat(webapp): add org slug and project name to deployment telemetry events

### DIFF
--- a/apps/webapp/app/v3/deploymentTelemetry.ts
+++ b/apps/webapp/app/v3/deploymentTelemetry.ts
@@ -15,7 +15,9 @@ import { BuildServerMetadata } from "@trigger.dev/core/v3";
  */
 export const DeploymentTelemetryAttributes = {
   ORG_ID: "$trigger.org.id",
+  ORG_SLUG: "$trigger.org.slug",
   PROJECT_ID: "$trigger.project.id",
+  PROJECT_NAME: "$trigger.project.name",
   // Project external ref ("proj_…")
   PROJECT_REF: "$trigger.project.ref",
   ENV_ID: "$trigger.env.id",

--- a/apps/webapp/app/v3/services/createDeploymentBackgroundWorkerV4.server.ts
+++ b/apps/webapp/app/v3/services/createDeploymentBackgroundWorkerV4.server.ts
@@ -340,7 +340,9 @@ export class CreateDeploymentBackgroundWorkerServiceV4 extends BaseService {
         deployment: { ...deployment, status: "FAILED", failedAt, errorData },
         environment: {
           organizationId: environment.organizationId,
+          organizationSlug: environment.organization.slug,
           projectId: environment.projectId,
+          projectName: environment.project.name,
           projectRef: environment.project.externalRef,
           environmentId: environment.id,
           environmentType: environment.type,

--- a/apps/webapp/app/v3/services/deployment.server.ts
+++ b/apps/webapp/app/v3/services/deployment.server.ts
@@ -256,7 +256,9 @@ export class DeploymentService extends BaseService {
           },
           environment: {
             organizationId: deployment.environment.project.organizationId,
+            organizationSlug: deployment.environment.organization.slug,
             projectId: deployment.environment.project.id,
+            projectName: deployment.environment.project.name,
             projectRef: deployment.environment.project.externalRef,
             environmentId: deployment.environment.id,
             environmentType: deployment.environment.type,
@@ -519,9 +521,13 @@ export class DeploymentService extends BaseService {
               project: {
                 select: {
                   id: true,
+                  name: true,
                   organizationId: true,
                   externalRef: true,
                 },
+              },
+              organization: {
+                select: { slug: true },
               },
             },
           },

--- a/apps/webapp/app/v3/services/failDeployment.server.ts
+++ b/apps/webapp/app/v3/services/failDeployment.server.ts
@@ -83,7 +83,9 @@ export class FailDeploymentService extends BaseService {
       deployment: failedDeployment,
       environment: {
         organizationId: authenticatedEnv.organizationId,
+        organizationSlug: authenticatedEnv.organization.slug,
         projectId: authenticatedEnv.projectId,
+        projectName: authenticatedEnv.project.name,
         projectRef: authenticatedEnv.project.externalRef,
         environmentId: authenticatedEnv.id,
         environmentType: authenticatedEnv.type,

--- a/apps/webapp/app/v3/services/finalizeDeployment.server.ts
+++ b/apps/webapp/app/v3/services/finalizeDeployment.server.ts
@@ -106,7 +106,9 @@ export class FinalizeDeploymentService extends BaseService {
       deployment: finalizedDeployment,
       environment: {
         organizationId: authenticatedEnv.organizationId,
+        organizationSlug: authenticatedEnv.organization.slug,
         projectId: authenticatedEnv.projectId,
+        projectName: authenticatedEnv.project.name,
         projectRef: authenticatedEnv.project.externalRef,
         environmentId: authenticatedEnv.id,
         environmentType: authenticatedEnv.type,

--- a/apps/webapp/app/v3/services/initializeDeployment.server.ts
+++ b/apps/webapp/app/v3/services/initializeDeployment.server.ts
@@ -399,7 +399,9 @@ export class InitializeDeploymentService extends BaseService {
         deployment,
         environment: {
           organizationId: environment.organizationId,
+          organizationSlug: environment.organization.slug,
           projectId: environment.projectId,
+          projectName: environment.project.name,
           projectRef: environment.project.externalRef,
           environmentId: environment.id,
           environmentType: environment.type,

--- a/apps/webapp/app/v3/services/recordDeploymentFinished.server.ts
+++ b/apps/webapp/app/v3/services/recordDeploymentFinished.server.ts
@@ -37,7 +37,9 @@ type FinishedDeployment = Pick<
 
 type EnvironmentInfo = {
   organizationId?: string;
+  organizationSlug?: string;
   projectId?: string;
+  projectName?: string;
   projectRef?: string;
   environmentId?: string;
   environmentType?: string;
@@ -73,7 +75,9 @@ export function recordDeploymentFinished(params: {
         attributes: {
           [SEMINTATTRS_FORCE_RECORDING]: true,
           [ATTRS.ORG_ID]: environment.organizationId,
+          [ATTRS.ORG_SLUG]: environment.organizationSlug,
           [ATTRS.PROJECT_ID]: environment.projectId,
+          [ATTRS.PROJECT_NAME]: environment.projectName,
           [ATTRS.PROJECT_REF]: environment.projectRef,
           [ATTRS.ENV_ID]: environment.environmentId,
           [ATTRS.ENV_TYPE]: environment.environmentType,
@@ -147,7 +151,9 @@ export function recordDeploymentInitialized(params: {
         attributes: {
           [SEMINTATTRS_FORCE_RECORDING]: true,
           [ATTRS.ORG_ID]: environment.organizationId,
+          [ATTRS.ORG_SLUG]: environment.organizationSlug,
           [ATTRS.PROJECT_ID]: environment.projectId,
+          [ATTRS.PROJECT_NAME]: environment.projectName,
           [ATTRS.PROJECT_REF]: environment.projectRef,
           [ATTRS.ENV_ID]: environment.environmentId,
           [ATTRS.ENV_TYPE]: environment.environmentType,

--- a/apps/webapp/app/v3/services/timeoutDeployment.server.ts
+++ b/apps/webapp/app/v3/services/timeoutDeployment.server.ts
@@ -17,6 +17,9 @@ export class TimeoutDeploymentService extends BaseService {
         environment: {
           include: {
             project: true,
+            organization: {
+              select: { slug: true },
+            },
           },
         },
       },
@@ -76,7 +79,9 @@ export class TimeoutDeploymentService extends BaseService {
       deployment: timedOutDeployment,
       environment: {
         organizationId: deployment.environment.project.organizationId,
+        organizationSlug: deployment.environment.organization.slug,
         projectId: deployment.environment.projectId,
+        projectName: deployment.environment.project.name,
         projectRef: deployment.environment.project.externalRef,
         environmentId: deployment.environmentId,
         environmentType: deployment.environment.type,


### PR DESCRIPTION
Adds `$trigger.org.slug` and `$trigger.project.name` attributes to the `deployment.finished` / `deployment.initialized` events (follow-up to #4778).