### PR TITLE
feat(database): add an infrastructure-error classifier and read-retry helper

### DIFF
--- a/internal-packages/database/src/index.ts
+++ b/internal-packages/database/src/index.ts
@@ -1,3 +1,5 @@
 export * from "../generated/prisma";
 export * from "./boundedIn";
+export * from "./infraError";
+export * from "./infraRetry";
 export * from "./transaction";

--- a/internal-packages/database/src/infraError.test.ts
+++ b/internal-packages/database/src/infraError.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { Prisma } from "../generated/prisma";
+import {
+  isInfrastructureError,
+  isRetryableInfrastructureError,
+  looksLikeConnectivityError,
+} from "./infraError";
+
+const known = (code: string, message = "") =>
+  new Prisma.PrismaClientKnownRequestError(message, { code, clientVersion: "6.14.0" });
+
+describe("isInfrastructureError", () => {
+  it("treats connection-level Prisma codes as infrastructure errors", () => {
+    for (const code of ["P1001", "P1002", "P1008", "P1017"]) {
+      expect(isInfrastructureError(known(code, "boom"))).toBe(true);
+    }
+  });
+
+  it("does not treat query/validation errors as infrastructure errors", () => {
+    expect(isInfrastructureError(known("P2025", "record not found"))).toBe(false);
+    expect(isInfrastructureError(known("P2002", "unique constraint"))).toBe(false);
+  });
+
+  it("treats P2010 as infrastructure only when the message looks like connectivity loss", () => {
+    expect(isInfrastructureError(known("P2010", "Connection terminated unexpectedly"))).toBe(true);
+    expect(isInfrastructureError(known("P2010", "syntax error at or near"))).toBe(false);
+  });
+
+  it("treats init / panic / unknown request errors as infrastructure errors", () => {
+    expect(
+      isInfrastructureError(new Prisma.PrismaClientInitializationError("no db", "6.14.0"))
+    ).toBe(true);
+  });
+
+  it("recognises raw connectivity errno / messages", () => {
+    expect(isInfrastructureError({ code: "ECONNRESET" })).toBe(true);
+    expect(isInfrastructureError(new Error("server has closed the connection"))).toBe(true);
+    expect(isInfrastructureError(new Error("column does not exist"))).toBe(false);
+  });
+});
+
+describe("looksLikeConnectivityError", () => {
+  it("matches known errno codes and message fragments", () => {
+    expect(looksLikeConnectivityError({ code: "EHOSTUNREACH" })).toBe(true);
+    expect(looksLikeConnectivityError(new Error("Can't reach database server"))).toBe(true);
+    expect(looksLikeConnectivityError(new Error("relation does not exist"))).toBe(false);
+  });
+});
+
+describe("isRetryableInfrastructureError", () => {
+  it("retries connection-level codes and connectivity errnos/messages", () => {
+    for (const code of ["P1001", "P1002", "P1008", "P1017"]) {
+      expect(isRetryableInfrastructureError(known(code, "boom"))).toBe(true);
+    }
+    expect(isRetryableInfrastructureError({ code: "ECONNRESET" })).toBe(true);
+    expect(isRetryableInfrastructureError(new Error("server has closed the connection"))).toBe(
+      true
+    );
+  });
+
+  it("does not retry query/validation errors", () => {
+    expect(isRetryableInfrastructureError(known("P2025", "record not found"))).toBe(false);
+    expect(isRetryableInfrastructureError(new Error("column does not exist"))).toBe(false);
+  });
+
+  it("retries an init error only with a connectivity signal (not a permanent one)", () => {
+    expect(
+      isRetryableInfrastructureError(
+        new Prisma.PrismaClientInitializationError("Can't reach database server", "6.14.0", "P1001")
+      )
+    ).toBe(true);
+    expect(
+      isRetryableInfrastructureError(
+        new Prisma.PrismaClientInitializationError(
+          "Authentication failed against database server",
+          "6.14.0",
+          "P1000"
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("never retries a Rust-engine panic", () => {
+    expect(
+      isRetryableInfrastructureError(new Prisma.PrismaClientRustPanicError("panic", "6.14.0"))
+    ).toBe(false);
+  });
+
+  it("never retries pool exhaustion (P2024), even though its message looks like connectivity", () => {
+    const poolMsg = "Timed out fetching a new connection from the connection pool";
+    expect(isRetryableInfrastructureError(known("P2024", poolMsg))).toBe(false);
+    expect(isRetryableInfrastructureError(new Error(poolMsg))).toBe(false);
+    // The broad classifier still flags it (used for logging, not retry).
+    expect(isInfrastructureError(new Error(poolMsg))).toBe(true);
+  });
+
+  it("retries an unknown-request error only with a connectivity signal", () => {
+    expect(
+      isRetryableInfrastructureError(
+        new Prisma.PrismaClientUnknownRequestError("connection terminated unexpectedly", {
+          clientVersion: "6.14.0",
+        })
+      )
+    ).toBe(true);
+    expect(
+      isRetryableInfrastructureError(
+        new Prisma.PrismaClientUnknownRequestError("unexpected engine failure", {
+          clientVersion: "6.14.0",
+        })
+      )
+    ).toBe(false);
+  });
+});

--- a/internal-packages/database/src/infraError.ts
+++ b/internal-packages/database/src/infraError.ts
@@ -1,0 +1,101 @@
+import { Prisma } from "../generated/prisma";
+
+// Prisma connectivity / infrastructure error codes — connection-level failures,
+// not query- or validation-level ones (e.g. P1001 "Can't reach database server").
+const INFRASTRUCTURE_PRISMA_CODES = new Set(["P1001", "P1002", "P1008", "P1017"]);
+
+const CONNECTIVITY_ERRNO = new Set([
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "EPIPE",
+]);
+
+const CONNECTIVITY_MESSAGE =
+  /ECONNREFUSED|ENOTFOUND|ETIMEDOUT|ECONNRESET|EHOSTUNREACH|database not reachable|can't reach database|connection terminated|server has closed the connection|timed out fetching a new connection/i;
+
+// Connection-pool exhaustion (P2024). Matched only to EXCLUDE it from retry:
+// retrying against an already-exhausted pool deepens the contention rather than
+// riding out a blip (the transaction-start retry gate excludes it for the same reason).
+const POOL_EXHAUSTION_MESSAGE = /timed out fetching a new connection/i;
+
+/** True for an errno/message that looks like a lost or unreachable connection. */
+export function looksLikeConnectivityError(error: unknown): boolean {
+  const e = error as { code?: unknown; message?: unknown };
+  if (typeof e?.code === "string" && CONNECTIVITY_ERRNO.has(e.code)) {
+    return true;
+  }
+  return typeof e?.message === "string" && CONNECTIVITY_MESSAGE.test(e.message);
+}
+
+/**
+ * True when `error` is a Prisma infrastructure/connectivity failure (DB
+ * unreachable, timed out, connection dropped) rather than a query- or
+ * validation-level error. Broad by design (matches the classifier used for
+ * logging); for the retry decision use {@link isRetryableInfrastructureError}.
+ */
+export function isInfrastructureError(error: unknown): boolean {
+  if (
+    error instanceof Prisma.PrismaClientInitializationError ||
+    error instanceof Prisma.PrismaClientRustPanicError ||
+    error instanceof Prisma.PrismaClientUnknownRequestError
+  ) {
+    return true;
+  }
+
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    if (INFRASTRUCTURE_PRISMA_CODES.has(error.code)) {
+      return true;
+    }
+    return error.code === "P2010" && looksLikeConnectivityError(error);
+  }
+
+  return looksLikeConnectivityError(error);
+}
+
+/**
+ * True when `error` is a *transient* infrastructure failure worth retrying — a
+ * genuine connectivity blip, not a permanent one. Narrower than
+ * {@link isInfrastructureError}: an initialization or unknown-request error
+ * counts only when it carries a connectivity signal (so a bad-URL / auth /
+ * database-selection failure is NOT retried), and a Rust-engine panic is never
+ * retried. This is the default retry gate for `withInfraRetry`.
+ */
+export function isRetryableInfrastructureError(error: unknown): boolean {
+  // Never retry pool exhaustion (P2024): another attempt only competes for the
+  // same exhausted pool. Checked before the connectivity fallbacks because its
+  // message otherwise matches CONNECTIVITY_MESSAGE.
+  const message = (error as { message?: unknown })?.message;
+  if (
+    (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2024") ||
+    (typeof message === "string" && POOL_EXHAUSTION_MESSAGE.test(message))
+  ) {
+    return false;
+  }
+
+  if (error instanceof Prisma.PrismaClientRustPanicError) {
+    return false;
+  }
+
+  if (error instanceof Prisma.PrismaClientInitializationError) {
+    return (
+      (typeof error.errorCode === "string" && INFRASTRUCTURE_PRISMA_CODES.has(error.errorCode)) ||
+      looksLikeConnectivityError(error)
+    );
+  }
+
+  if (error instanceof Prisma.PrismaClientUnknownRequestError) {
+    return looksLikeConnectivityError(error);
+  }
+
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    if (INFRASTRUCTURE_PRISMA_CODES.has(error.code)) {
+      return true;
+    }
+    return error.code === "P2010" && looksLikeConnectivityError(error);
+  }
+
+  return looksLikeConnectivityError(error);
+}

--- a/internal-packages/database/src/infraRetry.test.ts
+++ b/internal-packages/database/src/infraRetry.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from "vitest";
+import { Prisma } from "../generated/prisma";
+import { type RetryBudget } from "./transaction";
+import { withInfraRetry } from "./infraRetry";
+
+const options = { enabled: true, maxAttempts: 4, backoffMinMs: 0, backoffMaxMs: 0 };
+const noSleep = () => Promise.resolve();
+const retryable = () => true;
+
+// A thunk that throws `error` for its first `failTimes` calls, then resolves.
+function makeThunk(failTimes: number, error: unknown = new Error("infra"), value = "ok") {
+  let calls = 0;
+  return {
+    run: async () => {
+      calls++;
+      if (calls <= failTimes) throw error;
+      return value;
+    },
+    calls: () => calls,
+  };
+}
+
+describe("withInfraRetry", () => {
+  it("runs the thunk exactly once when disabled", async () => {
+    const t = makeThunk(Infinity);
+    await expect(
+      withInfraRetry(t.run, { options: { ...options, enabled: false }, isRetryable: retryable })
+    ).rejects.toThrow("infra");
+    expect(t.calls()).toBe(1);
+  });
+
+  it("retries a retryable error until it succeeds", async () => {
+    const t = makeThunk(2);
+    const result = await withInfraRetry(t.run, { options, isRetryable: retryable, sleep: noSleep });
+    expect(result).toBe("ok");
+    expect(t.calls()).toBe(3);
+  });
+
+  it("does not retry a non-retryable error", async () => {
+    const t = makeThunk(Infinity, new Error("query bug"));
+    await expect(
+      withInfraRetry(t.run, { options, isRetryable: () => false, sleep: noSleep })
+    ).rejects.toThrow("query bug");
+    expect(t.calls()).toBe(1);
+  });
+
+  it("gives up after maxAttempts", async () => {
+    const t = makeThunk(Infinity);
+    await expect(
+      withInfraRetry(t.run, { options, isRetryable: retryable, sleep: noSleep })
+    ).rejects.toThrow("infra");
+    expect(t.calls()).toBe(4);
+  });
+
+  it("stops retrying once the shared budget is exhausted", async () => {
+    const t = makeThunk(Infinity);
+    let tokens = 1;
+    const budget: RetryBudget = {
+      tryConsume: () => {
+        if (tokens > 0) {
+          tokens--;
+          return true;
+        }
+        return false;
+      },
+    };
+    await expect(
+      withInfraRetry(t.run, { options, isRetryable: retryable, budget, sleep: noSleep })
+    ).rejects.toThrow("infra");
+    // first attempt + one budgeted retry, then the budget denies the next
+    expect(t.calls()).toBe(2);
+  });
+
+  it("runs the thunk exactly once when maxAttempts <= 1", async () => {
+    const t = makeThunk(Infinity);
+    await expect(
+      withInfraRetry(t.run, {
+        options: { ...options, maxAttempts: 1 },
+        isRetryable: retryable,
+        sleep: noSleep,
+      })
+    ).rejects.toThrow("infra");
+    expect(t.calls()).toBe(1);
+  });
+
+  it("runs the thunk once (never skipped, never unbounded) for a non-finite maxAttempts", async () => {
+    for (const maxAttempts of [NaN, Infinity]) {
+      const t = makeThunk(Infinity);
+      await expect(
+        withInfraRetry(t.run, {
+          options: { ...options, maxAttempts },
+          isRetryable: retryable,
+          sleep: noSleep,
+        })
+      ).rejects.toThrow("infra");
+      expect(t.calls()).toBe(1);
+    }
+  });
+
+  it("floors a fractional maxAttempts to whole attempts", async () => {
+    const t = makeThunk(Infinity);
+    await expect(
+      withInfraRetry(t.run, {
+        options: { ...options, maxAttempts: 3.9 },
+        isRetryable: retryable,
+        sleep: noSleep,
+      })
+    ).rejects.toThrow("infra");
+    expect(t.calls()).toBe(3);
+  });
+
+  it("defaults to isRetryableInfrastructureError when no isRetryable is provided", async () => {
+    const infra = new Prisma.PrismaClientKnownRequestError("boom", {
+      code: "P1001",
+      clientVersion: "6.14.0",
+    });
+    const t = makeThunk(1, infra);
+    // no isRetryable in the config — the module must default to the classifier
+    const result = await withInfraRetry(t.run, { options, sleep: noSleep });
+    expect(result).toBe("ok");
+    expect(t.calls()).toBe(2);
+  });
+
+  it("with the default classifier, does not retry a real query error", async () => {
+    const queryError = new Prisma.PrismaClientKnownRequestError("not found", {
+      code: "P2025",
+      clientVersion: "6.14.0",
+    });
+    const t = makeThunk(Infinity, queryError);
+    await expect(withInfraRetry(t.run, { options, sleep: noSleep })).rejects.toBe(queryError);
+    expect(t.calls()).toBe(1);
+  });
+
+  it("does not retry a permanent init failure, but retries a transient one", async () => {
+    const authErr = new Prisma.PrismaClientInitializationError(
+      "Authentication failed against database server",
+      "6.14.0",
+      "P1000"
+    );
+    const permanent = makeThunk(Infinity, authErr);
+    await expect(withInfraRetry(permanent.run, { options, sleep: noSleep })).rejects.toBe(authErr);
+    expect(permanent.calls()).toBe(1);
+
+    const reachErr = new Prisma.PrismaClientInitializationError(
+      "Can't reach database server at localhost:5432",
+      "6.14.0",
+      "P1001"
+    );
+    const transient = makeThunk(1, reachErr);
+    const result = await withInfraRetry(transient.run, { options, sleep: noSleep });
+    expect(result).toBe("ok");
+    expect(transient.calls()).toBe(2);
+  });
+
+  it("never retries a Rust-engine panic", async () => {
+    const panic = new Prisma.PrismaClientRustPanicError("engine panicked", "6.14.0");
+    const t = makeThunk(Infinity, panic);
+    await expect(withInfraRetry(t.run, { options, sleep: noSleep })).rejects.toBe(panic);
+    expect(t.calls()).toBe(1);
+  });
+
+  it("retries an unknown-request error only when it carries a connectivity signal", async () => {
+    const opaque = new Prisma.PrismaClientUnknownRequestError("unexpected engine failure", {
+      clientVersion: "6.14.0",
+    });
+    const permanent = makeThunk(Infinity, opaque);
+    await expect(withInfraRetry(permanent.run, { options, sleep: noSleep })).rejects.toBe(opaque);
+    expect(permanent.calls()).toBe(1);
+
+    const connErr = new Prisma.PrismaClientUnknownRequestError(
+      "connection terminated unexpectedly",
+      {
+        clientVersion: "6.14.0",
+      }
+    );
+    const transient = makeThunk(1, connErr);
+    const result = await withInfraRetry(transient.run, { options, sleep: noSleep });
+    expect(result).toBe("ok");
+    expect(transient.calls()).toBe(2);
+  });
+
+  it("clamps a swapped min/max backoff", async () => {
+    const t = makeThunk(1);
+    const delays: number[] = [];
+    await withInfraRetry(t.run, {
+      options: { enabled: true, maxAttempts: 2, backoffMinMs: 300, backoffMaxMs: 100 },
+      isRetryable: retryable,
+      sleep: noSleep,
+      random: () => 0.9,
+      onRetry: ({ delayMs }) => delays.push(delayMs),
+    });
+    // min > max collapses to [100, 100], so the delay is 100 regardless of random
+    expect(delays).toEqual([100]);
+  });
+
+  it("computes a jittered delay within bounds and reports it", async () => {
+    const t = makeThunk(1);
+    const delays: number[] = [];
+    await withInfraRetry(t.run, {
+      options: { enabled: true, maxAttempts: 3, backoffMinMs: 100, backoffMaxMs: 300 },
+      isRetryable: retryable,
+      sleep: noSleep,
+      random: () => 0.5,
+      onRetry: ({ delayMs }) => delays.push(delayMs),
+    });
+    expect(delays[0]).toBe(200);
+  });
+
+  it("keeps the delay finite and in range for bad backoff bounds and out-of-range random", async () => {
+    // NaN backoff bound must not produce a NaN delay.
+    const t1 = makeThunk(1);
+    const nanDelays: number[] = [];
+    await withInfraRetry(t1.run, {
+      options: { enabled: true, maxAttempts: 2, backoffMinMs: 0, backoffMaxMs: NaN },
+      isRetryable: retryable,
+      sleep: noSleep,
+      onRetry: ({ delayMs }) => nanDelays.push(delayMs),
+    });
+    expect(nanDelays[0]).toBe(0);
+
+    // random() above 1 clamps to the high bound.
+    const t2 = makeThunk(1);
+    const highDelays: number[] = [];
+    await withInfraRetry(t2.run, {
+      options: { enabled: true, maxAttempts: 2, backoffMinMs: 100, backoffMaxMs: 300 },
+      isRetryable: retryable,
+      sleep: noSleep,
+      random: () => 2,
+      onRetry: ({ delayMs }) => highDelays.push(delayMs),
+    });
+    expect(highDelays[0]).toBe(300);
+
+    // random() below 0 clamps to the low bound.
+    const t3 = makeThunk(1);
+    const lowDelays: number[] = [];
+    await withInfraRetry(t3.run, {
+      options: { enabled: true, maxAttempts: 2, backoffMinMs: 100, backoffMaxMs: 300 },
+      isRetryable: retryable,
+      sleep: noSleep,
+      random: () => -1,
+      onRetry: ({ delayMs }) => lowDelays.push(delayMs),
+    });
+    expect(lowDelays[0]).toBe(100);
+
+    // random() returning NaN normalizes to the low bound, not a NaN delay.
+    const t4 = makeThunk(1);
+    const nanRandomDelays: number[] = [];
+    await withInfraRetry(t4.run, {
+      options: { enabled: true, maxAttempts: 2, backoffMinMs: 100, backoffMaxMs: 300 },
+      isRetryable: retryable,
+      sleep: noSleep,
+      random: () => NaN,
+      onRetry: ({ delayMs }) => nanRandomDelays.push(delayMs),
+    });
+    expect(nanRandomDelays[0]).toBe(100);
+  });
+});

--- a/internal-packages/database/src/infraRetry.ts
+++ b/internal-packages/database/src/infraRetry.ts
@@ -1,0 +1,91 @@
+import { isRetryableInfrastructureError } from "./infraError";
+import { type RetryBudget, UNLIMITED_RETRY_BUDGET } from "./transaction";
+
+/** Retry tuning for {@link withInfraRetry}. */
+export type InfraRetryOptions = {
+  /** Kill switch. When false, the thunk runs exactly once. Default off at call sites. */
+  enabled: boolean;
+  /** Total attempts including the first. `1` (or less) disables retrying. */
+  maxAttempts: number;
+  /** Lower bound of the jittered backoff between attempts, in ms. */
+  backoffMinMs: number;
+  /** Upper bound of the jittered backoff between attempts, in ms. */
+  backoffMaxMs: number;
+};
+
+export type InfraRetryConfig = {
+  options: InfraRetryOptions;
+  /** Shared budget; defaults to {@link UNLIMITED_RETRY_BUDGET}. */
+  budget?: RetryBudget;
+  /** Predicate for a retryable error; defaults to {@link isRetryableInfrastructureError}. */
+  isRetryable?: (error: unknown) => boolean;
+  sleep?: (ms: number) => Promise<void>;
+  random?: () => number;
+  onRetry?: (info: { attempt: number; delayMs: number; error: unknown }) => void;
+};
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Runs `run` and retries it on a transient connection-blip error ({@link isRetryableInfrastructureError}
+ * by default), up to `maxAttempts` with jittered backoff, gated by a shared
+ * `budget` so a mass freeze can't amplify into a retry storm. Any other error
+ * (or an exhausted budget) rethrows immediately.
+ *
+ * ONLY wrap operations that are safe to run more than once: reads, or writes
+ * that have been made idempotent. Never wrap a bare non-idempotent write.
+ */
+export async function withInfraRetry<R>(
+  run: () => Promise<R>,
+  config?: InfraRetryConfig
+): Promise<R> {
+  if (!config || !config.options.enabled) {
+    return run();
+  }
+
+  const { backoffMinMs, backoffMaxMs } = config.options;
+  // Bound the loop defensively: a non-finite maxAttempts (NaN/Infinity from a bad
+  // env parse) or a value below 2 means "run once, no retry" — never a skipped run
+  // or an unbounded loop. Fractional values floor to whole attempts.
+  const maxAttempts = Number.isFinite(config.options.maxAttempts)
+    ? Math.floor(config.options.maxAttempts)
+    : 1;
+  if (maxAttempts <= 1) {
+    return run();
+  }
+
+  const budget = config.budget ?? UNLIMITED_RETRY_BUDGET;
+  const isRetryable = config.isRetryable ?? isRetryableInfrastructureError;
+  const sleep = config.sleep ?? defaultSleep;
+  const random = config.random ?? Math.random;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await run();
+    } catch (error) {
+      lastError = error;
+      if (attempt >= maxAttempts || !isRetryable(error) || !budget.tryConsume()) {
+        throw error;
+      }
+      // Defend the delay math: non-finite bounds fall back to 0, and an injected
+      // random() outside [0, 1] is clamped, so delayMs is always finite and within
+      // [low, high]. A swapped min/max still collapses to the smaller bound.
+      const min = Number.isFinite(backoffMinMs) ? backoffMinMs : 0;
+      const max = Number.isFinite(backoffMaxMs) ? backoffMaxMs : min;
+      const low = Math.max(0, Math.min(min, max));
+      const high = Math.max(low, max);
+      const rand = random();
+      const r = Number.isFinite(rand) ? Math.min(1, Math.max(0, rand)) : 0;
+      const delayMs = Math.round(low + r * (high - low));
+      config.onRetry?.({ attempt, delayMs, error });
+      await sleep(delayMs);
+    }
+  }
+
+  // Unreachable: the final attempt always returns or throws above. Present so the
+  // function is statically known to return `R` or throw on every path.
+  throw lastError;
+}


### PR DESCRIPTION
## Summary

Adds two shared primitives to `@internal/database` for surviving brief database connection blips: a classifier that recognises connectivity/infrastructure failures (as opposed to real query errors), and `withInfraRetry`, a helper that retries an operation on those failures.

## Details

`isInfrastructureError` / `looksLikeConnectivityError` recognise connection-level failures (unreachable server, closed connection, connection reset, connect timeouts) and deliberately do not match query or validation errors, so retries never mask a real bug.

`withInfraRetry(run, config)` retries `run` on a classified infrastructure error with jittered backoff, gated by a shared token-bucket budget so a mass freeze cannot amplify into a retry storm. It has an `enabled` kill-switch (off by default) and reuses the existing retry-budget primitive.

It must only wrap operations that are safe to run more than once (reads, or writes made idempotent); it deliberately provides no path that silently retries a non-idempotent write.
