### PR TITLE
feat(webapp): polish the org Projects settings page

### DIFF
--- a/apps/webapp/app/components/navigation/OrganizationSettingsSideMenu.tsx
+++ b/apps/webapp/app/components/navigation/OrganizationSettingsSideMenu.tsx
@@ -141,7 +141,8 @@ export function OrganizationSettingsSideMenu({
             badge={
               hasProjectRuntimeUpdate ? (
                 <>
-                  <span aria-hidden className="size-2 shrink-0 rounded-full bg-warning" />
+                  {/* mr-1 lifts the right gap to 12px so it matches the dot's 12px top/bottom inset in the h-8 row */}
+                  <span aria-hidden className="mr-1 size-2 shrink-0 rounded-full bg-warning" />
                   <span className="sr-only">Runtime update available.</span>
                 </>
               ) : undefined

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.settings.projects/ProjectsPage.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.settings.projects/ProjectsPage.tsx
@@ -13,6 +13,7 @@ import {
   SettingsContainer,
   SettingsHeader,
   SettingsRow,
+  SettingsRowDescription,
   SettingsRowTitle,
   SettingsSection,
 } from "~/components/primitives/SettingsLayout";
@@ -52,6 +53,10 @@ export function ProjectsPage({
   otherProjects: ProjectRuntimeRow[];
 }) {
   const count = needsUpdate.length;
+  // "All projects" lists every project — both the ones needing an update and the rest — sorted by name.
+  const allProjects = [...needsUpdate, ...otherProjects].sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
 
   return (
     <PageContainer>
@@ -64,10 +69,15 @@ export function ProjectsPage({
             <>
               <SettingsSection>
                 <SettingsHeader
-                  title="Runtime update available"
+                  title={
+                    <span className="flex items-center gap-x-2">
+                      <span aria-hidden className="size-2 shrink-0 rounded-full bg-warning" />
+                      Runtime update available
+                    </span>
+                  }
                   description={`${count} ${
                     count === 1 ? "project is" : "projects are"
-                  } still running Node.js ${NODE_RUNTIME_UPDATE_MAJOR} in Production. Update each one to Node.js ${NODE_RUNTIME_TARGET_MAJOR} and deploy a new version.`}
+                  } still running Node.js ${NODE_RUNTIME_UPDATE_MAJOR} in production. Update each one to Node.js ${NODE_RUNTIME_TARGET_MAJOR} and deploy a new version.`}
                 />
 
                 <SettingsRow
@@ -76,11 +86,12 @@ export function ProjectsPage({
                   description={
                     <>
                       Set the runtime in{" "}
-                      <InlineCode variant="extra-small" className="whitespace-nowrap">
+                      <InlineCode variant="extra-extra-small" className="whitespace-nowrap">
                         trigger.config.ts
                       </InlineCode>
-                      , then deploy. <InlineCode variant="extra-small">node-22</InlineCode> and{" "}
-                      <InlineCode variant="extra-small">node-26</InlineCode> are also supported.
+                      , then deploy. <InlineCode variant="extra-extra-small">node-22</InlineCode>{" "}
+                      and <InlineCode variant="extra-extra-small">node-26</InlineCode> are also
+                      supported.
                     </>
                   }
                   action={
@@ -108,7 +119,13 @@ export function ProjectsPage({
               </SettingsSection>
 
               <SettingsSection>
-                <SettingsHeader title="Projects to update" />
+                <SettingsHeader
+                  title={
+                    <span className="text-warning">
+                      {count} {count === 1 ? "project" : "projects"} to update
+                    </span>
+                  }
+                />
                 {needsUpdate.map((project) => (
                   <ProjectRow
                     key={project.ref}
@@ -121,21 +138,34 @@ export function ProjectsPage({
           ) : null}
 
           <SettingsSection>
-            <SettingsHeader title="Projects" />
-            {otherProjects.length === 0 ? (
+            <SettingsHeader title="All projects" />
+            {allProjects.length === 0 ? (
               <SettingsBlock>
-                <Paragraph variant="small">
-                  {count === 0 ? "This organization has no projects yet." : "No other projects."}
-                </Paragraph>
+                <Paragraph variant="small">This organization has no projects yet.</Paragraph>
               </SettingsBlock>
             ) : (
-              otherProjects.map((project) => (
-                <ProjectRow
-                  key={project.ref}
-                  organizationSlug={organizationSlug}
-                  project={project}
-                />
-              ))
+              <>
+                {count === 0 ? (
+                  <SettingsBlock>
+                    <div className="space-y-0.5">
+                      <div className="flex items-center gap-x-2">
+                        <span aria-hidden className="size-2 shrink-0 rounded-full bg-success" />
+                        <SettingsRowTitle>All projects are up to date</SettingsRowTitle>
+                      </div>
+                      <SettingsRowDescription>
+                        Every project is running the latest Node.js version in production.
+                      </SettingsRowDescription>
+                    </div>
+                  </SettingsBlock>
+                ) : null}
+                {allProjects.map((project) => (
+                  <ProjectRow
+                    key={project.ref}
+                    organizationSlug={organizationSlug}
+                    project={project}
+                  />
+                ))}
+              </>
             )}
           </SettingsSection>
         </SettingsContainer>


### PR DESCRIPTION
## Changelog

Polish for the organization **Projects** settings page:

- Evened out the right padding on the side-menu runtime-update dot so it sits with equal spacing on all sides.
- Added a warning-orange dot beside the **Runtime update available** heading.
- The update heading now leads with the count, e.g. **"5 projects to update"**, in warning-orange.
- The bottom section is renamed **All projects** and now lists *every* project, not just the up-to-date ones.
- When nothing needs updating, an **"All projects are up to date"** status shows at the top of the list.
- Minor copy/style tweaks: lowercased "production" and shrank the inline config code one size.

All accent colors use the existing `warning`/`success` design tokens.

<img width="898" height="896" alt="CleanShot 2026-08-29 at 10 20 28" src="https://github.com/user-attachments/assets/ecf289a2-ea87-4ffb-b94a-b8a7a317279c" />

<img width="753" height="753" alt="CleanShot 2026-08-29 at 10 39 34" src="https://github.com/user-attachments/assets/dcf2d5a4-bb96-410d-8f4b-a4b850283664" />

---

[Open workspace in Conductor](https://app.conductor.build/workspace/bc053cd6-66db-4136-bea1-0929a3f1b4e5)
