### PR TITLE
feat(run-engine): queue gates enforced from the message payload

### DIFF
--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -1398,6 +1398,7 @@ const EnvironmentSchema = z
       .enum(["log", "error", "warn", "info", "debug"])
       .default("info"),
     RUN_ENGINE_TOTAL_CONCURRENCY_LIMITS_ENABLED: z.string().default("1"),
+    RUN_ENGINE_QUEUE_GATES_ENABLED: z.string().default("0"),
     RUN_ENGINE_TREAT_PRODUCTION_EXECUTION_STALLS_AS_OOM: z.string().default("0"),
     RUN_ENGINE_READ_REPLICA_SNAPSHOTS_SINCE_ENABLED: z.string().default("0"),
     RUN_ENGINE_SNAPSHOTS_SINCE_REPLICA_RETRY_MIN_MS: z.coerce.number().int().default(50),

--- a/apps/webapp/app/v3/runEngine.server.ts
+++ b/apps/webapp/app/v3/runEngine.server.ts
@@ -63,6 +63,7 @@ function createRunEngine() {
       defaultEnvConcurrency: env.DEFAULT_ENV_EXECUTION_CONCURRENCY_LIMIT,
       defaultEnvConcurrencyBurstFactor: env.DEFAULT_ENV_EXECUTION_CONCURRENCY_BURST_FACTOR,
       totalConcurrencyEnabled: env.RUN_ENGINE_TOTAL_CONCURRENCY_LIMITS_ENABLED === "1",
+      gatesEnabled: env.RUN_ENGINE_QUEUE_GATES_ENABLED === "1",
       logLevel: env.RUN_ENGINE_RUN_QUEUE_LOG_LEVEL,
       redis: {
         keyPrefix: "engine:",

--- a/internal-packages/run-engine/src/engine/index.ts
+++ b/internal-packages/run-engine/src/engine/index.ts
@@ -210,6 +210,7 @@ export class RunEngine {
       defaultEnvConcurrency: options.queue?.defaultEnvConcurrency ?? 10,
       defaultEnvConcurrencyBurstFactor: options.queue?.defaultEnvConcurrencyBurstFactor,
       totalConcurrencyEnabled: options.queue?.totalConcurrencyEnabled,
+      gatesEnabled: options.queue?.gatesEnabled,
       logger: new Logger("RunQueue", options.queue?.logLevel ?? "info"),
       redis: { ...options.queue.redis, keyPrefix: `${options.queue.redis.keyPrefix}runqueue:` },
       retryOptions: options.queue?.retryOptions,

--- a/internal-packages/run-engine/src/engine/types.ts
+++ b/internal-packages/run-engine/src/engine/types.ts
@@ -93,6 +93,8 @@ export type RunEngineOptions = {
     logLevel?: LogLevel;
     /** Enforce per-queue total concurrency limits across concurrency-key variants. See RunQueueOptions.totalConcurrencyEnabled. */
     totalConcurrencyEnabled?: boolean;
+    /** Enforce the gates carried in message payloads. See RunQueueOptions.gatesEnabled. */
+    gatesEnabled?: boolean;
     /** Optional queue-metrics emitter; enables gauge + counter emission from the RunQueue. */
     queueMetrics?: RunQueueMetricsEmitter;
     queueSelectionStrategyOptions?: Pick<

--- a/internal-packages/run-engine/src/run-queue/index.ts
+++ b/internal-packages/run-engine/src/run-queue/index.ts
@@ -74,11 +74,15 @@ const SemanticAttributes = {
 const QUEUE_GATES_LUA_HELPERS = `
 local function __gateKeys(gatesKeyPrefix, msg, gate)
   local base = gatesKeyPrefix .. '{org:' .. msg.orgId .. '}:proj:' .. msg.projectId .. ':env:' .. msg.environmentId .. ':queue:' .. gate.queue
-  local variant = base
-  if gate.concurrencyKey and gate.concurrencyKey ~= '' then
-    variant = base .. ':ck:' .. gate.concurrencyKey
+  local gateKey = gate.concurrencyKey
+  if (not gateKey or gateKey == '') and msg.concurrencyKey and msg.concurrencyKey ~= '' then
+    gateKey = msg.concurrencyKey
   end
-  return base, variant
+  local variant = base
+  if gateKey and gateKey ~= '' then
+    variant = base .. ':ck:' .. gateKey
+  end
+  return base, variant, gateKey
 end
 
 local function __gateReconcile(setKey, msgKeyPrefix)
@@ -96,22 +100,23 @@ local function __gateReconcile(setKey, msgKeyPrefix)
   end
 end
 
-local function __gatesHaveCapacity(gatesKeyPrefix, msg, envLimit, msgKeyPrefix)
+local function __gatesHaveCapacity(gatesKeyPrefix, msg, messageId, envLimit, msgKeyPrefix)
   if not msg.gates then return true end
   for _, gate in ipairs(msg.gates) do
-    local base, variant = __gateKeys(gatesKeyPrefix, msg, gate)
+    local base, variant, gateKey = __gateKeys(gatesKeyPrefix, msg, gate)
     local occupancy = tonumber(redis.call('SCARD', variant .. ':currentConcurrency') or '0')
     local perKeyLimit = math.min(tonumber(redis.call('GET', base .. ':concurrency') or '1000000'), envLimit)
-    if occupancy >= perKeyLimit then
+    if occupancy >= perKeyLimit and redis.call('SISMEMBER', variant .. ':currentConcurrency', messageId) == 0 then
       __gateReconcile(variant .. ':currentConcurrency', msgKeyPrefix)
       return false
     end
-    if gate.concurrencyKey and gate.concurrencyKey ~= '' then
+    if gateKey and gateKey ~= '' then
       local rawTotal = redis.call('GET', base .. ':totalConcurrency')
       if rawTotal then
         local totalLimit = math.min(tonumber(rawTotal), envLimit)
-        if tonumber(redis.call('SCARD', base .. ':groupConcurrency') or '0') >= totalLimit then
-          __gateReconcile(base .. ':groupConcurrency', msgKeyPrefix)
+        local groupKey = base .. ':groupConcurrency'
+        if tonumber(redis.call('SCARD', groupKey) or '0') >= totalLimit and redis.call('SISMEMBER', groupKey, messageId) == 0 then
+          __gateReconcile(groupKey, msgKeyPrefix)
           return false
         end
       end
@@ -123,9 +128,9 @@ end
 local function __gatesAcquire(gatesKeyPrefix, msg, messageId)
   if not msg.gates then return end
   for _, gate in ipairs(msg.gates) do
-    local base, variant = __gateKeys(gatesKeyPrefix, msg, gate)
+    local base, variant, gateKey = __gateKeys(gatesKeyPrefix, msg, gate)
     redis.call('SADD', variant .. ':currentConcurrency', messageId)
-    if gate.concurrencyKey and gate.concurrencyKey ~= '' then
+    if gateKey and gateKey ~= '' then
       redis.call('SADD', base .. ':groupConcurrency', messageId)
     end
   end
@@ -137,9 +142,9 @@ local function __gatesRelease(gatesKeyPrefix, rawPayload, messageId)
   local ok, msg = pcall(cjson.decode, rawPayload)
   if not ok or type(msg) ~= 'table' or not msg.gates then return end
   for _, gate in ipairs(msg.gates) do
-    local base, variant = __gateKeys(gatesKeyPrefix, msg, gate)
+    local base, variant, gateKey = __gateKeys(gatesKeyPrefix, msg, gate)
     local removed = redis.call('SREM', variant .. ':currentConcurrency', messageId)
-    if removed == 1 and gate.concurrencyKey and gate.concurrencyKey ~= '' then
+    if removed == 1 and gateKey and gateKey ~= '' then
       redis.call('SREM', base .. ':groupConcurrency', messageId)
     end
   end
@@ -3605,7 +3610,7 @@ if enableFastPath == '1' then
           local okDecode, decoded = pcall(cjson.decode, messageData)
           if okDecode and type(decoded) == 'table' and decoded.gates then
             gateMsg = decoded
-            gatesAllowFastPath = __gatesHaveCapacity(keyPrefix, decoded, envLimit, nil)
+            gatesAllowFastPath = __gatesHaveCapacity(keyPrefix, decoded, messageId, envLimit, nil)
           end
         end
 
@@ -3719,7 +3724,7 @@ if enableFastPath == '1' then
           local okDecode, decoded = pcall(cjson.decode, messageData)
           if okDecode and type(decoded) == 'table' and decoded.gates then
             gateMsg = decoded
-            gatesAllowFastPath = __gatesHaveCapacity(keyPrefix, decoded, envLimit, nil)
+            gatesAllowFastPath = __gatesHaveCapacity(keyPrefix, decoded, messageId, envLimit, nil)
           end
         end
 
@@ -4079,7 +4084,7 @@ if enableFastPath == '1' then
           local okDecode, decoded = pcall(cjson.decode, messageData)
           if okDecode and type(decoded) == 'table' and decoded.gates then
             gateMsg = decoded
-            gatesAllowFastPath = __gatesHaveCapacity(keyPrefix, decoded, envLimit, nil)
+            gatesAllowFastPath = __gatesHaveCapacity(keyPrefix, decoded, messageId, envLimit, nil)
           end
         end
 
@@ -4250,7 +4255,7 @@ if enableFastPath == '1' then
           local okDecode, decoded = pcall(cjson.decode, messageData)
           if okDecode and type(decoded) == 'table' and decoded.gates then
             gateMsg = decoded
-            gatesAllowFastPath = __gatesHaveCapacity(keyPrefix, decoded, envLimit, nil)
+            gatesAllowFastPath = __gatesHaveCapacity(keyPrefix, decoded, messageId, envLimit, nil)
           end
         end
 
@@ -4652,7 +4657,7 @@ for i = 1, #messages, 2 do
         else
             local gatesAllow = true
             if gatesEnabled then
-              gatesAllow = __gatesHaveCapacity(keyPrefix, messageData, envConcurrencyLimit, messageKeyPrefix)
+              gatesAllow = __gatesHaveCapacity(keyPrefix, messageData, messageId, envConcurrencyLimit, messageKeyPrefix)
             end
 
             if gatesAllow then
@@ -4903,11 +4908,13 @@ local queueConcurrencyLimit = math.min(tonumber(redis.call('GET', queueConcurren
 local envAvailableCapacity = envConcurrencyLimitWithBurstFactor - envCurrentConcurrency
 local actualMaxCount = math.min(maxCount, envAvailableCapacity)
 
--- Total-cap gate: bound this batch by the remaining headroom across ALL ck
--- variants (groupConcurrency SCARD vs the env-clamped total limit). Each admit
--- below SADDs into the group set and bumps dequeuedCount, and dequeuedCount is
--- bounded by actualMaxCount, so tightening here is sufficient to prevent
--- over-admitting past the cap within a single batch.
+-- Total-cap gate: track the remaining headroom across ALL ck variants
+-- (groupConcurrency SCARD vs the env-clamped total limit). Admission below
+-- decrements the headroom per new member, and a message that is ALREADY a
+-- group member passes even at zero headroom: it holds its own slot (an
+-- unmirrored release from an older build can leave a queued run's membership
+-- behind, and blocking on it would deadlock the run against itself).
+local totalHeadroom = nil
 if totalConcurrencyEnabled then
   local rawTotalLimit = redis.call('GET', totalConcurrencyLimitKey)
   if rawTotalLimit then
@@ -4939,7 +4946,7 @@ if totalConcurrencyEnabled then
       end
     end
 
-    actualMaxCount = math.min(actualMaxCount, totalConcurrencyLimit - groupCurrentConcurrency)
+    totalHeadroom = totalConcurrencyLimit - groupCurrentConcurrency
   end
 end
 
@@ -4997,10 +5004,17 @@ for _, ckQueueName in ipairs(ckQueues) do
         else
           local gatesAllow = true
           if gatesEnabled then
-            gatesAllow = __gatesHaveCapacity(keyPrefix, messageData, envConcurrencyLimit, messageKeyPrefix)
+            gatesAllow = __gatesHaveCapacity(keyPrefix, messageData, messageId, envConcurrencyLimit, messageKeyPrefix)
           end
 
-          if gatesAllow then
+          local alreadyInGroup = false
+          local totalAllows = true
+          if totalHeadroom ~= nil then
+            alreadyInGroup = redis.call('SISMEMBER', groupConcurrencyKey, messageId) == 1
+            totalAllows = alreadyInGroup or totalHeadroom > 0
+          end
+
+          if gatesAllow and totalAllows then
             redis.call('ZREM', fullQueueKey, messageId)
             redis.call('ZREM', envQueueKey, messageId)
             decrLengthCounter()
@@ -5008,6 +5022,9 @@ for _, ckQueueName in ipairs(ckQueues) do
             redis.call('SADD', envCurrentConcurrencyKey, messageId)
             if totalConcurrencyEnabled then
               redis.call('SADD', groupConcurrencyKey, messageId)
+              if totalHeadroom ~= nil and not alreadyInGroup then
+                totalHeadroom = totalHeadroom - 1
+              end
             end
             if gatesEnabled then
               __gatesAcquire(keyPrefix, messageData, messageId)

--- a/internal-packages/run-engine/src/run-queue/index.ts
+++ b/internal-packages/run-engine/src/run-queue/index.ts
@@ -67,8 +67,10 @@ const SemanticAttributes = {
  * __gatesHaveCapacity / __gatesAcquire run on admit paths behind the gatesEnabled
  * flag. __gatesRelease runs on every release path UNCONDITIONALLY and is payload-
  * driven (a cheap substring probe before decoding), so slots acquired while the flag
- * was on always drain, and gateless messages pay near zero. __gateReconcile is the
- * same bounded self-heal as the total-cap gate. Group and gate sets are strict
+ * was on always drain, and gateless messages pay near zero. Every holder joins the
+ * gate's groupConcurrency set — keyed or keyless — so a totalConcurrency limit caps
+ * across everything, matching the SDK's documented "total" semantics. __gateReconcile
+ * is the same bounded self-heal as the total-cap gate. Group and gate sets are strict
  * mirrors of the member's home-queue currentConcurrency set (admits populate both
  * in one script), so a member whose message key is gone, or who is absent from its
  * home currentConcurrency set, holds no legitimate slot and is pruned. The home-set
@@ -124,15 +126,13 @@ local function __gatesHaveCapacity(gatesKeyPrefix, msg, messageId, envLimit, msg
       __gateReconcile(variant .. ':currentConcurrency', msgKeyPrefix, gatesKeyPrefix)
       return false
     end
-    if gateKey and gateKey ~= '' then
-      local rawTotal = redis.call('GET', base .. ':totalConcurrency')
-      if rawTotal then
-        local totalLimit = math.min(tonumber(rawTotal), envLimit)
-        local groupKey = base .. ':groupConcurrency'
-        if tonumber(redis.call('SCARD', groupKey) or '0') >= totalLimit and redis.call('SISMEMBER', groupKey, messageId) == 0 then
-          __gateReconcile(groupKey, msgKeyPrefix, gatesKeyPrefix)
-          return false
-        end
+    local rawTotal = redis.call('GET', base .. ':totalConcurrency')
+    if rawTotal then
+      local totalLimit = math.min(tonumber(rawTotal), envLimit)
+      local groupKey = base .. ':groupConcurrency'
+      if tonumber(redis.call('SCARD', groupKey) or '0') >= totalLimit and redis.call('SISMEMBER', groupKey, messageId) == 0 then
+        __gateReconcile(groupKey, msgKeyPrefix, gatesKeyPrefix)
+        return false
       end
     end
   end
@@ -142,11 +142,9 @@ end
 local function __gatesAcquire(gatesKeyPrefix, msg, messageId)
   if not msg.gates then return end
   for _, gate in ipairs(msg.gates) do
-    local base, variant, gateKey = __gateKeys(gatesKeyPrefix, msg, gate)
+    local base, variant = __gateKeys(gatesKeyPrefix, msg, gate)
     redis.call('SADD', variant .. ':currentConcurrency', messageId)
-    if gateKey and gateKey ~= '' then
-      redis.call('SADD', base .. ':groupConcurrency', messageId)
-    end
+    redis.call('SADD', base .. ':groupConcurrency', messageId)
   end
 end
 
@@ -156,9 +154,9 @@ local function __gatesRelease(gatesKeyPrefix, rawPayload, messageId)
   local ok, msg = pcall(cjson.decode, rawPayload)
   if not ok or type(msg) ~= 'table' or not msg.gates then return end
   for _, gate in ipairs(msg.gates) do
-    local base, variant, gateKey = __gateKeys(gatesKeyPrefix, msg, gate)
+    local base, variant = __gateKeys(gatesKeyPrefix, msg, gate)
     local removed = redis.call('SREM', variant .. ':currentConcurrency', messageId)
-    if removed == 1 and gateKey and gateKey ~= '' then
+    if removed == 1 then
       redis.call('SREM', base .. ':groupConcurrency', messageId)
     end
   end

--- a/internal-packages/run-engine/src/run-queue/index.ts
+++ b/internal-packages/run-engine/src/run-queue/index.ts
@@ -85,16 +85,24 @@ local function __gateKeys(gatesKeyPrefix, msg, gate)
   return base, variant, gateKey
 end
 
-local function __gateReconcile(setKey, msgKeyPrefix)
+local function __gateReconcile(setKey, msgKeyPrefix, reconcileKeyPrefix)
   if not msgKeyPrefix then return end
   if redis.call('SET', setKey .. ':reconcileLock', '1', 'NX', 'EX', '10') then
     local cursorKey = setKey .. ':reconcileCursor'
     local cursor = redis.call('GET', cursorKey) or '0'
-    local scanResult = redis.call('SSCAN', setKey, cursor, 'COUNT', '500')
+    local scanResult = redis.call('SSCAN', setKey, cursor, 'COUNT', '100')
     redis.call('SET', cursorKey, scanResult[1], 'EX', '3600')
     for _, memberId in ipairs(scanResult[2]) do
-      if redis.call('EXISTS', msgKeyPrefix .. memberId) == 0 then
+      local rawMemberPayload = redis.call('GET', msgKeyPrefix .. memberId)
+      if not rawMemberPayload then
         redis.call('SREM', setKey, memberId)
+      elseif reconcileKeyPrefix then
+        local okMember, member = pcall(cjson.decode, rawMemberPayload)
+        if okMember and type(member) == 'table' and type(member.queue) == 'string' then
+          if redis.call('ZSCORE', reconcileKeyPrefix .. member.queue, memberId) then
+            redis.call('SREM', setKey, memberId)
+          end
+        end
       end
     end
   end
@@ -107,7 +115,7 @@ local function __gatesHaveCapacity(gatesKeyPrefix, msg, messageId, envLimit, msg
     local occupancy = tonumber(redis.call('SCARD', variant .. ':currentConcurrency') or '0')
     local perKeyLimit = math.min(tonumber(redis.call('GET', base .. ':concurrency') or '1000000'), envLimit)
     if occupancy >= perKeyLimit and redis.call('SISMEMBER', variant .. ':currentConcurrency', messageId) == 0 then
-      __gateReconcile(variant .. ':currentConcurrency', msgKeyPrefix)
+      __gateReconcile(variant .. ':currentConcurrency', msgKeyPrefix, gatesKeyPrefix)
       return false
     end
     if gateKey and gateKey ~= '' then
@@ -116,7 +124,7 @@ local function __gatesHaveCapacity(gatesKeyPrefix, msg, messageId, envLimit, msg
         local totalLimit = math.min(tonumber(rawTotal), envLimit)
         local groupKey = base .. ':groupConcurrency'
         if tonumber(redis.call('SCARD', groupKey) or '0') >= totalLimit and redis.call('SISMEMBER', groupKey, messageId) == 0 then
-          __gateReconcile(groupKey, msgKeyPrefix)
+          __gateReconcile(groupKey, msgKeyPrefix, gatesKeyPrefix)
           return false
         end
       end
@@ -4921,29 +4929,14 @@ if totalConcurrencyEnabled then
     local totalConcurrencyLimit = math.min(tonumber(rawTotalLimit), envConcurrencyLimit)
     local groupCurrentConcurrency = tonumber(redis.call('SCARD', groupConcurrencyKey) or '0')
 
-    -- Self-heal before holding the queue at its limit. A terminal release path
-    -- that misses the group mirror (an older build, or a future script) leaves
-    -- a member behind, but every terminal path deletes the run's message key,
-    -- so a member with no message key is provably dead. Members of re-queued
-    -- runs keep their message key and clear through the mirrored ack when the
-    -- run completes. The short lock bounds a saturated queue to one pass per
-    -- interval, and SSCAN with a persisted cursor bounds each pass to one
-    -- batch so a large set never blocks Redis for a full traversal; successive
-    -- passes cover the whole set.
+    -- Self-heal before holding the queue at its limit: a member with no message
+    -- key was terminally released without the mirror and is dead, and a member
+    -- whose message is QUEUED (in its variant zset) holds no legitimate slot,
+    -- since queued and in-flight are mutually exclusive on every path. Both are
+    -- pruned by the shared bounded reconcile.
     if groupCurrentConcurrency >= totalConcurrencyLimit then
-      local reconcileLockKey = groupConcurrencyKey .. ':reconcileLock'
-      if redis.call('SET', reconcileLockKey, '1', 'NX', 'EX', '10') then
-        local reconcileCursorKey = groupConcurrencyKey .. ':reconcileCursor'
-        local reconcileCursor = redis.call('GET', reconcileCursorKey) or '0'
-        local scanResult = redis.call('SSCAN', groupConcurrencyKey, reconcileCursor, 'COUNT', '500')
-        redis.call('SET', reconcileCursorKey, scanResult[1], 'EX', '3600')
-        for _, groupMemberId in ipairs(scanResult[2]) do
-          if redis.call('EXISTS', messageKeyPrefix .. groupMemberId) == 0 then
-            redis.call('SREM', groupConcurrencyKey, groupMemberId)
-          end
-        end
-        groupCurrentConcurrency = tonumber(redis.call('SCARD', groupConcurrencyKey) or '0')
-      end
+      __gateReconcile(groupConcurrencyKey, messageKeyPrefix, keyPrefix)
+      groupCurrentConcurrency = tonumber(redis.call('SCARD', groupConcurrencyKey) or '0')
     end
 
     totalHeadroom = totalConcurrencyLimit - groupCurrentConcurrency

--- a/internal-packages/run-engine/src/run-queue/index.ts
+++ b/internal-packages/run-engine/src/run-queue/index.ts
@@ -58,6 +58,93 @@ const SemanticAttributes = {
   ORG_ID: "runqueue.orgId",
 };
 
+/**
+ * Gate helpers, spliced into scripts that admit or release runs. A gate is another
+ * queue named in the message payload that the run must also hold a slot in while it
+ * executes (payload shape: gates = [{queue, concurrencyKey?}]). Keys are built from
+ * the payload's own org/proj/env, so gates always live in the message's hash slot.
+ *
+ * __gatesHaveCapacity / __gatesAcquire run on admit paths behind the gatesEnabled
+ * flag. __gatesRelease runs on every release path UNCONDITIONALLY and is payload-
+ * driven (a cheap substring probe before decoding), so slots acquired while the flag
+ * was on always drain, and gateless messages pay near zero. __gateReconcile is the
+ * same bounded self-heal as the total-cap gate: a member whose message key is gone
+ * was terminally released by a path that missed the mirror and is provably dead.
+ */
+const QUEUE_GATES_LUA_HELPERS = `
+local function __gateKeys(gatesKeyPrefix, msg, gate)
+  local base = gatesKeyPrefix .. '{org:' .. msg.orgId .. '}:proj:' .. msg.projectId .. ':env:' .. msg.environmentId .. ':queue:' .. gate.queue
+  local variant = base
+  if gate.concurrencyKey and gate.concurrencyKey ~= '' then
+    variant = base .. ':ck:' .. gate.concurrencyKey
+  end
+  return base, variant
+end
+
+local function __gateReconcile(setKey, msgKeyPrefix)
+  if not msgKeyPrefix then return end
+  if redis.call('SET', setKey .. ':reconcileLock', '1', 'NX', 'EX', '10') then
+    local cursorKey = setKey .. ':reconcileCursor'
+    local cursor = redis.call('GET', cursorKey) or '0'
+    local scanResult = redis.call('SSCAN', setKey, cursor, 'COUNT', '500')
+    redis.call('SET', cursorKey, scanResult[1], 'EX', '3600')
+    for _, memberId in ipairs(scanResult[2]) do
+      if redis.call('EXISTS', msgKeyPrefix .. memberId) == 0 then
+        redis.call('SREM', setKey, memberId)
+      end
+    end
+  end
+end
+
+local function __gatesHaveCapacity(gatesKeyPrefix, msg, envLimit, msgKeyPrefix)
+  if not msg.gates then return true end
+  for _, gate in ipairs(msg.gates) do
+    local base, variant = __gateKeys(gatesKeyPrefix, msg, gate)
+    local occupancy = tonumber(redis.call('SCARD', variant .. ':currentConcurrency') or '0')
+    local perKeyLimit = math.min(tonumber(redis.call('GET', base .. ':concurrency') or '1000000'), envLimit)
+    if occupancy >= perKeyLimit then
+      __gateReconcile(variant .. ':currentConcurrency', msgKeyPrefix)
+      return false
+    end
+    if gate.concurrencyKey and gate.concurrencyKey ~= '' then
+      local rawTotal = redis.call('GET', base .. ':totalConcurrency')
+      if rawTotal then
+        local totalLimit = math.min(tonumber(rawTotal), envLimit)
+        if tonumber(redis.call('SCARD', base .. ':groupConcurrency') or '0') >= totalLimit then
+          __gateReconcile(base .. ':groupConcurrency', msgKeyPrefix)
+          return false
+        end
+      end
+    end
+  end
+  return true
+end
+
+local function __gatesAcquire(gatesKeyPrefix, msg, messageId)
+  if not msg.gates then return end
+  for _, gate in ipairs(msg.gates) do
+    local base, variant = __gateKeys(gatesKeyPrefix, msg, gate)
+    redis.call('SADD', variant .. ':currentConcurrency', messageId)
+    if gate.concurrencyKey and gate.concurrencyKey ~= '' then
+      redis.call('SADD', base .. ':groupConcurrency', messageId)
+    end
+  end
+end
+
+local function __gatesRelease(gatesKeyPrefix, rawPayload, messageId)
+  if not rawPayload or rawPayload == false then return end
+  if not string.find(rawPayload, '"gates"', 1, true) then return end
+  local ok, msg = pcall(cjson.decode, rawPayload)
+  if not ok or type(msg) ~= 'table' or not msg.gates then return end
+  for _, gate in ipairs(msg.gates) do
+    local base, variant = __gateKeys(gatesKeyPrefix, msg, gate)
+    local removed = redis.call('SREM', variant .. ':currentConcurrency', messageId)
+    if removed == 1 and gate.concurrencyKey and gate.concurrencyKey ~= '' then
+      redis.call('SREM', base .. ':groupConcurrency', messageId)
+    end
+  end
+end`;
+
 // Prelude spliced at the top of every gauge-carrying script: declares the gauge slot and
 // the return wrapper. A splice fills __qm_g; every return goes through __qmret so the reply
 // is always {original, gauge}. A nil original becomes false, else Lua drops it from the
@@ -199,6 +286,15 @@ export type RunQueueOptions = {
    * no longer load-bearing for correctness.
    */
   totalConcurrencyEnabled?: boolean;
+  /**
+   * When true, admit paths enforce the gates carried in a message's payload: the run
+   * must also have capacity in, and holds a slot in, each gate queue until release.
+   * Default false: gated messages admit as if they had no gates. Release-side gate
+   * removal is payload-driven and always on, so slots acquired while the flag was on
+   * drain correctly after it is turned off, with the same message-key self-heal as
+   * the total cap covering releases from builds without the mirror.
+   */
+  gatesEnabled?: boolean;
   workerOptions?: {
     pollIntervalMs?: number;
     immediatePollIntervalMs?: number;
@@ -1305,6 +1401,7 @@ export class RunQueue {
             this.keys.queueRunningCounterKeyFromQueue(message.queue),
             this.keys.ckIndexKeyFromQueue(message.queue),
             this.keys.queueGroupConcurrencyKeyFromQueue(message.queue),
+            this.keys.messageKey(message.orgId, messageId),
             messageId,
             this.options.redis.keyPrefix ?? "",
             String(this.counterTtlSeconds)
@@ -1316,7 +1413,9 @@ export class RunQueue {
           this.keys.envCurrentConcurrencyKeyFromQueue(message.queue),
           this.keys.queueCurrentDequeuedKeyFromQueue(message.queue),
           this.keys.envCurrentDequeuedKeyFromQueue(message.queue),
-          messageId
+          this.keys.messageKey(message.orgId, messageId),
+          messageId,
+          this.options.redis.keyPrefix ?? ""
         );
       },
       {
@@ -2301,6 +2400,7 @@ export class RunQueue {
           ckKeyPrefix,
           String(this.counterTtlSeconds),
           totalConcurrencyEnabledArg,
+          this.options.gatesEnabled ? "1" : "0",
           metricsGaugeArg
         );
       } else {
@@ -2337,6 +2437,7 @@ export class RunQueue {
           ckKeyPrefix,
           String(this.counterTtlSeconds),
           totalConcurrencyEnabledArg,
+          this.options.gatesEnabled ? "1" : "0",
           metricsGaugeArg
         );
       }
@@ -2369,6 +2470,8 @@ export class RunQueue {
         defaultEnvConcurrencyBurstFactor,
         currentTime,
         enableFastPathArg,
+        this.options.redis.keyPrefix ?? "",
+        this.options.gatesEnabled ? "1" : "0",
         metricsGaugeArg
       );
     } else {
@@ -2396,6 +2499,8 @@ export class RunQueue {
         defaultEnvConcurrencyBurstFactor,
         currentTime,
         enableFastPathArg,
+        this.options.redis.keyPrefix ?? "",
+        this.options.gatesEnabled ? "1" : "0",
         metricsGaugeArg
       );
     }
@@ -2476,6 +2581,7 @@ export class RunQueue {
         String(this.options.defaultEnvConcurrencyBurstFactor ?? 1),
         this.options.redis.keyPrefix ?? "",
         String(maxCount),
+        this.options.gatesEnabled ? "1" : "0",
         metricsGaugeArg
       );
 
@@ -2612,6 +2718,7 @@ export class RunQueue {
         this.options.redis.keyPrefix ?? "",
         String(maxCount),
         this.options.totalConcurrencyEnabled ? "1" : "0",
+        this.options.gatesEnabled ? "1" : "0",
         metricsGaugeArg
       );
 
@@ -2866,7 +2973,8 @@ export class RunQueue {
         messageQueue,
         messageKeyValue,
         removeFromWorkerQueue ? "1" : "0",
-        ckWildcardName
+        ckWildcardName,
+        this.options.redis.keyPrefix ?? ""
       );
     }
 
@@ -2883,7 +2991,8 @@ export class RunQueue {
       messageId,
       messageQueue,
       messageKeyValue,
-      removeFromWorkerQueue ? "1" : "0"
+      removeFromWorkerQueue ? "1" : "0",
+      this.options.redis.keyPrefix ?? ""
     );
   }
 
@@ -2926,6 +3035,7 @@ export class RunQueue {
         this.keys.queueRunningCounterKeyFromQueue(queue),
         this.keys.ckIndexKeyFromQueue(queue),
         this.keys.queueGroupConcurrencyKeyFromQueue(queue),
+        messageKey,
         messageId,
         this.options.redis.keyPrefix ?? "",
         String(this.counterTtlSeconds)
@@ -2937,7 +3047,9 @@ export class RunQueue {
       envCurrentConcurrencyKey,
       queueCurrentDequeuedKey,
       envCurrentDequeuedKey,
-      messageId
+      messageKey,
+      messageId,
+      this.options.redis.keyPrefix ?? ""
     );
   }
 
@@ -3017,7 +3129,8 @@ export class RunQueue {
         messageId,
         messageQueue,
         JSON.stringify(message),
-        String(messageScore)
+        String(messageScore),
+        this.options.redis.keyPrefix ?? ""
       );
     }
   }
@@ -3059,7 +3172,8 @@ export class RunQueue {
         this.keys.queueGroupConcurrencyKeyFromQueue(messageQueue),
         messageId,
         messageQueue,
-        ckWildcardName
+        ckWildcardName,
+        this.options.redis.keyPrefix ?? ""
       );
     } else {
       await this.redis.moveToDeadLetterQueue(
@@ -3073,7 +3187,8 @@ export class RunQueue {
         envQueueKey,
         deadLetterQueueKey,
         messageId,
-        messageQueue
+        messageQueue,
+        this.options.redis.keyPrefix ?? ""
       );
     }
   }
@@ -3461,8 +3576,11 @@ local defaultEnvConcurrencyLimit = ARGV[6]
 local defaultEnvConcurrencyBurstFactor = ARGV[7]
 local currentTime = ARGV[8]
 local enableFastPath = ARGV[9]
+local keyPrefix = ARGV[10]
+local gatesEnabled = ARGV[11] == '1'
 
 ${QUEUE_METRICS_GAUGE_PRELUDE}
+${QUEUE_GATES_LUA_HELPERS}
 
 -- Fast path: check if we can skip the queue and go directly to worker queue
 if enableFastPath == '1' then
@@ -3481,12 +3599,27 @@ if enableFastPath == '1' then
       )
 
       if queueCurrent < queueLimit then
-        redis.call('SET', messageKey, messageData)
-        redis.call('SADD', queueCurrentConcurrencyKey, messageId)
-        redis.call('SADD', envCurrentConcurrencyKey, messageId)
-        redis.call('RPUSH', workerQueueKey, messageKeyValue)
+        local gateMsg = nil
+        local gatesAllowFastPath = true
+        if gatesEnabled and string.find(messageData, '"gates"', 1, true) then
+          local okDecode, decoded = pcall(cjson.decode, messageData)
+          if okDecode and type(decoded) == 'table' and decoded.gates then
+            gateMsg = decoded
+            gatesAllowFastPath = __gatesHaveCapacity(keyPrefix, decoded, envLimit, nil)
+          end
+        end
+
+        if gatesAllowFastPath then
+          redis.call('SET', messageKey, messageData)
+          redis.call('SADD', queueCurrentConcurrencyKey, messageId)
+          redis.call('SADD', envCurrentConcurrencyKey, messageId)
+          if gateMsg then
+            __gatesAcquire(keyPrefix, gateMsg, messageId)
+          end
+          redis.call('RPUSH', workerQueueKey, messageKeyValue)
 ${QUEUE_METRICS_ENQUEUE_FASTPATH_GAUGE_LUA}
-        return __qmret(1)
+          return __qmret(1)
+        end
       end
     end
   end
@@ -3516,6 +3649,7 @@ redis.call('SREM', queueCurrentConcurrencyKey, messageId)
 redis.call('SREM', envCurrentConcurrencyKey, messageId)
 redis.call('SREM', queueCurrentDequeuedKey, messageId)
 redis.call('SREM', envCurrentDequeuedKey, messageId)
+__gatesRelease(keyPrefix, messageData, messageId)
 ${QUEUE_METRICS_GAUGE_LUA}
 
 return __qmret(0)
@@ -3556,8 +3690,11 @@ local defaultEnvConcurrencyLimit = ARGV[8]
 local defaultEnvConcurrencyBurstFactor = ARGV[9]
 local currentTime = ARGV[10]
 local enableFastPath = ARGV[11]
+local keyPrefix = ARGV[12]
+local gatesEnabled = ARGV[13] == '1'
 
 ${QUEUE_METRICS_GAUGE_PRELUDE}
+${QUEUE_GATES_LUA_HELPERS}
 
 -- Fast path: check if we can skip the queue and go directly to worker queue
 if enableFastPath == '1' then
@@ -3576,13 +3713,28 @@ if enableFastPath == '1' then
       )
 
       if queueCurrent < queueLimit then
-        redis.call('SET', messageKey, messageData)
-        redis.call('SADD', queueCurrentConcurrencyKey, messageId)
-        redis.call('SADD', envCurrentConcurrencyKey, messageId)
-        redis.call('RPUSH', workerQueueKey, messageKeyValue)
+        local gateMsg = nil
+        local gatesAllowFastPath = true
+        if gatesEnabled and string.find(messageData, '"gates"', 1, true) then
+          local okDecode, decoded = pcall(cjson.decode, messageData)
+          if okDecode and type(decoded) == 'table' and decoded.gates then
+            gateMsg = decoded
+            gatesAllowFastPath = __gatesHaveCapacity(keyPrefix, decoded, envLimit, nil)
+          end
+        end
+
+        if gatesAllowFastPath then
+          redis.call('SET', messageKey, messageData)
+          redis.call('SADD', queueCurrentConcurrencyKey, messageId)
+          redis.call('SADD', envCurrentConcurrencyKey, messageId)
+          if gateMsg then
+            __gatesAcquire(keyPrefix, gateMsg, messageId)
+          end
+          redis.call('RPUSH', workerQueueKey, messageKeyValue)
 ${QUEUE_METRICS_ENQUEUE_FASTPATH_GAUGE_LUA}
         -- Skip TTL sorted set: the expireRun worker job handles TTL expiry independently
-        return __qmret(1)
+          return __qmret(1)
+        end
       end
     end
   end
@@ -3615,6 +3767,7 @@ redis.call('SREM', queueCurrentConcurrencyKey, messageId)
 redis.call('SREM', envCurrentConcurrencyKey, messageId)
 redis.call('SREM', queueCurrentDequeuedKey, messageId)
 redis.call('SREM', envCurrentDequeuedKey, messageId)
+__gatesRelease(keyPrefix, messageData, messageId)
 ${QUEUE_METRICS_GAUGE_LUA}
 
 return __qmret(0)
@@ -3884,8 +4037,10 @@ local keyPrefix = ARGV[11]
 -- TTL (seconds) applied to counter lazy-init SETs
 local counterTtl = ARGV[12]
 local totalConcurrencyEnabled = ARGV[13] == '1'
+local gatesEnabled = ARGV[14] == '1'
 
 ${QUEUE_METRICS_GAUGE_PRELUDE}
+${QUEUE_GATES_LUA_HELPERS}
 
 -- Fast path: check if we can skip the queue and go directly to worker queue
 if enableFastPath == '1' then
@@ -3918,12 +4073,25 @@ if enableFastPath == '1' then
           end
         end
 
-        if totalAllowsFastPath then
+        local gateMsg = nil
+        local gatesAllowFastPath = true
+        if gatesEnabled and string.find(messageData, '"gates"', 1, true) then
+          local okDecode, decoded = pcall(cjson.decode, messageData)
+          if okDecode and type(decoded) == 'table' and decoded.gates then
+            gateMsg = decoded
+            gatesAllowFastPath = __gatesHaveCapacity(keyPrefix, decoded, envLimit, nil)
+          end
+        end
+
+        if totalAllowsFastPath and gatesAllowFastPath then
           redis.call('SET', messageKey, messageData)
           redis.call('SADD', queueCurrentConcurrencyKey, messageId)
           redis.call('SADD', envCurrentConcurrencyKey, messageId)
           if totalConcurrencyEnabled then
             redis.call('SADD', groupConcurrencyKey, messageId)
+          end
+          if gateMsg then
+            __gatesAcquire(keyPrefix, gateMsg, messageId)
           end
           redis.call('RPUSH', workerQueueKey, messageKeyValue)
 ${QUEUE_METRICS_CK_ENQUEUE_FASTPATH_GAUGE_LUA}
@@ -3992,6 +4160,7 @@ end
 redis.call('SREM', envCurrentConcurrencyKey, messageId)
 redis.call('SREM', queueCurrentDequeuedKey, messageId)
 redis.call('SREM', envCurrentDequeuedKey, messageId)
+__gatesRelease(keyPrefix, messageData, messageId)
 ${QUEUE_METRICS_CK_ENQUEUE_GAUGE_LUA}
 
 return __qmret(0)
@@ -4041,8 +4210,10 @@ local keyPrefix = ARGV[13]
 -- TTL (seconds) applied to counter lazy-init SETs
 local counterTtl = ARGV[14]
 local totalConcurrencyEnabled = ARGV[15] == '1'
+local gatesEnabled = ARGV[16] == '1'
 
 ${QUEUE_METRICS_GAUGE_PRELUDE}
+${QUEUE_GATES_LUA_HELPERS}
 
 -- Fast path: check if we can skip the queue and go directly to worker queue
 if enableFastPath == '1' then
@@ -4073,12 +4244,25 @@ if enableFastPath == '1' then
           end
         end
 
-        if totalAllowsFastPath then
+        local gateMsg = nil
+        local gatesAllowFastPath = true
+        if gatesEnabled and string.find(messageData, '"gates"', 1, true) then
+          local okDecode, decoded = pcall(cjson.decode, messageData)
+          if okDecode and type(decoded) == 'table' and decoded.gates then
+            gateMsg = decoded
+            gatesAllowFastPath = __gatesHaveCapacity(keyPrefix, decoded, envLimit, nil)
+          end
+        end
+
+        if totalAllowsFastPath and gatesAllowFastPath then
           redis.call('SET', messageKey, messageData)
           redis.call('SADD', queueCurrentConcurrencyKey, messageId)
           redis.call('SADD', envCurrentConcurrencyKey, messageId)
           if totalConcurrencyEnabled then
             redis.call('SADD', groupConcurrencyKey, messageId)
+          end
+          if gateMsg then
+            __gatesAcquire(keyPrefix, gateMsg, messageId)
           end
           redis.call('RPUSH', workerQueueKey, messageKeyValue)
 ${QUEUE_METRICS_CK_ENQUEUE_FASTPATH_GAUGE_LUA}
@@ -4140,6 +4324,7 @@ end
 redis.call('SREM', envCurrentConcurrencyKey, messageId)
 redis.call('SREM', queueCurrentDequeuedKey, messageId)
 redis.call('SREM', envCurrentDequeuedKey, messageId)
+__gatesRelease(keyPrefix, messageData, messageId)
 ${QUEUE_METRICS_CK_ENQUEUE_GAUGE_LUA}
 
 return __qmret(0)
@@ -4275,6 +4460,7 @@ local function decrFloored(key)
     redis.call('DECR', key)
   end
 end
+${QUEUE_GATES_LUA_HELPERS}
 
 local expiredMembers = redis.call('ZRANGEBYSCORE', ttlQueueKey, '-inf', currentTime, 'LIMIT', 0, batchSize)
 
@@ -4306,6 +4492,7 @@ for i, member in ipairs(expiredMembers) do
 
       local messageKey = keyPrefix .. "{org:" .. orgFromQueue .. "}:message:" .. runId
 
+      local rawPayload = redis.call('GET', messageKey)
       redis.call('DEL', messageKey)
 
       -- ZREM from queue; if successful AND this is a CK variant, DECR lengthCounter.
@@ -4321,6 +4508,7 @@ for i, member in ipairs(expiredMembers) do
       local dequeuedKey = queueKey .. ":currentDequeued"
       local removedFromCurrent = redis.call('SREM', concurrencyKey, runId)
       local removedFromDequeued = redis.call('SREM', dequeuedKey, runId)
+      __gatesRelease(keyPrefix, rawPayload, runId)
 
       local projMatch = string.match(rawQueueKey, ":proj:([^:]+):env:")
       local envConcurrencyKey = keyPrefix .. "{org:" .. orgFromQueue .. "}:proj:" .. (projMatch or "") .. ":env:" .. (envMatch or "") .. ":currentConcurrency"
@@ -4391,7 +4579,9 @@ local defaultEnvConcurrencyLimit = ARGV[3]
 local defaultEnvConcurrencyBurstFactor = ARGV[4]
 local keyPrefix = ARGV[5]
 local maxCount = tonumber(ARGV[6] or '1')
+local gatesEnabled = ARGV[7] == '1'
 ${QUEUE_METRICS_GAUGE_PRELUDE}
+${QUEUE_GATES_LUA_HELPERS}
 ${QUEUE_METRICS_GAUGE_LUA}
 
 -- Check current env concurrency against the limit
@@ -4460,24 +4650,31 @@ for i = 1, #messages, 2 do
                 redis.call('ZADD', ttlQueueKey, ttlExpiresAt, ttlMember)
             end
         else
-            -- Not expired - process normally
-            redis.call('ZREM', queueKey, messageId)
-            redis.call('ZREM', envQueueKey, messageId)
-            redis.call('SADD', queueCurrentConcurrencyKey, messageId)
-            redis.call('SADD', envCurrentConcurrencyKey, messageId)
-
-            -- Remove from TTL set if provided (run is being executed, not expired)
-            if ttlQueueKey and ttlQueueKey ~= '' and ttlExpiresAt then
-                local ttlMember = queueName .. '|' .. messageId .. '|' .. (messageData.orgId or '')
-                redis.call('ZREM', ttlQueueKey, ttlMember)
+            local gatesAllow = true
+            if gatesEnabled then
+              gatesAllow = __gatesHaveCapacity(keyPrefix, messageData, envConcurrencyLimit, messageKeyPrefix)
             end
 
-            -- Add to results
-            table.insert(results, messageId)
-            table.insert(results, messageScore)
-            table.insert(results, messagePayload)
+            if gatesAllow then
+              redis.call('ZREM', queueKey, messageId)
+              redis.call('ZREM', envQueueKey, messageId)
+              redis.call('SADD', queueCurrentConcurrencyKey, messageId)
+              redis.call('SADD', envCurrentConcurrencyKey, messageId)
+              if gatesEnabled then
+                __gatesAcquire(keyPrefix, messageData, messageId)
+              end
 
-            dequeuedCount = dequeuedCount + 1
+              if ttlQueueKey and ttlQueueKey ~= '' and ttlExpiresAt then
+                  local ttlMember = queueName .. '|' .. messageId .. '|' .. (messageData.orgId or '')
+                  redis.call('ZREM', ttlQueueKey, ttlMember)
+              end
+
+              table.insert(results, messageId)
+              table.insert(results, messageScore)
+              table.insert(results, messagePayload)
+
+              dequeuedCount = dequeuedCount + 1
+            end
         end
     else
         -- Stale entry: message key was already deleted (e.g. acknowledged),
@@ -4680,7 +4877,9 @@ local defaultEnvConcurrencyBurstFactor = ARGV[4]
 local keyPrefix = ARGV[5]
 local maxCount = tonumber(ARGV[6] or '1')
 local totalConcurrencyEnabled = ARGV[7] == '1'
+local gatesEnabled = ARGV[8] == '1'
 ${QUEUE_METRICS_GAUGE_PRELUDE}
+${QUEUE_GATES_LUA_HELPERS}
 ${QUEUE_METRICS_CK_DEQUEUE_GAUGE_LUA}
 
 local function decrLengthCounter()
@@ -4796,25 +4995,35 @@ for _, ckQueueName in ipairs(ckQueues) do
             redis.call('ZADD', ttlQueueKey, ttlExpiresAt, ttlMember)
           end
         else
-          redis.call('ZREM', fullQueueKey, messageId)
-          redis.call('ZREM', envQueueKey, messageId)
-          decrLengthCounter()
-          redis.call('SADD', ckConcurrencyKey, messageId)
-          redis.call('SADD', envCurrentConcurrencyKey, messageId)
-          if totalConcurrencyEnabled then
-            redis.call('SADD', groupConcurrencyKey, messageId)
+          local gatesAllow = true
+          if gatesEnabled then
+            gatesAllow = __gatesHaveCapacity(keyPrefix, messageData, envConcurrencyLimit, messageKeyPrefix)
           end
 
-          if ttlQueueKey and ttlQueueKey ~= '' and ttlExpiresAt then
-            local ttlMember = ckQueueName .. '|' .. messageId .. '|' .. (messageData.orgId or '')
-            redis.call('ZREM', ttlQueueKey, ttlMember)
+          if gatesAllow then
+            redis.call('ZREM', fullQueueKey, messageId)
+            redis.call('ZREM', envQueueKey, messageId)
+            decrLengthCounter()
+            redis.call('SADD', ckConcurrencyKey, messageId)
+            redis.call('SADD', envCurrentConcurrencyKey, messageId)
+            if totalConcurrencyEnabled then
+              redis.call('SADD', groupConcurrencyKey, messageId)
+            end
+            if gatesEnabled then
+              __gatesAcquire(keyPrefix, messageData, messageId)
+            end
+
+            if ttlQueueKey and ttlQueueKey ~= '' and ttlExpiresAt then
+              local ttlMember = ckQueueName .. '|' .. messageId .. '|' .. (messageData.orgId or '')
+              redis.call('ZREM', ttlQueueKey, ttlMember)
+            end
+
+            table.insert(results, messageId)
+            table.insert(results, messageScore)
+            table.insert(results, messagePayload)
+
+            dequeuedCount = dequeuedCount + 1
           end
-
-          table.insert(results, messageId)
-          table.insert(results, messageScore)
-          table.insert(results, messagePayload)
-
-          dequeuedCount = dequeuedCount + 1
         end
       else
         redis.call('ZREM', fullQueueKey, messageId)
@@ -4990,6 +5199,10 @@ local messageId = ARGV[1]
 local messageQueueName = ARGV[2]
 local messageKeyValue = ARGV[3]
 local removeFromWorkerQueue = ARGV[4]
+local keyPrefix = ARGV[5]
+${QUEUE_GATES_LUA_HELPERS}
+
+local rawPayload = redis.call('GET', messageKey)
 
 -- Remove the message from the message key
 redis.call('DEL', messageKey)
@@ -5011,6 +5224,7 @@ redis.call('SREM', queueCurrentConcurrencyKey, messageId)
 redis.call('SREM', envCurrentConcurrencyKey, messageId)
 redis.call('SREM', queueCurrentDequeuedKey, messageId)
 redis.call('SREM', envCurrentDequeuedKey, messageId)
+__gatesRelease(keyPrefix, rawPayload, messageId)
 
 -- Remove the message from the worker queue
 if removeFromWorkerQueue == '1' then
@@ -5037,6 +5251,8 @@ local messageId = ARGV[1]
 local messageQueueName = ARGV[2]
 local messageData = ARGV[3]
 local messageScore = tonumber(ARGV[4])
+local keyPrefix = ARGV[5]
+${QUEUE_GATES_LUA_HELPERS}
 
 -- Update the message data
 redis.call('SET', messageKey, messageData)
@@ -5046,6 +5262,7 @@ redis.call('SREM', queueCurrentConcurrencyKey, messageId)
 redis.call('SREM', envCurrentConcurrencyKey, messageId)
 redis.call('SREM', queueCurrentDequeuedKey, messageId)
 redis.call('SREM', envCurrentDequeuedKey, messageId)
+__gatesRelease(keyPrefix, messageData, messageId)
 
 -- Enqueue the message into the queue
 redis.call('ZADD', messageQueueKey, messageScore, messageId)
@@ -5078,6 +5295,10 @@ local deadLetterQueueKey = KEYS[9]
 -- Args:
 local messageId = ARGV[1]
 local messageQueueName = ARGV[2]
+local keyPrefix = ARGV[3]
+${QUEUE_GATES_LUA_HELPERS}
+
+local rawPayload = redis.call('GET', messageKey)
 
 -- Remove the message from the queue
 redis.call('ZREM', messageQueue, messageId)
@@ -5099,6 +5320,7 @@ redis.call('SREM', queueCurrentConcurrencyKey, messageId)
 redis.call('SREM', envCurrentConcurrencyKey, messageId)
 redis.call('SREM', queueCurrentDequeuedKey, messageId)
 redis.call('SREM', envCurrentDequeuedKey, messageId)
+__gatesRelease(keyPrefix, rawPayload, messageId)
 `,
     });
 
@@ -5316,6 +5538,10 @@ local messageQueueName = ARGV[2]
 local messageKeyValue = ARGV[3]
 local removeFromWorkerQueue = ARGV[4]
 local ckWildcardName = ARGV[5]
+local keyPrefix = ARGV[6]
+${QUEUE_GATES_LUA_HELPERS}
+
+local rawPayload = redis.call('GET', messageKey)
 
 local function decrFloored(key)
   if tonumber(redis.call('GET', key) or '0') > 0 then
@@ -5373,6 +5599,7 @@ redis.call('SREM', envCurrentDequeuedKey, messageId)
 if removedFromDequeued == 1 then
   decrFloored(runningCounterKey)
 end
+__gatesRelease(keyPrefix, rawPayload, messageId)
 
 -- Remove the message from the worker queue
 if removeFromWorkerQueue == '1' then
@@ -5411,6 +5638,7 @@ local ckWildcardName = ARGV[5]
 local keyPrefix = ARGV[6]
 -- TTL (seconds) applied to counter lazy-init SETs
 local counterTtl = ARGV[7]
+${QUEUE_GATES_LUA_HELPERS}
 
 local function decrFloored(key)
   if tonumber(redis.call('GET', key) or '0') > 0 then
@@ -5436,6 +5664,7 @@ redis.call('SREM', envCurrentDequeuedKey, messageId)
 if removedFromDequeued == 1 then
   decrFloored(runningCounterKey)
 end
+__gatesRelease(keyPrefix, messageData, messageId)
 
 -- Lazy-init lengthCounter if missing (e.g. expired via 24h TTL). nack re-queues a
 -- message, which means lengthCounter must be present before we INCR. Without this,
@@ -5506,6 +5735,10 @@ local groupConcurrencyKey = KEYS[13]
 local messageId = ARGV[1]
 local messageQueueName = ARGV[2]
 local ckWildcardName = ARGV[3]
+local keyPrefix = ARGV[4]
+${QUEUE_GATES_LUA_HELPERS}
+
+local rawPayload = redis.call('GET', messageKey)
 
 local function decrFloored(key)
   if tonumber(redis.call('GET', key) or '0') > 0 then
@@ -5562,26 +5795,31 @@ redis.call('SREM', envCurrentDequeuedKey, messageId)
 if removedFromDequeued == 1 then
   decrFloored(runningCounterKey)
 end
+__gatesRelease(keyPrefix, rawPayload, messageId)
 `,
     });
 
     this.redis.defineCommand("releaseConcurrency", {
-      numberOfKeys: 4,
+      numberOfKeys: 5,
       lua: `
 -- Keys:
 local queueCurrentConcurrencyKey = KEYS[1]
 local envCurrentConcurrencyKey = KEYS[2]
 local queueCurrentDequeuedKey = KEYS[3]
 local envCurrentDequeuedKey = KEYS[4]
+local messageKey = KEYS[5]
 
 -- Args:
 local messageId = ARGV[1]
+local keyPrefix = ARGV[2]
+${QUEUE_GATES_LUA_HELPERS}
 
 -- Update the concurrency keys
 redis.call('SREM', queueCurrentConcurrencyKey, messageId)
 redis.call('SREM', envCurrentConcurrencyKey, messageId)
 redis.call('SREM', queueCurrentDequeuedKey, messageId)
 redis.call('SREM', envCurrentDequeuedKey, messageId)
+__gatesRelease(keyPrefix, redis.call('GET', messageKey), messageId)
 `,
     });
 
@@ -5590,7 +5828,7 @@ redis.call('SREM', envCurrentDequeuedKey, messageId)
     // something. Caller should only invoke this variant for CK queues — non-CK
     // queues should keep calling releaseConcurrency.
     this.redis.defineCommand("releaseConcurrencyTracked", {
-      numberOfKeys: 7,
+      numberOfKeys: 8,
       lua: `
 -- Keys:
 local queueCurrentConcurrencyKey = KEYS[1]
@@ -5600,12 +5838,14 @@ local envCurrentDequeuedKey = KEYS[4]
 local runningCounterKey = KEYS[5]
 local ckIndexKey = KEYS[6]
 local groupConcurrencyKey = KEYS[7]
+local messageKey = KEYS[8]
 
 -- Args:
 local messageId = ARGV[1]
 local keyPrefix = ARGV[2]
 -- TTL (seconds) applied to counter lazy-init SETs
 local counterTtl = ARGV[3]
+${QUEUE_GATES_LUA_HELPERS}
 
 -- Lazy-init runningCounter if missing (e.g. expired via 24h TTL). Runs BEFORE
 -- the SREM so the seed captures pre-release state; the subsequent DECR accounts
@@ -5634,6 +5874,7 @@ if removedFromDequeued == 1 then
     redis.call('DECR', runningCounterKey)
   end
 end
+__gatesRelease(keyPrefix, redis.call('GET', messageKey), messageId)
 `,
     });
 
@@ -5717,29 +5958,33 @@ return results
     });
 
     this.redis.defineCommand("clearMessageFromConcurrencySets", {
-      numberOfKeys: 4,
+      numberOfKeys: 5,
       lua: `
 -- Keys:
 local queueCurrentConcurrencyKey = KEYS[1]
 local envCurrentConcurrencyKey = KEYS[2]
 local queueCurrentDequeuedKey = KEYS[3]
 local envCurrentDequeuedKey = KEYS[4]
+local messageKey = KEYS[5]
 
 -- Args:
 local messageId = ARGV[1]
+local keyPrefix = ARGV[2]
+${QUEUE_GATES_LUA_HELPERS}
 
 -- Update the concurrency keys
 redis.call('SREM', queueCurrentConcurrencyKey, messageId)
 redis.call('SREM', envCurrentConcurrencyKey, messageId)
 redis.call('SREM', queueCurrentDequeuedKey, messageId)
 redis.call('SREM', envCurrentDequeuedKey, messageId)
+__gatesRelease(keyPrefix, redis.call('GET', messageKey), messageId)
 `,
     });
 
     // Tracked variant of clearMessageFromConcurrencySets — see releaseConcurrencyTracked
     // for the contract. Only invoke for CK queues.
     this.redis.defineCommand("clearMessageFromConcurrencySetsTracked", {
-      numberOfKeys: 7,
+      numberOfKeys: 8,
       lua: `
 -- Keys:
 local queueCurrentConcurrencyKey = KEYS[1]
@@ -5749,12 +5994,14 @@ local envCurrentDequeuedKey = KEYS[4]
 local runningCounterKey = KEYS[5]
 local ckIndexKey = KEYS[6]
 local groupConcurrencyKey = KEYS[7]
+local messageKey = KEYS[8]
 
 -- Args:
 local messageId = ARGV[1]
 local keyPrefix = ARGV[2]
 -- TTL (seconds) applied to counter lazy-init SETs
 local counterTtl = ARGV[3]
+${QUEUE_GATES_LUA_HELPERS}
 
 -- Lazy-init runningCounter if missing — see releaseConcurrencyTracked for rationale.
 if redis.call('EXISTS', runningCounterKey) == 0 then
@@ -5779,6 +6026,7 @@ if removedFromDequeued == 1 then
     redis.call('DECR', runningCounterKey)
   end
 end
+__gatesRelease(keyPrefix, redis.call('GET', messageKey), messageId)
 `,
     });
   }
@@ -5818,6 +6066,8 @@ declare module "@internal/redis" {
       defaultEnvConcurrencyBurstFactor: string,
       currentTime: string,
       enableFastPath: string,
+      keyPrefix: string,
+      gatesEnabled: string,
       metricsEnabled: string,
       callback?: Callback<[number, number[] | null]>
     ): Result<[number, number[] | null], Context>;
@@ -5849,6 +6099,8 @@ declare module "@internal/redis" {
       defaultEnvConcurrencyBurstFactor: string,
       currentTime: string,
       enableFastPath: string,
+      keyPrefix: string,
+      gatesEnabled: string,
       metricsEnabled: string,
       callback?: Callback<[number, number[] | null]>
     ): Result<[number, number[] | null], Context>;
@@ -5886,6 +6138,7 @@ declare module "@internal/redis" {
       defaultEnvConcurrencyBurstFactor: string,
       keyPrefix: string,
       maxCount: string,
+      gatesEnabled: string,
       metricsEnabled: string,
       callback?: Callback<[string[] | null, number[] | null]>
     ): Result<[string[] | null, number[] | null], Context>;
@@ -5919,6 +6172,7 @@ declare module "@internal/redis" {
       messageQueueName: string,
       messageKeyValue: string,
       removeFromWorkerQueue: string,
+      keyPrefix: string,
       callback?: Callback<void>
     ): Result<void, Context>;
 
@@ -5928,8 +6182,10 @@ declare module "@internal/redis" {
       envCurrentConcurrencyKey: string,
       queueCurrentDequeuedKey: string,
       envCurrentDequeuedKey: string,
+      messageKey: string,
       // args
       messageId: string,
+      keyPrefix: string,
       callback?: Callback<void>
     ): Result<void, Context>;
 
@@ -5948,6 +6204,7 @@ declare module "@internal/redis" {
       messageQueueName: string,
       messageData: string,
       messageScore: string,
+      keyPrefix: string,
       callback?: Callback<void>
     ): Result<void, Context>;
 
@@ -5965,6 +6222,7 @@ declare module "@internal/redis" {
       // args
       messageId: string,
       messageQueueName: string,
+      keyPrefix: string,
       callback?: Callback<void>
     ): Result<void, Context>;
 
@@ -5974,8 +6232,10 @@ declare module "@internal/redis" {
       envCurrentConcurrencyKey: string,
       queueCurrentDequeuedKey: string,
       envCurrentDequeuedKey: string,
+      messageKey: string,
       // args
       messageId: string,
+      keyPrefix: string,
       callback?: Callback<void>
     ): Result<void, Context>;
 
@@ -6178,6 +6438,7 @@ declare module "@internal/redis" {
       keyPrefix: string,
       counterTtl: string,
       totalConcurrencyEnabled: string,
+      gatesEnabled: string,
       metricsEnabled: string,
       callback?: Callback<[number, number[] | null]>
     ): Result<[number, number[] | null], Context>;
@@ -6216,6 +6477,7 @@ declare module "@internal/redis" {
       keyPrefix: string,
       counterTtl: string,
       totalConcurrencyEnabled: string,
+      gatesEnabled: string,
       metricsEnabled: string,
       callback?: Callback<[number, number[] | null]>
     ): Result<[number, number[] | null], Context>;
@@ -6241,6 +6503,7 @@ declare module "@internal/redis" {
       keyPrefix: string,
       maxCount: string,
       totalConcurrencyEnabled: string,
+      gatesEnabled: string,
       metricsEnabled: string,
       callback?: Callback<[string[] | null, number[] | null]>
     ): Result<[string[] | null, number[] | null], Context>;
@@ -6271,6 +6534,7 @@ declare module "@internal/redis" {
       messageKeyValue: string,
       removeFromWorkerQueue: string,
       ckWildcardName: string,
+      keyPrefix: string,
       callback?: Callback<void>
     ): Result<void, Context>;
 
@@ -6314,6 +6578,7 @@ declare module "@internal/redis" {
       messageId: string,
       messageQueueName: string,
       ckWildcardName: string,
+      keyPrefix: string,
       callback?: Callback<void>
     ): Result<void, Context>;
 
@@ -6337,6 +6602,7 @@ declare module "@internal/redis" {
       runningCounterKey: string,
       ckIndexKey: string,
       groupConcurrencyKey: string,
+      messageKey: string,
       messageId: string,
       keyPrefix: string,
       counterTtl: string,
@@ -6351,6 +6617,7 @@ declare module "@internal/redis" {
       runningCounterKey: string,
       ckIndexKey: string,
       groupConcurrencyKey: string,
+      messageKey: string,
       messageId: string,
       keyPrefix: string,
       counterTtl: string,

--- a/internal-packages/run-engine/src/run-queue/index.ts
+++ b/internal-packages/run-engine/src/run-queue/index.ts
@@ -68,8 +68,13 @@ const SemanticAttributes = {
  * flag. __gatesRelease runs on every release path UNCONDITIONALLY and is payload-
  * driven (a cheap substring probe before decoding), so slots acquired while the flag
  * was on always drain, and gateless messages pay near zero. __gateReconcile is the
- * same bounded self-heal as the total-cap gate: a member whose message key is gone
- * was terminally released by a path that missed the mirror and is provably dead.
+ * same bounded self-heal as the total-cap gate. Group and gate sets are strict
+ * mirrors of the member's home-queue currentConcurrency set (admits populate both
+ * in one script), so a member whose message key is gone, or who is absent from its
+ * home currentConcurrency set, holds no legitimate slot and is pruned. The home-set
+ * rule is what heals leaks from release paths without the mirror (older builds
+ * during a rolling upgrade), including runs parked in the DLQ or suspended on
+ * checkpoints, which older rules based on the queue zset could never prune.
  */
 const QUEUE_GATES_LUA_HELPERS = `
 local function __gateKeys(gatesKeyPrefix, msg, gate)
@@ -99,7 +104,8 @@ local function __gateReconcile(setKey, msgKeyPrefix, reconcileKeyPrefix)
       elseif reconcileKeyPrefix then
         local okMember, member = pcall(cjson.decode, rawMemberPayload)
         if okMember and type(member) == 'table' and type(member.queue) == 'string' then
-          if redis.call('ZSCORE', reconcileKeyPrefix .. member.queue, memberId) then
+          local homeConcurrencyKey = reconcileKeyPrefix .. member.queue .. ':currentConcurrency'
+          if homeConcurrencyKey ~= setKey and redis.call('SISMEMBER', homeConcurrencyKey, memberId) == 0 then
             redis.call('SREM', setKey, memberId)
           end
         end
@@ -294,9 +300,11 @@ export type RunQueueOptions = {
    * A release path that misses the group mirror (an instance on an older build during
    * rollout) leaves the member behind, briefly under-admitting. The dequeue gate
    * reconciles: when a queue sits at its total, members whose message key no longer
-   * exists are pruned, so such leaks clear within seconds instead of blocking the
-   * queue. Enabling only after every instance runs this build avoids the noise but is
-   * no longer load-bearing for correctness.
+   * exists or who are absent from their home currentConcurrency set are pruned, so
+   * such leaks clear within seconds instead of blocking the queue, including runs
+   * that dead-lettered or suspended through a mirror-less path. Enabling only after
+   * every instance runs this build avoids the noise but is no longer load-bearing
+   * for correctness.
    */
   totalConcurrencyEnabled?: boolean;
   /**
@@ -4930,10 +4938,9 @@ if totalConcurrencyEnabled then
     local groupCurrentConcurrency = tonumber(redis.call('SCARD', groupConcurrencyKey) or '0')
 
     -- Self-heal before holding the queue at its limit: a member with no message
-    -- key was terminally released without the mirror and is dead, and a member
-    -- whose message is QUEUED (in its variant zset) holds no legitimate slot,
-    -- since queued and in-flight are mutually exclusive on every path. Both are
-    -- pruned by the shared bounded reconcile.
+    -- key is dead, and a member absent from its home currentConcurrency set is
+    -- not in flight (group membership is a strict mirror of it), so neither
+    -- holds a legitimate slot. Both are pruned by the shared bounded reconcile.
     if groupCurrentConcurrency >= totalConcurrencyLimit then
       __gateReconcile(groupConcurrencyKey, messageKeyPrefix, keyPrefix)
       groupCurrentConcurrency = tonumber(redis.call('SCARD', groupConcurrencyKey) or '0')

--- a/internal-packages/run-engine/src/run-queue/tests/queueGates.test.ts
+++ b/internal-packages/run-engine/src/run-queue/tests/queueGates.test.ts
@@ -282,6 +282,75 @@ describe("RunQueue gates", () => {
     }
   });
 
+  redisTest(
+    "a run already holding its own gate slot is never deadlocked by it",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer, true);
+      try {
+        const keys = testOptions.keys;
+        await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "task/my-task", 5);
+        await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "shared-gate", 1);
+
+        /**
+         * An unmirrored release (an older build's nack) leaves the run's own
+         * membership behind while the run goes back to waiting in its queue. The
+         * gate is "full" with the run itself; admission must still let it through.
+         */
+        await queue.redis.sadd(
+          keys.queueCurrentConcurrencyKey(authenticatedEnvDev, "shared-gate"),
+          "r0"
+        );
+
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: makeMessage({
+            runId: "r0",
+            timestamp: Date.now() - 1000,
+            gates: [{ queue: "shared-gate" }],
+          }),
+          workerQueue: "main",
+        });
+
+        const r0Admitted = await waitFor(() => popWorkerQueue(queue, "r0"), 30_000);
+        expect(r0Admitted).toBe(true);
+        expect(await queue.currentConcurrencyOfQueue(authenticatedEnvDev, "shared-gate")).toBe(1);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
+    "a gate without a key inherits the run's concurrency key",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer, true);
+      try {
+        await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "task/my-task", 5);
+        await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "tenant", 1);
+
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: makeMessage({
+            runId: "r0",
+            concurrencyKey: "acme",
+            timestamp: Date.now() - 1000,
+            gates: [{ queue: "tenant" }],
+          }),
+          workerQueue: "main",
+        });
+
+        const admitted = await waitFor(
+          async () =>
+            (await queue.currentConcurrencyOfQueue(authenticatedEnvDev, "tenant", "acme")) === 1
+        );
+        expect(admitted).toBe(true);
+        expect(await queue.currentConcurrencyOfQueue(authenticatedEnvDev, "tenant")).toBe(0);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
   redisTest("enqueue fast path respects a full gate", async ({ redisContainer }) => {
     const queue = createQueue(redisContainer, true);
     try {

--- a/internal-packages/run-engine/src/run-queue/tests/queueGates.test.ts
+++ b/internal-packages/run-engine/src/run-queue/tests/queueGates.test.ts
@@ -1,0 +1,326 @@
+import { redisTest } from "@internal/testcontainers";
+import { trace } from "@internal/tracing";
+import { setTimeout } from "node:timers/promises";
+import { describe } from "vitest";
+import { FairQueueSelectionStrategy } from "../fairQueueSelectionStrategy.js";
+import { RunQueue } from "../index.js";
+import { RunQueueFullKeyProducer } from "../keyProducer.js";
+import type { InputPayload } from "../types.js";
+import { Decimal } from "@trigger.dev/database";
+
+const testOptions = {
+  name: "rq",
+  tracer: trace.getTracer("rq"),
+  workers: 1,
+  defaultEnvConcurrency: 25,
+  retryOptions: {
+    maxAttempts: 5,
+    factor: 1.1,
+    minTimeoutInMs: 100,
+    maxTimeoutInMs: 1_000,
+    randomize: true,
+  },
+  keys: new RunQueueFullKeyProducer(),
+};
+
+const authenticatedEnvDev = {
+  id: "e1234",
+  type: "DEVELOPMENT" as const,
+  maximumConcurrencyLimit: 10,
+  concurrencyLimitBurstFactor: new Decimal(2.0),
+  project: { id: "p1234" },
+  organization: { id: "o1234" },
+};
+
+function createQueue(redisContainer: any, gatesEnabled: boolean) {
+  return new RunQueue({
+    ...testOptions,
+    gatesEnabled,
+    queueSelectionStrategy: new FairQueueSelectionStrategy({
+      redis: {
+        keyPrefix: "runqueue:test:",
+        host: redisContainer.getHost(),
+        port: redisContainer.getPort(),
+      },
+      keys: testOptions.keys,
+    }),
+    redis: {
+      keyPrefix: "runqueue:test:",
+      host: redisContainer.getHost(),
+      port: redisContainer.getPort(),
+    },
+  });
+}
+
+function makeMessage(overrides: Partial<InputPayload> = {}): InputPayload {
+  return {
+    runId: "r1",
+    taskIdentifier: "task/my-task",
+    orgId: "o1234",
+    projectId: "p1234",
+    environmentId: "e1234",
+    environmentType: "DEVELOPMENT",
+    queue: "task/my-task",
+    timestamp: Date.now(),
+    attempt: 0,
+    ...overrides,
+  };
+}
+
+async function waitFor(condition: () => Promise<boolean>, timeoutMs = 20_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await condition()) {
+      return true;
+    }
+    await setTimeout(250);
+  }
+  return condition();
+}
+
+async function popWorkerQueue(queue: RunQueue, expected: string): Promise<boolean> {
+  const next = await queue.dequeueMessageFromWorkerQueue("consumer-1", "main", {
+    blockingPop: false,
+  });
+  return next?.messageId === expected;
+}
+
+vi.setConfig({ testTimeout: 60_000 });
+
+describe("RunQueue gates", () => {
+  redisTest("an unkeyed gate caps runs across its holders", async ({ redisContainer }) => {
+    const queue = createQueue(redisContainer, true);
+    try {
+      await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "task/my-task", 5);
+      await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "shared-gate", 1);
+
+      const now = Date.now();
+      for (const i of [0, 1]) {
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: makeMessage({
+            runId: `r${i}`,
+            timestamp: now - 1000 + i,
+            gates: [{ queue: "shared-gate" }],
+          }),
+          workerQueue: "main",
+        });
+      }
+
+      const oneAdmitted = await waitFor(
+        async () =>
+          (await queue.currentConcurrencyOfQueue(authenticatedEnvDev, "shared-gate")) === 1
+      );
+      expect(oneAdmitted).toBe(true);
+
+      /** The second run must stay queued while the gate is full. */
+      await setTimeout(2000);
+      expect(await queue.currentConcurrencyOfQueue(authenticatedEnvDev, "shared-gate")).toBe(1);
+      expect(await queue.lengthOfQueue(authenticatedEnvDev, "task/my-task")).toBe(1);
+
+      expect(await popWorkerQueue(queue, "r0")).toBe(true);
+      await queue.acknowledgeMessage(authenticatedEnvDev.organization.id, "r0");
+
+      /** Acking r0 frees the gate slot and its home slot; r1 is admitted. */
+      const r1Admitted = await waitFor(() => popWorkerQueue(queue, "r1"));
+      expect(r1Admitted).toBe(true);
+      expect(await queue.currentConcurrencyOfQueue(authenticatedEnvDev, "shared-gate")).toBe(1);
+    } finally {
+      await queue.quit();
+    }
+  });
+
+  redisTest(
+    "a keyed gate caps a tenant across home concurrency keys",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer, true);
+      try {
+        await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "task/my-task", 5);
+        await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "tenant", 1);
+
+        const now = Date.now();
+        for (const [i, ck] of ["ck-a", "ck-b"].entries()) {
+          await queue.enqueueMessage({
+            env: authenticatedEnvDev,
+            message: makeMessage({
+              runId: `r${i}`,
+              concurrencyKey: ck,
+              timestamp: now - 1000 + i,
+              gates: [{ queue: "tenant", concurrencyKey: "acme" }],
+            }),
+            workerQueue: "main",
+          });
+        }
+
+        const oneAdmitted = await waitFor(
+          async () =>
+            (await queue.currentConcurrencyOfQueue(authenticatedEnvDev, "tenant", "acme")) === 1
+        );
+        expect(oneAdmitted).toBe(true);
+
+        await setTimeout(2000);
+        expect(await queue.currentConcurrencyOfQueue(authenticatedEnvDev, "tenant", "acme")).toBe(
+          1
+        );
+        expect(await queue.lengthOfQueue(authenticatedEnvDev, "task/my-task")).toBe(1);
+        expect(await queue.totalConcurrencyOfQueue(authenticatedEnvDev, "tenant")).toBe(1);
+
+        expect(await popWorkerQueue(queue, "r0")).toBe(true);
+        await queue.acknowledgeMessage(authenticatedEnvDev.organization.id, "r0");
+
+        const r1Admitted = await waitFor(() => popWorkerQueue(queue, "r1"));
+        expect(r1Admitted).toBe(true);
+        expect(await queue.currentConcurrencyOfQueue(authenticatedEnvDev, "tenant", "acme")).toBe(
+          1
+        );
+        expect(await queue.totalConcurrencyOfQueue(authenticatedEnvDev, "tenant")).toBe(1);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest("ignores gates and holds no gate slots when disabled", async ({ redisContainer }) => {
+    const queue = createQueue(redisContainer, false);
+    try {
+      await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "task/my-task", 5);
+      await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "shared-gate", 1);
+
+      const now = Date.now();
+      for (const i of [0, 1]) {
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: makeMessage({
+            runId: `r${i}`,
+            timestamp: now - 1000 + i,
+            gates: [{ queue: "shared-gate" }],
+          }),
+          workerQueue: "main",
+        });
+      }
+
+      const bothAdmitted = await waitFor(
+        async () => (await queue.lengthOfQueue(authenticatedEnvDev, "task/my-task")) === 0
+      );
+      expect(bothAdmitted).toBe(true);
+      expect(await queue.currentConcurrencyOfQueue(authenticatedEnvDev, "shared-gate")).toBe(0);
+    } finally {
+      await queue.quit();
+    }
+  });
+
+  redisTest("nacking releases the gate slot", async ({ redisContainer }) => {
+    const queue = createQueue(redisContainer, true);
+    try {
+      await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "task/my-task", 5);
+      await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "shared-gate", 1);
+
+      const now = Date.now();
+      for (const i of [0, 1]) {
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: makeMessage({
+            runId: `r${i}`,
+            timestamp: now - 1000 + i,
+            gates: [{ queue: "shared-gate" }],
+          }),
+          workerQueue: "main",
+        });
+      }
+
+      const r0Admitted = await waitFor(async () => {
+        if ((await queue.currentConcurrencyOfQueue(authenticatedEnvDev, "shared-gate")) !== 1) {
+          return false;
+        }
+        return popWorkerQueue(queue, "r0");
+      });
+      expect(r0Admitted).toBe(true);
+
+      await queue.nackMessage({
+        orgId: authenticatedEnvDev.organization.id,
+        messageId: "r0",
+        retryAt: Date.now() + 120_000,
+      });
+
+      /** r0's gate slot must be released so r1 (the only eligible run) is admitted. */
+      const r1Admitted = await waitFor(() => popWorkerQueue(queue, "r1"));
+      expect(r1Admitted).toBe(true);
+      expect(await queue.currentConcurrencyOfQueue(authenticatedEnvDev, "shared-gate")).toBe(1);
+    } finally {
+      await queue.quit();
+    }
+  });
+
+  redisTest("reconciles a leaked gate member instead of blocking", async ({ redisContainer }) => {
+    const queue = createQueue(redisContainer, true);
+    try {
+      const keys = testOptions.keys;
+      await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "task/my-task", 5);
+      await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "shared-gate", 1);
+
+      /** A dead member with no message key occupies the gate. */
+      await queue.redis.sadd(
+        keys.queueCurrentConcurrencyKey(authenticatedEnvDev, "shared-gate"),
+        "dead-0"
+      );
+
+      await queue.enqueueMessage({
+        env: authenticatedEnvDev,
+        message: makeMessage({
+          runId: "r0",
+          timestamp: Date.now() - 1000,
+          gates: [{ queue: "shared-gate" }],
+        }),
+        workerQueue: "main",
+      });
+
+      const r0Admitted = await waitFor(() => popWorkerQueue(queue, "r0"), 30_000);
+      expect(r0Admitted).toBe(true);
+      expect(await queue.currentConcurrencyOfQueue(authenticatedEnvDev, "shared-gate")).toBe(1);
+    } finally {
+      await queue.quit();
+    }
+  });
+
+  redisTest("enqueue fast path respects a full gate", async ({ redisContainer }) => {
+    const queue = createQueue(redisContainer, true);
+    try {
+      await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "task/my-task", 5);
+      await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "shared-gate", 1);
+
+      await queue.enqueueMessage({
+        env: authenticatedEnvDev,
+        message: makeMessage({
+          runId: "r0",
+          timestamp: Date.now() - 1000,
+          gates: [{ queue: "shared-gate" }],
+        }),
+        workerQueue: "main",
+        enableFastPath: true,
+        skipDequeueProcessing: true,
+      });
+
+      /** The fast path admits synchronously and takes the gate slot. */
+      expect(await queue.currentConcurrencyOfQueue(authenticatedEnvDev, "shared-gate")).toBe(1);
+      expect(await queue.lengthOfQueue(authenticatedEnvDev, "task/my-task")).toBe(0);
+
+      await queue.enqueueMessage({
+        env: authenticatedEnvDev,
+        message: makeMessage({
+          runId: "r1",
+          timestamp: Date.now() - 999,
+          gates: [{ queue: "shared-gate" }],
+        }),
+        workerQueue: "main",
+        enableFastPath: true,
+        skipDequeueProcessing: true,
+      });
+
+      /** At the gate's limit the fast path must fall back to a normal enqueue. */
+      expect(await queue.currentConcurrencyOfQueue(authenticatedEnvDev, "shared-gate")).toBe(1);
+      expect(await queue.lengthOfQueue(authenticatedEnvDev, "task/my-task")).toBe(1);
+    } finally {
+      await queue.quit();
+    }
+  });
+});

--- a/internal-packages/run-engine/src/run-queue/tests/queueGates.test.ts
+++ b/internal-packages/run-engine/src/run-queue/tests/queueGates.test.ts
@@ -180,6 +180,57 @@ describe("RunQueue gates", () => {
     }
   );
 
+  redisTest(
+    "a gate's total limit caps keyed and keyless holders together",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer, true);
+      try {
+        await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "task/my-task", 5);
+        await queue.updateQueueTotalConcurrencyLimits(authenticatedEnvDev, "db-limit", 1);
+
+        const now = Date.now();
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: makeMessage({
+            runId: "r0",
+            timestamp: now - 1000,
+            gates: [{ queue: "db-limit" }],
+          }),
+          workerQueue: "main",
+        });
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: makeMessage({
+            runId: "r1",
+            timestamp: now - 999,
+            gates: [{ queue: "db-limit", concurrencyKey: "acme" }],
+          }),
+          workerQueue: "main",
+        });
+
+        const oneAdmitted = await waitFor(
+          async () => (await queue.totalConcurrencyOfQueue(authenticatedEnvDev, "db-limit")) === 1
+        );
+        expect(oneAdmitted).toBe(true);
+
+        /** The keyed run must stay queued: the keyless holder occupies the total pool. */
+        await setTimeout(2000);
+        expect(await queue.totalConcurrencyOfQueue(authenticatedEnvDev, "db-limit")).toBe(1);
+        expect(await queue.lengthOfQueue(authenticatedEnvDev, "task/my-task")).toBe(1);
+
+        expect(await popWorkerQueue(queue, "r0")).toBe(true);
+        await queue.acknowledgeMessage(authenticatedEnvDev.organization.id, "r0");
+
+        /** Acking the keyless holder frees the total pool; the keyed run is admitted. */
+        const r1Admitted = await waitFor(() => popWorkerQueue(queue, "r1"));
+        expect(r1Admitted).toBe(true);
+        expect(await queue.totalConcurrencyOfQueue(authenticatedEnvDev, "db-limit")).toBe(1);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
   redisTest("ignores gates and holds no gate slots when disabled", async ({ redisContainer }) => {
     const queue = createQueue(redisContainer, false);
     try {

--- a/internal-packages/run-engine/src/run-queue/tests/totalConcurrency.test.ts
+++ b/internal-packages/run-engine/src/run-queue/tests/totalConcurrency.test.ts
@@ -424,6 +424,79 @@ describe("RunQueue total concurrency limit", () => {
   );
 
   redisTest(
+    "reconciles a member whose run dead-lettered or suspended without the mirror",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer, true);
+      try {
+        const keys = testOptions.keys;
+        await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "task/my-task", 5);
+        await queue.updateQueueTotalConcurrencyLimits(authenticatedEnvDev, "task/my-task", 1);
+
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: makeMessage({
+            runId: "r0",
+            concurrencyKey: "ck-a",
+            timestamp: Date.now() - 1000,
+          }),
+          workerQueue: "main",
+        });
+
+        const admitted = await waitFor(
+          async () =>
+            (await queue.totalConcurrencyOfQueue(authenticatedEnvDev, "task/my-task")) === 1
+        );
+        expect(admitted).toBe(true);
+
+        const dequeued = await queue.dequeueMessageFromWorkerQueue("consumer-1", "main");
+        assertNonNullable(dequeued);
+        expect(dequeued.messageId).toBe("r0");
+
+        /**
+         * Simulate a dead-letter or checkpoint release from a build without the
+         * group mirror: the per-key and env sets are cleared but the MESSAGE KEY
+         * SURVIVES (dead-letter keeps it for redrive; suspension keeps it until
+         * the terminal ack) and the run sits in no queue zset. Only the
+         * home-currentConcurrency reconcile rule can prune this member.
+         */
+        await queue.redis.srem(
+          keys.queueCurrentConcurrencyKey(authenticatedEnvDev, "task/my-task", "ck-a"),
+          "r0"
+        );
+        await queue.redis.srem(keys.envCurrentConcurrencyKey(authenticatedEnvDev), "r0");
+        expect(
+          await queue.redis.exists(keys.messageKey(authenticatedEnvDev.organization.id, "r0"))
+        ).toBe(1);
+        expect(await queue.totalConcurrencyOfQueue(authenticatedEnvDev, "task/my-task")).toBe(1);
+
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: makeMessage({
+            runId: "r1",
+            concurrencyKey: "ck-b",
+            timestamp: Date.now() - 500,
+          }),
+          workerQueue: "main",
+        });
+
+        const r1Admitted = await waitFor(async () => {
+          await queue.redis.del(
+            `${keys.queueGroupConcurrencyKey(authenticatedEnvDev, "task/my-task")}:reconcileLock`
+          );
+          const next = await queue.dequeueMessageFromWorkerQueue("consumer-1", "main", {
+            blockingPop: false,
+          });
+          return next?.messageId === "r1";
+        }, 30_000);
+        expect(r1Admitted).toBe(true);
+        expect(await queue.totalConcurrencyOfQueue(authenticatedEnvDev, "task/my-task")).toBe(1);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
     "reconciles a large leaked backlog across bounded passes",
     async ({ redisContainer }) => {
       const queue = createQueue(redisContainer, true);

--- a/internal-packages/run-engine/src/run-queue/tests/totalConcurrency.test.ts
+++ b/internal-packages/run-engine/src/run-queue/tests/totalConcurrency.test.ts
@@ -366,6 +366,64 @@ describe("RunQueue total concurrency limit", () => {
   );
 
   redisTest(
+    "reconciles a member whose run went back to waiting in a queue",
+    async ({ redisContainer }) => {
+      const queue = createQueue(redisContainer, true);
+      try {
+        const keys = testOptions.keys;
+        await queue.updateQueueConcurrencyLimits(authenticatedEnvDev, "task/my-task", 5);
+        await queue.updateQueueTotalConcurrencyLimits(authenticatedEnvDev, "task/my-task", 1);
+
+        /**
+         * A run on ANOTHER queue whose message exists and is queued there, leaked
+         * into this queue's group set by an unmirrored release. It can never be a
+         * dequeue candidate here, so only the reconcile can free the slot: queued
+         * and in-flight are mutually exclusive, so a queued member holds nothing.
+         */
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: makeMessage({
+            runId: "x0",
+            queue: "other-queue",
+            concurrencyKey: "ck-x",
+            timestamp: Date.now() + 3_600_000,
+          }),
+          workerQueue: "main",
+        });
+        await queue.redis.sadd(
+          keys.queueGroupConcurrencyKey(authenticatedEnvDev, "task/my-task"),
+          "x0"
+        );
+        expect(await queue.totalConcurrencyOfQueue(authenticatedEnvDev, "task/my-task")).toBe(1);
+
+        await queue.enqueueMessage({
+          env: authenticatedEnvDev,
+          message: makeMessage({
+            runId: "r0",
+            concurrencyKey: "ck-a",
+            timestamp: Date.now() - 1000,
+          }),
+          workerQueue: "main",
+        });
+
+        const r0Admitted = await waitFor(async () => {
+          await queue.redis.del(
+            `${keys.queueGroupConcurrencyKey(authenticatedEnvDev, "task/my-task")}:reconcileLock`
+          );
+          const next = await queue.dequeueMessageFromWorkerQueue("consumer-1", "main", {
+            blockingPop: false,
+          });
+          return next?.messageId === "r0";
+        }, 30_000);
+        expect(r0Admitted).toBe(true);
+        expect(await queue.totalConcurrencyOfQueue(authenticatedEnvDev, "task/my-task")).toBe(1);
+      } finally {
+        await queue.quit();
+      }
+    }
+  );
+
+  redisTest(
     "reconciles a large leaked backlog across bounded passes",
     async ({ redisContainer }) => {
       const queue = createQueue(redisContainer, true);

--- a/internal-packages/run-engine/src/run-queue/types.ts
+++ b/internal-packages/run-engine/src/run-queue/types.ts
@@ -2,6 +2,19 @@ import { z } from "zod";
 import { RuntimeEnvironmentType } from "@trigger.dev/database";
 import type { MinimalAuthenticatedEnvironment } from "../shared/index.js";
 
+/**
+ * A gate is another declared queue this run must also hold a concurrency slot in
+ * while it executes. The run waits in its own queue; each gate contributes an
+ * extra admit condition (the gate queue's per-key limit, and its total limit when
+ * the entry is keyed) and an extra slot held until release. `queue` is the bare
+ * queue name; the org/project/env scope comes from the run's own payload.
+ */
+const QueueGate = z.object({
+  queue: z.string(),
+  concurrencyKey: z.string().optional(),
+});
+type QueueGate = z.infer<typeof QueueGate>;
+
 export const InputPayload = z.object({
   runId: z.string(),
   /** Deprecated: not read on the V2 dequeue path; will stop being written in a follow-up. Optional to keep new readers compatible with old payloads that still include it, and vice versa. */
@@ -19,6 +32,8 @@ export const InputPayload = z.object({
   attempt: z.number(),
   /** TTL expiration timestamp (unix ms). If set, run will be expired when this time is reached. */
   ttlExpiresAt: z.number().optional(),
+  /** Additional queues this run must also hold a slot in while executing. At most two. */
+  gates: QueueGate.array().max(2).optional(),
 });
 export type InputPayload = z.infer<typeof InputPayload>;
 

--- a/internal-packages/run-engine/src/run-queue/types.ts
+++ b/internal-packages/run-engine/src/run-queue/types.ts
@@ -10,8 +10,8 @@ import type { MinimalAuthenticatedEnvironment } from "../shared/index.js";
  * queue name; the org/project/env scope comes from the run's own payload.
  */
 const QueueGate = z.object({
-  queue: z.string(),
-  concurrencyKey: z.string().optional(),
+  queue: z.string().min(1).max(128),
+  concurrencyKey: z.string().min(1).max(128).optional(),
 });
 type QueueGate = z.infer<typeof QueueGate>;
 

--- a/internal-packages/run-engine/src/run-queue/types.ts
+++ b/internal-packages/run-engine/src/run-queue/types.ts
@@ -32,7 +32,8 @@ export const InputPayload = z.object({
   attempt: z.number(),
   /** TTL expiration timestamp (unix ms). If set, run will be expired when this time is reached. */
   ttlExpiresAt: z.number().optional(),
-  /** Additional queues this run must also hold a slot in while executing. At most two. */
+  /** Additional queues this run must also hold a slot in while executing. At most
+   * three: a task's anonymous inline-limit gate plus two named limits. */
   gates: QueueGate.array().max(3).optional(),
 });
 export type InputPayload = z.infer<typeof InputPayload>;

--- a/internal-packages/run-engine/src/run-queue/types.ts
+++ b/internal-packages/run-engine/src/run-queue/types.ts
@@ -33,8 +33,8 @@ export const InputPayload = z.object({
   /** TTL expiration timestamp (unix ms). If set, run will be expired when this time is reached. */
   ttlExpiresAt: z.number().optional(),
   /** Additional queues this run must also hold a slot in while executing. At most
-   * three: a task's anonymous inline-limit gate plus two named limits. */
-  gates: QueueGate.array().max(3).optional(),
+   * four: three requested gates plus the task's anonymous inline-limit gate. */
+  gates: QueueGate.array().max(4).optional(),
 });
 export type InputPayload = z.infer<typeof InputPayload>;
 

--- a/internal-packages/run-engine/src/run-queue/types.ts
+++ b/internal-packages/run-engine/src/run-queue/types.ts
@@ -33,7 +33,7 @@ export const InputPayload = z.object({
   /** TTL expiration timestamp (unix ms). If set, run will be expired when this time is reached. */
   ttlExpiresAt: z.number().optional(),
   /** Additional queues this run must also hold a slot in while executing. At most two. */
-  gates: QueueGate.array().max(2).optional(),
+  gates: QueueGate.array().max(3).optional(),
 });
 export type InputPayload = z.infer<typeof InputPayload>;
 


### PR DESCRIPTION
## Summary

Stacked on [#4823](https://github.com/triggerdotdev/trigger.dev/pull/4823). Adds queue gates to the run queue: a run can name up to three additional declared queues (in practice a task's anonymous inline-limit gate plus two named limits) it must also hold a concurrency slot in while it executes. The run waits in its own queue as today; each gate contributes an extra admit condition and an extra slot held until release. This is the engine mechanism behind two long-requested shapes:

- a per-tenant cap that spans task queues (every run gated on a `tenant` queue keyed by tenant id, so one tenant's total across all tasks is bounded), and
- a shared external-resource cap (every run that calls a rate-limited provider gated on one `provider` queue).

Gates ride the message payload as `gates: [{ queue, concurrencyKey? }]`. At a gate, the gate queue's `concurrencyLimit` applies per key value and its `totalConcurrencyLimit` bounds the sum across keys, exactly the same semantics a run meets in its own queue. Enforcement is gated behind `RUN_ENGINE_QUEUE_GATES_ENABLED` (default off). The SDK and trigger API surface that populates `gates` follows in a PR stacked on this one; nothing produces gated payloads yet.

## Design

Admit: both dequeue scripts already decode each message's payload, so the gate check reads it directly and skips a message whose gates are full (it stays queued in place). The enqueue fast paths probe the raw payload for `"gates"` before decoding, so ungated messages pay a substring scan and nothing more. On admit the run is added to each gate's per-key concurrency set, and to the gate's group set when the entry is keyed, reusing the exact structures the base queue and total cap already use. Gate keys are built in Lua from the payload's own org/project/environment, so they always live in the message's hash slot.

Release: every release path (ack, nack, dead-letter, concurrency release, sweeper clear, TTL expiry, re-enqueue cleanup) removes the run from its gate sets, driven by the payload rather than the flag, so slots acquired while the flag was on always drain after it is turned off. A saturated gate self-heals with the same bounded cursor reconciliation as the total cap in #4823: a member whose message key no longer exists was terminally released by a path without the removal and is pruned, one bounded batch per interval.

Head-of-line note: a message whose gate is full blocks the messages behind it in the same (sub-)queue. That is the intended trade and the contract PR enforces the rule that makes it benign: a gate's key must be a function of the run's own concurrency key, or a constant.

Covered by tests for unkeyed and keyed gates, flag-off behavior, nack release, fast-path fallback, and leaked-member reconciliation, plus the existing run-queue suite (129 tests).
