### PR TITLE
feat: recognize OrcaRouter as a named AI provider in dashboard analytics

### DIFF
--- a/.server-changes/orcarouter-ai-runs-provider-and-cost.md
+++ b/.server-changes/orcarouter-ai-runs-provider-and-cost.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: feature
+---
+
+AI runs that go through OrcaRouter now show the correct downstream model provider and usage cost in the dashboard, just like OpenRouter runs.

--- a/apps/webapp/app/components/metrics/ModelsFilter.tsx
+++ b/apps/webapp/app/components/metrics/ModelsFilter.tsx
@@ -28,9 +28,9 @@ interface ModelsFilterProps {
 }
 
 function modelIcon(system: string, model: string): ReactNode {
-  // For gateway/openrouter, derive provider from model prefix
+  // For gateway/openrouter/orcarouter, derive provider from model prefix
   let provider = system.split(".")[0];
-  if (provider === "gateway" || provider === "openrouter") {
+  if (provider === "gateway" || provider === "openrouter" || provider === "orcarouter") {
     if (model.includes("/")) {
       provider = model.split("/")[0].replace(/-/g, "");
     }

--- a/apps/webapp/app/components/runs/v3/ai/aiHelpers.ts
+++ b/apps/webapp/app/components/runs/v3/ai/aiHelpers.ts
@@ -30,7 +30,7 @@ export function formatDuration(ms: number): string {
 
 /**
  * Parse provider metadata from a JSON string.
- * Handles Anthropic, Azure, OpenAI, Gateway, and OpenRouter formats.
+ * Handles Anthropic, Azure, OpenAI, Gateway, OpenRouter, and OrcaRouter formats.
  */
 export function parseProviderMetadata(raw: unknown):
   | {
@@ -72,6 +72,11 @@ export function parseProviderMetadata(raw: unknown):
     // OpenRouter: { openrouter: { provider: "xAI" } }
     if (!resolvedProvider) {
       resolvedProvider = str(rec(parsed.openrouter).provider);
+    }
+
+    // OrcaRouter: { orcarouter: { provider: "xAI" } } — same shape as OpenRouter
+    if (!resolvedProvider) {
+      resolvedProvider = str(rec(parsed.orcarouter).provider);
     }
 
     if (!serviceTier && !resolvedProvider && !gatewayCost && !responseId) return undefined;

--- a/apps/webapp/app/components/runs/v3/ai/types.ts
+++ b/apps/webapp/app/components/runs/v3/ai/types.ts
@@ -72,7 +72,7 @@ export type AISpanData = {
   // Categorical tags
   finishReason?: string;
   serviceTier?: string;
-  /** Resolved downstream provider for gateway/openrouter spans (e.g. "xAI", "mistral") */
+  /** Resolved downstream provider for gateway/openrouter/orcarouter spans (e.g. "xAI", "mistral") */
   resolvedProvider?: string;
   toolChoice?: string;
   toolCount?: number;

--- a/apps/webapp/app/routes/admin.llm-models.missing.$model.tsx
+++ b/apps/webapp/app/routes/admin.llm-models.missing.$model.tsx
@@ -292,7 +292,7 @@ function getNestedObj(
 // ---------------------------------------------------------------------------
 
 type ProviderCostInfo = {
-  source: string; // "gateway" or "openrouter"
+  source: string; // "gateway", "openrouter", or "orcarouter"
   cost: number;
   inputTokens: number;
   outputTokens: number;
@@ -347,6 +347,17 @@ function extractProviderCosts(samples: MissingModelSample[]): ProviderCostInfo[]
       const cost = Number(orUsage.cost ?? 0);
       if (cost > 0) {
         costs.push({ source: "openrouter", cost, inputTokens, outputTokens });
+        continue;
+      }
+    }
+
+    // OrcaRouter: { orcarouter: { usage: { cost: 4.94e-06 } } } — same shape as OpenRouter
+    const orc = getNestedObj(providerMeta, ["orcarouter"]);
+    const orcUsage = orc ? getNestedObj(orc, ["usage"]) : null;
+    if (orcUsage) {
+      const cost = Number(orcUsage.cost ?? 0);
+      if (cost > 0) {
+        costs.push({ source: "orcarouter", cost, inputTokens, outputTokens });
         continue;
       }
     }

--- a/apps/webapp/app/services/admin/missingLlmModels.server.ts
+++ b/apps/webapp/app/services/admin/missingLlmModels.server.ts
@@ -73,7 +73,7 @@ export async function getMissingLlmModels(
   if (candidates.length === 0) return [];
 
   // Filter out models that now have pricing in the database (added after spans were inserted).
-  // The registry's match() handles prefix stripping for gateway/openrouter models.
+  // The registry's match() handles prefix stripping for gateway/openrouter/orcarouter models.
   if (!llmPricingRegistry || !llmPricingRegistry.isLoaded) return candidates;
   const registry = llmPricingRegistry;
   return candidates.filter((c) => !registry.match(c.model));

--- a/apps/webapp/app/v3/querySchemas.ts
+++ b/apps/webapp/app/v3/querySchemas.ts
@@ -1039,7 +1039,7 @@ const llmMetricsSchema: TableSchema = {
     cost_source: {
       name: "cost_source",
       ...column("LowCardinality(String)", {
-        description: "Where cost data came from (registry, gateway, openrouter)",
+        description: "Where cost data came from (registry, gateway, openrouter, orcarouter)",
         example: "registry",
       }),
     },
@@ -1133,7 +1133,7 @@ const llmMetricsSchema: TableSchema = {
     provider_cost: {
       name: "provider_cost",
       ...column("Decimal64(12)", {
-        description: "Provider-reported cost in USD (from gateway or openrouter)",
+        description: "Provider-reported cost in USD (from gateway, openrouter, or orcarouter)",
         customRenderType: "costInDollars",
       }),
     },

--- a/apps/webapp/app/v3/utils/enrichCreatableEvents.server.test.ts
+++ b/apps/webapp/app/v3/utils/enrichCreatableEvents.server.test.ts
@@ -156,6 +156,27 @@ describe("enrichLlmMetrics — provider-reported cost", () => {
     expect(out.properties["trigger.llm.cost_source"]).toBe("openrouter");
   });
 
+  it("prefers the orcarouter-reported cost over catalog pricing", () => {
+    setLlmPricingRegistry(registryReturning(catalogCost({ totalCost: 0.02 })));
+
+    const out = enrichOne(
+      makeEvent({
+        "gen_ai.system": "orcarouter",
+        "gen_ai.request.model": "orcarouter/fusion-flash",
+        "gen_ai.response.model": "openai/gpt-oss-120b",
+        "gen_ai.usage.input_tokens": 74,
+        "gen_ai.usage.output_tokens": 16,
+        "ai.response.providerMetadata": JSON.stringify({
+          orcarouter: { provider: "OpenAI", usage: { cost: 0.00000494 } },
+        }),
+      })
+    );
+
+    expect(out.properties["trigger.llm.total_cost"]).toBe(0.00000494);
+    expect(out.properties["trigger.llm.cost_source"]).toBe("orcarouter");
+    expect(out._llmMetrics?.costSource).toBe("orcarouter");
+  });
+
   it("falls back to catalog pricing when no provider cost is reported", () => {
     setLlmPricingRegistry(
       registryReturning(

--- a/apps/webapp/app/v3/utils/enrichCreatableEvents.server.ts
+++ b/apps/webapp/app/v3/utils/enrichCreatableEvents.server.ts
@@ -372,6 +372,17 @@ function extractProviderCost(
     }
   }
 
+  // OrcaRouter: { orcarouter: { usage: { cost: 4.94e-06 } } } — same shape as OpenRouter
+  const orcarouter = meta.orcarouter;
+  if (orcarouter && typeof orcarouter === "object") {
+    const orc = orcarouter as Record<string, unknown>;
+    const usage = orc.usage;
+    if (usage && typeof usage === "object") {
+      const cost = Number((usage as Record<string, unknown>).cost ?? 0);
+      if (cost > 0) return { totalCost: cost, source: "orcarouter" };
+    }
+  }
+
   return null;
 }
 


### PR DESCRIPTION
Trigger.dev is the open-source platform for building AI workflows in TypeScript, and its run analytics already treats OpenAI-compatible gateways as first-class citizens: OpenRouter spans get a resolved downstream provider, provider-reported usage cost, and a model-filter icon derived from the model prefix.

This PR gives [OrcaRouter](https://www.orcarouter.ai) the same treatment. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The changes mirror the existing `openrouter` handling in four spots:

- `aiHelpers.ts`: resolve `resolvedProvider` from `orcarouter.provider` span metadata
- `enrichCreatableEvents.server.ts` + `admin.llm-models.missing.$model.tsx`: extract `orcarouter.usage.cost` as provider-reported cost
- `ModelsFilter.tsx`: derive the model-filter icon from the model prefix for `orcarouter`
- added a unit test mirroring the OpenRouter cost-preference case

**Verification**

- [x] `oxfmt --check` and `oxlint` clean on all changed files
- [x] New unit test for orcarouter cost extraction (mirrors existing openrouter tests)
- [x] Live-tested the OrcaRouter endpoint: `GET /v1/models` and `POST /v1/chat/completions` return 200, with usage cost in provider metadata

I'm an engineer on the OrcaRouter team.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter