### PR TITLE
feat(sdk): route chat.agent transcript persistence through a TranscriptStorage seam

### DIFF
--- a/apps/webapp/test/chat-snapshot-integration.test.ts
+++ b/apps/webapp/test/chat-snapshot-integration.test.ts
@@ -1,27 +1,8 @@
-// Plan F.3: integration test that round-trips a `ChatSnapshotV1` blob
-// through the SDK's snapshot helpers + a real MinIO backing store. Mirrors
-// the testcontainer pattern from `objectStore.test.ts`.
-//
-// What this verifies end-to-end:
-//   - SDK's `writeChatSnapshot` calls `apiClient.createUploadPayloadUrl`
-//     to mint a presigned PUT, then PUTs JSON to it.
-//   - SDK's `readChatSnapshot` calls `apiClient.getPayloadUrl` to mint a
-//     presigned GET, then fetches and parses.
-//   - The webapp's `generatePresignedUrl` produces URLs MinIO accepts.
-//   - The blob round-trips with `version: 1` shape preserved.
-//   - 404 (no snapshot for a fresh session) returns `undefined`, not an
-//     error.
-//
-// This is the integration safety net behind the unit tests in
-// `packages/trigger-sdk/test/chat-snapshot.test.ts` — those tests mock
-// `fetch`; this one drives a real S3-compatible backend.
-
 import { postgresAndMinioTest } from "@internal/testcontainers";
-import { apiClientManager } from "@trigger.dev/core/v3";
+import { apiClientManager, type TranscriptSnapshotV2 } from "@trigger.dev/core/v3";
 import {
   __readChatSnapshotProductionPathForTests as readChatSnapshot,
   __writeChatSnapshotProductionPathForTests as writeChatSnapshot,
-  type ChatSnapshotV1,
 } from "@trigger.dev/sdk/ai";
 import type { UIMessage } from "ai";
 import { afterEach, describe, expect, vi } from "vitest";
@@ -35,22 +16,24 @@ vi.setConfig({ testTimeout: 60_000 });
 
 function makeSnapshot(
   opts: { messages?: UIMessage[]; lastOutEventId?: string } = {}
-): ChatSnapshotV1 {
+): TranscriptSnapshotV2 {
+  const messages = opts.messages ?? [
+    {
+      id: "u-1",
+      role: "user",
+      parts: [{ type: "text", text: "hello" }],
+    },
+    {
+      id: "a-1",
+      role: "assistant",
+      parts: [{ type: "text", text: "world" }],
+    },
+  ];
   return {
-    version: 1,
+    version: 2,
     savedAt: 1_700_000_000_000,
-    messages: opts.messages ?? [
-      {
-        id: "u-1",
-        role: "user",
-        parts: [{ type: "text", text: "hello" }],
-      },
-      {
-        id: "a-1",
-        role: "assistant",
-        parts: [{ type: "text", text: "world" }],
-      },
-    ],
+    messages: messages.map((message) => ({ id: message.id, final: true, message })),
+    state: null,
     lastOutEventId: opts.lastOutEventId ?? "evt-42",
   };
 }

--- a/apps/webapp/test/replay-after-crash.test.ts
+++ b/apps/webapp/test/replay-after-crash.test.ts
@@ -24,11 +24,10 @@
 // through it), even though the replay path itself doesn't read from S3.
 
 import { postgresAndMinioTest } from "@internal/testcontainers";
-import { apiClientManager } from "@trigger.dev/core/v3";
+import { apiClientManager, type TranscriptSnapshotV2 } from "@trigger.dev/core/v3";
 import {
   __readChatSnapshotProductionPathForTests as readChatSnapshot,
   __replaySessionOutTailProductionPathForTests as replaySessionOutTail,
-  type ChatSnapshotV1,
 } from "@trigger.dev/sdk/ai";
 import type { UIMessageChunk } from "ai";
 import { afterEach, describe, expect, vi } from "vitest";
@@ -265,13 +264,26 @@ describe("replay after crash (MinIO + SDK helpers)", () => {
 
       // Pre-write a snapshot to MinIO via real apiClient stub.
       const sessionId = "sess_merge_round_trip";
-      const snapshot: ChatSnapshotV1 = {
-        version: 1,
+      const snapshot: TranscriptSnapshotV2 = {
+        version: 2,
         savedAt: 1_700_000_000_000,
         messages: [
-          { id: "u-1", role: "user", parts: [{ type: "text", text: "hi" }] },
-          { id: "a-1", role: "assistant", parts: [{ type: "text", text: "stale-assistant" }] },
+          {
+            id: "u-1",
+            final: true,
+            message: { id: "u-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+          },
+          {
+            id: "a-1",
+            final: true,
+            message: {
+              id: "a-1",
+              role: "assistant",
+              parts: [{ type: "text", text: "stale-assistant" }],
+            },
+          },
         ],
+        state: null,
         lastOutEventId: "evt-prev",
       };
 

--- a/packages/core/src/v3/sessionStreams/chatSnapshot.ts
+++ b/packages/core/src/v3/sessionStreams/chatSnapshot.ts
@@ -44,7 +44,7 @@ export type ChatSnapshotV1<TUIMessage extends UIMessage = UIMessage> = {
  */
 export const ChatSnapshotV1Schema = z.object({
   version: z.literal(1),
-  savedAt: z.number(),
+  savedAt: z.number().optional(),
   messages: z.array(z.unknown()),
   lastOutEventId: z.string().optional(),
   lastInEventId: z.string().optional(),
@@ -81,7 +81,7 @@ export type TranscriptSnapshotV2<TUIMessage extends UIMessage = UIMessage> = {
 
 export const TranscriptSnapshotV2Schema = z.object({
   version: z.literal(2),
-  savedAt: z.number(),
+  savedAt: z.number().optional(),
   messages: z.array(
     z.object({
       id: z.string(),
@@ -102,6 +102,9 @@ export const TranscriptSnapshotV2Schema = z.object({
  * `message` are dropped; a version 2 entry whose `message.id` disagrees with
  * the envelope `id` is dropped too, since a reader keys by one and renders by
  * the other. A caller never sees an entry it would crash on or mis-order.
+ * A missing `savedAt` defaults to `0` rather than rejecting the whole blob:
+ * the field only orders snapshot history before live chunks, and dropping a
+ * whole conversation over an absent timestamp is the wrong failure mode.
  * Returns `undefined` for an unknown version or a body that is not a
  * snapshot; callers treat that as "no snapshot".
  */
@@ -119,7 +122,7 @@ export function parseTranscriptSnapshot<TUIMessage extends UIMessage = UIMessage
     }
     return {
       version: 2,
-      savedAt: v2.data.savedAt,
+      savedAt: v2.data.savedAt ?? 0,
       messages,
       state: v2.data.state ?? null,
       lastOutEventId: v2.data.lastOutEventId,
@@ -137,7 +140,7 @@ export function parseTranscriptSnapshot<TUIMessage extends UIMessage = UIMessage
     }
     return {
       version: 2,
-      savedAt: v1.data.savedAt,
+      savedAt: v1.data.savedAt ?? 0,
       messages,
       state: null,
       lastOutEventId: v1.data.lastOutEventId,

--- a/packages/core/src/v3/test/test-session-stream-manager.ts
+++ b/packages/core/src/v3/test/test-session-stream-manager.ts
@@ -220,7 +220,11 @@ export class TestSessionStreamManager implements SessionStreamManager {
   }
 
   setLastSeqNum(sessionId: string, io: SessionChannelIO, seqNum: number): void {
-    this.seqNums.set(keyFor(sessionId, io), seqNum);
+    const key = keyFor(sessionId, io);
+    const current = this.seqNums.get(key);
+    if (current === undefined || seqNum > current) {
+      this.seqNums.set(key, seqNum);
+    }
   }
 
   consumeRecord(sessionId: string, io: SessionChannelIO, seqNum: number): void {

--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -77,6 +77,14 @@ import {
   zodSchema,
 } from "../imports/ai-runtime.js";
 import {
+  createTranscriptShadow,
+  defaultStorage,
+  diffTranscript,
+  type TranscriptChangeReason,
+  type TranscriptShadow,
+  type TranscriptStorageContext,
+} from "./transcriptStorage.js";
+import {
   type ChatInputChunk,
   type ChatTaskWirePayload,
   type InferChatClientData,
@@ -240,224 +248,24 @@ async function findLatestSessionInCursor(chatId: string): Promise<number | undef
 }
 
 /**
- * Versioned blob written to S3 after every turn completes (when no
- * `hydrateMessages` hook is registered). Read at run boot to seed the
- * accumulator with prior conversation state, replacing the old wire-borne
- * full-history seed.
+ * Versioned blob written to the object store after every turn completes
+ * (when no `hydrateMessages` hook is registered). Read at run boot to seed
+ * the accumulator with prior conversation state.
  *
- * The shape is shared with the Sessions dashboard (which reads the same
- * blob to render the full conversation transcript) via
- * `@trigger.dev/core/v3`. Customer code shouldn't reach in here — the
- * SDK transports surface the messages through the standard `messages`
- * accumulator.
+ * The shape is shared with the Sessions dashboard via `@trigger.dev/core/v3`.
+ * Customer code shouldn't reach in here; the SDK transports surface the
+ * messages through the standard `messages` accumulator.
  *
  * @internal
  */
 export type { ChatSnapshotV1, ChatInputChunk, ChatTaskWirePayload };
 
-/**
- * Test-only override hook — `mockChatAgent` installs a fake to return
- * synthetic snapshots without hitting S3. Mirrors the `__set*ImplForTests`
- * pattern in `sessions.ts`. Not part of the public API.
- * @internal
- */
-type ReadChatSnapshotImpl = <TUIMessage extends UIMessage>(
-  sessionId: string
-) => Promise<ChatSnapshotV1<TUIMessage> | undefined> | ChatSnapshotV1<TUIMessage> | undefined;
-let readChatSnapshotImpl: ReadChatSnapshotImpl | undefined;
-
-export function __setReadChatSnapshotImplForTests(impl: ReadChatSnapshotImpl | undefined): void {
-  readChatSnapshotImpl = impl;
-}
-
-/**
- * Test-only override hook — see `__setReadChatSnapshotImplForTests`. The
- * mock harness records writes for assertion via this setter. Not public.
- * @internal
- */
-type WriteChatSnapshotImpl = <TUIMessage extends UIMessage>(
-  sessionId: string,
-  snapshot: ChatSnapshotV1<TUIMessage>
-) => Promise<void> | void;
-let writeChatSnapshotImpl: WriteChatSnapshotImpl | undefined;
-
-export function __setWriteChatSnapshotImplForTests(impl: WriteChatSnapshotImpl | undefined): void {
-  writeChatSnapshotImpl = impl;
-}
-
-/**
- * Read the persisted snapshot for a session. Returns `undefined` on:
- *   - missing object (404 from the presigned GET — fresh session, never
- *     persisted)
- *   - presign failure (network/auth issue)
- *   - malformed JSON
- *   - version mismatch (forward-compat — older runtimes ignore newer blobs)
- *
- * Always swallows errors via `logger.warn`. The agent boot loop must stay
- * available even if S3 hiccups; the worst case is replaying more of
- * `session.out` than strictly necessary.
- * @internal
- */
-async function readChatSnapshot<TUIMessage extends UIMessage>(
-  sessionId: string
-): Promise<ChatSnapshotV1<TUIMessage> | undefined> {
-  if (readChatSnapshotImpl) {
-    return (await readChatSnapshotImpl<TUIMessage>(sessionId)) ?? undefined;
-  }
-  const apiClient = apiClientManager.clientOrThrow();
-  let presignedUrl: string;
-  try {
-    const resp = await apiClient.getChatSnapshotUrl(sessionId);
-    presignedUrl = resp.presignedUrl;
-  } catch (error) {
-    logger.warn("chat.agent: snapshot presign (read) failed; continuing without snapshot", {
-      error: error instanceof Error ? error.message : String(error),
-      sessionId,
-    });
-    return undefined;
-  }
-  let response: Response;
-  try {
-    response = await fetch(presignedUrl, { method: "GET" });
-  } catch (error) {
-    logger.warn("chat.agent: snapshot fetch failed; continuing without snapshot", {
-      error: error instanceof Error ? error.message : String(error),
-      sessionId,
-    });
-    return undefined;
-  }
-  if (response.status === 404) {
-    // First-ever boot for this session — no snapshot yet. Caller falls
-    // through to replay-only.
-    return undefined;
-  }
-  if (!response.ok) {
-    logger.warn("chat.agent: snapshot fetch returned non-OK; continuing without snapshot", {
-      status: response.status,
-      sessionId,
-    });
-    return undefined;
-  }
-  let parsed: unknown;
-  try {
-    parsed = await response.json();
-  } catch (error) {
-    logger.warn("chat.agent: snapshot JSON parse failed; continuing without snapshot", {
-      error: error instanceof Error ? error.message : String(error),
-      sessionId,
-    });
-    return undefined;
-  }
-  if (!parsed || typeof parsed !== "object") return undefined;
-  const candidate = parsed as Partial<ChatSnapshotV1<TUIMessage>>;
-  if (candidate.version !== 1 || !Array.isArray(candidate.messages)) {
-    logger.warn("chat.agent: snapshot version/shape mismatch; ignoring", {
-      version: candidate.version,
-      sessionId,
-    });
-    return undefined;
-  }
-  return candidate as ChatSnapshotV1<TUIMessage>;
-}
-
-/**
- * Persist the snapshot for a session. Awaited by callers immediately after
- * `onTurnComplete` — the agent may suspend right after this point, and
- * fire-and-forget promises don't reliably complete on suspend.
- *
- * Errors are swallowed via `logger.warn`. A failed write means the next
- * boot replays slightly more of `session.out` (back to the previous
- * snapshot's cursor) instead of failing — the conversation stays
- * coherent, only the boot path does marginally more work.
- * @internal
- */
-async function writeChatSnapshot<TUIMessage extends UIMessage>(
-  sessionId: string,
-  snapshot: ChatSnapshotV1<TUIMessage>
-): Promise<void> {
-  if (writeChatSnapshotImpl) {
-    await writeChatSnapshotImpl<TUIMessage>(sessionId, snapshot);
-    return;
-  }
-  const apiClient = apiClientManager.clientOrThrow();
-  let presignedUrl: string;
-  try {
-    const resp = await apiClient.createChatSnapshotUploadUrl(sessionId);
-    presignedUrl = resp.presignedUrl;
-  } catch (error) {
-    logger.warn("chat.agent: snapshot presign (write) failed; next run will replay further", {
-      error: error instanceof Error ? error.message : String(error),
-      sessionId,
-    });
-    return;
-  }
-  let response: Response;
-  try {
-    response = await fetch(presignedUrl, {
-      method: "PUT",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(snapshot),
-    });
-  } catch (error) {
-    logger.warn("chat.agent: snapshot upload failed; next run will replay further", {
-      error: error instanceof Error ? error.message : String(error),
-      sessionId,
-    });
-    return;
-  }
-  if (!response.ok) {
-    logger.warn("chat.agent: snapshot upload returned non-OK; next run will replay further", {
-      status: response.status,
-      sessionId,
-    });
-  }
-}
-
-/**
- * Test-only entry point that bypasses `__setReadChatSnapshotImplForTests`
- * and reaches the real `apiClient.getPayloadUrl` + `fetch` + JSON-parse path.
- * Used by `chat-snapshot.test.ts` to verify 404 / 500 / malformed JSON /
- * version-mismatch / network-error behavior end-to-end. Tests mock global
- * `fetch` and the api-client config; this wrapper lets them drive the
- * production code without the override hook short-circuiting.
- *
- * Not part of the public API. The `__` prefix and `ForTests` suffix mirror
- * the override-hook setters above.
- * @internal
- */
-export async function __readChatSnapshotProductionPathForTests<TUIMessage extends UIMessage>(
-  sessionId: string
-): Promise<ChatSnapshotV1<TUIMessage> | undefined> {
-  const saved = readChatSnapshotImpl;
-  readChatSnapshotImpl = undefined;
-  try {
-    return await readChatSnapshot<TUIMessage>(sessionId);
-  } finally {
-    readChatSnapshotImpl = saved;
-  }
-}
-
-/**
- * Test-only entry point that bypasses `__setWriteChatSnapshotImplForTests`
- * and reaches the real `apiClient.createUploadPayloadUrl` + `fetch` PUT
- * path. Pairs with `__readChatSnapshotProductionPathForTests` — see that
- * function's note for the rationale.
- *
- * Not part of the public API.
- * @internal
- */
-export async function __writeChatSnapshotProductionPathForTests<TUIMessage extends UIMessage>(
-  sessionId: string,
-  snapshot: ChatSnapshotV1<TUIMessage>
-): Promise<void> {
-  const saved = writeChatSnapshotImpl;
-  writeChatSnapshotImpl = undefined;
-  try {
-    await writeChatSnapshot<TUIMessage>(sessionId, snapshot);
-  } finally {
-    writeChatSnapshotImpl = saved;
-  }
-}
+export {
+  __readChatSnapshotProductionPathForTests,
+  __setReadChatSnapshotImplForTests,
+  __setWriteChatSnapshotImplForTests,
+  __writeChatSnapshotProductionPathForTests,
+} from "./chatSnapshotIo.js";
 
 /**
  * Merge two `UIMessage[]` lists by `id`, with the second list winning on
@@ -7140,7 +6948,19 @@ function chatAgent<
       // collectively cost ~600ms on every first-message TTFC. Both reads
       // swallow errors internally; the agent stays available either way.
       const sessionIdForSnapshot = payload.sessionId ?? payload.chatId;
-      let bootSnapshot: ChatSnapshotV1<TUIMessage> | undefined;
+      const transcriptStorage = defaultStorage;
+      let transcriptShadow: TranscriptShadow = createTranscriptShadow([]);
+      let bootSnapshot:
+        | { messages: TUIMessage[]; lastOutEventId?: string; lastInEventId?: string }
+        | undefined;
+      let bootClientData: unknown = payload.metadata;
+      if (parseClientData) {
+        try {
+          bootClientData = await parseClientData(payload.metadata);
+        } catch {
+          bootClientData = payload.metadata;
+        }
+      }
 
       /**
        * The `lastOutEventId` the most recent snapshot carried.
@@ -7152,33 +6972,90 @@ function chatAgent<
        */
       let lastSnapshotOutEventId: string | undefined;
 
+      const storageTrigger = (trigger: string): TranscriptStorageContext["trigger"] =>
+        trigger === "regenerate-message"
+          ? "regenerate-message"
+          : trigger === "action" || trigger === "action-turn"
+            ? "action"
+            : "submit-message";
+
+      /**
+       * Hand the runtime's view of the transcript to the storage as a
+       * changeset: the diff against what was last saved, plus the cursors the
+       * next boot resumes from. The shadow only advances when the save
+       * succeeds, so a failed save is folded into the next changeset.
+       */
+      /** The runtime's opaque state as of the last save; carried on every changeset's transcript. */
+      let transcriptState: unknown | null = null;
+      const saveTranscript = async (opts: {
+        reason: TranscriptChangeReason;
+        messages: TUIMessage[];
+        turn: number;
+        trigger: TranscriptStorageContext["trigger"];
+        clientData: unknown;
+        lastOutEventId: string | undefined;
+        nonFinalIds?: ReadonlySet<string>;
+      }) => {
+        const { changes, shadow } = diffTranscript(transcriptShadow, opts.messages, {
+          nonFinalIds: opts.nonFinalIds,
+        });
+        const inCursor = chatInputRouter().resumeFloor();
+        await transcriptStorage.save(
+          {
+            chatId: payload.chatId,
+            clientData: opts.clientData,
+            turn: opts.turn,
+            trigger: opts.trigger,
+            runId: ctx.run.id,
+            ctx,
+          },
+          {
+            reason: opts.reason,
+            changes,
+            transcript: {
+              entries: opts.messages.map((message) => ({
+                id: message.id,
+                final: !shadow.nonFinal.has(message.id),
+                message,
+              })),
+              state: transcriptState,
+            },
+            cursors: {
+              lastOutEventId: opts.lastOutEventId,
+              lastInEventId: inCursor !== undefined ? String(inCursor) : undefined,
+            },
+          }
+        );
+        transcriptShadow = shadow;
+      };
+
       /**
        * Persist the accumulator outside a turn.
        *
        * An action is not a turn, so it never reaches the turn-complete path where
-       * the snapshot is normally written — but it can change the conversation in
-       * two ways: a `chat.history` mutation, and a response streamed back from
-       * `onAction`. Both have to survive, and one write at the end of the action
-       * covers both rather than writing twice for a regenerate that does both.
+       * the transcript is normally saved, but a `chat.history` mutation changes
+       * the conversation and has to survive the run ending.
        *
        * Cursor-neutral: an action has no turn cursor of its own, and writing
        * `undefined` would drop the resume point the last turn established and make
        * the next boot replay from further back.
        */
-      const writeSnapshotOutsideTurn = async (reason: string) => {
+      const writeSnapshotOutsideTurn = async (
+        reason: string,
+        turnContext: { turn: number; clientData: unknown }
+      ) => {
         if (hydrateMessages) return;
         try {
           await tracer.startActiveSpan(
             "snapshot.write",
             async () => {
-              const snapshotInCursor = chatInputRouter().resumeFloor();
-              await writeChatSnapshot<TUIMessage>(sessionIdForSnapshot, {
-                version: 1,
-                savedAt: Date.now(),
+              await saveTranscript({
+                reason: "action",
                 messages: accumulatedUIMessages,
+                turn: turnContext.turn,
+                trigger: "action",
+                clientData: turnContext.clientData,
                 lastOutEventId: lastSnapshotOutEventId,
-                lastInEventId:
-                  snapshotInCursor !== undefined ? String(snapshotInCursor) : undefined,
               });
             },
             {
@@ -7229,17 +7106,28 @@ function chatAgent<
             // snapshot read
             const snapStart = Date.now();
             try {
-              bootSnapshot = await readChatSnapshot<TUIMessage>(sessionIdForSnapshot);
+              const loaded = await transcriptStorage.load<TUIMessage>({
+                chatId: payload.chatId,
+                clientData: bootClientData,
+              });
+              transcriptShadow = createTranscriptShadow(loaded.messages);
+              bootSnapshot = {
+                messages: loaded.messages,
+                lastOutEventId: loaded.cursors?.lastOutEventId,
+                lastInEventId: loaded.cursors?.lastInEventId,
+              };
             } catch (error) {
-              // `readChatSnapshot` already swallows + warns internally; this catch
-              // is just belt-and-suspenders against tracer/span errors.
-              logger.warn("chat.agent: snapshot read failed; continuing without snapshot", {
+              logger.warn("chat.agent: transcript load failed; continuing from the stream tail", {
                 error: error instanceof Error ? error.message : String(error),
                 sessionId: sessionIdForSnapshot,
               });
             }
             bootSpan.setAttribute("chat.boot.snapshot.durationMs", Date.now() - snapStart);
-            bootSpan.setAttribute("chat.boot.snapshot.present", !!bootSnapshot);
+            bootSpan.setAttribute(
+              "chat.boot.snapshot.present",
+              bootSnapshot !== undefined &&
+                (bootSnapshot.messages.length > 0 || bootSnapshot.lastOutEventId !== undefined)
+            );
             bootSpan.setAttribute(
               "chat.boot.snapshot.messageCount",
               bootSnapshot?.messages?.length ?? 0
@@ -8011,6 +7899,7 @@ function chatAgent<
         }
 
         for (let turn = 0; turn < maxTurns; turn++) {
+          let turnClientData: unknown = payload.metadata;
           // Declared here so the finally can detach it — a handler leaked past
           // its turn duplicates every mid-stream message into the shared buffer.
           let turnMsgSub: { off: () => void } | undefined;
@@ -8041,6 +7930,7 @@ function chatAgent<
             const clientData = (
               parseClientData ? await parseClientData(wireMetadata) : wireMetadata
             ) as inferSchemaOut<TClientDataSchema>;
+            turnClientData = clientData;
             const lastUserMessage = extractLastUserMessageText(cleanedIncomingMessages);
 
             // Actions are not turns. They use a different span name
@@ -8596,7 +8486,7 @@ function chatAgent<
                     // history rather than from the snapshot the edit replaced.
                     // The turn then does its own hooks, completion and snapshot.
                     if (actionChangedHistory) {
-                      await writeSnapshotOutsideTurn("action");
+                      await writeSnapshotOutsideTurn("action", { turn, clientData });
                     }
                     actionTurn = true;
                   } else if (actionResult !== undefined) {
@@ -8608,7 +8498,7 @@ function chatAgent<
                   } else {
                     msgSub?.off();
                     if (actionChangedHistory) {
-                      await writeSnapshotOutsideTurn("action");
+                      await writeSnapshotOutsideTurn("action", { turn, clientData });
                     }
                     await writeTurnCompleteChunk(currentWirePayload.chatId);
                     // Don't consume a turn iteration — actions aren't turns.
@@ -9433,16 +9323,19 @@ function chatAgent<
                       await tracer.startActiveSpan(
                         "snapshot.write",
                         async () => {
-                          const snapshotInCursor = chatInputRouter().resumeFloor();
                           lastSnapshotOutEventId =
                             turnCompleteResult?.lastEventId ?? lastSnapshotOutEventId;
-                          await writeChatSnapshot<TUIMessage>(sessionIdForSnapshot, {
-                            version: 1,
-                            savedAt: Date.now(),
+                          await saveTranscript({
+                            reason: "turn-complete",
                             messages: accumulatedUIMessages,
+                            turn,
+                            trigger: storageTrigger(currentWirePayload.trigger),
+                            clientData,
                             lastOutEventId: lastSnapshotOutEventId,
-                            lastInEventId:
-                              snapshotInCursor !== undefined ? String(snapshotInCursor) : undefined,
+                            nonFinalIds:
+                              wasStopped && capturedResponseMessage?.id
+                                ? new Set([capturedResponseMessage.id])
+                                : undefined,
                           });
                         },
                         {
@@ -9815,14 +9708,15 @@ function chatAgent<
             // neither the snapshot nor the replayable `.in` tail.
             if (!hydrateMessages) {
               try {
-                const errorSnapshotInCursor = chatInputRouter().resumeFloor();
-                await writeChatSnapshot<TUIMessage>(sessionIdForSnapshot, {
-                  version: 1,
-                  savedAt: Date.now(),
+                await saveTranscript({
+                  reason: "turn-error",
                   messages: erroredUIMessagesWithPartial,
-                  lastOutEventId: errorTurnCompleteResult?.lastEventId,
-                  lastInEventId:
-                    errorSnapshotInCursor !== undefined ? String(errorSnapshotInCursor) : undefined,
+                  turn,
+                  trigger: storageTrigger(currentWirePayload.trigger),
+                  clientData: turnClientData,
+                  lastOutEventId: lastSnapshotOutEventId,
+                  nonFinalIds:
+                    includePartial && partialResponse ? new Set([partialResponse.id]) : undefined,
                 });
               } catch (error) {
                 logger.warn("chat.agent: error-path snapshot write failed", {

--- a/packages/trigger-sdk/src/v3/chatSnapshotIo.ts
+++ b/packages/trigger-sdk/src/v3/chatSnapshotIo.ts
@@ -1,0 +1,198 @@
+import {
+  apiClientManager,
+  logger,
+  parseTranscriptSnapshot,
+  type TranscriptSnapshotV2,
+} from "@trigger.dev/core/v3";
+import type { UIMessage } from "ai";
+
+/**
+ * Test-only override hook. `mockChatAgent` installs a fake to return
+ * synthetic snapshots without hitting S3. The fake may return a blob of any
+ * known version; it is parsed the same way a fetched body is.
+ * @internal
+ */
+export type ReadChatSnapshotImpl = (sessionId: string) => Promise<unknown> | unknown;
+let readChatSnapshotImpl: ReadChatSnapshotImpl | undefined;
+
+export function __setReadChatSnapshotImplForTests(impl: ReadChatSnapshotImpl | undefined): void {
+  readChatSnapshotImpl = impl;
+}
+
+/**
+ * Test-only override hook. The mock harness records writes for assertion
+ * via this setter.
+ * @internal
+ */
+export type WriteChatSnapshotImpl = <TUIMessage extends UIMessage>(
+  sessionId: string,
+  snapshot: TranscriptSnapshotV2<TUIMessage>
+) => Promise<void> | void;
+let writeChatSnapshotImpl: WriteChatSnapshotImpl | undefined;
+
+export function __setWriteChatSnapshotImplForTests(impl: WriteChatSnapshotImpl | undefined): void {
+  writeChatSnapshotImpl = impl;
+}
+
+/**
+ * Read the persisted snapshot for a session, in the version 2 shape
+ * whatever version was stored. Returns `undefined` on:
+ *   - missing object (404 from the presigned GET: fresh session, never persisted)
+ *   - presign failure (network/auth issue)
+ *   - malformed JSON
+ *   - a version this runtime does not know
+ *
+ * Always swallows errors via `logger.warn`. The agent boot loop must stay
+ * available even if S3 hiccups; the worst case is replaying more of
+ * `session.out` than strictly necessary.
+ * @internal
+ */
+export async function readChatSnapshot<TUIMessage extends UIMessage>(
+  sessionId: string
+): Promise<TranscriptSnapshotV2<TUIMessage> | undefined> {
+  if (readChatSnapshotImpl) {
+    const seeded = await readChatSnapshotImpl(sessionId);
+    return seeded === undefined || seeded === null
+      ? undefined
+      : parseTranscriptSnapshot<TUIMessage>(seeded);
+  }
+  const apiClient = apiClientManager.clientOrThrow();
+  let presignedUrl: string;
+  try {
+    const resp = await apiClient.getChatSnapshotUrl(sessionId);
+    presignedUrl = resp.presignedUrl;
+  } catch (error) {
+    logger.warn("chat.agent: snapshot presign (read) failed; continuing without snapshot", {
+      error: error instanceof Error ? error.message : String(error),
+      sessionId,
+    });
+    return undefined;
+  }
+  let response: Response;
+  try {
+    response = await fetch(presignedUrl, { method: "GET" });
+  } catch (error) {
+    logger.warn("chat.agent: snapshot fetch failed; continuing without snapshot", {
+      error: error instanceof Error ? error.message : String(error),
+      sessionId,
+    });
+    return undefined;
+  }
+  if (response.status === 404) {
+    return undefined;
+  }
+  if (!response.ok) {
+    logger.warn("chat.agent: snapshot fetch returned non-OK; continuing without snapshot", {
+      status: response.status,
+      sessionId,
+    });
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = await response.json();
+  } catch (error) {
+    logger.warn("chat.agent: snapshot JSON parse failed; continuing without snapshot", {
+      error: error instanceof Error ? error.message : String(error),
+      sessionId,
+    });
+    return undefined;
+  }
+  const snapshot = parseTranscriptSnapshot<TUIMessage>(parsed);
+  if (!snapshot) {
+    logger.warn("chat.agent: snapshot version/shape mismatch; ignoring", {
+      version: (parsed as { version?: unknown } | null)?.version,
+      sessionId,
+    });
+    return undefined;
+  }
+  return snapshot;
+}
+
+/**
+ * Persist the snapshot for a session. Awaited by callers immediately after
+ * `onTurnComplete`: the agent may suspend right after this point, and
+ * fire-and-forget promises don't reliably complete on suspend.
+ *
+ * Errors are swallowed via `logger.warn`. A failed write means the next
+ * boot replays slightly more of `session.out` (back to the previous
+ * snapshot's cursor) instead of failing.
+ * @internal
+ */
+export async function writeChatSnapshot<TUIMessage extends UIMessage>(
+  sessionId: string,
+  snapshot: TranscriptSnapshotV2<TUIMessage>
+): Promise<void> {
+  if (writeChatSnapshotImpl) {
+    await writeChatSnapshotImpl<TUIMessage>(sessionId, snapshot);
+    return;
+  }
+  const apiClient = apiClientManager.clientOrThrow();
+  let presignedUrl: string;
+  try {
+    const resp = await apiClient.createChatSnapshotUploadUrl(sessionId);
+    presignedUrl = resp.presignedUrl;
+  } catch (error) {
+    logger.warn("chat.agent: snapshot presign (write) failed; next run will replay further", {
+      error: error instanceof Error ? error.message : String(error),
+      sessionId,
+    });
+    return;
+  }
+  let response: Response;
+  try {
+    response = await fetch(presignedUrl, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(snapshot),
+    });
+  } catch (error) {
+    logger.warn("chat.agent: snapshot upload failed; next run will replay further", {
+      error: error instanceof Error ? error.message : String(error),
+      sessionId,
+    });
+    return;
+  }
+  if (!response.ok) {
+    logger.warn("chat.agent: snapshot upload returned non-OK; next run will replay further", {
+      status: response.status,
+      sessionId,
+    });
+  }
+}
+
+/**
+ * Test-only entry point that bypasses `__setReadChatSnapshotImplForTests`
+ * and reaches the real presign + `fetch` + parse path, so tests can drive
+ * the production code by mocking global `fetch` and the api client.
+ * @internal
+ */
+export async function __readChatSnapshotProductionPathForTests<TUIMessage extends UIMessage>(
+  sessionId: string
+): Promise<TranscriptSnapshotV2<TUIMessage> | undefined> {
+  const saved = readChatSnapshotImpl;
+  readChatSnapshotImpl = undefined;
+  try {
+    return await readChatSnapshot<TUIMessage>(sessionId);
+  } finally {
+    readChatSnapshotImpl = saved;
+  }
+}
+
+/**
+ * Test-only entry point that bypasses `__setWriteChatSnapshotImplForTests`
+ * and reaches the real presign + `fetch` PUT path.
+ * @internal
+ */
+export async function __writeChatSnapshotProductionPathForTests<TUIMessage extends UIMessage>(
+  sessionId: string,
+  snapshot: TranscriptSnapshotV2<TUIMessage>
+): Promise<void> {
+  const saved = writeChatSnapshotImpl;
+  writeChatSnapshotImpl = undefined;
+  try {
+    await writeChatSnapshot<TUIMessage>(sessionId, snapshot);
+  } finally {
+    writeChatSnapshotImpl = saved;
+  }
+}

--- a/packages/trigger-sdk/src/v3/test/mock-chat-agent.ts
+++ b/packages/trigger-sdk/src/v3/test/mock-chat-agent.ts
@@ -1,6 +1,6 @@
 import type { UIMessage, UIMessageChunk } from "ai";
 import { resourceCatalog, sessionStreams } from "@trigger.dev/core/v3";
-import type { LocalsKey, SessionChannelIO } from "@trigger.dev/core/v3";
+import type { LocalsKey, SessionChannelIO, TranscriptSnapshotV2 } from "@trigger.dev/core/v3";
 import { runInMockTaskContext, type MockTaskContextOptions } from "@trigger.dev/core/v3/test";
 import {
   __setSessionCloseImplForTests,
@@ -101,7 +101,7 @@ export type MockChatAgentOptions = {
    *
    * See plan section B.3 for the boot orchestration spec.
    */
-  snapshot?: ChatSnapshotV1;
+  snapshot?: ChatSnapshotV1 | TranscriptSnapshotV2;
   /**
    * Set `payload.continuation = true` on the initial wire payload. Used
    * to simulate a continuation-run boot (a new run picking up after a
@@ -237,7 +237,7 @@ export type MockChatAgentHarness = {
    * Effective on the next run boot only. Calling mid-turn is a no-op
    * because the snapshot read happens once at run boot.
    */
-  seedSnapshot(snapshot: ChatSnapshotV1 | undefined): void;
+  seedSnapshot(snapshot: ChatSnapshotV1 | TranscriptSnapshotV2 | undefined): void;
 
   /**
    * Pre-seed `session.out` chunks for the next boot's replay. The runtime's
@@ -311,7 +311,7 @@ export type MockChatAgentHarness = {
    * has been written yet. Updated each time `writeChatSnapshot` is
    * invoked from the run loop's snapshot-write site (plan section B.6).
    */
-  getSnapshot(): ChatSnapshotV1 | undefined;
+  getSnapshot(): TranscriptSnapshotV2 | undefined;
 
   /**
    * Close the chat session cleanly. Sends `trigger: "close"` and awaits the
@@ -440,8 +440,8 @@ export function mockChatAgent(
   // `lastWrittenSnapshot` for harness consumers to assert via
   // `getSnapshot()`. Installed below alongside the session overrides;
   // cleared on close in the same finally block.
-  let seededSnapshot: ChatSnapshotV1 | undefined = options.snapshot;
-  let lastWrittenSnapshot: ChatSnapshotV1 | undefined;
+  let seededSnapshot: ChatSnapshotV1 | TranscriptSnapshotV2 | undefined = options.snapshot;
+  let lastWrittenSnapshot: TranscriptSnapshotV2 | undefined;
   let seededReplayChunks: UIMessageChunk[] = [];
   let seededReplayPartial: UIMessage | undefined;
   let seededSessionInMessages: UIMessage[] = [];
@@ -450,12 +450,10 @@ export function mockChatAgent(
 
   __resetChatInputRouterForTests();
 
-  __setReadChatSnapshotImplForTests(<T extends UIMessage>(_id: string) => {
-    return seededSnapshot as ChatSnapshotV1<T> | undefined;
-  });
+  __setReadChatSnapshotImplForTests(() => seededSnapshot);
   __setWriteChatSnapshotImplForTests(
-    <T extends UIMessage>(_id: string, snapshot: ChatSnapshotV1<T>) => {
-      lastWrittenSnapshot = snapshot as ChatSnapshotV1;
+    <T extends UIMessage>(_id: string, snapshot: TranscriptSnapshotV2<T>) => {
+      lastWrittenSnapshot = snapshot as TranscriptSnapshotV2;
     }
   );
 

--- a/packages/trigger-sdk/src/v3/test/mock-chat-agent.ts
+++ b/packages/trigger-sdk/src/v3/test/mock-chat-agent.ts
@@ -336,6 +336,16 @@ function isControlChunk(chunk: unknown): boolean {
 }
 
 /**
+ * Highest `session.in` seqNum any harness has produced for a session id,
+ * keyed by `sessionId`. Production `session.in` is a durable S2 stream whose
+ * seqNums are monotonic across the runs of a chat; a fresh in-memory manager
+ * per `mockChatAgent` would otherwise restart at 0, so a continuation's
+ * follow-up message would collide with the resume floor and be dropped. This
+ * survives the per-run manager reset so continuation runs stay monotonic.
+ */
+const durableSessionInSeq = new Map<string, number>();
+
+/**
  * Create an offline test harness for a `chat.agent` task.
  *
  * The harness starts the agent's `run()` function in a mocked task context,
@@ -574,7 +584,21 @@ export function mockChatAgent(
       ...(options.headStartMessages ? { headStartMessages: options.headStartMessages } : {}),
     };
 
-    sendSessionInput = drivers.sessions.in.send;
+    const durableSeq = durableSessionInSeq.get(sessionId);
+    if (durableSeq !== undefined) {
+      sessionStreams.setLastSeqNum(sessionId, "in", durableSeq);
+    }
+    const rawSendSessionInput = drivers.sessions.in.send;
+    sendSessionInput = async (id, data, io, metadata) => {
+      await rawSendSessionInput(id, data, io, metadata);
+      const io2 = io ?? "in";
+      if (io2 === "in") {
+        const latest = sessionStreams.lastSeqNum(id, "in");
+        if (latest !== undefined) {
+          durableSessionInSeq.set(id, Math.max(durableSessionInSeq.get(id) ?? latest, latest));
+        }
+      }
+    };
     closeSessionInput = drivers.sessions.in.close;
 
     // Record every chunk written to session.out, detect turn-complete.

--- a/packages/trigger-sdk/src/v3/transcriptStorage.ts
+++ b/packages/trigger-sdk/src/v3/transcriptStorage.ts
@@ -1,0 +1,297 @@
+import type { TaskRunContext, TranscriptSnapshotEntry } from "@trigger.dev/core/v3";
+import type { UIMessage } from "ai";
+import { readChatSnapshot, writeChatSnapshot } from "./chatSnapshotIo.js";
+
+/**
+ * One change to a transcript. Ops address messages by id; position is the
+ * storage's own concern.
+ *
+ * - `put` upserts by `message.id`: an unknown id appends, a known id is
+ *   replaced in place. `final` is false when the runtime captured a partial
+ *   assistant message from an errored or stopped turn; it defaults to true.
+ * - `remove` deletes by id and is a no-op for an unknown id.
+ * - `truncateAfter` drops every message ordered after `afterId` (a rollback)
+ *   and is a no-op when `afterId` is unknown.
+ * - `state` replaces the opaque runtime record; `null` clears it.
+ */
+export type TranscriptChange =
+  | { op: "put"; message: UIMessage; final?: boolean }
+  | { op: "remove"; id: string }
+  | { op: "truncateAfter"; afterId: string }
+  | { op: "state"; value: unknown | null };
+
+export type TranscriptChangeReason =
+  | "turn-complete"
+  | "turn-error"
+  | "action"
+  | "compaction"
+  | "recovery";
+
+type TranscriptCursors = {
+  lastOutEventId?: string;
+  lastInEventId?: string;
+};
+
+/**
+ * What the runtime hands to `save`: the ordered changes since the last save
+ * (one transaction where the backend supports it), the whole transcript as
+ * it stands after those changes, and the stream cursors the next boot should
+ * resume from. A row-per-message store applies `changes`; a store that keeps
+ * the conversation as one document writes `transcript` as-is and needs no
+ * state of its own. Cursors are runtime-computed and persisted opaquely; a
+ * storage never interprets them.
+ */
+type TranscriptChangeset = {
+  reason: TranscriptChangeReason;
+  changes: TranscriptChange[];
+  transcript: TranscriptState;
+  cursors?: TranscriptCursors;
+};
+
+/** The tenant scope of a read. A render read has no run, so this is all `load` gets. */
+type TranscriptScope<TClientData = unknown> = {
+  chatId: string;
+  clientData: TClientData;
+};
+
+/** The run context of a write. Supplied by the runtime; always in-run. */
+export type TranscriptStorageContext<TClientData = unknown> = TranscriptScope<TClientData> & {
+  turn: number;
+  trigger: "submit-message" | "regenerate-message" | "action";
+  runId: string;
+  ctx: TaskRunContext;
+};
+
+type TranscriptLoadOptions = {
+  /** Return at most this many messages, the most recent ones. */
+  limit?: number;
+  /** Return messages ordered before this message id (a `nextCursor` from a previous page). */
+  before?: string;
+};
+
+type TranscriptLoadResult<TUIMessage extends UIMessage = UIMessage> = {
+  messages: TUIMessage[];
+  state: unknown | null;
+  cursors?: TranscriptCursors;
+  /** The id to pass as `before` for the previous page; absent on the last page. */
+  nextCursor?: string;
+  /**
+   * Ids among `messages` that were saved with `final: false` (a partial
+   * answer). A storage that keeps `final` returns them so a partial stays
+   * partial when a continuation saves it again unchanged; a storage that
+   * does not keep `final` may leave this out.
+   */
+  nonFinalIds?: string[];
+};
+
+/**
+ * A persistence adapter for a `chat.agent` transcript. The runtime calls
+ * `load` once at a continuation boot and `save` after every change to the
+ * conversation. Both are best-effort from the runtime's point of view: an
+ * error is logged and the turn continues.
+ */
+export type TranscriptStorage<TClientData = unknown> = {
+  load<TUIMessage extends UIMessage = UIMessage>(
+    scope: TranscriptScope<TClientData>,
+    opts?: TranscriptLoadOptions
+  ): Promise<TranscriptLoadResult<TUIMessage>>;
+  save(ctx: TranscriptStorageContext<TClientData>, changeset: TranscriptChangeset): Promise<void>;
+};
+
+/** An in-memory transcript: ordered entries plus the opaque state record. */
+export type TranscriptState<TUIMessage extends UIMessage = UIMessage> = {
+  entries: TranscriptSnapshotEntry<TUIMessage>[];
+  state: unknown | null;
+};
+
+export function emptyTranscriptState<
+  TUIMessage extends UIMessage = UIMessage,
+>(): TranscriptState<TUIMessage> {
+  return { entries: [], state: null };
+}
+
+/**
+ * Apply changes to a transcript, in order. Pure: returns a new state and
+ * never mutates the input. Replaying the same changes converges, which is
+ * what lets a storage retry a failed write without checking what landed.
+ */
+export function reduceTranscriptChanges<TUIMessage extends UIMessage = UIMessage>(
+  prev: TranscriptState<TUIMessage>,
+  changes: readonly TranscriptChange[]
+): TranscriptState<TUIMessage> {
+  let entries = prev.entries.slice();
+  let state = prev.state;
+  for (const change of changes) {
+    switch (change.op) {
+      case "put": {
+        const message = change.message as TUIMessage;
+        const entry = { id: message.id, final: change.final ?? true, message };
+        const idx = entries.findIndex((e) => e.id === message.id);
+        if (idx === -1) entries.push(entry);
+        else entries[idx] = entry;
+        break;
+      }
+      case "remove": {
+        entries = entries.filter((e) => e.id !== change.id);
+        break;
+      }
+      case "truncateAfter": {
+        const idx = entries.findIndex((e) => e.id === change.afterId);
+        if (idx !== -1) entries = entries.slice(0, idx + 1);
+        break;
+      }
+      case "state": {
+        state = change.value ?? null;
+        break;
+      }
+    }
+  }
+  return { entries, state };
+}
+
+/**
+ * What the runtime remembers about the transcript it last handed to
+ * `save`: the ids in order and a fingerprint per message, so the next
+ * changeset can be derived from the accumulator without asking the storage.
+ */
+export type TranscriptShadow = {
+  ids: string[];
+  fingerprints: Map<string, string>;
+  /** Ids last saved with `final: false`. Everything else was saved final. */
+  nonFinal: Set<string>;
+};
+
+function fingerprintMessage(message: UIMessage): string {
+  return JSON.stringify(message);
+}
+
+/**
+ * Build the shadow for `messages`. An id is non-final when this save says so
+ * (`nonFinalIds`) or when it was non-final before and its content has not
+ * changed: a partial answer stays partial until the message itself changes.
+ */
+export function createTranscriptShadow(
+  messages: readonly UIMessage[],
+  nonFinalIds?: ReadonlySet<string>,
+  previous?: TranscriptShadow
+): TranscriptShadow {
+  const ids: string[] = [];
+  const fingerprints = new Map<string, string>();
+  const nonFinal = new Set<string>();
+  for (const message of messages) {
+    const fingerprint = fingerprintMessage(message);
+    ids.push(message.id);
+    fingerprints.set(message.id, fingerprint);
+    if (
+      nonFinalIds?.has(message.id) ||
+      (previous?.nonFinal.has(message.id) && previous.fingerprints.get(message.id) === fingerprint)
+    ) {
+      nonFinal.add(message.id);
+    }
+  }
+  return { ids, fingerprints, nonFinal };
+}
+
+/**
+ * Derive the changes that take `shadow` to `next`.
+ *
+ * The common prefix (by id) is compared message by message and a changed
+ * message becomes an in-place `put`. Past the prefix, everything the shadow
+ * still had is dropped with one `truncateAfter` on the last common id (or
+ * one `remove` per message when there is no common prefix) and everything
+ * `next` has is appended with `put`, in order. Applying the result with
+ * {@link reduceTranscriptChanges} reproduces `next` exactly, including
+ * order, for any two lists.
+ */
+export function diffTranscript(
+  shadow: TranscriptShadow,
+  next: readonly UIMessage[],
+  options: { nonFinalIds?: ReadonlySet<string> } = {}
+): { changes: TranscriptChange[]; shadow: TranscriptShadow } {
+  const nextShadow = createTranscriptShadow(next, options.nonFinalIds, shadow);
+  const changes: TranscriptChange[] = [];
+  const put = (message: UIMessage) => {
+    const final = nextShadow.nonFinal.has(message.id) ? false : undefined;
+    changes.push(final === undefined ? { op: "put", message } : { op: "put", message, final });
+  };
+
+  let lcp = 0;
+  while (lcp < shadow.ids.length && lcp < next.length && shadow.ids[lcp] === next[lcp]!.id) {
+    lcp++;
+  }
+  for (let i = 0; i < lcp; i++) {
+    const message = next[i]!;
+    if (
+      shadow.fingerprints.get(message.id) !== nextShadow.fingerprints.get(message.id) ||
+      shadow.nonFinal.has(message.id) !== nextShadow.nonFinal.has(message.id)
+    ) {
+      put(message);
+    }
+  }
+  if (shadow.ids.length > lcp) {
+    if (lcp > 0) {
+      changes.push({ op: "truncateAfter", afterId: shadow.ids[lcp - 1]! });
+    } else {
+      for (const id of shadow.ids) changes.push({ op: "remove", id });
+    }
+  }
+  for (let i = lcp; i < next.length; i++) {
+    put(next[i]!);
+  }
+  return { changes, shadow: nextShadow };
+}
+
+/**
+ * The built-in storage: the whole transcript as one versioned blob in the
+ * platform's object store, the same blob the Sessions dashboard renders.
+ *
+ * Stateless. Every changeset carries the whole transcript as it stands after
+ * the changes, so `save` serialises that and rewrites the blob: one PUT per
+ * turn, no read and nothing kept in memory between saves.
+ */
+export function snapshotTranscriptStorage(): TranscriptStorage<unknown> {
+  return {
+    async load<TUIMessage extends UIMessage = UIMessage>(
+      scope: TranscriptScope<unknown>,
+      opts?: TranscriptLoadOptions
+    ): Promise<TranscriptLoadResult<TUIMessage>> {
+      const snapshot = await readChatSnapshot<TUIMessage>(scope.chatId);
+      const full: TranscriptState<TUIMessage> = snapshot
+        ? { entries: snapshot.messages, state: snapshot.state }
+        : emptyTranscriptState<TUIMessage>();
+
+      let entries = full.entries;
+      if (opts?.before !== undefined) {
+        const idx = entries.findIndex((e) => e.id === opts.before);
+        if (idx !== -1) entries = entries.slice(0, idx);
+      }
+      let nextCursor: string | undefined;
+      if (opts?.limit !== undefined && entries.length > opts.limit) {
+        entries = entries.slice(entries.length - opts.limit);
+        nextCursor = entries[0]?.id;
+      }
+      return {
+        messages: entries.map((e) => e.message),
+        state: full.state,
+        cursors: snapshot
+          ? { lastOutEventId: snapshot.lastOutEventId, lastInEventId: snapshot.lastInEventId }
+          : undefined,
+        nextCursor,
+      };
+    },
+
+    async save(ctx, changeset) {
+      await writeChatSnapshot(ctx.chatId, {
+        version: 2,
+        savedAt: Date.now(),
+        messages: changeset.transcript.entries,
+        state: changeset.transcript.state,
+        lastOutEventId: changeset.cursors?.lastOutEventId,
+        lastInEventId: changeset.cursors?.lastInEventId,
+      });
+    },
+  };
+}
+
+/** The storage `chat.agent` uses when none is configured: {@link snapshotTranscriptStorage}. */
+export const defaultStorage: TranscriptStorage<unknown> = snapshotTranscriptStorage();

--- a/packages/trigger-sdk/test/action-snapshot.test.ts
+++ b/packages/trigger-sdk/test/action-snapshot.test.ts
@@ -63,7 +63,10 @@ describe("snapshot durability of history mutated by an action", () => {
       await new Promise((r) => setTimeout(r, 30));
 
       // After a turn the snapshot holds the exchange.
-      expect(harness.getSnapshot()?.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+      expect(harness.getSnapshot()?.messages.map((e) => e.message.role)).toEqual([
+        "user",
+        "assistant",
+      ]);
 
       await harness.sendAction({ type: "undo" });
       await new Promise((r) => setTimeout(r, 30));

--- a/packages/trigger-sdk/test/action-stream-accumulator.test.ts
+++ b/packages/trigger-sdk/test/action-stream-accumulator.test.ts
@@ -64,7 +64,10 @@ describe("a regenerate action that returns chat.turn()", () => {
         .map((c) => c.delta ?? "")
         .join("");
       expect(streamed).toBe("regenerated answer");
-      expect(harness.getSnapshot()?.messages.map(textOf)).toEqual(["ask", "regenerated answer"]);
+      expect(harness.getSnapshot()?.messages.map((e) => textOf(e.message))).toEqual([
+        "ask",
+        "regenerated answer",
+      ]);
     } finally {
       await harness.close();
     }
@@ -123,7 +126,11 @@ describe("a regenerate action that returns chat.turn()", () => {
       expect(errors.length).toBeGreaterThan(0);
       // A turn failure: the hook saw it, and the partial is kept, not discarded.
       expect(completes.at(-1)?.finishReason).toBe("error");
-      expect(harness.getSnapshot()?.messages.map(textOf).at(-1)).toContain("half an answer");
+      const lastText = harness
+        .getSnapshot()
+        ?.messages.map((e) => textOf(e.message))
+        .at(-1);
+      expect(lastText).toContain("half an answer");
     } finally {
       await harness.close();
     }

--- a/packages/trigger-sdk/test/action-turn.test.ts
+++ b/packages/trigger-sdk/test/action-turn.test.ts
@@ -80,11 +80,12 @@ function agentWith(onAction: (action: { type: string }) => unknown) {
     onAction: async ({ action }) => onAction(action) as never,
     run: async ({ messages, signal, trigger }) => {
       triggers.push(trigger);
-      snapshotsAtRun.push((snapshotReader?.()?.messages ?? []).map(textOf));
+      snapshotsAtRun.push((snapshotReader?.()?.messages ?? []).map((e) => textOf(e.message)));
       return streamText({ model, messages, abortSignal: signal, ...chat.toStreamTextOptions() });
     },
   });
-  let snapshotReader: (() => { messages: { parts?: unknown[] }[] } | undefined) | undefined;
+  type SnapshotLike = { messages: { message: { parts?: unknown[] } }[] };
+  let snapshotReader: (() => SnapshotLike | undefined) | undefined;
   return {
     agent,
     prompts,
@@ -92,7 +93,7 @@ function agentWith(onAction: (action: { type: string }) => unknown) {
     snapshotsAtRun,
     starts,
     completes,
-    attach: (h: { getSnapshot: () => { messages: { parts?: unknown[] }[] } | undefined }) => {
+    attach: (h: { getSnapshot: () => SnapshotLike | undefined }) => {
       snapshotReader = () => h.getSnapshot();
     },
   };
@@ -126,7 +127,10 @@ describe("an action that returns chat.turn()", () => {
       expect(p).toContain("AGENT-SYSTEM");
       expect(p).not.toContain("answer-0");
       // Its answer replaced the old one in the conversation.
-      expect(harness.getSnapshot()?.messages.map(textOf)).toEqual(["ask", "answer-1"]);
+      expect(harness.getSnapshot()?.messages.map((e) => textOf(e.message))).toEqual([
+        "ask",
+        "answer-1",
+      ]);
       // run() saw it as a turn requested by an action, not as the action, so a
       // handler that returns early on "action" still answers.
       expect(triggers[1]).toBe("action-turn");

--- a/packages/trigger-sdk/test/chat-snapshot.test.ts
+++ b/packages/trigger-sdk/test/chat-snapshot.test.ts
@@ -6,6 +6,7 @@ import "../src/v3/test/index.js";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { apiClientManager } from "@trigger.dev/core/v3";
+import type { TranscriptSnapshotV2 } from "@trigger.dev/core/v3";
 import {
   __readChatSnapshotProductionPathForTests as readChatSnapshot,
   __writeChatSnapshotProductionPathForTests as writeChatSnapshot,
@@ -29,6 +30,20 @@ function buildSnapshot(count = 1): ChatSnapshotV1 {
       parts: [{ type: "text" as const, text: `hello ${i}` }],
     })),
     lastOutEventId: "evt-42",
+  };
+}
+
+/**
+ * The version 2 counterpart, which is what the runtime writes.
+ */
+function buildSnapshotV2(count = 1): TranscriptSnapshotV2 {
+  const v1 = buildSnapshot(count);
+  return {
+    version: 2,
+    savedAt: v1.savedAt,
+    messages: v1.messages.map((message) => ({ id: message.id, final: true, message })),
+    state: null,
+    lastOutEventId: v1.lastOutEventId,
   };
 }
 
@@ -85,7 +100,7 @@ describe("chat snapshot helpers", () => {
   });
 
   describe("readChatSnapshot", () => {
-    it("returns the snapshot on a successful GET", async () => {
+    it("returns a version 1 snapshot upgraded to the version 2 shape on a successful GET", async () => {
       const { getChatSnapshotUrl } = stubApiClient({});
       const snapshot = buildSnapshot(2);
       stubFetch(
@@ -98,11 +113,21 @@ describe("chat snapshot helpers", () => {
 
       const result = await readChatSnapshot("session-1");
       expect(getChatSnapshotUrl).toHaveBeenCalledWith("session-1");
-      expect(result).toMatchObject({
-        version: 1,
-        messages: snapshot.messages,
-        lastOutEventId: "evt-42",
-      });
+      expect(result).toEqual(buildSnapshotV2(2));
+    });
+
+    it("returns a version 2 snapshot as-is on a successful GET", async () => {
+      stubApiClient({});
+      const snapshot = buildSnapshotV2(2);
+      stubFetch(
+        async () =>
+          new Response(JSON.stringify(snapshot), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          })
+      );
+
+      expect(await readChatSnapshot("session-1")).toEqual(snapshot);
     });
 
     it("returns undefined on 404 (fresh session, no snapshot yet)", async () => {
@@ -206,7 +231,7 @@ describe("chat snapshot helpers", () => {
       const { createChatSnapshotUploadUrl } = stubApiClient({});
       const fetchSpy = stubFetch(async () => new Response(null, { status: 200 }));
 
-      const snapshot = buildSnapshot(3);
+      const snapshot = buildSnapshotV2(3);
       await writeChatSnapshot("session-2", snapshot);
 
       expect(createChatSnapshotUploadUrl).toHaveBeenCalledWith("session-2");
@@ -227,7 +252,7 @@ describe("chat snapshot helpers", () => {
       stubFetch(async () => new Response("forbidden", { status: 403 }));
 
       await expect(
-        writeChatSnapshot("forbidden-session", buildSnapshot())
+        writeChatSnapshot("forbidden-session", buildSnapshotV2())
       ).resolves.toBeUndefined();
     });
 
@@ -237,7 +262,9 @@ describe("chat snapshot helpers", () => {
         throw new Error("ETIMEDOUT");
       });
 
-      await expect(writeChatSnapshot("timeout-session", buildSnapshot())).resolves.toBeUndefined();
+      await expect(
+        writeChatSnapshot("timeout-session", buildSnapshotV2())
+      ).resolves.toBeUndefined();
     });
 
     it("returns without throwing when presign fails (warns)", async () => {
@@ -248,7 +275,7 @@ describe("chat snapshot helpers", () => {
       });
       const fetchSpy = stubFetch(async () => new Response(null, { status: 200 }));
 
-      await expect(writeChatSnapshot("denied-session", buildSnapshot())).resolves.toBeUndefined();
+      await expect(writeChatSnapshot("denied-session", buildSnapshotV2())).resolves.toBeUndefined();
       // Presign failed → no PUT attempted.
       expect(fetchSpy).not.toHaveBeenCalled();
     });
@@ -270,7 +297,7 @@ describe("chat snapshot helpers", () => {
         createChatSnapshotUploadUrl: async () => ({ presignedUrl: "https://example.invalid/put" }),
       });
       stubFetch(async () => new Response(null, { status: 200 }));
-      await writeChatSnapshot("round-trip-session", buildSnapshot());
+      await writeChatSnapshot("round-trip-session", buildSnapshotV2());
       const [writeArg] = createChatSnapshotUploadUrl.mock.calls[0]!;
 
       expect(readArg).toBe(writeArg);

--- a/packages/trigger-sdk/test/mockChatAgent.test.ts
+++ b/packages/trigger-sdk/test/mockChatAgent.test.ts
@@ -1875,9 +1875,9 @@ describe("mockChatAgent", () => {
         await new Promise((r) => setTimeout(r, 50));
         const snap = harness.getSnapshot();
         expect(snap).toBeDefined();
-        expect(snap!.version).toBe(1);
+        expect(snap!.version).toBe(2);
         // The snapshot reflects the post-turn accumulator: 1 user + 1 assistant.
-        const roles = snap!.messages.map((m) => m.role);
+        const roles = snap!.messages.map((e) => e.message.role);
         expect(roles).toEqual(["user", "assistant"]);
         // TestSessionStreamManager assigns the same zero-based sequence
         // numbers as the durable channel, so the committed input cursor is

--- a/packages/trigger-sdk/test/transcript-storage.test.ts
+++ b/packages/trigger-sdk/test/transcript-storage.test.ts
@@ -1,0 +1,339 @@
+import "../src/v3/test/index.js";
+
+import type { TranscriptSnapshotV2 } from "@trigger.dev/core/v3";
+import type { UIMessage } from "ai";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __setReadChatSnapshotImplForTests,
+  __setWriteChatSnapshotImplForTests,
+} from "../src/v3/chatSnapshotIo.js";
+import {
+  createTranscriptShadow,
+  diffTranscript,
+  emptyTranscriptState,
+  reduceTranscriptChanges,
+  snapshotTranscriptStorage,
+  type TranscriptChange,
+  type TranscriptStorageContext,
+} from "../src/v3/transcriptStorage.js";
+
+const msg = (id: string, text: string, role: UIMessage["role"] = "user"): UIMessage => ({
+  id,
+  role,
+  parts: [{ type: "text", text }],
+});
+
+const u1 = msg("u-1", "hi");
+const a1 = msg("a-1", "hello", "assistant");
+const u2 = msg("u-2", "more");
+const a2 = msg("a-2", "sure", "assistant");
+
+function applyDiff(prev: UIMessage[], next: UIMessage[], nonFinalIds?: Set<string>) {
+  const shadow = createTranscriptShadow(prev);
+  const { changes, shadow: nextShadow } = diffTranscript(shadow, next, { nonFinalIds });
+  const state = reduceTranscriptChanges(
+    reduceTranscriptChanges(
+      emptyTranscriptState(),
+      prev.map((m) => ({ op: "put", message: m }))
+    ),
+    changes
+  );
+  return { changes, state, nextShadow };
+}
+
+describe("reduceTranscriptChanges", () => {
+  it("appends an unknown id and replaces a known id in place", () => {
+    const s1 = reduceTranscriptChanges(emptyTranscriptState(), [
+      { op: "put", message: u1 },
+      { op: "put", message: a1 },
+    ]);
+    const edited = msg("u-1", "hi (edited)");
+    const s2 = reduceTranscriptChanges(s1, [{ op: "put", message: edited }]);
+
+    expect(s2.entries.map((e) => e.id)).toEqual(["u-1", "a-1"]);
+    expect(s2.entries[0]!.message).toEqual(edited);
+    expect(s2.entries.every((e) => e.final)).toBe(true);
+    expect(s1.entries[0]!.message).toEqual(u1);
+  });
+
+  it("records final: false from a put and defaults to true", () => {
+    const s = reduceTranscriptChanges(emptyTranscriptState(), [
+      { op: "put", message: u1 },
+      { op: "put", message: a1, final: false },
+    ]);
+    expect(s.entries.map((e) => e.final)).toEqual([true, false]);
+  });
+
+  it("removes by id, truncates after an id, and sets state; unknown ids are no-ops", () => {
+    const base = reduceTranscriptChanges(emptyTranscriptState(), [
+      { op: "put", message: u1 },
+      { op: "put", message: a1 },
+      { op: "put", message: u2 },
+      { op: "put", message: a2 },
+    ]);
+
+    const removed = reduceTranscriptChanges(base, [{ op: "remove", id: "a-1" }]);
+    expect(removed.entries.map((e) => e.id)).toEqual(["u-1", "u-2", "a-2"]);
+
+    const truncated = reduceTranscriptChanges(base, [{ op: "truncateAfter", afterId: "a-1" }]);
+    expect(truncated.entries.map((e) => e.id)).toEqual(["u-1", "a-1"]);
+
+    const noop = reduceTranscriptChanges(base, [
+      { op: "remove", id: "nope" },
+      { op: "truncateAfter", afterId: "nope" },
+    ]);
+    expect(noop.entries).toEqual(base.entries);
+
+    const withState = reduceTranscriptChanges(base, [{ op: "state", value: { summary: "s" } }]);
+    expect(withState.state).toEqual({ summary: "s" });
+    expect(reduceTranscriptChanges(withState, [{ op: "state", value: null }]).state).toBeNull();
+  });
+
+  it("converges when the same changes are applied twice", () => {
+    const changes: TranscriptChange[] = [
+      { op: "put", message: u1 },
+      { op: "put", message: a1 },
+      { op: "truncateAfter", afterId: "u-1" },
+      { op: "put", message: msg("a-1b", "again", "assistant") },
+      { op: "remove", id: "u-1" },
+    ];
+    const once = reduceTranscriptChanges(emptyTranscriptState(), changes);
+    const twice = reduceTranscriptChanges(once, changes);
+    expect(twice).toEqual(once);
+  });
+});
+
+describe("diffTranscript", () => {
+  it("emits puts for appended messages", () => {
+    const { changes, state } = applyDiff([u1, a1], [u1, a1, u2, a2]);
+    expect(changes).toEqual([
+      { op: "put", message: u2 },
+      { op: "put", message: a2 },
+    ]);
+    expect(state.entries.map((e) => e.message)).toEqual([u1, a1, u2, a2]);
+  });
+
+  it("emits an in-place put for a changed message with the same id", () => {
+    const a1Grown = msg("a-1", "hello there", "assistant");
+    const { changes, state } = applyDiff([u1, a1], [u1, a1Grown]);
+    expect(changes).toEqual([{ op: "put", message: a1Grown }]);
+    expect(state.entries.map((e) => e.message)).toEqual([u1, a1Grown]);
+  });
+
+  it("emits nothing when nothing changed", () => {
+    const { changes } = applyDiff([u1, a1], [structuredClone(u1), structuredClone(a1)]);
+    expect(changes).toEqual([]);
+  });
+
+  it("expresses an undo as one truncateAfter", () => {
+    const { changes, state } = applyDiff([u1, a1, u2, a2], [u1, a1]);
+    expect(changes).toEqual([{ op: "truncateAfter", afterId: "a-1" }]);
+    expect(state.entries.map((e) => e.id)).toEqual(["u-1", "a-1"]);
+  });
+
+  it("expresses a regenerate as truncateAfter plus a put", () => {
+    const a2b = msg("a-2b", "better", "assistant");
+    const { changes, state } = applyDiff([u1, a1, u2, a2], [u1, a1, u2, a2b]);
+    expect(changes).toEqual([
+      { op: "truncateAfter", afterId: "u-2" },
+      { op: "put", message: a2b },
+    ]);
+    expect(state.entries.map((e) => e.id)).toEqual(["u-1", "a-1", "u-2", "a-2b"]);
+  });
+
+  it("removes everything when there is no common prefix, then puts the new list", () => {
+    const { changes, state } = applyDiff([u1, a1], [u2, a2]);
+    expect(changes).toEqual([
+      { op: "remove", id: "u-1" },
+      { op: "remove", id: "a-1" },
+      { op: "put", message: u2 },
+      { op: "put", message: a2 },
+    ]);
+    expect(state.entries.map((e) => e.id)).toEqual(["u-2", "a-2"]);
+  });
+
+  it("reproduces an arbitrary reorder exactly", () => {
+    const { state } = applyDiff([u1, a1, u2, a2], [u1, u2, a1, a2]);
+    expect(state.entries.map((e) => e.id)).toEqual(["u-1", "u-2", "a-1", "a-2"]);
+  });
+
+  it("marks the ids in nonFinalIds as final: false", () => {
+    const { changes } = applyDiff([u1], [u1, a1], new Set(["a-1"]));
+    expect(changes).toEqual([{ op: "put", message: a1, final: false }]);
+  });
+
+  it("keeps a partial answer non-final until its content changes", () => {
+    const first = applyDiff([u1], [u1, a1], new Set(["a-1"]));
+    expect(first.changes).toEqual([{ op: "put", message: a1, final: false }]);
+    expect(first.state.entries[1]!.final).toBe(false);
+
+    const unchanged = diffTranscript(first.nextShadow, [u1, a1]);
+    expect(unchanged.changes).toEqual([]);
+    expect(unchanged.shadow.nonFinal.has("a-1")).toBe(true);
+
+    const completed = msg("a-1", "hello, finished", "assistant");
+    const settled = diffTranscript(unchanged.shadow, [u1, completed]);
+    expect(settled.changes).toEqual([{ op: "put", message: completed }]);
+    expect(settled.shadow.nonFinal.has("a-1")).toBe(false);
+    expect(reduceTranscriptChanges(first.state, settled.changes).entries[1]!.final).toBe(true);
+  });
+
+  it("returns a shadow that makes the next diff incremental", () => {
+    const first = applyDiff([], [u1, a1]);
+    const { changes } = diffTranscript(first.nextShadow, [u1, a1, u2]);
+    expect(changes).toEqual([{ op: "put", message: u2 }]);
+  });
+});
+
+describe("snapshotTranscriptStorage", () => {
+  const ctx = (chatId: string): TranscriptStorageContext<unknown> => ({
+    chatId,
+    clientData: undefined,
+    turn: 0,
+    trigger: "submit-message",
+    runId: "run_1",
+    ctx: {} as TranscriptStorageContext["ctx"],
+  });
+
+  let stored: TranscriptSnapshotV2 | undefined;
+  let reads = 0;
+  let writes: TranscriptSnapshotV2[] = [];
+
+  function install(initial: unknown) {
+    stored = undefined;
+    reads = 0;
+    writes = [];
+    __setReadChatSnapshotImplForTests(() => {
+      reads++;
+      return initial;
+    });
+    __setWriteChatSnapshotImplForTests((_id, snapshot) => {
+      stored = snapshot as TranscriptSnapshotV2;
+      writes.push(stored);
+    });
+  }
+
+  afterEach(() => {
+    __setReadChatSnapshotImplForTests(undefined);
+    __setWriteChatSnapshotImplForTests(undefined);
+  });
+
+  it("loads a version 1 blob as messages plus cursors with null state", async () => {
+    install({
+      version: 1,
+      savedAt: 5,
+      messages: [u1, a1],
+      lastOutEventId: "9",
+      lastInEventId: "3",
+    });
+    const storage = snapshotTranscriptStorage();
+    const loaded = await storage.load({ chatId: "c1", clientData: undefined });
+
+    expect(loaded.messages).toEqual([u1, a1]);
+    expect(loaded.state).toBeNull();
+    expect(loaded.cursors).toEqual({ lastOutEventId: "9", lastInEventId: "3" });
+    expect(loaded.nextCursor).toBeUndefined();
+  });
+
+  it("loads with no snapshot as an empty transcript and no cursors", async () => {
+    install(undefined);
+    const storage = snapshotTranscriptStorage();
+    const loaded = await storage.load({ chatId: "c1", clientData: undefined });
+    expect(loaded).toEqual({
+      messages: [],
+      state: null,
+      cursors: undefined,
+      nextCursor: undefined,
+    });
+  });
+
+  it("pages from the most recent message backwards with limit and before", async () => {
+    install({
+      version: 2,
+      savedAt: 5,
+      messages: [u1, a1, u2, a2].map((m) => ({ id: m.id, final: true, message: m })),
+      state: null,
+    });
+    const storage = snapshotTranscriptStorage();
+
+    const last = await storage.load({ chatId: "c1", clientData: undefined }, { limit: 2 });
+    expect(last.messages.map((m) => m.id)).toEqual(["u-2", "a-2"]);
+    expect(last.nextCursor).toBe("u-2");
+
+    const prev = await storage.load(
+      { chatId: "c1", clientData: undefined },
+      { limit: 2, before: last.nextCursor }
+    );
+    expect(prev.messages.map((m) => m.id)).toEqual(["u-1", "a-1"]);
+    expect(prev.nextCursor).toBeUndefined();
+  });
+
+  it("writes the changeset's transcript and cursors as a version 2 blob without reading", async () => {
+    install({ version: 1, savedAt: 5, messages: [u1, a1], lastOutEventId: "9" });
+    const storage = snapshotTranscriptStorage();
+
+    await storage.save(ctx("c1"), {
+      reason: "turn-complete",
+      changes: [
+        { op: "put", message: u2 },
+        { op: "put", message: a2, final: false },
+        { op: "state", value: { summary: "s" } },
+      ],
+      transcript: {
+        entries: [
+          { id: "u-1", final: true, message: u1 },
+          { id: "a-1", final: true, message: a1 },
+          { id: "u-2", final: true, message: u2 },
+          { id: "a-2", final: false, message: a2 },
+        ],
+        state: { summary: "s" },
+      },
+      cursors: { lastOutEventId: "12", lastInEventId: "4" },
+    });
+
+    expect(reads).toBe(0);
+    expect(writes).toHaveLength(1);
+    expect(stored).toMatchObject({
+      version: 2,
+      messages: [
+        { id: "u-1", final: true, message: u1 },
+        { id: "a-1", final: true, message: a1 },
+        { id: "u-2", final: true, message: u2 },
+        { id: "a-2", final: false, message: a2 },
+      ],
+      state: { summary: "s" },
+      lastOutEventId: "12",
+      lastInEventId: "4",
+    });
+    expect(typeof stored!.savedAt).toBe("number");
+  });
+
+  it("overwrites the blob with each changeset's transcript and keeps nothing in memory", async () => {
+    install(undefined);
+    const storage = snapshotTranscriptStorage();
+    await storage.save(ctx("fresh"), {
+      reason: "turn-complete",
+      changes: [{ op: "put", message: u1 }],
+      transcript: { entries: [{ id: "u-1", final: true, message: u1 }], state: null },
+      cursors: { lastOutEventId: "1" },
+    });
+    await storage.save(ctx("fresh"), {
+      reason: "action",
+      changes: [{ op: "truncateAfter", afterId: "u-1" }],
+      transcript: { entries: [{ id: "u-1", final: true, message: u1 }], state: null },
+      cursors: { lastOutEventId: "1" },
+    });
+    await storage.save(ctx("other"), {
+      reason: "turn-complete",
+      changes: [{ op: "put", message: u2 }],
+      transcript: { entries: [{ id: "u-2", final: true, message: u2 }], state: null },
+    });
+
+    expect(reads).toBe(0);
+    expect(writes).toHaveLength(3);
+    expect(writes[1]!.messages.map((e) => e.id)).toEqual(["u-1"]);
+    expect(writes[1]!.lastOutEventId).toBe("1");
+    expect(writes[2]!.messages.map((e) => e.id)).toEqual(["u-2"]);
+    expect(writes[2]!.lastOutEventId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Introduces the `TranscriptStorage` seam inside `chat.agent` and makes the built-in snapshot writer its default implementation. No public option yet; the default path behaves as before, apart from the blob now being written as version 2.

## Design

A storage has `load` (called once when a run boots to continue a conversation) and `save` (called after every turn, failed turn and history-changing action). `save` receives a changeset of id-addressed operations: `put` (upsert by message id), `remove`, `truncateAfter` and `state`, plus the stream cursors the next boot resumes from.

The runtime keeps a shadow of the transcript it last handed to `save` (ids in order plus a fingerprint per message) and diffs the accumulator against it. A changed message in the common prefix is an in-place `put`; anything past the prefix is one `truncateAfter` on the last common id followed by `put`s in order. Applying the result reproduces the accumulator exactly for any edit, and the common cases come out as the natural operations: a turn is two `put`s, an undo is one `truncateAfter`, a regenerate is a `truncateAfter` and a `put`. The shadow only advances when `save` resolves, so a failed save is folded into the next changeset; every operation is idempotent, so a retried changeset converges.

Every changeset also carries the whole transcript as it stands after the changes (entries with a `final` flag, plus the runtime's `state`). A row-per-message store applies the changes; a store that keeps the conversation as one document writes the transcript as-is and needs no state of its own between saves. The default storage is the second kind: it serialises the transcript and rewrites the blob, so a turn still costs one PUT and no GET, and nothing is held in memory between saves. The snapshot read and write helpers move to their own module so the storage can import them without a cycle; the test seams keep their import path.
