### PR TITLE
perf(webapp): bound missing LLM model queries

### DIFF
--- a/apps/webapp/app/services/admin/missingLlmModels.server.ts
+++ b/apps/webapp/app/services/admin/missingLlmModels.server.ts
@@ -1,5 +1,19 @@
+import { LRUCache } from "lru-cache";
+import { trail } from "agentcrumbs"; // @crumbs
 import { getAdminClickhouse } from "~/services/clickhouse/clickhouseFactory.server";
 import { llmPricingRegistry } from "~/v3/llmPricingRegistry.server";
+
+const crumb = trail("webapp"); // @crumbs
+
+const DEFAULT_LOOKBACK_HOURS = 24;
+const MAX_LOOKBACK_HOURS = 30 * 24;
+const MISSING_LLM_MODELS_CACHE_TTL_MS = 60_000;
+const MISSING_LLM_QUERY_SETTINGS = {
+  // Stop server-side before the ClickHouse client's default 30-second request timeout.
+  max_execution_time: 25,
+  max_memory_usage: String(512 * 1024 * 1024),
+  max_threads: 2,
+};
 
 export type MissingLlmModel = {
   model: string;
@@ -7,14 +21,46 @@ export type MissingLlmModel = {
   count: number;
 };
 
+const missingLlmModelsCache = new LRUCache<number, Promise<MissingLlmModel[]>>({
+  max: 16,
+  ttl: MISSING_LLM_MODELS_CACHE_TTL_MS,
+});
+
 export async function getMissingLlmModels(
   opts: {
     lookbackHours?: number;
   } = {}
 ): Promise<MissingLlmModel[]> {
-  const lookbackHours = opts.lookbackHours ?? 24;
-  const since = new Date(Date.now() - lookbackHours * 60 * 60 * 1000);
+  const lookbackHours = validateLookbackHours(opts.lookbackHours);
+  let candidatesPromise = missingLlmModelsCache.get(lookbackHours);
 
+  if (candidatesPromise) {
+    crumb("missing LLM models cache hit", { lookbackHours }); // @crumbs
+  } else {
+    crumb("missing LLM models cache miss", { lookbackHours }); // @crumbs
+    candidatesPromise = queryMissingLlmModels(lookbackHours);
+    missingLlmModelsCache.set(lookbackHours, candidatesPromise);
+  }
+
+  let candidates: MissingLlmModel[];
+  try {
+    candidates = await candidatesPromise;
+  } catch (error) {
+    if (missingLlmModelsCache.get(lookbackHours) === candidatesPromise) {
+      missingLlmModelsCache.delete(lookbackHours);
+    }
+    throw error;
+  }
+
+  // Filter out models that now have pricing in the database (added after spans were inserted).
+  // The registry's match() handles prefix stripping for gateway/openrouter models.
+  if (!llmPricingRegistry || !llmPricingRegistry.isLoaded) return candidates;
+  const registry = llmPricingRegistry;
+  return candidates.filter((c) => !registry.match(c.model));
+}
+
+async function queryMissingLlmModels(lookbackHours: number): Promise<MissingLlmModel[]> {
+  const since = new Date(Date.now() - lookbackHours * 60 * 60 * 1000);
   const adminClickhouse = getAdminClickhouse();
 
   // queryBuilderFast returns a factory function — call it to get the builder
@@ -36,13 +82,14 @@ export async function getMissingLlmModels(
       },
       { name: "cnt", expression: "count()" },
     ],
+    settings: MISSING_LLM_QUERY_SETTINGS,
   });
   const qb = createBuilder();
 
-  // Partition pruning on inserted_at (partition key is toDate(inserted_at))
-  qb.where("inserted_at >= {since: DateTime64(3)}", {
-    since: formatDateTime(since),
-  });
+  // Read narrow filter columns before materializing and parsing attributes_text.
+  qb.prewhere("inserted_at >= {since: DateTime64(3)}", { since: formatDateTime(since) });
+  qb.prewhere("kind = {kind: String}", { kind: "SPAN" });
+  qb.prewhere("status = {status: String}", { status: "OK" });
 
   // Only spans that have a model set
   qb.where("JSONExtractString(attributes_text, 'gen_ai', 'response', 'model') != {empty: String}", {
@@ -54,10 +101,6 @@ export async function getMissingLlmModels(
     "JSONExtract(attributes_text, 'trigger', 'llm', 'total_cost', 'Nullable(Float64)') IS NULL",
     {}
   );
-
-  // Only completed spans
-  qb.where("kind = {kind: String}", { kind: "SPAN" });
-  qb.where("status = {status: String}", { status: "OK" });
 
   qb.groupBy("model, system");
   qb.orderBy("cnt DESC");
@@ -81,13 +124,8 @@ export async function getMissingLlmModels(
       count: parseInt(r.cnt, 10),
     }));
 
-  if (candidates.length === 0) return [];
-
-  // Filter out models that now have pricing in the database (added after spans were inserted).
-  // The registry's match() handles prefix stripping for gateway/openrouter models.
-  if (!llmPricingRegistry || !llmPricingRegistry.isLoaded) return candidates;
-  const registry = llmPricingRegistry;
-  return candidates.filter((c) => !registry.match(c.model));
+  crumb("missing LLM models query complete", { lookbackHours, candidates: candidates.length }); // @crumbs
+  return candidates;
 }
 
 export type MissingModelSample = {
@@ -104,7 +142,7 @@ export async function getMissingModelSamples(opts: {
   lookbackHours?: number;
   limit?: number;
 }): Promise<MissingModelSample[]> {
-  const lookbackHours = opts.lookbackHours ?? 24;
+  const lookbackHours = validateLookbackHours(opts.lookbackHours);
   const limit = opts.limit ?? 10;
   const since = new Date(Date.now() - lookbackHours * 60 * 60 * 1000);
 
@@ -114,10 +152,14 @@ export async function getMissingModelSamples(opts: {
     name: "missingModelSamples",
     table: "trigger_dev.task_events_v2",
     columns: ["span_id", "run_id", "message", "attributes_text", "duration", "start_time"],
+    settings: MISSING_LLM_QUERY_SETTINGS,
   });
   const qb = createBuilder();
 
-  qb.where("inserted_at >= {since: DateTime64(3)}", { since: formatDateTime(since) });
+  // Read narrow filter columns before materializing and parsing attributes_text.
+  qb.prewhere("inserted_at >= {since: DateTime64(3)}", { since: formatDateTime(since) });
+  qb.prewhere("kind = {kind: String}", { kind: "SPAN" });
+  qb.prewhere("status = {status: String}", { status: "OK" });
   qb.where("JSONExtractString(attributes_text, 'gen_ai', 'response', 'model') = {model: String}", {
     model: opts.model,
   });
@@ -125,8 +167,6 @@ export async function getMissingModelSamples(opts: {
     "JSONExtract(attributes_text, 'trigger', 'llm', 'total_cost', 'Nullable(Float64)') IS NULL",
     {}
   );
-  qb.where("kind = {kind: String}", { kind: "SPAN" });
-  qb.where("status = {status: String}", { status: "OK" });
   qb.orderBy("start_time DESC");
   qb.limit(limit);
 
@@ -137,6 +177,14 @@ export async function getMissingModelSamples(opts: {
   }
 
   return rows ?? [];
+}
+
+function validateLookbackHours(lookbackHours = DEFAULT_LOOKBACK_HOURS): number {
+  if (!Number.isInteger(lookbackHours) || lookbackHours < 1 || lookbackHours > MAX_LOOKBACK_HOURS) {
+    throw new RangeError(`lookbackHours must be between 1 and ${MAX_LOOKBACK_HOURS}`);
+  }
+
+  return lookbackHours;
 }
 
 function formatDateTime(date: Date): string {

--- a/apps/webapp/app/services/clickhouse/clickhouseFactory.server.ts
+++ b/apps/webapp/app/services/clickhouse/clickhouseFactory.server.ts
@@ -97,6 +97,8 @@ function initializeLogsClickhouseClient() {
   });
 }
 
+const ADMIN_CLICKHOUSE_REQUEST_TIMEOUT_MS = 30_000;
+
 const defaultAdminClickhouseClient = singleton(
   "adminClickhouseClient",
   initializeAdminClickhouseClient
@@ -109,6 +111,7 @@ function initializeAdminClickhouseClient() {
 
   const url = new URL(env.ADMIN_CLICKHOUSE_URL);
   url.searchParams.delete("secure");
+  url.searchParams.delete("readonly");
 
   return new ClickHouse({
     url: url.toString(),
@@ -120,6 +123,10 @@ function initializeAdminClickhouseClient() {
     logLevel: env.CLICKHOUSE_LOG_LEVEL,
     compression: { request: true },
     maxOpenConnections: env.CLICKHOUSE_MAX_OPEN_CONNECTIONS,
+    // readonly=2 blocks writes while allowing bounded per-query settings.
+    clickhouseSettings: { readonly: 2 },
+    // Keep this above the missing-model query's 25-second execution limit.
+    requestTimeoutMs: ADMIN_CLICKHOUSE_REQUEST_TIMEOUT_MS,
   });
 }
 


### PR DESCRIPTION
## Summary

Protect missing LLM model diagnostics from expensive event scans by filtering narrow columns before parsing attributes, enforcing per-query resource limits, and reusing recent aggregate results.

## Design

Both queries apply their time, kind, and status predicates in `PREWHERE` before reading `attributes_text`. Lookbacks are constrained to the existing supported range, while execution time, memory, and thread use are bounded per query.

Aggregate results are cached for one minute with a small entry limit. Concurrent requests share the same in-flight query, and failed queries are removed from the cache immediately.

This PR builds on [#4866](https://github.com/triggerdotdev/trigger.dev/pull/4866), which builds on [#4860](https://github.com/triggerdotdev/trigger.dev/pull/4860).
