### PR TITLE
fix(webapp): integrations page follow-ups — build settings visibility, onboarding spinner, dead code

### DIFF
--- a/apps/webapp/app/components/integrations/VercelBuildSettings.tsx
+++ b/apps/webapp/app/components/integrations/VercelBuildSettings.tsx
@@ -49,7 +49,6 @@ type BuildSettingsFieldsProps = {
    * the pin status is unknown — distinct from "not set". */
   currentTriggerVersionFetchFailed?: boolean;
   /** Hide the section-level master toggles for "Pull env vars" and "Discover new env vars". */
-  hideSectionToggles?: boolean;
   showAtomicDeployments?: boolean;
   layout?: "settings" | "card";
 };
@@ -68,7 +67,6 @@ export function BuildSettingsFields({
   onAutoPromoteChange,
   currentTriggerVersion,
   currentTriggerVersionFetchFailed,
-  hideSectionToggles,
   showAtomicDeployments = true,
   layout = "card",
 }: BuildSettingsFieldsProps) {
@@ -222,7 +220,7 @@ export function BuildSettingsFields({
           <div className="mb-2">
             <div className="flex items-center justify-between">
               <Label>Pull env vars before build</Label>
-              {!hideSectionToggles && availableEnvSlugs.length > 1 && (
+              {availableEnvSlugs.length > 1 && (
                 <Switch
                   variant="small"
                   checked={
@@ -292,7 +290,7 @@ export function BuildSettingsFields({
           <div className="mb-2">
             <div className="flex items-center justify-between">
               <Label>Discover new env vars</Label>
-              {!hideSectionToggles && availableEnvSlugs.length > 1 && (
+              {availableEnvSlugs.length > 1 && (
                 <Switch
                   variant="small"
                   checked={

--- a/apps/webapp/app/components/integrations/VercelOnboardingModal.tsx
+++ b/apps/webapp/app/components/integrations/VercelOnboardingModal.tsx
@@ -4,7 +4,7 @@ import {
   ChevronDownIcon,
   ChevronUpIcon,
 } from "@heroicons/react/20/solid";
-import { useFetcher, useNavigation, useSearchParams } from "@remix-run/react";
+import { useFetcher, useSearchParams } from "@remix-run/react";
 import { useTypedFetcher } from "remix-typedjson";
 import { Dialog, DialogContent, DialogHeader } from "~/components/primitives/Dialog";
 import { Button, LinkButton } from "~/components/primitives/Buttons";
@@ -34,13 +34,11 @@ import {
   type EnvSlug,
   ALL_ENV_SLUGS,
   shouldSyncEnvVarForAnyEnvironment,
-  getAvailableEnvSlugs,
   getAvailableEnvSlugsForBuildSettings,
 } from "~/v3/vercel/vercelProjectIntegrationSchema";
 import { type VercelCustomEnvironment } from "~/models/vercelIntegration.server";
 import { type VercelOnboardingData } from "~/presenters/v3/VercelSettingsPresenter.server";
 import {
-  vercelAppInstallPath,
   v3ProjectSettingsIntegrationsPath,
   githubAppInstallPath,
   vercelResourcePath,
@@ -78,7 +76,6 @@ function formatVercelTargets(targets: string[]): string {
 
 type OnboardingState =
   | "idle"
-  | "installing"
   | "loading-projects"
   | "project-selection"
   | "loading-env-mapping"
@@ -120,11 +117,9 @@ export function VercelOnboardingModal({
   vercelManageAccessUrl?: string;
 }) {
   const { capture, startSessionRecording } = usePostHogTracking();
-  const navigation = useNavigation();
   const fetcher = useTypedFetcher<typeof loader>();
   const envMappingFetcher = useFetcher();
   const completeOnboardingFetcher = useFetcher();
-  const { Form: _CompleteOnboardingForm } = completeOnboardingFetcher;
   const [searchParams] = useSearchParams();
   const origin = searchParams.get("origin");
   const fromMarketplaceContext = origin === "marketplace";
@@ -133,7 +128,6 @@ export function VercelOnboardingModal({
     () => onboardingData?.availableProjects ?? [],
     [onboardingData?.availableProjects]
   );
-  const _hasProjectSelected = onboardingData?.hasProjectSelected ?? false;
   const customEnvironments = useMemo(
     () => onboardingData?.customEnvironments ?? [],
     [onboardingData?.customEnvironments]
@@ -227,10 +221,6 @@ export function VercelOnboardingModal({
     environmentId: string;
     displayName: string;
   } | null>(null);
-  const _availableEnvSlugsForOnboarding = getAvailableEnvSlugs(
-    hasStagingEnvironment,
-    hasPreviewEnvironment
-  );
   const availableEnvSlugsForOnboardingBuildSettings = getAvailableEnvSlugsForBuildSettings(
     hasStagingEnvironment,
     hasPreviewEnvironment
@@ -378,7 +368,6 @@ export function VercelOnboardingModal({
         }
         break;
 
-      case "installing":
       case "project-selection":
       case "env-mapping":
       case "env-var-sync":
@@ -461,8 +450,6 @@ export function VercelOnboardingModal({
   );
 
   const overlappingEnvVarsCount = enabledEnvVars.filter((v) => existingVars[v.key]).length;
-
-  const _isSubmitting = navigation.state === "submitting" || navigation.state === "loading";
 
   const actionUrl = vercelResourcePath(organizationSlug, projectSlug, environmentSlug);
 
@@ -637,19 +624,6 @@ export function VercelOnboardingModal({
     gitHubAppInstallations.length,
   ]);
 
-  const _handleFinishOnboarding = useCallback(
-    (e: React.FormEvent<HTMLFormElement>) => {
-      e.preventDefault();
-      const form = e.currentTarget;
-      const formData = new FormData(form);
-      completeOnboardingFetcher.submit(formData, {
-        method: "post",
-        action: actionUrl,
-      });
-    },
-    [completeOnboardingFetcher, actionUrl]
-  );
-
   useEffect(() => {
     if (
       completeOnboardingFetcher.data &&
@@ -702,13 +676,6 @@ export function VercelOnboardingModal({
   }, [state, onClose, trackOnboarding, isGitHubConnectedForOnboarding]);
 
   useEffect(() => {
-    if (state === "installing") {
-      const installUrl = vercelAppInstallPath(organizationSlug, projectSlug);
-      window.location.href = installUrl;
-    }
-  }, [state, organizationSlug, projectSlug]);
-
-  useEffect(() => {
     if (
       envMappingFetcher.data &&
       typeof envMappingFetcher.data === "object" &&
@@ -752,7 +719,6 @@ export function VercelOnboardingModal({
     state === "loading-projects" ||
     state === "loading-env-mapping" ||
     state === "loading-env-vars" ||
-    state === "installing" ||
     (state === "idle" && !onboardingData);
 
   if (isLoadingState) {
@@ -761,9 +727,7 @@ export function VercelOnboardingModal({
         open={isOpen}
         onOpenChange={(open) => {
           if (!open && !fromMarketplaceContext) {
-            if ((state as string) !== "completed") {
-              trackOnboarding("vercel onboarding abandoned");
-            }
+            trackOnboarding("vercel onboarding abandoned");
             onClose();
           }
         }}
@@ -788,12 +752,7 @@ export function VercelOnboardingModal({
                   </Button>
                 )}
                 {vercelManageAccessUrl && (
-                  <LinkButton
-                    to={vercelManageAccessUrl}
-                    target="_blank"
-                    rel="noreferrer noopener"
-                    variant="tertiary/small"
-                  >
+                  <LinkButton to={vercelManageAccessUrl} target="_blank" variant="tertiary/small">
                     Manage access on Vercel
                   </LinkButton>
                 )}

--- a/apps/webapp/app/components/integrations/VercelOnboardingModal.tsx
+++ b/apps/webapp/app/components/integrations/VercelOnboardingModal.tsx
@@ -99,6 +99,7 @@ export function VercelOnboardingModal({
   hasStagingEnvironment,
   hasPreviewEnvironment,
   hasOrgIntegration,
+  onboardingDataUnavailable = false,
   nextUrl,
   onDataReload,
   vercelManageAccessUrl,
@@ -112,6 +113,8 @@ export function VercelOnboardingModal({
   hasStagingEnvironment: boolean;
   hasPreviewEnvironment: boolean;
   hasOrgIntegration: boolean;
+  /** The onboarding fetch settled without returning data - show an error instead of spinning. */
+  onboardingDataUnavailable?: boolean;
   nextUrl?: string;
   onDataReload?: (vercelStagingEnvironment?: string) => void;
   vercelManageAccessUrl?: string;
@@ -772,9 +775,35 @@ export function VercelOnboardingModal({
               <span>Set up Vercel Integration</span>
             </div>
           </DialogHeader>
-          <div className="flex items-center justify-center py-8">
-            <Spinner color="blue" className="size-6" />
-          </div>
+          {onboardingDataUnavailable ? (
+            <div className="flex flex-col items-start gap-3 py-4">
+              <Paragraph variant="small">
+                We couldn't load your Vercel projects. The integration may have been removed or lost
+                access to this organization on Vercel.
+              </Paragraph>
+              <div className="flex items-center gap-2">
+                {onDataReload && (
+                  <Button variant="secondary/small" onClick={() => onDataReload()}>
+                    Try again
+                  </Button>
+                )}
+                {vercelManageAccessUrl && (
+                  <LinkButton
+                    to={vercelManageAccessUrl}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    variant="tertiary/small"
+                  >
+                    Manage access on Vercel
+                  </LinkButton>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="flex items-center justify-center py-8">
+              <Spinner color="blue" className="size-6" />
+            </div>
+          )}
         </DialogContent>
       </Dialog>
     );

--- a/apps/webapp/app/presenters/v3/VercelSettingsPresenter.server.ts
+++ b/apps/webapp/app/presenters/v3/VercelSettingsPresenter.server.ts
@@ -173,6 +173,9 @@ export class VercelSettingsPresenter extends BasePresenter {
         })
       ).map((repo) => repo !== null);
 
+    // Match on slug, not type: preview branches are PREVIEW rows too, and only the
+    // branchable parent carries the "preview" slug. Keeps this in step with
+    // GitHubSettingsPresenter and ProjectSettingsService, which ask the same question.
     const checkStagingEnvironment = () =>
       fromPromise(
         (this._replica as PrismaClient).runtimeEnvironment.findFirst({
@@ -181,7 +184,7 @@ export class VercelSettingsPresenter extends BasePresenter {
           },
           where: {
             projectId,
-            type: "STAGING",
+            slug: "stg",
           },
         }),
         (error) => ({
@@ -198,7 +201,7 @@ export class VercelSettingsPresenter extends BasePresenter {
           },
           where: {
             projectId,
-            type: "PREVIEW",
+            slug: "preview",
           },
         }),
         (error) => ({

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
@@ -375,24 +375,26 @@ export default function IntegrationsSettingsPage() {
                 />
               </SettingsSection>
             )}
-
-            <SettingsSection>
-              <SettingsHeader
-                title="Build settings"
-                description={
-                  <>
-                    Applies to deployments triggered from GitHub, and CLI deployments run with the{" "}
-                    <InlineCode variant="extra-small" className="whitespace-nowrap">
-                      --native-build-server
-                    </InlineCode>{" "}
-                    flag.
-                  </>
-                }
-              />
-              <BuildSettingsForm buildSettings={buildSettings ?? {}} />
-            </SettingsSection>
           </>
         )}
+
+        {/* Build settings also drive CLI deploys, so they stay available when the
+            GitHub app is disabled and the Git/Vercel sections above are hidden. */}
+        <SettingsSection>
+          <SettingsHeader
+            title="Build settings"
+            description={
+              <>
+                Applies to deployments triggered from GitHub, and CLI deployments run with the{" "}
+                <InlineCode variant="extra-small" className="whitespace-nowrap">
+                  --native-build-server
+                </InlineCode>{" "}
+                flag.
+              </>
+            }
+          />
+          <BuildSettingsForm buildSettings={buildSettings ?? {}} />
+        </SettingsSection>
       </SettingsContainer>
 
       {/* Vercel Onboarding Modal */}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
@@ -223,6 +223,10 @@ export default function IntegrationsSettingsPage() {
   const loadVercelOnboarding = vercelFetcher.load;
   const onboardingData = vercelFetcher.data?.onboardingData ?? null;
   const hasVercelFetcherData = vercelFetcher.data !== undefined;
+  // The fetcher always requests `?vercelOnboarding=true`, so a settled load with no
+  // onboardingData means the presenter returned null - not that we simply didn't ask.
+  const onboardingDataUnavailable =
+    hasVercelFetcherData && vercelFetcher.state === "idle" && onboardingData === null;
   const vercelOnboardingPath = `${vercelResourcePath(
     organization.slug,
     project.slug,
@@ -409,6 +413,7 @@ export default function IntegrationsSettingsPage() {
           hasStagingEnvironment={vercelFetcher.data?.hasStagingEnvironment ?? false}
           hasPreviewEnvironment={vercelFetcher.data?.hasPreviewEnvironment ?? false}
           hasOrgIntegration={vercelFetcher.data?.hasOrgIntegration ?? false}
+          onboardingDataUnavailable={onboardingDataUnavailable}
           nextUrl={nextUrl ?? undefined}
           vercelManageAccessUrl={vercelFetcher.data?.vercelManageAccessUrl}
           onDataReload={(vercelEnvironmentId) => {

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.vercel.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.vercel.tsx
@@ -2,7 +2,7 @@ import { getFormProps, useForm } from "@conform-to/react";
 import { parseWithZod } from "@conform-to/zod";
 import { CheckCircleIcon } from "@heroicons/react/20/solid";
 import { DialogClose } from "@radix-ui/react-dialog";
-import { Form, useActionData, useFetcher, useLocation, useNavigation } from "@remix-run/react";
+import { Form, useActionData, useFetcher, useNavigation } from "@remix-run/react";
 import { type LoaderFunctionArgs, json } from "@remix-run/server-runtime";
 import { Result, fromPromise } from "neverthrow";
 import { useEffect, useRef, useState } from "react";
@@ -62,7 +62,6 @@ import {
   type SyncEnvVarsMapping,
   type VercelProjectIntegrationData,
   envSlugArrayField,
-  getAvailableEnvSlugs,
   getAvailableEnvSlugsForBuildSettings,
 } from "~/v3/vercel/vercelProjectIntegrationSchema";
 import { sanitizeVercelNextUrl } from "~/v3/vercel/vercelUrls.server";
@@ -596,7 +595,6 @@ function VercelLoadingIcon() {
 function VercelSettingsRows({
   organizationSlug,
   projectSlug,
-  environmentSlug: _environmentSlug,
   hasOrgIntegration,
   isGitHubConnected,
   onOpenModal,
@@ -605,7 +603,6 @@ function VercelSettingsRows({
 }: {
   organizationSlug: string;
   projectSlug: string;
-  environmentSlug: string;
   hasOrgIntegration: boolean;
   isGitHubConnected: boolean;
   onOpenModal?: () => void;
@@ -698,19 +695,6 @@ function VercelGitHubWarning() {
   );
 }
 
-function envSlugLabel(slug: EnvSlug): string {
-  switch (slug) {
-    case "prod":
-      return "Production";
-    case "stg":
-      return "Staging";
-    case "preview":
-      return "Preview";
-    case "dev":
-      return "Development";
-  }
-}
-
 function ConnectedVercelProjectForm({
   connectedProject,
   hasStagingEnvironment,
@@ -774,7 +758,7 @@ function ConnectedVercelProjectForm({
     stagingEnvChanged ||
     autoPromoteChanged;
 
-  const [configForm, _fields] = useForm({
+  const [configForm] = useForm({
     id: "update-vercel-config",
     lastResult: lastSubmission,
     shouldRevalidate: "onSubmit",
@@ -833,7 +817,6 @@ function ConnectedVercelProjectForm({
 
   const actionUrl = vercelResourcePath(organizationSlug, projectSlug, environmentSlug);
 
-  const availableEnvSlugs = getAvailableEnvSlugs(hasStagingEnvironment, hasPreviewEnvironment);
   const availableEnvSlugsForBuildSettings = getAvailableEnvSlugsForBuildSettings(
     hasStagingEnvironment,
     hasPreviewEnvironment
@@ -843,15 +826,6 @@ function ConnectedVercelProjectForm({
     hasStagingEnvironment && !configValues.vercelStagingEnvironment
       ? { stg: "Set a Vercel environment for Staging first." }
       : undefined;
-
-  const _formatSelectedEnvs = (
-    selected: EnvSlug[],
-    availableSlugs: EnvSlug[] = availableEnvSlugs
-  ): string => {
-    if (selected.length === 0) return "None selected";
-    if (selected.length === availableSlugs.length) return "All environments";
-    return selected.map(envSlugLabel).join(", ");
-  };
 
   return (
     <>
@@ -1041,7 +1015,6 @@ function ConnectedVercelProjectForm({
           }
           currentTriggerVersion={currentTriggerVersion}
           currentTriggerVersionFetchFailed={currentTriggerVersionFetchFailed}
-          hideSectionToggles
           layout="settings"
         />
 
@@ -1205,7 +1178,6 @@ function VercelSettingsPanel({
 }) {
   const fetcher = useTypedFetcher<typeof loader>();
   const { load } = fetcher;
-  const _location = useLocation();
   const data = fetcher.data;
   const [hasFetched, setHasFetched] = useState(false);
 
@@ -1270,7 +1242,6 @@ function VercelSettingsPanel({
     <VercelSettingsRows
       organizationSlug={organizationSlug}
       projectSlug={projectSlug}
-      environmentSlug={environmentSlug}
       hasOrgIntegration={data.hasOrgIntegration}
       isGitHubConnected={data.isGitHubConnected}
       onOpenModal={onOpenVercelModal}


### PR DESCRIPTION
Stacked on #4784. Clears TRI-13488, the follow-ups found while fixing James's two tickets.

## `fix`: show build settings when the GitHub app is disabled

The page wrapped Git settings, the Vercel section **and** build settings in one `githubAppEnabled` guard, so with the GitHub app off it rendered an empty container.

Item 3 turned out narrower than the ticket described. The Vercel section genuinely depends on GitHub — it can't sync environment variables or link deployments without a connected repo, which is what `VercelGitHubWarning` says — so it stays gated. Build settings don't: they also apply to CLI deploys run with `--native-build-server`, exactly as the section's own description states. They now render regardless.

## `fix`: stop the Vercel onboarding modal spinning forever

`computeInitialState` starts in `loading-projects` whenever the org has a Vercel integration but no onboarding data yet, and the effect that escapes it waits for `availableProjects !== undefined`. When `getOnboardingData` returns `null` — it does that on any thrown error, and when the org integration row is missing — nothing ever arrives.

The empty-array case self-resolves (`[] !== undefined`), so this is specifically the null case. The route can tell "still loading" from "loaded nothing" because its fetcher always requests `?vercelOnboarding=true`; it now passes that down and the modal explains the failure with a retry and a link to check the integration's access on Vercel.

## `fix`: match preview environment on slug, not type

`VercelSettingsPresenter` asked for a `PREVIEW`-typed environment with no parent filter, so any preview *branch* row satisfied it — branches are `PREVIEW` rows too. `GitHubSettingsPresenter` and `ProjectSettingsService` ask via the `"preview"` slug, which only the branchable parent carries, so two presenters feeding the same page could disagree. All four checks now match on slug.

## `chore`: remove the remaining dead code

Continues the sweep from the parent branch:

- The `"installing"` `OnboardingState` is unproducible — no `setState` call yields it — so its redirect effect, switch arm, `isLoadingState` conjunct and the `vercelAppInstallPath` import it was the only user of are all dead.
- `(state as string) !== "completed"` sits in a branch where TypeScript has already narrowed `"completed"` out; the cast is what let it compile.
- `hideSectionToggles` was only ever passed alongside `layout="settings"` but only read inside `layout="card"` blocks, so it could never take effect. Removed the prop entirely.
- Unused bindings and the helpers only they referenced: `envSlugLabel`, `_formatSelectedEnvs`, `_CompleteOnboardingForm`, `_handleFinishOnboarding`, and the rest.

No behaviour change in that commit.

## Not included

Per Oskar, the three overlapping modal-open effects in `settings.integrations/route.tsx` are left alone — they're defensive against a close-then-reopen race, and untangling them is a behavioural risk with no user-visible payoff.

## Verification

`pnpm run typecheck --filter webapp`, `pnpm run lint` and `pnpm run knip` are clean, and the four Vercel/project-settings test files pass (39 tests). The one `vite.config.ts` duplicate-`allowedHosts` error in my local output is pre-existing and comes from an unrelated branch in my workspace, not this diff.

No changeset or `.server-changes/` note: the build-settings visibility fix and the spinner fix only bite when the GitHub app is disabled or the Vercel integration has broken, and the rest is internal.

refs TRI-13488
