### PR TITLE
chore(sdk,core,build): stop publishing compiled test files

### DIFF
--- a/.changeset/quiet-tests-stay-home.md
+++ b/.changeset/quiet-tests-stay-home.md
@@ -1,0 +1,7 @@
+---
+"@trigger.dev/sdk": patch
+"@trigger.dev/core": patch
+"@trigger.dev/build": patch
+---
+
+Stop shipping compiled test files in the published packages. The `*.test.ts` sources were being emitted into `dist`, adding dead weight to every install and leaving modules that `require("vitest")` (not a dependency) inside the tarball, which tripped tooling that walks every file in a package.

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -17,6 +17,9 @@
   ],
   "tshy": {
     "selfLink": false,
+    "exclude": [
+      "src/**/*.test.ts"
+    ],
     "main": true,
     "module": true,
     "project": "./tsconfig.src.json",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,9 @@
   ],
   "tshy": {
     "selfLink": false,
+    "exclude": [
+      "src/**/*.test.ts"
+    ],
     "main": true,
     "module": true,
     "project": "./tsconfig.src.json",

--- a/packages/trigger-sdk/package.json
+++ b/packages/trigger-sdk/package.json
@@ -20,6 +20,9 @@
   ],
   "tshy": {
     "selfLink": false,
+    "exclude": [
+      "src/**/*.test.ts"
+    ],
     "main": true,
     "module": true,
     "project": "./tsconfig.build.json",


### PR DESCRIPTION
## Summary

Fixes [#4825](https://github.com/triggerdotdev/trigger.dev/issues/4825).

The published `@trigger.dev/sdk`, `@trigger.dev/core` and `@trigger.dev/build` tarballs included every `*.test.ts` file compiled into `dist`, plus their `.d.ts` and source maps. Those modules `require("vitest")`, which is not a dependency of any of the packages, so the tarballs contained modules that cannot resolve. That is dead weight on every install, and it trips tooling that walks or bundles every file in a package.

## Fix

tshy supports an `exclude` list in its `package.json` config that applies to every dialect build, so each affected package now sets:

```json
"tshy": {
  "exclude": ["src/**/*.test.ts"]
}
```

Only `*.test.ts` files are excluded. The public test-helper entry points (`@trigger.dev/sdk/ai/test`, `@trigger.dev/core/v3/test`) live in `src/v3/test/` and are still built and exported. The CLI package already had an equivalent exclude. Type checking and vitest are unaffected because they run off the package `tsconfig.json`, not the tshy build config.

Verified with clean builds of all three packages: zero `*.test.*` artifacts in `dist`, public entry points still present.