### PR TITLE
chore(webapp): integration settings copy update

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
@@ -26,6 +26,7 @@ import {
   redirectBackWithErrorMessage,
   redirectBackWithSuccessMessage,
 } from "~/models/message.server";
+import { $replica } from "~/db.server";
 import { resolveOrgIdFromSlug } from "~/models/organization.server";
 import { OrgIntegrationRepository } from "~/models/orgIntegration.server";
 import { logger } from "~/services/logger.server";
@@ -34,7 +35,7 @@ import { ProjectSettingsPresenter } from "~/services/projectSettingsPresenter.se
 import { dashboardAction, dashboardLoader } from "~/services/routeBuilders/dashboardBuilder";
 import { EnvironmentParamSchema, v3BillingPath, vercelResourcePath } from "~/utils/pathBuilder";
 import { throwPermissionDenied } from "~/utils/permissionDenied";
-import { type BuildSettings } from "~/v3/buildSettings";
+import { BuildSettingsSchema, type BuildSettings } from "~/v3/buildSettings";
 import { GitHubSettingsPanel } from "../resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.github";
 import type { loader as vercelLoader } from "../resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.vercel";
 import {
@@ -184,12 +185,24 @@ export const action = dashboardAction(
     const { installCommand, preBuildCommand, triggerConfigFilePath, useNativeBuildServer } =
       submission.value;
 
+    // Only admins may change the opt-out; other saves carry the stored value forward.
+    let disableNativeBuildServer: true | undefined = useNativeBuildServer ? undefined : true;
+    if (!user.admin && !user.isImpersonating) {
+      const project = await $replica.project.findFirst({
+        where: { id: projectId },
+        select: { buildSettings: true },
+      });
+      const stored = BuildSettingsSchema.safeParse(project?.buildSettings);
+      disableNativeBuildServer =
+        stored.success && stored.data.disableNativeBuildServer === true ? true : undefined;
+    }
+
     const resultOrFail = await projectSettingsService.updateBuildSettings(projectId, {
       installCommand: installCommand || undefined,
       preBuildCommand: preBuildCommand || undefined,
       triggerConfigFilePath: triggerConfigFilePath || undefined,
       // Native build server is the default, so we only persist the opt-out.
-      disableNativeBuildServer: useNativeBuildServer ? undefined : true,
+      disableNativeBuildServer,
     });
 
     if (resultOrFail.isErr()) {
@@ -584,12 +597,7 @@ function BuildSettingsForm({
             {fields.useNativeBuildServer.errors}
           </FormError>
         </>
-      ) : (
-        // An absent field would read as an opt-out on save, so keep submitting the stored value.
-        nativeBuildServerEnabled && (
-          <input type="hidden" name={fields.useNativeBuildServer.name} value="on" />
-        )
-      )}
+      ) : null}
       <FormError>{buildSettingsForm.errors}</FormError>
 
       <SettingsActions>

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
@@ -26,7 +26,7 @@ import {
   redirectBackWithErrorMessage,
   redirectBackWithSuccessMessage,
 } from "~/models/message.server";
-import { $replica } from "~/db.server";
+import { prisma } from "~/db.server";
 import { resolveOrgIdFromSlug } from "~/models/organization.server";
 import { OrgIntegrationRepository } from "~/models/orgIntegration.server";
 import { logger } from "~/services/logger.server";
@@ -188,7 +188,7 @@ export const action = dashboardAction(
     // Only admins may change the opt-out; other saves carry the stored value forward.
     let disableNativeBuildServer: true | undefined = useNativeBuildServer ? undefined : true;
     if (!user.admin && !user.isImpersonating) {
-      const project = await $replica.project.findFirst({
+      const project = await prisma.project.findFirst({
         where: { id: projectId },
         select: { buildSettings: true },
       });

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
@@ -390,7 +390,7 @@ export default function IntegrationsSettingsPage() {
               <>
                 Applies to deployments triggered from GitHub, and CLI deployments run with the{" "}
                 <InlineCode variant="extra-small" className="whitespace-nowrap">
-                  --native-build-server
+                  --native-build
                 </InlineCode>{" "}
                 flag.
               </>
@@ -487,7 +487,7 @@ function BuildSettingsForm({
         align="start"
         htmlFor={fields.triggerConfigFilePath.id}
         title="Trigger config file"
-        description="Auto-detected by default. Set a path relative to your repo root to override."
+        description="Path relative to your repo root. Auto-detected by default."
         action={
           <SettingsControl>
             <Input
@@ -538,14 +538,14 @@ function BuildSettingsForm({
         align="start"
         htmlFor={fields.preBuildCommand.id}
         title="Pre-build command"
-        description="Runs from your repo root, before the build, e.g., npm run prisma:generate."
+        description="Runs from your repo root, before the build."
         action={
           <SettingsControl>
             <Input
               {...getInputProps(fields.preBuildCommand, { type: "text" })}
               variant="medium"
               defaultValue={buildSettings?.preBuildCommand || ""}
-              placeholder="npm run prisma:generate"
+              placeholder="e.g., npm run prisma:generate"
               onChange={(e) => {
                 setBuildSettingsValues((prev) => ({
                   ...prev,

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
@@ -533,7 +533,7 @@ function BuildSettingsForm({
               {...getInputProps(fields.installCommand, { type: "text" })}
               variant="medium"
               defaultValue={buildSettings?.installCommand || ""}
-              placeholder="pnpm install"
+              placeholder="e.g., pnpm install"
               onChange={(e) => {
                 setBuildSettingsValues((prev) => ({
                   ...prev,

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.settings.integrations/route.tsx
@@ -19,6 +19,7 @@ import {
 import { SpinnerWhite } from "~/components/primitives/Spinner";
 import { Switch } from "~/components/primitives/Switch";
 import { useEnvironment } from "~/hooks/useEnvironment";
+import { useHasAdminAccess } from "~/hooks/useUser";
 import { useOrganization } from "~/hooks/useOrganizations";
 import { useProject } from "~/hooks/useProject";
 import {
@@ -443,6 +444,8 @@ function BuildSettingsForm({
   const navigation = useNavigation();
 
   const [hasBuildSettingsChanges, setHasBuildSettingsChanges] = useState(false);
+  const hasAdminAccess = useHasAdminAccess();
+
   // The native build server is enabled by default; it's only off when the
   // project has explicitly opted out via `disableNativeBuildServer`.
   const nativeBuildServerEnabled = buildSettings?.disableNativeBuildServer !== true;
@@ -484,7 +487,7 @@ function BuildSettingsForm({
         align="start"
         htmlFor={fields.triggerConfigFilePath.id}
         title="Trigger config file"
-        description="Path relative to your repo root."
+        description="Auto-detected by default. Set a path relative to your repo root to override."
         action={
           <SettingsControl>
             <Input
@@ -535,7 +538,7 @@ function BuildSettingsForm({
         align="start"
         htmlFor={fields.preBuildCommand.id}
         title="Pre-build command"
-        description="Runs from your repo root, before the build."
+        description="Runs from your repo root, before the build, e.g., npm run prisma:generate."
         action={
           <SettingsControl>
             <Input
@@ -557,27 +560,36 @@ function BuildSettingsForm({
         }
       />
 
-      <SettingsRow
-        title="Use native build server"
-        description="Builds without an external build provider. Requires trigger.dev v4.2.0 or newer."
-        action={
-          <Switch
-            variant="medium"
-            name={fields.useNativeBuildServer.name}
-            defaultChecked={nativeBuildServerEnabled}
-            onCheckedChange={(isChecked) => {
-              setBuildSettingsValues((prev) => ({
-                ...prev,
-                useNativeBuildServer: isChecked,
-              }));
-            }}
+      {hasAdminAccess ? (
+        <>
+          <SettingsRow
+            title="Use native build server"
+            description="Builds without an external build provider. Requires trigger.dev v4.2.0 or newer."
+            action={
+              <Switch
+                variant="medium"
+                name={fields.useNativeBuildServer.name}
+                defaultChecked={nativeBuildServerEnabled}
+                onCheckedChange={(isChecked) => {
+                  setBuildSettingsValues((prev) => ({
+                    ...prev,
+                    useNativeBuildServer: isChecked,
+                  }));
+                }}
+              />
+            }
           />
-        }
-      />
 
-      <FormError id={fields.useNativeBuildServer.errorId}>
-        {fields.useNativeBuildServer.errors}
-      </FormError>
+          <FormError id={fields.useNativeBuildServer.errorId}>
+            {fields.useNativeBuildServer.errors}
+          </FormError>
+        </>
+      ) : (
+        // An absent field would read as an opt-out on save, so keep submitting the stored value.
+        nativeBuildServerEnabled && (
+          <input type="hidden" name={fields.useNativeBuildServer.name} value="on" />
+        )
+      )}
       <FormError>{buildSettingsForm.errors}</FormError>
 
       <SettingsActions>

--- a/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.github.tsx
+++ b/apps/webapp/app/routes/resources.orgs.$organizationSlug.projects.$projectParam.env.$envParam.github.tsx
@@ -698,8 +698,8 @@ function GitHubAppInstalledRow() {
       title="GitHub app"
       action={
         <span className="flex items-center gap-1.5 text-sm text-text-dimmed">
-          <CheckCircleIcon className="size-4 text-success" />
           Installed
+          <CheckCircleIcon className="size-4 text-success" />
         </span>
       }
     />
@@ -841,8 +841,8 @@ export function ConnectedGitHubRepoForm({
         title="GitHub repo"
         action={
           <span className="flex items-center gap-1.5 text-sm text-text-dimmed">
-            <CheckCircleIcon className="size-4 text-success" />
             Connected
+            <CheckCircleIcon className="size-4 text-success" />
           </span>
         }
       />


### PR DESCRIPTION
Project → Settings → Integrations, build settings for GitHub deploys:

- **Trigger config file**: description now says it is auto-detected by default and a path only overrides that.
- **Use native build server**: rendered only for admins — GitHub deployments always use the native build server unless an admin opts a project out. The option to disable native builds in GitHub deployments will be removed entirely.