### PR TITLE
fix(run-engine,webapp): guard run finalization against lost resume signals

### DIFF
--- a/.server-changes/run-finalization-guard.md
+++ b/.server-changes/run-finalization-guard.md
@@ -3,4 +3,4 @@ area: webapp
 type: fix
 ---
 
-Runs waiting on triggerAndWait or batchTriggerAndWait can no longer get stuck forever when a database error interrupts a child run finishing (completing, failing, being canceled, or expiring). A durable guard now re-delivers the lost completion signal and resumes the waiting run automatically.
+A durable guard improves reliability for runs waiting on triggerAndWait or batchTriggerAndWait if there's a database error that interrupts a child run finishing.

--- a/.server-changes/run-finalization-guard.md
+++ b/.server-changes/run-finalization-guard.md
@@ -3,4 +3,4 @@ area: webapp
 type: fix
 ---
 
-Runs waiting on triggerAndWait or batchTriggerAndWait can no longer get stuck forever when a database error interrupts a child run's completion. A durable guard now re-delivers the lost completion signal and resumes the waiting run automatically.
+Runs waiting on triggerAndWait or batchTriggerAndWait can no longer get stuck forever when a database error interrupts a child run finishing (completing, failing, being canceled, or expiring). A durable guard now re-delivers the lost completion signal and resumes the waiting run automatically.

--- a/.server-changes/run-finalization-guard.md
+++ b/.server-changes/run-finalization-guard.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Runs waiting on triggerAndWait or batchTriggerAndWait can no longer get stuck forever when a database error interrupts a child run's completion. A durable guard now re-delivers the lost completion signal and resumes the waiting run automatically.

--- a/apps/webapp/app/v3/runOpsMigration/unblockRouteCatalog.ts
+++ b/apps/webapp/app/v3/runOpsMigration/unblockRouteCatalog.ts
@@ -95,6 +95,12 @@ export const UNBLOCK_ROUTES: readonly UnblockRoute[] = [
     site: RUN_ATTEMPT_SYSTEM,
     symbol: "#permanentlyFailRun",
   },
+  {
+    id: "runAttempt.ensureFinalized",
+    kind: "RUN",
+    site: RUN_ATTEMPT_SYSTEM,
+    symbol: "ensureRunFinalized",
+  },
 ];
 
 export function expectedCompleteWaitpointCallSites(): { site: string; symbol: string }[] {

--- a/internal-packages/run-engine/src/engine/index.ts
+++ b/internal-packages/run-engine/src/engine/index.ts
@@ -309,6 +309,11 @@ export class RunEngine {
             runId: payload.runId,
           });
         },
+        ensureRunFinalized: async ({ payload }) => {
+          await this.runAttemptSystem.ensureRunFinalized({
+            runId: payload.runId,
+          });
+        },
         enqueueDelayedRun: async ({ payload }) => {
           await this.delayedRunSystem.enqueueDelayedRun({ runId: payload.runId });
         },
@@ -505,6 +510,7 @@ export class RunEngine {
       delayedRunSystem: this.delayedRunSystem,
       machines: this.options.machines,
       retryWarmStartThresholdMs: this.options.retryWarmStartThresholdMs,
+      finalizationGuardDelayMs: this.options.finalizationGuardDelayMs,
       redisOptions: this.options.cache?.redis ?? this.options.runLock.redis,
     });
 

--- a/internal-packages/run-engine/src/engine/index.ts
+++ b/internal-packages/run-engine/src/engine/index.ts
@@ -312,6 +312,7 @@ export class RunEngine {
         ensureRunFinalized: async ({ payload }) => {
           await this.runAttemptSystem.ensureRunFinalized({
             runId: payload.runId,
+            deferCount: payload.deferCount,
           });
         },
         enqueueDelayedRun: async ({ payload }) => {

--- a/internal-packages/run-engine/src/engine/index.ts
+++ b/internal-packages/run-engine/src/engine/index.ts
@@ -427,6 +427,7 @@ export class RunEngine {
     this.ttlSystem = new TtlSystem({
       resources,
       waitpointSystem: this.waitpointSystem,
+      finalizationGuardDelayMs: this.options.finalizationGuardDelayMs,
     });
 
     const ttlWorkerCatalog = createTtlWorkerCatalog({

--- a/internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
@@ -104,6 +104,14 @@ const DEPLOYMENT_STALE_TTL = 60000 * 60 * 24 * 2; // 2 days
 const QUEUE_FRESH_TTL = 60000 * 60; // 1 hour
 const QUEUE_STALE_TTL = 60000 * 60 * 2; // 2 hours
 
+/**
+ * How many times the finalization guard defers to an in-flight cancellation before
+ * delivering anyway. The worker-owned states normally exit within a heartbeat cycle
+ * or two, so exhausting this budget means the heartbeat itself was lost; resuming the
+ * parent with the identical cancel error then beats watching forever.
+ */
+const MAX_FINALIZATION_GUARD_DEFERRALS = 10;
+
 export class RunAttemptSystem {
   private readonly $: SystemResources;
   private readonly executionSnapshotSystem: ExecutionSnapshotSystem;
@@ -1798,11 +1806,11 @@ export class RunAttemptSystem {
    * {@link #finalizeRun} once every inline side effect succeeded. It only ever
    * executes when the inline path died in between.
    */
-  async #scheduleFinalizationGuard(runId: string): Promise<void> {
+  async #scheduleFinalizationGuard(runId: string, deferCount?: number): Promise<void> {
     await this.$.worker.enqueue({
       id: `ensureRunFinalized:${runId}`,
       job: "ensureRunFinalized",
-      payload: { runId },
+      payload: { runId, deferCount },
       availableAt: new Date(Date.now() + this.finalizationGuardDelayMs),
     });
   }
@@ -1819,7 +1827,13 @@ export class RunAttemptSystem {
    * finalize path owns that window, and completing early would resume the parent while
    * the child is still running.
    */
-  public async ensureRunFinalized({ runId }: { runId: string }): Promise<void> {
+  public async ensureRunFinalized({
+    runId,
+    deferCount,
+  }: {
+    runId: string;
+    deferCount?: number;
+  }): Promise<void> {
     return startSpan(this.$.tracer, "ensureRunFinalized", async (span) => {
       span.setAttribute("runId", runId);
 
@@ -1879,15 +1893,30 @@ export class RunAttemptSystem {
           latestSnapshot.executionStatus === "PENDING_CANCEL";
 
         if (latestSnapshot.executionStatus !== "FINISHED" && workerOwnsExecution) {
-          this.$.logger.info(
-            "ensureRunFinalized: run is canceled but the worker is still winding down, keeping watch until the cancellation finalize path completes it",
+          const currentDeferCount = deferCount ?? 0;
+
+          if (currentDeferCount < MAX_FINALIZATION_GUARD_DEFERRALS) {
+            this.$.logger.info(
+              "ensureRunFinalized: run is canceled but the worker is still winding down, keeping watch until the cancellation finalize path completes it",
+              {
+                runId,
+                executionStatus: latestSnapshot.executionStatus,
+                deferCount: currentDeferCount,
+              }
+            );
+            await this.#scheduleFinalizationGuard(runId, currentDeferCount + 1);
+            return;
+          }
+
+          this.rederivationsCounter.add(1, { leg: "cancel_deferral_budget" });
+          this.$.logger.warn(
+            "ensureRunFinalized: canceled run never reached a finished execution within the deferral budget, delivering anyway",
             {
               runId,
               executionStatus: latestSnapshot.executionStatus,
+              deferCount: currentDeferCount,
             }
           );
-          await this.#scheduleFinalizationGuard(runId);
-          return;
         }
       }
 

--- a/internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
@@ -1815,9 +1815,9 @@ export class RunAttemptSystem {
    * blocked-run fan-out (which covers a lost `continueRunIfUnblocked` enqueue). A
    * non-final run means the finish commit itself never landed; the caller's retry
    * re-runs the whole completion, so there is nothing to re-deliver. A canceled run
-   * whose execution has not reached FINISHED re-arms the guard and waits: the
-   * cancellation finalize path owns that window, and completing early would resume the
-   * parent while the child is still winding down.
+   * whose worker is still winding down re-arms the guard and waits: the cancellation
+   * finalize path owns that window, and completing early would resume the parent while
+   * the child is still running.
    */
   public async ensureRunFinalized({ runId }: { runId: string }): Promise<void> {
     return startSpan(this.$.tracer, "ensureRunFinalized", async (span) => {
@@ -1865,9 +1865,22 @@ export class RunAttemptSystem {
           this.$.runStore
         );
 
-        if (latestSnapshot.executionStatus !== "FINISHED") {
+        /**
+         * Defer only while a worker still owns the execution: those states carry
+         * heartbeats that force the cancellation finalize path, which completes the
+         * waitpoint with the run's actual wind-down and acks this guard, so the watch
+         * always terminates. In any other snapshot state (queued, delayed, suspended,
+         * created) nobody is left to produce a FINISHED snapshot for a canceled run,
+         * so the guard must deliver or the parent is stranded.
+         */
+        const workerOwnsExecution =
+          isExecuting(latestSnapshot.executionStatus) ||
+          isPendingExecuting(latestSnapshot.executionStatus) ||
+          latestSnapshot.executionStatus === "PENDING_CANCEL";
+
+        if (latestSnapshot.executionStatus !== "FINISHED" && workerOwnsExecution) {
           this.$.logger.info(
-            "ensureRunFinalized: run is canceled but execution has not finished, keeping watch until the cancellation finalize path completes it",
+            "ensureRunFinalized: run is canceled but the worker is still winding down, keeping watch until the cancellation finalize path completes it",
             {
               runId,
               executionStatus: latestSnapshot.executionStatus,

--- a/internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
@@ -7,7 +7,7 @@ import {
   RedisCacheStore,
 } from "@internal/cache";
 import type { RedisOptions } from "@internal/redis";
-import { startSpan } from "@internal/tracing";
+import { startSpan, type Counter } from "@internal/tracing";
 import { tryCatch } from "@trigger.dev/core/utils";
 import type {
   CompleteRunAttemptResult,
@@ -41,6 +41,7 @@ import { getMachinePreset, machinePresetFromName } from "../machinePresets.js";
 import { retryOutcomeFromCompletion } from "../retrying.js";
 import {
   isExecuting,
+  isFinalRunStatus,
   isFinishedOrPendingFinished,
   isInitialState,
   isPendingExecuting,
@@ -67,6 +68,7 @@ export type RunAttemptSystemOptions = {
   waitpointSystem: WaitpointSystem;
   delayedRunSystem: DelayedRunSystem;
   retryWarmStartThresholdMs?: number;
+  finalizationGuardDelayMs?: number;
   machines: RunEngineOptions["machines"];
   redisOptions: RedisOptions;
 };
@@ -108,6 +110,8 @@ export class RunAttemptSystem {
   private readonly batchSystem: BatchSystem;
   private readonly waitpointSystem: WaitpointSystem;
   private readonly delayedRunSystem: DelayedRunSystem;
+  private readonly finalizationGuardDelayMs: number;
+  private readonly rederivationsCounter: Counter;
   private readonly cache: UnkeyCache<{
     tasks: BackwardsCompatibleTaskRunExecution["task"];
     machinePresets: MachinePreset;
@@ -123,6 +127,15 @@ export class RunAttemptSystem {
     this.batchSystem = options.batchSystem;
     this.waitpointSystem = options.waitpointSystem;
     this.delayedRunSystem = options.delayedRunSystem;
+    this.finalizationGuardDelayMs = options.finalizationGuardDelayMs ?? 60_000;
+    this.rederivationsCounter = this.$.meter.createCounter(
+      "run_attempt_system.finalization_rederivations",
+      {
+        description:
+          "Lost run-finalization side effects re-delivered by the ensureRunFinalized guard",
+        unit: "runs",
+      }
+    );
 
     const ctx = new DefaultStatefulContext();
     const memory = createLRUMemoryStore(5000);
@@ -756,6 +769,8 @@ export class RunAttemptSystem {
             machinePresetName: currentRun.machinePreset,
             environmentType: latestSnapshot.environmentType,
           });
+
+          await this.#scheduleFinalizationGuard(runId);
 
           const run = await this.$.runStore.completeAttemptSuccess(
             runId,
@@ -1532,6 +1547,8 @@ export class RunAttemptSystem {
           // finalizeRun is true — fall through to finish the run immediately
         }
 
+        await this.#scheduleFinalizationGuard(runId);
+
         //not executing, so we will actually finish the run
         const newSnapshot = await this.executionSnapshotSystem.createExecutionSnapshot(prisma, {
           run,
@@ -1654,6 +1671,8 @@ export class RunAttemptSystem {
         environmentType: latestSnapshot.environmentType,
       });
 
+      await this.#scheduleFinalizationGuard(runId);
+
       //run permanently failed
       const run = await this.$.runStore.failRunPermanently(
         runId,
@@ -1769,6 +1788,96 @@ export class RunAttemptSystem {
 
     //cancel the heartbeats
     await this.$.worker.ack(`heartbeatSnapshot.${id}`);
+
+    await this.$.worker.ack(`ensureRunFinalized:${id}`);
+  }
+
+  /**
+   * Write-ahead guard for run finalization. Enqueued BEFORE the finish commit (so no
+   * finish write can exist without a durable watcher) and acked at the end of
+   * {@link #finalizeRun} once every inline side effect succeeded. It only ever
+   * executes when the inline path died in between.
+   */
+  async #scheduleFinalizationGuard(runId: string): Promise<void> {
+    await this.$.worker.enqueue({
+      id: `ensureRunFinalized:${runId}`,
+      job: "ensureRunFinalized",
+      payload: { runId },
+      availableAt: new Date(Date.now() + this.finalizationGuardDelayMs),
+    });
+  }
+
+  /**
+   * Re-delivers a finished run's finalization side effects: the associated waitpoint's
+   * completion, the parent unblock fan-out, and the batch completion nudge. Safe to run
+   * at-least-once and to race the inline path — every leg is idempotent, and completing
+   * an already-completed waitpoint still re-runs the blocked-run fan-out (which covers a
+   * lost `continueRunIfUnblocked` enqueue). A non-final run means the finish commit
+   * itself never landed; the caller's retry re-runs the whole completion, so there is
+   * nothing to re-deliver.
+   */
+  public async ensureRunFinalized({ runId }: { runId: string }): Promise<void> {
+    return startSpan(this.$.tracer, "ensureRunFinalized", async (span) => {
+      span.setAttribute("runId", runId);
+
+      const run = await this.$.runStore.findRun(
+        { id: runId },
+        {
+          select: {
+            id: true,
+            status: true,
+            output: true,
+            outputType: true,
+            error: true,
+            batchId: true,
+            associatedWaitpoint: {
+              select: {
+                id: true,
+                status: true,
+              },
+            },
+          },
+        },
+        this.$.prisma
+      );
+
+      if (!run) {
+        this.$.logger.error("ensureRunFinalized: run not found", { runId });
+        return;
+      }
+
+      if (!isFinalRunStatus(run.status)) {
+        this.$.logger.debug("ensureRunFinalized: run is not final, nothing to re-deliver", {
+          runId,
+          status: run.status,
+        });
+        return;
+      }
+
+      span.setAttribute("runStatus", run.status);
+
+      if (run.associatedWaitpoint) {
+        const wasPending = run.associatedWaitpoint.status === "PENDING";
+
+        if (wasPending) {
+          this.rederivationsCounter.add(1, { leg: "waitpoint" });
+          this.$.logger.warn("ensureRunFinalized: re-deriving lost waitpoint completion", {
+            runId,
+            runStatus: run.status,
+            waitpointId: run.associatedWaitpoint.id,
+          });
+        }
+
+        await this.waitpointSystem.completeWaitpoint({
+          id: run.associatedWaitpoint.id,
+          output: this.waitpointSystem.buildWaitpointOutputFromRun(run),
+        });
+      }
+
+      if (run.batchId) {
+        await this.batchSystem.scheduleCompleteBatch({ batchId: run.batchId });
+      }
+    });
   }
 
   async #resolveTaskRunExecutionTask(

--- a/internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
@@ -1854,6 +1854,25 @@ export class RunAttemptSystem {
         return;
       }
 
+      if (run.status === "CANCELED") {
+        const latestSnapshot = await getLatestExecutionSnapshot(
+          this.$.prisma,
+          runId,
+          this.$.runStore
+        );
+
+        if (latestSnapshot.executionStatus !== "FINISHED") {
+          this.$.logger.info(
+            "ensureRunFinalized: run is canceled but execution has not finished, the cancellation finalize path owns the re-delivery",
+            {
+              runId,
+              executionStatus: latestSnapshot.executionStatus,
+            }
+          );
+          return;
+        }
+      }
+
       span.setAttribute("runStatus", run.status);
 
       if (run.associatedWaitpoint) {

--- a/internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/runAttemptSystem.ts
@@ -1454,6 +1454,8 @@ export class RunAttemptSystem {
           });
         }
 
+        await this.#scheduleFinalizationGuard(runId);
+
         const run = await this.$.runStore.cancelRun(
           runId,
           {
@@ -1546,8 +1548,6 @@ export class RunAttemptSystem {
           }
           // finalizeRun is true — fall through to finish the run immediately
         }
-
-        await this.#scheduleFinalizationGuard(runId);
 
         //not executing, so we will actually finish the run
         const newSnapshot = await this.executionSnapshotSystem.createExecutionSnapshot(prisma, {
@@ -1808,13 +1808,16 @@ export class RunAttemptSystem {
   }
 
   /**
-   * Re-delivers a finished run's finalization side effects: the associated waitpoint's
-   * completion, the parent unblock fan-out, and the batch completion nudge. Safe to run
-   * at-least-once and to race the inline path — every leg is idempotent, and completing
-   * an already-completed waitpoint still re-runs the blocked-run fan-out (which covers a
-   * lost `continueRunIfUnblocked` enqueue). A non-final run means the finish commit
-   * itself never landed; the caller's retry re-runs the whole completion, so there is
-   * nothing to re-deliver.
+   * Re-delivers a finished run's finalization side effects: the queue ack, the
+   * associated waitpoint's completion, the parent unblock fan-out, and the batch
+   * completion nudge. Safe to run at-least-once and to race the inline path — every leg
+   * is idempotent, and completing an already-completed waitpoint still re-runs the
+   * blocked-run fan-out (which covers a lost `continueRunIfUnblocked` enqueue). A
+   * non-final run means the finish commit itself never landed; the caller's retry
+   * re-runs the whole completion, so there is nothing to re-deliver. A canceled run
+   * whose execution has not reached FINISHED re-arms the guard and waits: the
+   * cancellation finalize path owns that window, and completing early would resume the
+   * parent while the child is still winding down.
    */
   public async ensureRunFinalized({ runId }: { runId: string }): Promise<void> {
     return startSpan(this.$.tracer, "ensureRunFinalized", async (span) => {
@@ -1830,6 +1833,7 @@ export class RunAttemptSystem {
             outputType: true,
             error: true,
             batchId: true,
+            runtimeEnvironmentId: true,
             associatedWaitpoint: {
               select: {
                 id: true,
@@ -1863,17 +1867,31 @@ export class RunAttemptSystem {
 
         if (latestSnapshot.executionStatus !== "FINISHED") {
           this.$.logger.info(
-            "ensureRunFinalized: run is canceled but execution has not finished, the cancellation finalize path owns the re-delivery",
+            "ensureRunFinalized: run is canceled but execution has not finished, keeping watch until the cancellation finalize path completes it",
             {
               runId,
               executionStatus: latestSnapshot.executionStatus,
             }
           );
+          await this.#scheduleFinalizationGuard(runId);
           return;
         }
       }
 
       span.setAttribute("runStatus", run.status);
+
+      const env = await this.$.controlPlaneResolver.resolveEnv(run.runtimeEnvironmentId);
+
+      if (env) {
+        await this.$.runQueue.acknowledgeMessage(env.organizationId, runId, {
+          removeFromWorkerQueue: true,
+        });
+      } else {
+        this.$.logger.error("ensureRunFinalized: environment not found, skipping queue ack", {
+          runId,
+          runtimeEnvironmentId: run.runtimeEnvironmentId,
+        });
+      }
 
       if (run.associatedWaitpoint) {
         const wasPending = run.associatedWaitpoint.status === "PENDING";

--- a/internal-packages/run-engine/src/engine/systems/ttlSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/ttlSystem.ts
@@ -12,15 +12,33 @@ import { boundedIn } from "@trigger.dev/database";
 export type TtlSystemOptions = {
   resources: SystemResources;
   waitpointSystem: WaitpointSystem;
+  finalizationGuardDelayMs?: number;
 };
 
 export class TtlSystem {
   private readonly $: SystemResources;
   private readonly waitpointSystem: WaitpointSystem;
+  private readonly finalizationGuardDelayMs: number;
 
   constructor(private readonly options: TtlSystemOptions) {
     this.$ = options.resources;
     this.waitpointSystem = options.waitpointSystem;
+    this.finalizationGuardDelayMs = options.finalizationGuardDelayMs ?? 60_000;
+  }
+
+  /**
+   * Write-ahead guard for TTL expiry, mirroring the run attempt system's: enqueued
+   * before the EXPIRED commit so a crash or error between that commit and the
+   * waitpoint completion cannot strand a waiting parent, and acked once the inline
+   * side effects succeed.
+   */
+  async #scheduleFinalizationGuard(runId: string): Promise<void> {
+    await this.$.worker.enqueue({
+      id: `ensureRunFinalized:${runId}`,
+      job: "ensureRunFinalized",
+      payload: { runId },
+      availableAt: new Date(Date.now() + this.finalizationGuardDelayMs),
+    });
   }
 
   async expireRun({ runId, tx }: { runId: string; tx?: PrismaClientOrTransaction }) {
@@ -61,6 +79,8 @@ export class TtlSystem {
         type: "STRING_ERROR",
         raw: `Run expired because the TTL (${run.ttl}) was reached`,
       };
+
+      await this.#scheduleFinalizationGuard(runId);
 
       const updatedRun = await this.$.runStore.expireRun(
         runId,
@@ -121,6 +141,8 @@ export class TtlSystem {
         project: { id: snapshot.projectId },
         environment: { id: snapshot.environmentId },
       });
+
+      await this.$.worker.ack(`ensureRunFinalized:${runId}`);
     });
   }
 
@@ -220,6 +242,10 @@ export class TtlSystem {
         raw: "Run expired because the TTL was reached",
       };
 
+      await pMap(runsToExpire, (run) => this.#scheduleFinalizationGuard(run.id), {
+        concurrency: 10,
+      });
+
       await this.$.runStore.expireRunsBatch(runIdsToExpire, { error, now }, this.$.prisma);
 
       // Process each run: enqueue waitpoint completion jobs and emit events
@@ -261,6 +287,16 @@ export class TtlSystem {
               project: { id: run.projectId },
               environment: { id: run.runtimeEnvironmentId },
             });
+
+            /**
+             * Waitpoint completion in this path is delegated to the finishWaitpoint job,
+             * which can still exhaust its retries, so the guard stays armed for runs with
+             * a waiting parent and verifies the completion landed. Runs with no waitpoint
+             * have nothing left to re-deliver, so release their guard now.
+             */
+            if (!run.associatedWaitpoint) {
+              await this.$.worker.ack(`ensureRunFinalized:${run.id}`);
+            }
 
             expired.push(run.id);
           } catch (e) {

--- a/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
+++ b/internal-packages/run-engine/src/engine/systems/waitpointSystem.ts
@@ -741,7 +741,7 @@ export class WaitpointSystem {
   /**
    * Builds the waitpoint output payload from a completed run's stored output/error.
    */
-  #buildWaitpointOutputFromRun(
+  public buildWaitpointOutputFromRun(
     run: Pick<TaskRun, "status" | "output" | "outputType" | "error">
   ): { value: string; type?: string; isError: boolean } | undefined {
     if (run.status === "COMPLETED_SUCCESSFULLY") {
@@ -830,7 +830,7 @@ export class WaitpointSystem {
 
       // If run has already finished (per snapshot), complete the waitpoint immediately so the parent can resume
       if (snapshot.executionStatus === "FINISHED") {
-        const output = this.#buildWaitpointOutputFromRun(runAfterLock);
+        const output = this.buildWaitpointOutputFromRun(runAfterLock);
         const completed = await this.completeWaitpoint({
           id: waitpoint.id,
           output,

--- a/internal-packages/run-engine/src/engine/tests/ensureRunFinalized.test.ts
+++ b/internal-packages/run-engine/src/engine/tests/ensureRunFinalized.test.ts
@@ -389,6 +389,54 @@ describe("RunEngine ensureRunFinalized guard", () => {
   );
 
   containerTest(
+    "re-derives a cancellation lost after the CANCELED commit on a queued child",
+    async ({ prisma, redisOptions }) => {
+      const engine = createEngine(prisma, redisOptions);
+
+      try {
+        const authenticatedEnvironment = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+        const { parentRun, childRun } = await setupParentAndChild(
+          engine,
+          prisma,
+          authenticatedEnvironment,
+          { dequeueChild: false }
+        );
+
+        vi.spyOn((engine as any).runQueue, "acknowledgeMessage").mockRejectedValueOnce(
+          new Error("simulated redis loss")
+        );
+
+        await expect(engine.cancelRun({ runId: childRun.id })).rejects.toThrow(
+          "simulated redis loss"
+        );
+
+        const childAfterCrash = await prisma.taskRun.findFirstOrThrow({
+          where: { id: childRun.id },
+          include: { associatedWaitpoint: true },
+        });
+        expect(childAfterCrash.status).toBe("CANCELED");
+        expect(childAfterCrash.associatedWaitpoint?.status).toBe("PENDING");
+
+        await setTimeout(5_000);
+
+        const childAfterGuard = await prisma.taskRun.findFirstOrThrow({
+          where: { id: childRun.id },
+          include: { associatedWaitpoint: true },
+        });
+        expect(childAfterGuard.associatedWaitpoint?.status).toBe("COMPLETED");
+        expect(childAfterGuard.associatedWaitpoint?.outputIsError).toBe(true);
+
+        const parentExecutionData = await engine.getRunExecutionData({ runId: parentRun.id });
+        assertNonNullable(parentExecutionData);
+        expect(parentExecutionData.snapshot.executionStatus).toBe("EXECUTING");
+        expect(parentExecutionData.completedWaitpoints?.length).toBe(1);
+      } finally {
+        await engine.quit();
+      }
+    }
+  );
+
+  containerTest(
     "re-derives a waitpoint completion lost during TTL expiry",
     async ({ prisma, redisOptions }) => {
       const engine = createEngine(prisma, redisOptions);

--- a/internal-packages/run-engine/src/engine/tests/ensureRunFinalized.test.ts
+++ b/internal-packages/run-engine/src/engine/tests/ensureRunFinalized.test.ts
@@ -1,0 +1,281 @@
+import { assertNonNullable, containerTest } from "@internal/testcontainers";
+import { trace } from "@internal/tracing";
+import { setTimeout } from "node:timers/promises";
+import { expect, vi } from "vitest";
+import { RunEngine } from "../index.js";
+import { setupAuthenticatedEnvironment, setupBackgroundWorker } from "./setup.js";
+
+vi.setConfig({ testTimeout: 60_000 });
+
+/**
+ * The ensureRunFinalized write-ahead guard: enqueued before every run-finish commit,
+ * acked when the inline side effects (waitpoint completion, unblock fan-out, batch
+ * nudge) all succeed, and re-delivering them when the inline path died in between.
+ * Reproduces the 2026-08-29 incident shape: a DB error after the finish commit left a
+ * RUN waitpoint PENDING forever and the parent blocked.
+ */
+describe("RunEngine ensureRunFinalized guard", () => {
+  function createEngine(prisma: any, redisOptions: any) {
+    return new RunEngine({
+      prisma,
+      worker: {
+        redis: redisOptions,
+        workers: 1,
+        tasksPerWorker: 10,
+        pollIntervalMs: 100,
+      },
+      queue: {
+        redis: redisOptions,
+        masterQueueConsumersDisabled: true,
+        processWorkerQueueDebounceMs: 50,
+      },
+      runLock: {
+        redis: redisOptions,
+      },
+      machines: {
+        defaultMachine: "small-1x",
+        machines: {
+          "small-1x": {
+            name: "small-1x" as const,
+            cpu: 0.5,
+            memory: 0.5,
+            centsPerMs: 0.0001,
+          },
+        },
+        baseCostInCents: 0.0001,
+      },
+      finalizationGuardDelayMs: 1_000,
+      tracer: trace.getTracer("test", "0.0.0"),
+    });
+  }
+
+  async function setupParentAndChild(
+    engine: RunEngine,
+    prisma: any,
+    authenticatedEnvironment: any
+  ) {
+    const parentTask = "parent-task";
+    const childTask = "child-task";
+
+    await setupBackgroundWorker(engine, authenticatedEnvironment, [parentTask, childTask]);
+
+    const parentRun = await engine.trigger(
+      {
+        number: 1,
+        friendlyId: "run_p1234",
+        environment: authenticatedEnvironment,
+        taskIdentifier: parentTask,
+        payload: "{}",
+        payloadType: "application/json",
+        context: {},
+        traceContext: {},
+        traceId: "t12345",
+        spanId: "s12345",
+        queue: `task/${parentTask}`,
+        isTest: false,
+        tags: [],
+        workerQueue: "main",
+      },
+      prisma
+    );
+
+    await setTimeout(500);
+    await engine.dequeueFromWorkerQueue({
+      consumerId: "test_12345",
+      workerQueue: "main",
+    });
+    const initialExecutionData = await engine.getRunExecutionData({ runId: parentRun.id });
+    assertNonNullable(initialExecutionData);
+    await engine.startRunAttempt({
+      runId: parentRun.id,
+      snapshotId: initialExecutionData.snapshot.id,
+    });
+
+    const childRun = await engine.trigger(
+      {
+        number: 1,
+        friendlyId: "run_c1234",
+        environment: authenticatedEnvironment,
+        taskIdentifier: childTask,
+        payload: "{}",
+        payloadType: "application/json",
+        context: {},
+        traceContext: {},
+        traceId: "t12346",
+        spanId: "s12346",
+        queue: `task/${childTask}`,
+        isTest: false,
+        tags: [],
+        resumeParentOnCompletion: true,
+        parentTaskRunId: parentRun.id,
+        workerQueue: "main",
+      },
+      prisma
+    );
+
+    await setTimeout(500);
+    const dequeuedChild = await engine.dequeueFromWorkerQueue({
+      consumerId: "test_12345",
+      workerQueue: "main",
+    });
+    const childAttempt = await engine.startRunAttempt({
+      runId: childRun.id,
+      snapshotId: dequeuedChild[0].snapshot.id,
+    });
+
+    return { parentRun, childRun, childAttempt };
+  }
+
+  containerTest(
+    "re-derives a waitpoint completion lost after the finish commit",
+    async ({ prisma, redisOptions }) => {
+      const engine = createEngine(prisma, redisOptions);
+
+      try {
+        const authenticatedEnvironment = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+        const { parentRun, childRun, childAttempt } = await setupParentAndChild(
+          engine,
+          prisma,
+          authenticatedEnvironment
+        );
+
+        vi.spyOn(engine.waitpointSystem, "completeWaitpoint").mockRejectedValueOnce(
+          new Error("simulated DB connection loss")
+        );
+
+        await expect(
+          engine.completeRunAttempt({
+            runId: childRun.id,
+            snapshotId: childAttempt.snapshot.id,
+            completion: {
+              id: childRun.id,
+              ok: true,
+              output: '{"foo":"bar"}',
+              outputType: "application/json",
+            },
+          })
+        ).rejects.toThrow("simulated DB connection loss");
+
+        const childAfterFailure = await prisma.taskRun.findFirstOrThrow({
+          where: { id: childRun.id },
+          include: { associatedWaitpoint: true },
+        });
+        expect(childAfterFailure.status).toBe("COMPLETED_SUCCESSFULLY");
+        expect(childAfterFailure.associatedWaitpoint?.status).toBe("PENDING");
+
+        await setTimeout(5_000);
+
+        const childAfterGuard = await prisma.taskRun.findFirstOrThrow({
+          where: { id: childRun.id },
+          include: { associatedWaitpoint: true },
+        });
+        expect(childAfterGuard.associatedWaitpoint?.status).toBe("COMPLETED");
+
+        const parentExecutionData = await engine.getRunExecutionData({ runId: parentRun.id });
+        assertNonNullable(parentExecutionData);
+        expect(parentExecutionData.snapshot.executionStatus).toBe("EXECUTING");
+        expect(parentExecutionData.completedWaitpoints?.length).toBe(1);
+        expect(parentExecutionData.completedWaitpoints![0].output).toBe('{"foo":"bar"}');
+      } finally {
+        await engine.quit();
+      }
+    }
+  );
+
+  containerTest(
+    "re-runs the unblock fan-out when the continueRunIfUnblocked enqueue was lost",
+    async ({ prisma, redisOptions }) => {
+      const engine = createEngine(prisma, redisOptions);
+
+      try {
+        const authenticatedEnvironment = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+        const { parentRun, childRun, childAttempt } = await setupParentAndChild(
+          engine,
+          prisma,
+          authenticatedEnvironment
+        );
+
+        const worker = (engine as any).worker;
+        const originalEnqueue = worker.enqueue.bind(worker);
+        let failedOnce = false;
+        const enqueueSpy = vi.spyOn(worker, "enqueue").mockImplementation(async (opts: any) => {
+          if (opts.job === "continueRunIfUnblocked" && !failedOnce) {
+            failedOnce = true;
+            throw new Error("simulated redis enqueue loss");
+          }
+          return originalEnqueue(opts);
+        });
+
+        await expect(
+          engine.completeRunAttempt({
+            runId: childRun.id,
+            snapshotId: childAttempt.snapshot.id,
+            completion: {
+              id: childRun.id,
+              ok: true,
+              output: '{"foo":"bar"}',
+              outputType: "application/json",
+            },
+          })
+        ).rejects.toThrow("simulated redis enqueue loss");
+
+        const childAfterFailure = await prisma.taskRun.findFirstOrThrow({
+          where: { id: childRun.id },
+          include: { associatedWaitpoint: true },
+        });
+        expect(childAfterFailure.status).toBe("COMPLETED_SUCCESSFULLY");
+        expect(childAfterFailure.associatedWaitpoint?.status).toBe("COMPLETED");
+
+        await setTimeout(5_000);
+        enqueueSpy.mockRestore();
+
+        const parentExecutionData = await engine.getRunExecutionData({ runId: parentRun.id });
+        assertNonNullable(parentExecutionData);
+        expect(parentExecutionData.snapshot.executionStatus).toBe("EXECUTING");
+        expect(parentExecutionData.completedWaitpoints?.length).toBe(1);
+      } finally {
+        await engine.quit();
+      }
+    }
+  );
+
+  containerTest(
+    "guard is acked on the happy path and never executes",
+    async ({ prisma, redisOptions }) => {
+      const engine = createEngine(prisma, redisOptions);
+
+      try {
+        const authenticatedEnvironment = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+        const { parentRun, childRun, childAttempt } = await setupParentAndChild(
+          engine,
+          prisma,
+          authenticatedEnvironment
+        );
+
+        const guardSpy = vi.spyOn(engine.runAttemptSystem, "ensureRunFinalized");
+
+        await engine.completeRunAttempt({
+          runId: childRun.id,
+          snapshotId: childAttempt.snapshot.id,
+          completion: {
+            id: childRun.id,
+            ok: true,
+            output: '{"foo":"bar"}',
+            outputType: "application/json",
+          },
+        });
+
+        await setTimeout(4_000);
+
+        expect(guardSpy).not.toHaveBeenCalled();
+
+        const parentExecutionData = await engine.getRunExecutionData({ runId: parentRun.id });
+        assertNonNullable(parentExecutionData);
+        expect(parentExecutionData.snapshot.executionStatus).toBe("EXECUTING");
+        expect(parentExecutionData.completedWaitpoints?.length).toBe(1);
+      } finally {
+        await engine.quit();
+      }
+    }
+  );
+});

--- a/internal-packages/run-engine/src/engine/tests/ensureRunFinalized.test.ts
+++ b/internal-packages/run-engine/src/engine/tests/ensureRunFinalized.test.ts
@@ -28,6 +28,11 @@ describe("RunEngine ensureRunFinalized guard", () => {
         redis: redisOptions,
         masterQueueConsumersDisabled: true,
         processWorkerQueueDebounceMs: 50,
+        ttlSystem: {
+          pollIntervalMs: 100,
+          batchSize: 10,
+          batchMaxWaitMs: 100,
+        },
       },
       runLock: {
         redis: redisOptions,
@@ -52,7 +57,8 @@ describe("RunEngine ensureRunFinalized guard", () => {
   async function setupParentAndChild(
     engine: RunEngine,
     prisma: any,
-    authenticatedEnvironment: any
+    authenticatedEnvironment: any,
+    options?: { childTtl?: string; dequeueChild?: boolean }
   ) {
     const parentTask = "parent-task";
     const childTask = "child-task";
@@ -109,9 +115,15 @@ describe("RunEngine ensureRunFinalized guard", () => {
         resumeParentOnCompletion: true,
         parentTaskRunId: parentRun.id,
         workerQueue: "main",
+        ttl: options?.childTtl,
+        enableFastPath: options?.childTtl ? false : undefined,
       },
       prisma
     );
+
+    if (options?.dequeueChild === false) {
+      return { parentRun, childRun, childAttempt: undefined };
+    }
 
     await setTimeout(500);
     const dequeuedChild = await engine.dequeueFromWorkerQueue({
@@ -370,6 +382,55 @@ describe("RunEngine ensureRunFinalized guard", () => {
         assertNonNullable(parentAfterFinalize);
         expect(parentAfterFinalize.snapshot.executionStatus).toBe("EXECUTING");
         expect(parentAfterFinalize.completedWaitpoints?.length).toBe(1);
+      } finally {
+        await engine.quit();
+      }
+    }
+  );
+
+  containerTest(
+    "re-derives a waitpoint completion lost during TTL expiry",
+    async ({ prisma, redisOptions }) => {
+      const engine = createEngine(prisma, redisOptions);
+
+      try {
+        const authenticatedEnvironment = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+        const { parentRun, childRun } = await setupParentAndChild(
+          engine,
+          prisma,
+          authenticatedEnvironment,
+          { childTtl: "1s", dequeueChild: false }
+        );
+
+        vi.spyOn(engine.waitpointSystem, "completeWaitpoint").mockRejectedValueOnce(
+          new Error("simulated DB connection loss")
+        );
+
+        await expect(engine.ttlSystem.expireRun({ runId: childRun.id })).rejects.toThrow(
+          "simulated DB connection loss"
+        );
+
+        const childAfterFailure = await prisma.taskRun.findFirstOrThrow({
+          where: { id: childRun.id },
+          include: { associatedWaitpoint: true },
+        });
+        expect(childAfterFailure.status).toBe("EXPIRED");
+        expect(childAfterFailure.associatedWaitpoint?.status).toBe("PENDING");
+
+        await setTimeout(5_000);
+
+        const childAfterGuard = await prisma.taskRun.findFirstOrThrow({
+          where: { id: childRun.id },
+          include: { associatedWaitpoint: true },
+        });
+        expect(childAfterGuard.status).toBe("EXPIRED");
+        expect(childAfterGuard.associatedWaitpoint?.status).toBe("COMPLETED");
+        expect(childAfterGuard.associatedWaitpoint?.outputIsError).toBe(true);
+
+        const parentExecutionData = await engine.getRunExecutionData({ runId: parentRun.id });
+        assertNonNullable(parentExecutionData);
+        expect(parentExecutionData.snapshot.executionStatus).toBe("EXECUTING");
+        expect(parentExecutionData.completedWaitpoints?.length).toBe(1);
       } finally {
         await engine.quit();
       }

--- a/internal-packages/run-engine/src/engine/tests/ensureRunFinalized.test.ts
+++ b/internal-packages/run-engine/src/engine/tests/ensureRunFinalized.test.ts
@@ -240,6 +240,143 @@ describe("RunEngine ensureRunFinalized guard", () => {
   );
 
   containerTest(
+    "a failed guard enqueue fails the completion request with nothing committed",
+    async ({ prisma, redisOptions }) => {
+      const engine = createEngine(prisma, redisOptions);
+
+      try {
+        const authenticatedEnvironment = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+        const { parentRun, childRun, childAttempt } = await setupParentAndChild(
+          engine,
+          prisma,
+          authenticatedEnvironment
+        );
+
+        const worker = (engine as any).worker;
+        const originalEnqueue = worker.enqueue.bind(worker);
+        const enqueueSpy = vi.spyOn(worker, "enqueue").mockImplementation(async (opts: any) => {
+          if (opts.job === "ensureRunFinalized") {
+            throw new Error("simulated redis enqueue failure");
+          }
+          return originalEnqueue(opts);
+        });
+
+        await expect(
+          engine.completeRunAttempt({
+            runId: childRun.id,
+            snapshotId: childAttempt.snapshot.id,
+            completion: {
+              id: childRun.id,
+              ok: true,
+              output: '{"foo":"bar"}',
+              outputType: "application/json",
+            },
+          })
+        ).rejects.toThrow("simulated redis enqueue failure");
+
+        const childAfterFailure = await prisma.taskRun.findFirstOrThrow({
+          where: { id: childRun.id },
+          include: { associatedWaitpoint: true },
+        });
+        expect(childAfterFailure.status).toBe("EXECUTING");
+        expect(childAfterFailure.associatedWaitpoint?.status).toBe("PENDING");
+
+        enqueueSpy.mockRestore();
+
+        await engine.completeRunAttempt({
+          runId: childRun.id,
+          snapshotId: childAttempt.snapshot.id,
+          completion: {
+            id: childRun.id,
+            ok: true,
+            output: '{"foo":"bar"}',
+            outputType: "application/json",
+          },
+        });
+
+        await setTimeout(1_000);
+
+        const parentExecutionData = await engine.getRunExecutionData({ runId: parentRun.id });
+        assertNonNullable(parentExecutionData);
+        expect(parentExecutionData.snapshot.executionStatus).toBe("EXECUTING");
+        expect(parentExecutionData.completedWaitpoints?.length).toBe(1);
+      } finally {
+        await engine.quit();
+      }
+    }
+  );
+
+  containerTest(
+    "a stale guard does not resume the parent while a cancellation is still in flight",
+    async ({ prisma, redisOptions }) => {
+      const engine = createEngine(prisma, redisOptions);
+
+      try {
+        const authenticatedEnvironment = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+        const { parentRun, childRun, childAttempt } = await setupParentAndChild(
+          engine,
+          prisma,
+          authenticatedEnvironment
+        );
+
+        vi.spyOn((engine as any).runStore, "completeAttemptSuccess").mockRejectedValueOnce(
+          new Error("simulated finish commit failure")
+        );
+
+        await expect(
+          engine.completeRunAttempt({
+            runId: childRun.id,
+            snapshotId: childAttempt.snapshot.id,
+            completion: {
+              id: childRun.id,
+              ok: true,
+              output: '{"foo":"bar"}',
+              outputType: "application/json",
+            },
+          })
+        ).rejects.toThrow("simulated finish commit failure");
+
+        await engine.cancelRun({ runId: childRun.id });
+
+        const childAfterCancel = await prisma.taskRun.findFirstOrThrow({
+          where: { id: childRun.id },
+          include: { associatedWaitpoint: true },
+        });
+        expect(childAfterCancel.status).toBe("CANCELED");
+
+        await setTimeout(5_000);
+
+        const childDuringPendingCancel = await prisma.taskRun.findFirstOrThrow({
+          where: { id: childRun.id },
+          include: { associatedWaitpoint: true },
+        });
+        expect(childDuringPendingCancel.associatedWaitpoint?.status).toBe("PENDING");
+
+        const parentWhilePending = await engine.getRunExecutionData({ runId: parentRun.id });
+        assertNonNullable(parentWhilePending);
+        expect(parentWhilePending.snapshot.executionStatus).toBe("EXECUTING_WITH_WAITPOINTS");
+
+        await engine.cancelRun({ runId: childRun.id, finalizeRun: true });
+
+        await setTimeout(1_000);
+
+        const childAfterFinalize = await prisma.taskRun.findFirstOrThrow({
+          where: { id: childRun.id },
+          include: { associatedWaitpoint: true },
+        });
+        expect(childAfterFinalize.associatedWaitpoint?.status).toBe("COMPLETED");
+
+        const parentAfterFinalize = await engine.getRunExecutionData({ runId: parentRun.id });
+        assertNonNullable(parentAfterFinalize);
+        expect(parentAfterFinalize.snapshot.executionStatus).toBe("EXECUTING");
+        expect(parentAfterFinalize.completedWaitpoints?.length).toBe(1);
+      } finally {
+        await engine.quit();
+      }
+    }
+  );
+
+  containerTest(
     "guard is acked on the happy path and never executes",
     async ({ prisma, redisOptions }) => {
       const engine = createEngine(prisma, redisOptions);

--- a/internal-packages/run-engine/src/engine/tests/ensureRunFinalized.test.ts
+++ b/internal-packages/run-engine/src/engine/tests/ensureRunFinalized.test.ts
@@ -389,6 +389,67 @@ describe("RunEngine ensureRunFinalized guard", () => {
   );
 
   containerTest(
+    "an exhausted deferral budget delivers even while cancellation looks in flight",
+    async ({ prisma, redisOptions }) => {
+      const engine = createEngine(prisma, redisOptions);
+
+      try {
+        const authenticatedEnvironment = await setupAuthenticatedEnvironment(prisma, "PRODUCTION");
+        const { parentRun, childRun, childAttempt } = await setupParentAndChild(
+          engine,
+          prisma,
+          authenticatedEnvironment
+        );
+
+        vi.spyOn((engine as any).runStore, "completeAttemptSuccess").mockRejectedValueOnce(
+          new Error("simulated finish commit failure")
+        );
+
+        await expect(
+          engine.completeRunAttempt({
+            runId: childRun.id,
+            snapshotId: childAttempt.snapshot.id,
+            completion: {
+              id: childRun.id,
+              ok: true,
+              output: '{"foo":"bar"}',
+              outputType: "application/json",
+            },
+          })
+        ).rejects.toThrow("simulated finish commit failure");
+
+        await engine.cancelRun({ runId: childRun.id });
+
+        await engine.runAttemptSystem.ensureRunFinalized({ runId: childRun.id, deferCount: 3 });
+
+        const childWithinBudget = await prisma.taskRun.findFirstOrThrow({
+          where: { id: childRun.id },
+          include: { associatedWaitpoint: true },
+        });
+        expect(childWithinBudget.associatedWaitpoint?.status).toBe("PENDING");
+
+        await engine.runAttemptSystem.ensureRunFinalized({ runId: childRun.id, deferCount: 10 });
+
+        const childAfterBudget = await prisma.taskRun.findFirstOrThrow({
+          where: { id: childRun.id },
+          include: { associatedWaitpoint: true },
+        });
+        expect(childAfterBudget.associatedWaitpoint?.status).toBe("COMPLETED");
+        expect(childAfterBudget.associatedWaitpoint?.outputIsError).toBe(true);
+
+        await setTimeout(1_000);
+
+        const parentExecutionData = await engine.getRunExecutionData({ runId: parentRun.id });
+        assertNonNullable(parentExecutionData);
+        expect(parentExecutionData.snapshot.executionStatus).toBe("EXECUTING");
+        expect(parentExecutionData.completedWaitpoints?.length).toBe(1);
+      } finally {
+        await engine.quit();
+      }
+    }
+  );
+
+  containerTest(
     "re-derives a cancellation lost after the CANCELED commit on a queued child",
     async ({ prisma, redisOptions }) => {
       const engine = createEngine(prisma, redisOptions);

--- a/internal-packages/run-engine/src/engine/types.ts
+++ b/internal-packages/run-engine/src/engine/types.ts
@@ -218,6 +218,12 @@ export type RunEngineOptions = {
   };
   /** If not set then checkpoints won't ever be used */
   retryWarmStartThresholdMs?: number;
+  /**
+   * Delay before the `ensureRunFinalized` write-ahead guard fires after a run-finish
+   * commit whose inline side effects never acked it. Long enough that the guard
+   * stays a pure failure path in steady state. Default: 60s.
+   */
+  finalizationGuardDelayMs?: number;
   heartbeatTimeoutsMs?: Partial<HeartbeatTimeouts>;
   repairSnapshotTimeoutMs?: number;
   treatProductionExecutionStallsAsOOM?: boolean;

--- a/internal-packages/run-engine/src/engine/workerCatalog.ts
+++ b/internal-packages/run-engine/src/engine/workerCatalog.ts
@@ -77,6 +77,25 @@ export const workerCatalog = {
     }),
     visibilityTimeoutMs: 30_000,
   },
+  /**
+   * Write-ahead guard enqueued before every run-finish commit and acked when the
+   * inline finalization side effects (waitpoint completion, parent unblock fan-out,
+   * batch nudge) all succeed. It must never dead-letter: it is the recovery
+   * mechanism for a finish whose side effects were lost mid-flight, so the retry
+   * budget is effectively unbounded with a capped backoff — it has to outlive any
+   * database outage.
+   */
+  ensureRunFinalized: {
+    schema: z.object({
+      runId: z.string(),
+    }),
+    visibilityTimeoutMs: 30_000,
+    retry: {
+      maxAttempts: 10_000,
+      minTimeoutInMs: 1_000,
+      maxTimeoutInMs: 300_000,
+    },
+  },
   enqueueDelayedRun: {
     schema: z.object({
       runId: z.string(),

--- a/internal-packages/run-engine/src/engine/workerCatalog.ts
+++ b/internal-packages/run-engine/src/engine/workerCatalog.ts
@@ -80,10 +80,11 @@ export const workerCatalog = {
   /**
    * Write-ahead guard enqueued before every run-finish commit and acked when the
    * inline finalization side effects (waitpoint completion, parent unblock fan-out,
-   * batch nudge) all succeed. It must never dead-letter: it is the recovery
-   * mechanism for a finish whose side effects were lost mid-flight, so the retry
-   * budget is effectively unbounded with a capped backoff — it has to outlive any
-   * database outage.
+   * batch nudge) all succeed. It is the recovery mechanism for a finish whose side
+   * effects were lost mid-flight, so its retry budget must outlive any database
+   * outage: roughly five weeks at the capped backoff before it dead-letters, where
+   * a genuinely poisoned item becomes visible and redrivable instead of retrying
+   * silently forever.
    */
   ensureRunFinalized: {
     schema: z.object({

--- a/internal-packages/run-engine/src/engine/workerCatalog.ts
+++ b/internal-packages/run-engine/src/engine/workerCatalog.ts
@@ -89,6 +89,12 @@ export const workerCatalog = {
   ensureRunFinalized: {
     schema: z.object({
       runId: z.string(),
+      /**
+       * How many times the guard has already deferred to an in-flight cancellation.
+       * Bounds the watch: past the budget the guard delivers anyway, so a lost
+       * heartbeat job cannot turn the deferral into an infinite loop.
+       */
+      deferCount: z.number().int().nonnegative().optional(),
     }),
     visibilityTimeoutMs: 30_000,
     retry: {


### PR DESCRIPTION
## Summary

A run's finish commit and its follow-up side effects (completing the associated waitpoint, waking blocked parents, releasing the queue slot, nudging batch completion) are separate writes across Postgres and Redis. If a database error landed between them, the child run was already finished, so the runner's retries hit the "Run is already finished" guard and the completion signal was lost for good. A parent blocked on `triggerAndWait` or `batchTriggerAndWait` then stayed waiting forever. TTL expiry had the same shape: its worker retry returned early on a non-pending run, and the batch expiry path swallowed a failed waitpoint-job enqueue.

## Fix

Every finalizing path (attempt success, permanent failure, cancellation, TTL expiry) now enqueues a durable `ensureRunFinalized` job before the finish commit, and acks it once the inline side effects all succeed. In steady state the guard never executes; the cost is one Redis enqueue and ack per completion.

When the inline path dies in between, the guard fires after a short delay and re-derives everything from current state: it releases the run's queue message and concurrency slot, completes a still-pending associated waitpoint from the run row's output or error, re-runs the blocked-run fan-out (covering a lost unblock enqueue even after the waitpoint committed), and re-schedules the batch completion check. Every leg is idempotent, so racing the inline path is a no-op. The job retries with a capped backoff for roughly five weeks before dead-lettering, so it outlives any database outage while a genuinely poisoned item still becomes visible.

Cancellation gets special handling: CANCELED is the only terminal run status where execution can still be in flight, so the guard only re-delivers for a canceled run once its execution snapshot is FINISHED, re-arming itself until then rather than resuming the parent while the child is still winding down.

A `finalization_rederivations` counter increments whenever the guard actually re-delivers a lost signal; it should stay at zero in a healthy system.

Tests cover six shapes: waitpoint completion lost after the finish commit, unblock fan-out lost after the waitpoint completed, a failed guard enqueue failing the completion request with nothing committed, a stale guard held back during an in-flight cancellation, waitpoint completion lost during TTL expiry, and the happy path where the guard is acked and never runs.

Known accepted edge: a guard re-run after a partial inline completion can re-emit a cached-run completion event for the same span; this only happens during failure recovery and is bounded to duplicate trace events.
