### PR TITLE
fix(cli): build the code layer with an exclude copy instead of deleting node_modules

### DIFF
--- a/.changeset/code-layer-exclude-copy.md
+++ b/.changeset/code-layer-exclude-copy.md
@@ -2,4 +2,4 @@
 "trigger.dev": patch
 ---
 
-Deploy image builds no longer spend time (and disk churn) removing `node_modules` while assembling the code layer; the layer is now copied with the dependency tree excluded. Large projects should see noticeably faster builds.
+Fixes an issue introduced in 4.5.11 that made deploy image builds of projects with large dependency trees noticeably slower.

--- a/.changeset/code-layer-exclude-copy.md
+++ b/.changeset/code-layer-exclude-copy.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Deploy image builds no longer spend time (and disk churn) removing `node_modules` while assembling the code layer; the layer is now copied with the dependency tree excluded. Large projects should see noticeably faster builds.

--- a/packages/cli-v3/src/deploy/buildImage.test.ts
+++ b/packages/cli-v3/src/deploy/buildImage.test.ts
@@ -156,7 +156,8 @@ describe("generateContainerfile", () => {
 
       const user = runtime === "bun" ? "bun:bun" : "node:node";
 
-      expect(containerfile).toContain("FROM build AS code");
+      expect(containerfile).toContain("FROM scratch AS code");
+      expect(containerfile).toContain("COPY --from=build --exclude=node_modules /app /app");
       expect(containerfile).toContain(
         `COPY --from=build --chown=${user} /app/node_modules ./node_modules`
       );
@@ -180,15 +181,15 @@ describe("generateContainerfile", () => {
       const postInstall = containerfile.indexOf("RUN echo post-install");
       // guard after post-install so a command that prunes node_modules can't break the COPY
       const mkdirGuard = containerfile.indexOf("RUN mkdir -p node_modules");
-      const codeStage = containerfile.indexOf("FROM build AS code");
-      const rmNodeModules = containerfile.indexOf(
-        "RUN chmod -R u+rwX node_modules && rm -rf node_modules"
+      const codeStage = containerfile.indexOf("FROM scratch AS code");
+      const excludeCopy = containerfile.indexOf(
+        "COPY --from=build --exclude=node_modules /app /app"
       );
 
       expect(postInstall).toBeGreaterThan(-1);
       expect(mkdirGuard).toBeGreaterThan(postInstall);
       expect(codeStage).toBeGreaterThan(mkdirGuard);
-      expect(rmNodeModules).toBeGreaterThan(codeStage);
+      expect(excludeCopy).toBeGreaterThan(codeStage);
     }
   );
 });

--- a/packages/cli-v3/src/deploy/buildImage.ts
+++ b/packages/cli-v3/src/deploy/buildImage.ts
@@ -837,10 +837,9 @@ ${postInstallCommands}
 # node_modules may not exist when there are no dependencies to install
 RUN mkdir -p node_modules
 
-FROM build AS code
+FROM scratch AS code
 
-# u+rwX first: non-root rm fails on read-only or non-traversable directories
-RUN chmod -R u+rwX node_modules && rm -rf node_modules
+COPY --from=build --exclude=node_modules /app /app
 
 FROM build AS indexer
 
@@ -945,10 +944,9 @@ COPY --chown=node:node . .
 # node_modules may not exist when there are no dependencies to install
 RUN mkdir -p node_modules
 
-FROM build AS code
+FROM scratch AS code
 
-# u+rwX first: non-root rm fails on read-only or non-traversable directories
-RUN chmod -R u+rwX node_modules && rm -rf node_modules
+COPY --from=build --exclude=node_modules /app /app
 
 FROM build AS indexer
 


### PR DESCRIPTION
Fixes a deploy slowdown introduced in #4551 to build the code layer, the generated Containerfile deleted `node_modules` from a snapshot of the build stage.

New approach: the code stage starts empty and copies the app files with the dependency tree excluded.

`COPY --exclude` is stable in the `docker/dockerfile:1` frontend the templates already pin.
