### PR TITLE
fix(cli): report build log stream failures clearly and exit instead of hanging

### DIFF
--- a/.changeset/deploy-log-stream-disconnect.md
+++ b/.changeset/deploy-log-stream-disconnect.md
@@ -2,4 +2,4 @@
 "trigger.dev": patch
 ---
 
-When the build log stream disconnects during a build server deploy, the CLI now explains that the deployment itself is still running and exits immediately with a non-zero code, instead of printing the raw stream error and hanging.
+When the build log stream cannot be opened or disconnects during a build server deploy, the CLI now explains that the deployment itself is unaffected and exits immediately with a non-zero code, since it can no longer confirm the outcome. Previously a disconnect printed the raw stream error and left the process hanging.

--- a/.changeset/deploy-log-stream-disconnect.md
+++ b/.changeset/deploy-log-stream-disconnect.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+When the build log stream disconnects during a build server deploy, the CLI now explains that the deployment itself is still running and exits immediately with a non-zero code, instead of printing the raw stream error and hanging.

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -2331,9 +2331,32 @@ async function followBuildServerDeployment({
     return process.exit(0);
   }
 
-  const finalDeploymentEvent = await streamDeploymentEvents(readSession, renderer, () =>
-    abortController.abort()
+  const [streamError, finalDeploymentEvent] = await tryCatch(
+    streamDeploymentEvents(readSession, renderer, () => abortController.abort()).finally(() =>
+      abortController.abort()
+    )
   );
+
+  if (streamError) {
+    renderer.finish("Log stream stopped", "failure");
+
+    logger.debug("Build log stream failed", { error: streamError });
+
+    log.error(`Lost connection to the build log stream: ${streamError.message}`);
+    log.info(
+      "This is not a deployment failure, the build server is still working on it. Check the dashboard for the final status."
+    );
+
+    if (!isLinksSupported) {
+      log.info(`View deployment: ${rawDeploymentLink}`);
+    }
+
+    throw new OutroCommandError(
+      `Version ${deployment.version} ${
+        isLinksSupported ? `| ${cliLink("View deployment", rawDeploymentLink)}` : ""
+      }`
+    );
+  }
 
   if (!renderer.started && !finalDeploymentEvent) {
     // unlikely that it happens in practice, only in rare corner cases

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -26,7 +26,7 @@ import { resolveAlwaysExternal } from "../build/externals.js";
 import { createContextArchive, getArchiveSize } from "../deploy/archiveContext.js";
 import { createBundleArchive } from "../deploy/bundleArchive.js";
 import {
-  BuildLogRenderer,
+  type BuildLogRenderer,
   BuildLogsMode,
   createBuildLogRenderer,
   resolveBuildLogsMode,

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -2340,9 +2340,13 @@ async function followBuildServerDeployment({
 
     logger.debug("Build log stream failed", { error: streamError });
 
-    log.error(`Lost connection to the build log stream: ${streamError.message}`);
+    const reason = (streamError instanceof Error ? streamError.message : String(streamError))
+      .replace(/\s+/g, " ")
+      .slice(0, 200);
+
+    log.error(`Build log stream failed: ${reason}`);
     log.info(
-      "This is not a deployment failure, the build server is still working on it. Check the dashboard for the final status."
+      "The deployment itself is unaffected and continues on the build server. Check the dashboard for the final status."
     );
 
     if (!isLinksSupported) {

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -2332,9 +2332,7 @@ async function followBuildServerDeployment({
   }
 
   const [streamError, finalDeploymentEvent] = await tryCatch(
-    streamDeploymentEvents(readSession, renderer, () => abortController.abort()).finally(() =>
-      abortController.abort()
-    )
+    streamDeploymentEvents(readSession, renderer, () => abortController.abort())
   );
 
   if (streamError) {

--- a/packages/cli-v3/src/commands/deploy.ts
+++ b/packages/cli-v3/src/commands/deploy.ts
@@ -26,6 +26,7 @@ import { resolveAlwaysExternal } from "../build/externals.js";
 import { createContextArchive, getArchiveSize } from "../deploy/archiveContext.js";
 import { createBundleArchive } from "../deploy/bundleArchive.js";
 import {
+  BuildLogRenderer,
   BuildLogsMode,
   createBuildLogRenderer,
   resolveBuildLogsMode,
@@ -2284,6 +2285,36 @@ function showFullBuildLogs(options: DeployCommandOptions) {
   return resolveBuildLogsMode(options.buildLogs, buildLogsEnv(options)) === "full";
 }
 
+function buildLogStreamError(
+  error: unknown,
+  renderer: BuildLogRenderer,
+  deployment: Pick<InitializeDeploymentResponseBody, "version">,
+  rawDeploymentLink: string
+): OutroCommandError {
+  renderer.finish("Log stream stopped", "failure");
+
+  logger.debug("Build log stream failed", { error });
+
+  const reason = (error instanceof Error ? error.message : String(error))
+    .replace(/\s+/g, " ")
+    .slice(0, 200);
+
+  log.error(`Build log stream failed: ${reason}`);
+  log.info(
+    "The deployment itself is unaffected and continues on the build server. Check the dashboard for the final status."
+  );
+
+  if (!isLinksSupported) {
+    log.info(`View deployment: ${rawDeploymentLink}`);
+  }
+
+  return new OutroCommandError(
+    `Version ${deployment.version} ${
+      isLinksSupported ? `| ${cliLink("View deployment", rawDeploymentLink)}` : ""
+    }`
+  );
+}
+
 async function followBuildServerDeployment({
   deployment,
   eventStream,
@@ -2319,16 +2350,7 @@ async function followBuildServerDeployment({
   );
 
   if (readSessionError) {
-    renderer.finish("Failed to query build progress", "abandoned");
-    log.warn(`Failed streaming build logs, open the deployment in the dashboard to view the logs`);
-
-    outro(
-      `Version ${deployment.version} is being deployed ${
-        isLinksSupported ? `| ${cliLink("View deployment", rawDeploymentLink)}` : ""
-      }`
-    );
-
-    return process.exit(0);
+    throw buildLogStreamError(readSessionError, renderer, deployment, rawDeploymentLink);
   }
 
   const [streamError, finalDeploymentEvent] = await tryCatch(
@@ -2336,28 +2358,7 @@ async function followBuildServerDeployment({
   );
 
   if (streamError) {
-    renderer.finish("Log stream stopped", "failure");
-
-    logger.debug("Build log stream failed", { error: streamError });
-
-    const reason = (streamError instanceof Error ? streamError.message : String(streamError))
-      .replace(/\s+/g, " ")
-      .slice(0, 200);
-
-    log.error(`Build log stream failed: ${reason}`);
-    log.info(
-      "The deployment itself is unaffected and continues on the build server. Check the dashboard for the final status."
-    );
-
-    if (!isLinksSupported) {
-      log.info(`View deployment: ${rawDeploymentLink}`);
-    }
-
-    throw new OutroCommandError(
-      `Version ${deployment.version} ${
-        isLinksSupported ? `| ${cliLink("View deployment", rawDeploymentLink)}` : ""
-      }`
-    );
+    throw buildLogStreamError(streamError, renderer, deployment, rawDeploymentLink);
   }
 
   if (!renderer.started && !finalDeploymentEvent) {

--- a/packages/cli-v3/src/deploy/buildLogs.test.ts
+++ b/packages/cli-v3/src/deploy/buildLogs.test.ts
@@ -258,6 +258,34 @@ describe("streamDeploymentEvents", () => {
     expect(onFinalized).toHaveBeenCalledTimes(1);
   });
 
+  it("stops consuming the stream once the finalized event arrives", async () => {
+    let released = false;
+    async function* recordsThenThrow() {
+      try {
+        yield {
+          seqNum: 0,
+          timestamp: 1_700_000_000_000,
+          body: JSON.stringify({ type: "log", data: { message: "a" } }),
+        };
+        yield {
+          seqNum: 1,
+          timestamp: 1_700_000_000_000,
+          body: JSON.stringify({ type: "finalized", data: { result: "succeeded" } }),
+        };
+        throw new Error("stream closed with unparsed data remaining");
+      } finally {
+        released = true;
+      }
+    }
+    const final = await streamDeploymentEvents(
+      recordsThenThrow(),
+      { started: false, log: vi.fn(), finish: vi.fn() },
+      vi.fn()
+    );
+    expect(final).toEqual({ result: "succeeded" });
+    expect(released).toBe(true);
+  });
+
   it("returns undefined when the stream ends without a finalized event", async () => {
     const final = await streamDeploymentEvents(
       records([JSON.stringify({ type: "log", data: { message: "a" } })]),

--- a/packages/cli-v3/src/deploy/buildLogs.test.ts
+++ b/packages/cli-v3/src/deploy/buildLogs.test.ts
@@ -277,12 +277,16 @@ describe("streamDeploymentEvents", () => {
         released = true;
       }
     }
+    let finalizedCalls = 0;
     const final = await streamDeploymentEvents(
       recordsThenThrow(),
-      { started: false, log: vi.fn(), finish: vi.fn() },
-      vi.fn()
+      { started: false, log: () => {}, finish: () => {} },
+      () => {
+        finalizedCalls++;
+      }
     );
     expect(final).toEqual({ result: "succeeded" });
+    expect(finalizedCalls).toBe(1);
     expect(released).toBe(true);
   });
 

--- a/packages/cli-v3/src/deploy/buildLogs.ts
+++ b/packages/cli-v3/src/deploy/buildLogs.ts
@@ -158,8 +158,6 @@ export async function streamDeploymentEvents(
   renderer: BuildLogRenderer,
   onFinalized: () => void
 ): Promise<DeploymentFinalizedEvent["data"] | undefined> {
-  let finalEvent: DeploymentFinalizedEvent["data"] | undefined;
-
   for await (const record of records) {
     const result = DeploymentEventFromString.safeParse(record.body);
     if (!result.success) {
@@ -182,9 +180,8 @@ export async function streamDeploymentEvents(
         break;
       }
       case "finalized": {
-        finalEvent = event.data;
         onFinalized();
-        break;
+        return event.data;
       }
       default: {
         event satisfies never;
@@ -193,5 +190,5 @@ export async function streamDeploymentEvents(
     }
   }
 
-  return finalEvent;
+  return undefined;
 }


### PR DESCRIPTION
When the build log stream failed during a build server deploy, the CLI printed the raw stream error (e.g. `X Error: Invalid access token`) and then hung the process. Only the log stream was lost, the deployment itself kept running.

The CLI now stops the spinner, says the log stream failed and that the deployment continues on the build server, links the dashboard, and exits 1 right away. The non-zero exit is deliberate: the CLI can no longer confirm the outcome. Failing to open the stream now behaves the same way instead of exiting 0.

### Fix

- One handler for both stream failures that prints the message and throws an `OutroCommandError`, which exits the process instead of waiting for open handles.
- Return from the event loop on the `finalized` event, which cancels the read session directly. A late transport error can no longer discard a result already received or keep the stream reconnecting after the build is done.