### PR TITLE
fix(cli): reject known-bad esbuild versions at build time

### DIFF
--- a/.changeset/esbuild-version-guard.md
+++ b/.changeset/esbuild-version-guard.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Detect the esbuild version actually resolved at build time instead of trusting the declared range. A package manager `overrides` entry can install a version the CLI is not tested against without any warning; esbuild 0.25.0 in particular emits sourcemaps whose mappings reference dropped `sources` entries, which makes `source-map-support` throw at runtime inside a deployed task. Known-bad versions now fail the build with a clear message, and other out-of-range versions warn.

--- a/packages/cli-v3/src/build/bundle.ts
+++ b/packages/cli-v3/src/build/bundle.ts
@@ -24,6 +24,7 @@ import {
   shims,
 } from "./packageModules.js";
 import { buildPlugins } from "./plugins.js";
+import { checkEsbuildVersion } from "./esbuildVersion.js";
 import { cliLink, prettyError } from "../utilities/cliOutput.js";
 import { SkipLoggingError } from "../cli/common.js";
 
@@ -68,6 +69,21 @@ export class BundleError extends Error {
 
 export async function bundleWorker(options: BundleOptions): Promise<BundleResult> {
   const { resolvedConfig } = options;
+
+  // Check the esbuild that actually got installed, not the range we declare: a
+  // package manager `overrides` entry can resolve a version outside it without
+  // any warning, and some of those silently emit corrupt sourcemaps.
+  const esbuildVersionIssue = checkEsbuildVersion(esbuild.version);
+
+  if (esbuildVersionIssue) {
+    if (esbuildVersionIssue.level === "error") {
+      prettyError("Unsupported esbuild version", esbuildVersionIssue.message);
+
+      throw new SkipLoggingError();
+    }
+
+    logger.warn(esbuildVersionIssue.message);
+  }
 
   let currentContext: esbuild.BuildContext | undefined;
 

--- a/packages/cli-v3/src/build/esbuildVersion.test.ts
+++ b/packages/cli-v3/src/build/esbuildVersion.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { checkEsbuildVersion, SUPPORTED_ESBUILD_RANGE } from "./esbuildVersion.js";
+
+describe("checkEsbuildVersion", () => {
+  it("accepts a version inside the declared range", () => {
+    expect(checkEsbuildVersion("0.23.0")).toBeUndefined();
+    expect(checkEsbuildVersion("0.23.9")).toBeUndefined();
+  });
+
+  it("rejects 0.25.0, which emits sourcemaps with dangling source indices", () => {
+    // The out-of-bounds source-index regression makes source-map-support throw
+    // `No element indexed by N` inside recordSpanException at runtime, long
+    // after the build reported success.
+    const issue = checkEsbuildVersion("0.25.0");
+
+    expect(issue?.level).toBe("error");
+    expect(issue?.message).toContain("0.25.1");
+    expect(issue?.message).toContain("overrides");
+  });
+
+  it("does not reject the release that fixed the regression", () => {
+    const issue = checkEsbuildVersion("0.25.1");
+
+    expect(issue?.level).not.toBe("error");
+  });
+
+  it("warns, but does not fail, for an out-of-range version that is not known bad", () => {
+    const issue = checkEsbuildVersion("0.24.2");
+
+    expect(issue?.level).toBe("warning");
+    expect(issue?.message).toContain(SUPPORTED_ESBUILD_RANGE);
+  });
+
+  it("ignores a version it cannot parse", () => {
+    expect(checkEsbuildVersion("not-a-version")).toBeUndefined();
+  });
+});

--- a/packages/cli-v3/src/build/esbuildVersion.ts
+++ b/packages/cli-v3/src/build/esbuildVersion.ts
@@ -1,0 +1,86 @@
+import * as semver from "semver";
+
+/**
+ * The esbuild range the CLI declares in its package.json.
+ *
+ * Kept in sync manually: a package manager `overrides`/`resolutions` entry can
+ * install a version outside this range without any warning, which is exactly
+ * the case this module exists to catch.
+ */
+export const SUPPORTED_ESBUILD_RANGE = "^0.23.0";
+
+export type EsbuildVersionIssue = {
+  level: "error" | "warning";
+  message: string;
+};
+
+type KnownBadRange = {
+  /** Versions known to miscompile in a way that breaks deployed workers. */
+  range: string;
+  /** First release containing the fix. */
+  fixedIn: string;
+  summary: string;
+};
+
+/**
+ * Versions we refuse to build with, rather than merely warn about, because the
+ * output is silently corrupt and only fails at runtime inside a deployed task.
+ */
+const KNOWN_BAD_RANGES: KnownBadRange[] = [
+  {
+    range: "0.25.0",
+    fixedIn: "0.25.1",
+    summary:
+      "emits sourcemaps whose mappings reference input `sources` entries that were dropped, so `source-map-support` throws `No element indexed by N` the first time a stack trace touches an affected chunk",
+  },
+];
+
+/**
+ * Check the esbuild version actually resolved at runtime — not the range the
+ * CLI declares — and report anything that will produce a broken build.
+ *
+ * Returns `undefined` when the version is fine.
+ */
+export function checkEsbuildVersion(version: string): EsbuildVersionIssue | undefined {
+  const parsed = semver.valid(semver.coerce(version));
+
+  if (!parsed) {
+    // An unparseable version is not worth failing a build over; the caller has
+    // nothing actionable to say about it.
+    return undefined;
+  }
+
+  const knownBad = KNOWN_BAD_RANGES.find((candidate) =>
+    semver.satisfies(parsed, candidate.range, { includePrerelease: true })
+  );
+
+  if (knownBad) {
+    return {
+      level: "error",
+      message: [
+        `esbuild ${version} is known to produce corrupt builds and cannot be used.`,
+        "",
+        `It ${knownBad.summary}.`,
+        "",
+        `Fixed in esbuild ${knownBad.fixedIn}. The Trigger.dev CLI expects esbuild ${SUPPORTED_ESBUILD_RANGE}.`,
+        "",
+        "This usually means a package manager `overrides`, `resolutions` or `pnpm.overrides` entry",
+        "pinned esbuild across your whole dependency tree. Remove the pin, or raise it to a fixed",
+        `version (>= ${knownBad.fixedIn}), and reinstall.`,
+      ].join("\n"),
+    };
+  }
+
+  if (!semver.satisfies(parsed, SUPPORTED_ESBUILD_RANGE, { includePrerelease: true })) {
+    return {
+      level: "warning",
+      message: [
+        `esbuild ${version} is outside the range the Trigger.dev CLI is tested against (${SUPPORTED_ESBUILD_RANGE}).`,
+        "This is usually caused by a package manager `overrides` or `resolutions` entry.",
+        "If you hit unexpected build output or broken stack traces, try removing the pin first.",
+      ].join("\n"),
+    };
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Problem

The CLI declares `esbuild ^0.23.0`, but a package manager `overrides` /
`resolutions` entry is honoured silently, so the CLI can bundle with a version
it has never been tested against.

esbuild 0.25.0 has an out-of-bounds source-index regression, fixed in 0.25.1,
that drops input `sources` entries while keeping the mapping indices. The
resulting chunks are internally inconsistent. Because the worker installs
`source-map-support` globally (`entryPoints/managed-run-worker.js`), the first
stack trace touching an affected chunk makes `originalPositionFor` throw
`Error: No element indexed by N` inside `recordSpanException` (`otel/utils.ts`).

The build itself reports success, so the failure only surfaces in a deployed run.

## Change

Check `esbuild.version` — the version actually resolved, not the declared range —
at the top of `bundleWorker`:

- a **known-bad** version fails the build with a message naming the fixed release
  and pointing at the `overrides` entry that is the usual cause
- any other **out-of-range** version warns rather than fails, so users who
  deliberately move to a newer good release are not blocked

The known-bad list is a small table in `esbuildVersion.ts`, so future entries are
one line.

## Cost/benefit

This adds a gate to every `deploy` and `dev` build, so the risk is a false
positive blocking a legitimate build. That is why only versions with a known
output-corrupting defect hard-fail; everything else warns. The benefit is that
the failure mode it replaces is a runtime crash inside a deployed task with a
message (`No element indexed by 6`) that gives no hint the cause is a
dependency pin.

## Tests

`packages/cli-v3/src/build/esbuildVersion.test.ts` — 5 tests: in-range accepted,
0.25.0 rejected with the fix version named, 0.25.1 not rejected, out-of-range
warns without failing, unparseable version ignored.

```
pnpm vitest run src/build/esbuildVersion.test.ts   -> 5 passed
pnpm run typecheck                                 -> clean
```

Note: the cli-v3 suite has 5 failing test files and 1 failing test on unmodified
`main` (`snapshot.test.ts` and four "No test suite found" files). I baselined
before and after — this branch adds no new failures.

refs #4801
