### PR TITLE
fix(build): playwright extension parses the Playwright 1.58+ `install --dry-run` output

### DIFF
--- a/.changeset/playwright-extension-dry-run-1-58.md
+++ b/.changeset/playwright-extension-dry-run-1-58.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/build": patch
+---
+
+Fix the `playwright` build extension for Playwright 1.58+. The extension reads `playwright install --dry-run` to find each browser's download URL, and 1.58 changed the per-browser header from `browser: chromium-headless-shell version …` to `Chrome Headless Shell … (playwright chromium-headless-shell v…)`, so the image build failed at the `grep` step with exit code 1. The header match now accepts both formats, and the context window after the header is narrowed to the two lines actually used (install location and download url): 1.58+ blocks are shorter than before, so the old window ran into the next browser's install location and would have extracted the archive into the wrong directory.

--- a/.changeset/playwright-extension-dry-run-1-58.md
+++ b/.changeset/playwright-extension-dry-run-1-58.md
@@ -2,4 +2,4 @@
 "@trigger.dev/build": patch
 ---
 
-Fix the `playwright` build extension for Playwright 1.58+. The extension reads `playwright install --dry-run` to find each browser's download URL, and 1.58 changed the per-browser header from `browser: chromium-headless-shell version …` to `Chrome Headless Shell … (playwright chromium-headless-shell v…)`, so the image build failed at the `grep` step with exit code 1. The header match now accepts both formats, and the context window after the header is narrowed to the two lines actually used (install location and download url): 1.58+ blocks are shorter than before, so the old window ran into the next browser's install location and would have extracted the archive into the wrong directory.
+The `playwright` build extension now works with Playwright 1.58 and later. 1.58 changed the `playwright install --dry-run` output, which made deploy image builds fail while downloading the browsers.

--- a/packages/build/src/extensions/playwright.test.ts
+++ b/packages/build/src/extensions/playwright.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { BuildContext, BuildLayer } from "@trigger.dev/core/v3/build";
-import { playwright } from "./playwright.js";
+import { dryRunHeaderPattern } from "./playwright.js";
 
 // Real `playwright install --dry-run` headers, before and after the 1.58 format change.
 const HEADERS = {
@@ -19,52 +18,18 @@ const HEADERS = {
   },
 } as const;
 
-type BrowserKey = keyof (typeof HEADERS)["1.57"];
+const browsers = Object.keys(HEADERS["1.57"]) as Array<keyof (typeof HEADERS)["1.57"]>;
 
-function generatedInstructions(options: Parameters<typeof playwright>[0]): string[] {
-  let captured: BuildLayer | undefined;
-
-  const context = {
-    target: "deploy",
-    logger: { debug: () => {} },
-    addLayer: (layer: BuildLayer) => {
-      captured = layer;
-    },
-  } as unknown as BuildContext;
-
-  const manifest = {
-    externals: [{ name: "playwright", version: "1.62.0" }],
-  } as any;
-
-  playwright(options).onBuildComplete!(context, manifest);
-
-  return captured?.image?.instructions ?? [];
-}
-
-/** The ERE the generated `grep -E "<pattern>"` step selects a browser's block with. */
-function headerPattern(instructions: string[], browser: BrowserKey): RegExp {
-  const step = instructions.find((line) => line.endsWith(`> /tmp/${browser}-info.txt`));
-  const match = step?.match(/grep [^"]*"(.+)" \/tmp\/browser-info\.txt/);
-  if (!match?.[1]) throw new Error(`no header grep generated for ${browser}`);
-  return new RegExp(match[1]);
-}
-
-describe("playwright extension dry-run header parsing", () => {
-  const instructions = generatedInstructions({
-    browsers: ["chromium", "firefox", "webkit"],
-    headless: false,
-  });
-  const browsers = Object.keys(HEADERS["1.57"]) as BrowserKey[];
-
+describe("playwright extension dry-run header pattern", () => {
   it.each(browsers)("selects the %s block in both output formats", (browser) => {
-    const pattern = headerPattern(instructions, browser);
+    const pattern = new RegExp(dryRunHeaderPattern(browser));
 
     expect(pattern.test(HEADERS["1.57"][browser])).toBe(true);
     expect(pattern.test(HEADERS["1.62"][browser])).toBe(true);
   });
 
   it.each(browsers)("does not select another browser's block for %s", (browser) => {
-    const pattern = headerPattern(instructions, browser);
+    const pattern = new RegExp(dryRunHeaderPattern(browser));
 
     for (const other of browsers.filter((b) => b !== browser)) {
       expect(pattern.test(HEADERS["1.57"][other])).toBe(false);

--- a/packages/build/src/extensions/playwright.test.ts
+++ b/packages/build/src/extensions/playwright.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { BuildContext, BuildLayer } from "@trigger.dev/core/v3/build";
+import { playwright } from "./playwright.js";
+
+// Real `playwright install --dry-run` headers, before and after the 1.58 format change.
+const HEADERS = {
+  "1.57": {
+    chromium: "browser: chromium version 143.0.7499.4",
+    "chromium-headless-shell": "browser: chromium-headless-shell version 143.0.7499.4",
+    firefox: "browser: firefox version 144.0.2",
+    webkit: "browser: webkit version 26.0",
+  },
+  "1.62": {
+    chromium: "Chrome for Testing 151.0.7922.34 (playwright chromium v1234)",
+    "chromium-headless-shell":
+      "Chrome Headless Shell 151.0.7922.34 (playwright chromium-headless-shell v1234)",
+    firefox: "Firefox 153.0 (playwright firefox v1538)",
+    webkit: "WebKit 26.5 (playwright webkit v2336)",
+  },
+} as const;
+
+type BrowserKey = keyof (typeof HEADERS)["1.57"];
+
+function generatedInstructions(options: Parameters<typeof playwright>[0]): string[] {
+  let captured: BuildLayer | undefined;
+
+  const context = {
+    target: "deploy",
+    logger: { debug: () => {} },
+    addLayer: (layer: BuildLayer) => {
+      captured = layer;
+    },
+  } as unknown as BuildContext;
+
+  const manifest = {
+    externals: [{ name: "playwright", version: "1.62.0" }],
+  } as any;
+
+  playwright(options).onBuildComplete!(context, manifest);
+
+  return captured?.image?.instructions ?? [];
+}
+
+/** The ERE the generated `grep -E "<pattern>"` step selects a browser's block with. */
+function headerPattern(instructions: string[], browser: BrowserKey): RegExp {
+  const step = instructions.find((line) => line.endsWith(`> /tmp/${browser}-info.txt`));
+  const match = step?.match(/grep [^"]*"(.+)" \/tmp\/browser-info\.txt/);
+  if (!match?.[1]) throw new Error(`no header grep generated for ${browser}`);
+  return new RegExp(match[1]);
+}
+
+describe("playwright extension dry-run header parsing", () => {
+  const instructions = generatedInstructions({
+    browsers: ["chromium", "firefox", "webkit"],
+    headless: false,
+  });
+  const browsers = Object.keys(HEADERS["1.57"]) as BrowserKey[];
+
+  it.each(browsers)("selects the %s block in both output formats", (browser) => {
+    const pattern = headerPattern(instructions, browser);
+
+    expect(pattern.test(HEADERS["1.57"][browser])).toBe(true);
+    expect(pattern.test(HEADERS["1.62"][browser])).toBe(true);
+  });
+
+  it.each(browsers)("does not select another browser's block for %s", (browser) => {
+    const pattern = headerPattern(instructions, browser);
+
+    for (const other of browsers.filter((b) => b !== browser)) {
+      expect(pattern.test(HEADERS["1.57"][other])).toBe(false);
+      expect(pattern.test(HEADERS["1.62"][other])).toBe(false);
+    }
+  });
+});

--- a/packages/build/src/extensions/playwright.ts
+++ b/packages/build/src/extensions/playwright.ts
@@ -197,6 +197,19 @@ export function playwright(options: PlaywrightExtensionOptions = {}) {
 }
 
 /**
+ * Extended regex selecting a browser's block header in `playwright install --dry-run` output.
+ *
+ * Playwright < 1.58 prints `browser: <name> version <v>`; 1.58+ prints
+ * `<Product> <v> (playwright <name> v<build>)`. The trailing space / `v` keep
+ * `chromium` from matching the `chromium-headless-shell` block.
+ *
+ * @internal
+ */
+export function dryRunHeaderPattern(browser: string): string {
+  return `browser: ${browser} |\\(playwright ${browser} v`;
+}
+
+/**
  * Background:
  *
  * Running `npx playwright install --with-deps` normally will install the browsers and the dependencies.
@@ -317,12 +330,9 @@ class PlaywrightExtension implements BuildExtension {
 
     Array.from(browsersToInstall).forEach((browser) => {
       instructions.push(
-        // Playwright < 1.58 prints `browser: <name> version <v>`; 1.58+ prints
-        // `<Product> <v> (playwright <name> v<build>)`. The trailing space / `v`
-        // keep `chromium` from matching the `chromium-headless-shell` block, and
-        // only the two lines after the header (install location, download url)
+        // Only the two lines after the header (install location, download url)
         // are read, so the window stops there.
-        `RUN grep -A2 -m1 -E "browser: ${browser} |\\(playwright ${browser} v" /tmp/browser-info.txt > /tmp/${browser}-info.txt`,
+        `RUN grep -A2 -m1 -E "${dryRunHeaderPattern(browser)}" /tmp/browser-info.txt > /tmp/${browser}-info.txt`,
 
         `RUN INSTALL_DIR=$(grep "Install location:" /tmp/${browser}-info.txt | cut -d':' -f2- | xargs) && \
           DIR_NAME=$(basename "$INSTALL_DIR") && \

--- a/packages/build/src/extensions/playwright.ts
+++ b/packages/build/src/extensions/playwright.ts
@@ -319,10 +319,9 @@ class PlaywrightExtension implements BuildExtension {
       instructions.push(
         // Playwright < 1.58 prints `browser: <name> version <v>`; 1.58+ prints
         // `<Product> <v> (playwright <name> v<build>)`. The trailing space / `v`
-        // keep `chromium` from matching the `chromium-headless-shell` block.
-        // Only the two lines after the header are needed (install location and
-        // download url); 1.58+ blocks are that short, so a longer window would
-        // bleed into the next browser's install location.
+        // keep `chromium` from matching the `chromium-headless-shell` block, and
+        // only the two lines after the header (install location, download url)
+        // are read, so the window stops there.
         `RUN grep -A2 -m1 -E "browser: ${browser} |\\(playwright ${browser} v" /tmp/browser-info.txt > /tmp/${browser}-info.txt`,
 
         `RUN INSTALL_DIR=$(grep "Install location:" /tmp/${browser}-info.txt | cut -d':' -f2- | xargs) && \

--- a/packages/build/src/extensions/playwright.ts
+++ b/packages/build/src/extensions/playwright.ts
@@ -317,7 +317,13 @@ class PlaywrightExtension implements BuildExtension {
 
     Array.from(browsersToInstall).forEach((browser) => {
       instructions.push(
-        `RUN grep -A5 -m1 "browser: ${browser}" /tmp/browser-info.txt > /tmp/${browser}-info.txt`,
+        // Playwright < 1.58 prints `browser: <name> version <v>`; 1.58+ prints
+        // `<Product> <v> (playwright <name> v<build>)`. The trailing space / `v`
+        // keep `chromium` from matching the `chromium-headless-shell` block.
+        // Only the two lines after the header are needed (install location and
+        // download url); 1.58+ blocks are that short, so a longer window would
+        // bleed into the next browser's install location.
+        `RUN grep -A2 -m1 -E "browser: ${browser} |\\(playwright ${browser} v" /tmp/browser-info.txt > /tmp/${browser}-info.txt`,
 
         `RUN INSTALL_DIR=$(grep "Install location:" /tmp/${browser}-info.txt | cut -d':' -f2- | xargs) && \
           DIR_NAME=$(basename "$INSTALL_DIR") && \


### PR DESCRIPTION
Fixes #3089

## Problem

The `playwright` build extension reads `npx playwright install --dry-run` to find each browser's install directory and download URL. Playwright 1.58 changed the per-browser header, so the extension's `grep` finds nothing and the image build fails at that step with exit code 1:

```
< 1.58   browser: chromium-headless-shell version 143.0.7499.4
>= 1.58  Chrome Headless Shell 151.0.7922.34 (playwright chromium-headless-shell v1234)
```

There is a second problem hiding behind the first. The old blocks were five lines (install location, download url, two fallback urls, blank), so `grep -A5` was exact. The Chrome-for-Testing blocks in 1.58+ (`chromium` and `chromium-headless-shell`, the default install) are three lines (install location, download url, blank; Firefox and WebKit still print the fallbacks), so `-A5` runs into the next browser's `Install location:` line. The downstream `grep "Install location:" | cut | xargs` then joins two paths and `basename` returns the *next* browser's directory: with the header grep alone fixed, `chromium-headless-shell` gets unpacked into `firefox-<build>/`. Any grep-only fix (including the pnpm patch shared in #3089) has this bug.

## Fix

- The header match accepts both formats: `grep -E "browser: <name> |\(playwright <name> v"`. The trailing space / `v` keep `chromium` from matching the `chromium-headless-shell` block in either format.
- The context window is narrowed to `-A2`, the two lines the extension actually reads. Both formats put `Install location:` and `Download url:` immediately after the header.
- A unit test asserts the generated header pattern selects each browser's block in both formats and never another browser's.

I left the `sed "s/mac-arm64/linux/g"` rewrite alone, and I do not think the "dead `linux64` URLs" report in #3089 is reachable from the extension. The `--dry-run` executes inside the Linux build container, so the URL it prints is already the Linux one and there is nothing for the rewrite to match. Checked by running the same command in a container:

```
$ docker run --rm --platform linux/amd64 node:22-bookworm-slim \
    sh -c 'npx -y playwright@1.62.0 install --dry-run'
Chrome Headless Shell 151.0.7922.34 (playwright chromium-headless-shell v1234)
  Download url:        https://cdn.playwright.dev/builds/cft/151.0.7922.34/linux64/chrome-headless-shell-linux64.zip
Firefox 153.0 (playwright firefox v1538)
  Download url:        https://cdn.playwright.dev/dbazure/download/playwright/builds/firefox/1538/firefox-debian-12.zip
```

Rewriting `mac-arm64` to `linux64` would also be wrong for < 1.58, where the Linux artifact is `…-linux.zip`, so changing it would trade a dead branch for an incorrect one.

## Verification

Ran the generated extraction (`grep -A2 -m1 -E … | grep "Install location:" | cut | xargs | basename`, and the same for `Download url:`) against real `--dry-run` output from Playwright 1.57.0 and 1.62.0, for all four browser keys:

| output | browser | directory | url |
|---|---|---|---|
| 1.57 | chromium | chromium-1200 | chromium-linux.zip |
| 1.57 | chromium-headless-shell | chromium_headless_shell-1200 | chromium-headless-shell-linux.zip |
| 1.57 | firefox | firefox-1497 | firefox-linux.zip |
| 1.57 | webkit | webkit-2227 | webkit-ubuntu-20.04.zip |
| 1.62 | chromium | chromium-1234 | chrome-linux.zip |
| 1.62 | chromium-headless-shell | chromium_headless_shell-1234 | chrome-headless-shell-linux.zip |
| 1.62 | firefox | firefox-1538 | firefox-linux.zip |
| 1.62 | webkit | webkit-2336 | webkit-mac-26-arm64.zip |

(The webkit 1.62 URL shows the mac name only because my sample output came from a Mac; in the build container the dry-run prints Linux URLs.)

End to end: built a `node:22-bookworm-slim` image (linux/amd64) that runs the extension's generated `RUN` steps verbatim for `chromium-headless-shell` against Playwright 1.62.0, then launched the browser through Playwright with `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`:

```
install dir: chromium_headless_shell-1234
Downloading from https://cdn.playwright.dev/builds/cft/151.0.7922.34/linux64/chrome-headless-shell-linux64.zip
/ms-playwright/chromium_headless_shell-1234/chrome-headless-shell-linux64
title: pw-e2e-ok | version: 151.0.7922.34
```

So the Chrome-for-Testing archive layout unpacks into the directory Playwright's registry expects, and the browser starts.

## Changeset

`@trigger.dev/build` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


