### PR TITLE
chore: ignore Vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ packages/**/styles/tailwind.css
 
 # misc
 .DS_Store
+*.swp
 *.pem
 
 # debug


### PR DESCRIPTION
## Summary

Prevents local Vim swap files from appearing as untracked repository changes.