### PR TITLE
fix(cli): forward TRIGGER_WORKER_INSTANCE_NAME into the run process

### DIFF
--- a/.changeset/forward-worker-instance-name.md
+++ b/.changeset/forward-worker-instance-name.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Forward `TRIGGER_WORKER_INSTANCE_NAME` into the task run process so run telemetry reports the host it executed on. On Kubernetes the supervisor already sources the node name from the downward API, but it never reached the forked run process, so OTLP spans exported to an off-node collector arrived with an empty hostname.

--- a/packages/cli-v3/src/entryPoints/managed/env.test.ts
+++ b/packages/cli-v3/src/entryPoints/managed/env.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { RunnerEnv } from "./env.js";
+
+function buildEnv(overrides: Record<string, string> = {}) {
+  return new RunnerEnv({
+    TRIGGER_CONTENT_HASH: "hash_1234",
+    TRIGGER_PROJECT_ID: "project_1234",
+    TRIGGER_PROJECT_REF: "proj_1234",
+    TRIGGER_DEPLOYMENT_ID: "deployment_1234",
+    TRIGGER_DEPLOYMENT_VERSION: "20260831.1",
+    TRIGGER_ENV_ID: "env_1234",
+    OTEL_EXPORTER_OTLP_ENDPOINT: "http://localhost:4318",
+    TRIGGER_RUNNER_ID: "runner_1234",
+    TRIGGER_POD_SCHEDULED_AT_MS: "1756600000000",
+    TRIGGER_DEQUEUED_AT_MS: "1756600001000",
+    TRIGGER_SUPERVISOR_API_PROTOCOL: "http",
+    TRIGGER_SUPERVISOR_API_DOMAIN: "localhost",
+    TRIGGER_SUPERVISOR_API_PORT: "8020",
+    TRIGGER_WORKER_INSTANCE_NAME: "ip-10-0-1-23.ec2.internal",
+    ...overrides,
+  });
+}
+
+describe("RunnerEnv.gatherProcessEnv", () => {
+  it("forwards the worker instance name into the run process", () => {
+    // The task run worker is forked with this explicit env rather than the
+    // container's process.env, so anything missing here never reaches the run
+    // and telemetry exports with an empty host.
+    const processEnv = buildEnv().gatherProcessEnv();
+
+    expect(processEnv.TRIGGER_WORKER_INSTANCE_NAME).toBe("ip-10-0-1-23.ec2.internal");
+  });
+
+  it("carries the node name set by the Kubernetes downward API", () => {
+    const processEnv = buildEnv({
+      TRIGGER_WORKER_INSTANCE_NAME: "gke-prod-pool-a-9f21",
+    }).gatherProcessEnv();
+
+    expect(processEnv.TRIGGER_WORKER_INSTANCE_NAME).toBe("gke-prod-pool-a-9f21");
+  });
+
+  it("still forwards the OTLP endpoint under both names", () => {
+    const processEnv = buildEnv().gatherProcessEnv();
+
+    expect(processEnv.OTEL_EXPORTER_OTLP_ENDPOINT).toBe("http://localhost:4318");
+    expect(processEnv.TRIGGER_OTEL_EXPORTER_OTLP_ENDPOINT).toBe("http://localhost:4318");
+  });
+
+  it("omits undefined values", () => {
+    const processEnv = buildEnv().gatherProcessEnv();
+
+    expect(processEnv).not.toHaveProperty("NODE_EXTRA_CA_CERTS");
+    expect(Object.values(processEnv).every((value) => value !== undefined)).toBe(true);
+  });
+});

--- a/packages/cli-v3/src/entryPoints/managed/env.ts
+++ b/packages/cli-v3/src/entryPoints/managed/env.ts
@@ -247,6 +247,11 @@ export class RunnerEnv {
       OTEL_EXPORTER_OTLP_ENDPOINT: this.OTEL_EXPORTER_OTLP_ENDPOINT,
       TRIGGER_OTEL_EXPORTER_OTLP_ENDPOINT: this.OTEL_EXPORTER_OTLP_ENDPOINT,
       UV_USE_IO_URING: this.UV_USE_IO_URING,
+      // Identifies the node the run is executing on. On Kubernetes the
+      // supervisor sources this from the downward API (spec.nodeName), so
+      // without it here a user's `trigger.config.ts` telemetry resource has no
+      // way to recover the host and OTLP spans export with an empty hostname.
+      TRIGGER_WORKER_INSTANCE_NAME: this.TRIGGER_WORKER_INSTANCE_NAME,
     };
 
     // Filter out undefined values


### PR DESCRIPTION
## Problem

On self-hosted Kubernetes, task-run spans and logs exported over OTLP to an
off-node collector arrive with no host, so every such span gets tagged
`issue_type:empty_hostname`.

The node name is already on the pod. `apps/supervisor/src/workloadManager/kubernetes.ts`
injects it into the **run-controller container** via the downward API:

```ts
{ name: "TRIGGER_WORKER_INSTANCE_NAME", valueFrom: { fieldRef: { fieldPath: "spec.nodeName" } } }
```

But the task-run worker is `fork()`ed with an explicit, replaced env built by
`RunnerEnv.gatherProcessEnv()`, which allowlisted only `NODE_ENV`,
`NODE_EXTRA_CA_CERTS`, the two OTLP endpoint names and `UV_USE_IO_URING`.

So the node identity never reaches the run process, and there is no supported
way for a user's `trigger.config.ts` telemetry `resource` to recover it.

## Change

Add `TRIGGER_WORKER_INSTANCE_NAME` to the forwarded set.

It is a required field on the runner env schema (`env.ts:55`, `z.string()`), so
it is always present, and the existing undefined-filter leaves behaviour
unchanged for the optional entries.

## Cost/benefit

Small and low-risk: one additional key in an env allowlist, on a value the
supervisor already computes and already passes to the controller. It adds no new
config surface and no new failure mode. The benefit is that self-hosted
Kubernetes users get a usable host on their run telemetry instead of an
empty one.

## Tests

`packages/cli-v3/src/entryPoints/managed/env.test.ts` — 4 tests: the instance
name is forwarded, a Kubernetes-style node name survives, the OTLP endpoint is
still forwarded under both names, and undefined values are still filtered out.

```
pnpm vitest run src/entryPoints/managed/env.test.ts   -> 4 passed
pnpm run typecheck                                    -> clean
```

Removing the added line makes 2 of the 4 fail, so they pin the behaviour rather
than restate it.

Note: the cli-v3 suite has 5 failing test files and 1 failing test on unmodified
`main`. I baselined before and after — this branch adds no new failures.

refs #4214
