### PR TITLE
ci(publish): skip publish for packages not built into the images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,18 @@ on:
       - "packages/**"
       - "!packages/**/*.md"
       - "!packages/**/*.eslintrc"
+      # CLI + libraries published to npm; none are built into the webapp/supervisor images.
+      - "!packages/cli-v3/**"
+      - "!packages/build/**"
+      - "!packages/python/**"
+      - "!packages/react-hooks/**"
+      - "!packages/rsc/**"
+      - "!packages/schema-to-json/**"
       - "internal-packages/**"
+      # Test/tooling-only internal packages, never in an image.
+      - "!internal-packages/testcontainers/**"
+      - "!internal-packages/sdk-compat-tests/**"
+      - "!internal-packages/observability-map/**"
       - "apps/**"
       - "!apps/**/*.md"
       - "!apps/**/*.eslintrc"


### PR DESCRIPTION
`publish.yml` builds the webapp and worker/supervisor images (and dispatches the enterprise-image build off the webapp). It currently triggers on all of `packages/**` and `internal-packages/**`, so a change confined to a package that never lands in those images still publishes new images.

This adds `paths` negations for packages that are not built into either image:

- **packages** (npm-only libraries / CLI): `cli-v3`, `build`, `python`, `react-hooks`, `rsc`, `schema-to-json`
- **internal-packages** (test/tooling only): `testcontainers`, `sdk-compat-tests`, `observability-map`