### PR TITLE
fix(clickhouse): drop obsolete task event index variants

### DIFF
--- a/internal-packages/clickhouse/schema/042_reduce_task_events_v2_storage_overhead.sql
+++ b/internal-packages/clickhouse/schema/042_reduce_task_events_v2_storage_overhead.sql
@@ -2,16 +2,12 @@
 
 -- Full-text search is served outside the source event table. Keeping these
 -- indexes here adds work to every event insert and merge without serving reads.
-ALTER TABLE trigger_dev.task_events_v2
-    DROP INDEX IF EXISTS idx_attributes_text_search;
-
-ALTER TABLE trigger_dev.task_events_v2
-    DROP INDEX IF EXISTS idx_message_text_search;
-
 -- attributes remains an insert input for attributes_text, but is no longer
 -- stored. Writers must include attributes in an explicit insert column list
 -- because implicit INSERT column lists exclude EPHEMERAL columns.
 ALTER TABLE trigger_dev.task_events_v2
+    DROP INDEX IF EXISTS idx_attributes_text_search,
+    DROP INDEX IF EXISTS idx_message_text_search,
     MODIFY COLUMN attributes JSON EPHEMERAL;
 
 -- +goose Down

--- a/internal-packages/clickhouse/schema/042_reduce_task_events_v2_storage_overhead.sql
+++ b/internal-packages/clickhouse/schema/042_reduce_task_events_v2_storage_overhead.sql
@@ -2,11 +2,7 @@
 
 -- Full-text search is served outside the source event table. Keeping these
 -- indexes here adds work to every event insert and merge without serving reads.
--- attributes remains an insert input for attributes_text, but is no longer
--- stored. Writers must include attributes in an explicit insert column list
--- because implicit INSERT column lists exclude EPHEMERAL columns.
 ALTER TABLE trigger_dev.task_events_v2
-    MODIFY COLUMN attributes JSON EPHEMERAL,
     DROP INDEX IF EXISTS idx_attributes_text_search,
     DROP INDEX IF EXISTS idx_attributes_text,
     DROP INDEX IF EXISTS idx_message_text_search,
@@ -15,6 +11,6 @@ SETTINGS mutations_sync = 2, alter_sync = 2;
 
 -- +goose Down
 
--- Restoring the stored JSON column safely requires inspecting the live schema
--- and coordinating the writer rollback. Use a new forward migration instead.
+-- Restoring these indexes safely requires selecting the appropriate index
+-- definitions and materializing them in a new forward migration.
 SELECT throwIf(1, 'This migration cannot be rolled back automatically');

--- a/internal-packages/clickhouse/schema/042_reduce_task_events_v2_storage_overhead.sql
+++ b/internal-packages/clickhouse/schema/042_reduce_task_events_v2_storage_overhead.sql
@@ -6,9 +6,12 @@
 -- stored. Writers must include attributes in an explicit insert column list
 -- because implicit INSERT column lists exclude EPHEMERAL columns.
 ALTER TABLE trigger_dev.task_events_v2
+    MODIFY COLUMN attributes JSON EPHEMERAL,
     DROP INDEX IF EXISTS idx_attributes_text_search,
+    DROP INDEX IF EXISTS idx_attributes_text,
     DROP INDEX IF EXISTS idx_message_text_search,
-    MODIFY COLUMN attributes JSON EPHEMERAL;
+    DROP INDEX IF EXISTS message_text_search
+SETTINGS mutations_sync = 2, alter_sync = 2;
 
 -- +goose Down
 

--- a/internal-packages/clickhouse/schema/042_reduce_task_events_v2_storage_overhead.sql
+++ b/internal-packages/clickhouse/schema/042_reduce_task_events_v2_storage_overhead.sql
@@ -6,11 +6,6 @@ ALTER TABLE trigger_dev.task_events_v2
     DROP INDEX IF EXISTS idx_attributes_text_search,
     DROP INDEX IF EXISTS idx_attributes_text,
     DROP INDEX IF EXISTS idx_message_text_search,
-    DROP INDEX IF EXISTS message_text_search
-SETTINGS mutations_sync = 2, alter_sync = 2;
+    DROP INDEX IF EXISTS message_text_search;
 
 -- +goose Down
-
--- Restoring these indexes safely requires selecting the appropriate index
--- definitions and materializing them in a new forward migration.
-SELECT throwIf(1, 'This migration cannot be rolled back automatically');

--- a/internal-packages/clickhouse/src/taskEvents.test.ts
+++ b/internal-packages/clickhouse/src/taskEvents.test.ts
@@ -13,7 +13,7 @@ describe("task events v2", () => {
       const ch = new ClickHouse({ url: clickhouseContainer.getConnectionUrl(), name: "test" });
       const startTime = new Date("2026-09-01T10:00:00.000Z");
       const expiresAt = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000);
-      const spanId = "span_ephemeral_attributes";
+      const spanId = "span_materialized_attributes";
 
       const [insertError] = await ch.taskEventsV2.insert([
         {
@@ -42,7 +42,7 @@ describe("task events v2", () => {
       expect(insertError).toBeNull();
 
       const readAttributes = ch.reader.query({
-        name: "read-ephemeral-task-event-attributes",
+        name: "read-task-event-attributes",
         query: `SELECT attributes_text,
           toUInt8(inserted_at > toDateTime64('2020-01-01 00:00:00', 3)) AS has_inserted_at
         FROM trigger_dev.task_events_v2
@@ -82,8 +82,8 @@ describe("task events v2", () => {
       expect(columns).toEqual([
         {
           name: "attributes",
-          default_kind: "EPHEMERAL",
-          default_expression: "defaultValueOfTypeName('JSON')",
+          default_kind: "",
+          default_expression: "",
         },
         {
           name: "attributes_text",
@@ -98,7 +98,12 @@ describe("task events v2", () => {
         FROM system.data_skipping_indices
         WHERE database = 'trigger_dev'
           AND table = 'task_events_v2'
-          AND name IN ('idx_attributes_text_search', 'idx_message_text_search')
+          AND name IN (
+            'idx_attributes_text_search',
+            'idx_attributes_text',
+            'idx_message_text_search',
+            'message_text_search'
+          )
         ORDER BY name`,
         schema: z.object({ name: z.string() }),
       });


### PR DESCRIPTION
## Summary

Removes the obsolete task event full-text indexes in one `ALTER TABLE`, accounting for both known index naming variants.

## Fix

The original migration issued back-to-back alters while ClickHouse could still be processing the preceding index mutation. Combining the index removals avoids scheduling a subsequent alter against an unfinished mutation.

The native JSON storage change is deferred until it can be performed without rewriting populated parts.
