### PR TITLE
feat(sdk): persist compaction and injected context through the transcript storage state

### DIFF
--- a/packages/trigger-sdk/src/v3/ai.ts
+++ b/packages/trigger-sdk/src/v3/ai.ts
@@ -80,10 +80,29 @@ import {
   createTranscriptShadow,
   defaultStorage,
   diffTranscript,
+  parseTranscriptRuntimeState,
+  prefixFingerprint,
+  restoreModelLane,
+  type TranscriptChange,
   type TranscriptChangeReason,
+  type TranscriptRuntimeState,
   type TranscriptShadow,
+  type TranscriptStorage,
   type TranscriptStorageContext,
 } from "./transcriptStorage.js";
+
+let transcriptStorageOverride: TranscriptStorage<unknown> | undefined;
+
+/**
+ * Test-only override for the storage `chat.agent` persists through, so a
+ * test can capture the exact changesets the runtime produces.
+ * @internal
+ */
+export function __setTranscriptStorageForTests(
+  storage: TranscriptStorage<unknown> | undefined
+): void {
+  transcriptStorageOverride = storage;
+}
 import {
   type ChatInputChunk,
   type ChatTaskWirePayload,
@@ -2539,6 +2558,13 @@ function spliceHandoverPartial(
  * @internal
  */
 const chatBackgroundQueueKey = locals.create<ModelMessage[]>("chat.backgroundQueue");
+/**
+ * Background injections a step-boundary drain handed to the model this turn,
+ * with the transcript message they followed. Reconciled into the model lane
+ * and the persisted injections once the turn's response is in.
+ */
+const chatPendingBackgroundKey =
+  locals.create<{ afterId: string; messages: ModelMessage[] }[]>("chat.pendingBackground");
 
 /**
  * System-role context injected mid-conversation, held for the instructions lane.
@@ -5019,6 +5045,13 @@ function toStreamTextOptions(options?: ToStreamTextOptionsOptions): Record<strin
       if (bgQueue && bgQueue.length > 0) {
         const injected = bgQueue.splice(0); // drain
         resultMessages = [...(resultMessages ?? messages), ...injected];
+        const pendingBackground = locals.get(chatPendingBackgroundKey) ?? [];
+        pendingBackground.push({
+          afterId:
+            (locals.get(chatCurrentUIMessagesKey) as UIMessage[] | undefined)?.at(-1)?.id ?? "",
+          messages: injected,
+        });
+        locals.set(chatPendingBackgroundKey, pendingBackground);
       }
 
       return resultMessages ? { messages: resultMessages } : undefined;
@@ -6910,6 +6943,23 @@ function chatAgent<
       // registered) — the wire is delta-only now, no longer a seed.
       let accumulatedMessages: ModelMessage[] = [];
       /**
+       * Give the model accumulator the background injections a step-boundary
+       * drain handed to the model this turn, and record them for persistence.
+       * Returns how many model messages were appended.
+       */
+      const reconcilePendingBackground = (): number => {
+        const pending = locals.get(chatPendingBackgroundKey);
+        if (!pending || pending.length === 0) return 0;
+        locals.set(chatPendingBackgroundKey, []);
+        let appended = 0;
+        for (const entry of pending) {
+          accumulatedMessages.push(...entry.messages);
+          laneInjections.push(entry);
+          appended += entry.messages.length;
+        }
+        return appended;
+      };
+      /**
        * Give the model accumulator the steering messages a drain consumed,
        * in the form the model actually received. Appended, never reconverted
        * from the UI lane, so a model-only compaction summary survives. Called
@@ -6948,8 +6998,18 @@ function chatAgent<
       // collectively cost ~600ms on every first-message TTFC. Both reads
       // swallow errors internally; the agent stays available either way.
       const sessionIdForSnapshot = payload.sessionId ?? payload.chatId;
-      const transcriptStorage = defaultStorage;
+      const transcriptStorage = transcriptStorageOverride ?? defaultStorage;
       let transcriptShadow: TranscriptShadow = createTranscriptShadow([]);
+      let bootTranscriptState: unknown = null;
+      /**
+       * True while the model lane holds a compaction summary, so it cannot be
+       * rebuilt from the transcript and has to be persisted as state. Reset
+       * wherever the lane is reconverted from the UI lane.
+       */
+      let laneCompacted = false;
+      /** Conversational `chat.inject` messages in the lane, anchored to the transcript. */
+      let laneInjections: NonNullable<TranscriptRuntimeState["injections"]> = [];
+      let persistedStateSet = false;
       let bootSnapshot:
         | { messages: TUIMessage[]; lastOutEventId?: string; lastInEventId?: string }
         | undefined;
@@ -6999,6 +7059,30 @@ function chatAgent<
         const { changes, shadow } = diffTranscript(transcriptShadow, opts.messages, {
           nonFinalIds: opts.nonFinalIds,
         });
+        const throughId = opts.messages.at(-1)?.id ?? "";
+        const queued = locals.get(chatBackgroundQueueKey) ?? [];
+        const runtimeState: TranscriptRuntimeState | null =
+          laneCompacted || laneInjections.length > 0 || queued.length > 0
+            ? {
+                v: 1,
+                ...(laneCompacted
+                  ? {
+                      compaction: {
+                        modelMessages: accumulatedMessages,
+                        throughId,
+                        fingerprint: prefixFingerprint(shadow, throughId),
+                      },
+                    }
+                  : laneInjections.length > 0
+                    ? { injections: laneInjections }
+                    : {}),
+                ...(queued.length > 0 ? { queued: [...queued] } : {}),
+              }
+            : null;
+        if (runtimeState !== null || persistedStateSet) {
+          changes.push({ op: "state", value: runtimeState } satisfies TranscriptChange);
+        }
+        transcriptState = runtimeState;
         const inCursor = chatInputRouter().resumeFloor();
         await transcriptStorage.save(
           {
@@ -7027,6 +7111,7 @@ function chatAgent<
           }
         );
         transcriptShadow = shadow;
+        persistedStateSet = runtimeState !== null;
       };
 
       /**
@@ -7111,6 +7196,8 @@ function chatAgent<
                 clientData: bootClientData,
               });
               transcriptShadow = createTranscriptShadow(loaded.messages);
+              bootTranscriptState = loaded.state;
+              persistedStateSet = loaded.state !== null && loaded.state !== undefined;
               bootSnapshot = {
                 messages: loaded.messages,
                 lastOutEventId: loaded.cursors?.lastOutEventId,
@@ -7450,7 +7537,21 @@ function chatAgent<
             }
           }
           try {
-            accumulatedMessages = await toModelMessages(accumulatedUIMessages);
+            const bootRuntimeState = parseTranscriptRuntimeState(bootTranscriptState);
+            const restored = await restoreModelLane(
+              accumulatedUIMessages,
+              bootRuntimeState,
+              (messages) => toModelMessages(messages)
+            );
+            accumulatedMessages = restored.messages;
+            laneCompacted = restored.compacted;
+            laneInjections = restored.injections;
+            if (bootRuntimeState?.queued && bootRuntimeState.queued.length > 0) {
+              locals.set(chatBackgroundQueueKey, [
+                ...(locals.get(chatBackgroundQueueKey) ?? []),
+                ...bootRuntimeState.queued,
+              ]);
+            }
           } catch (error) {
             logger.warn("chat.agent: toModelMessages failed at boot; starting empty", {
               error: error instanceof Error ? error.message : String(error),
@@ -7979,6 +8080,7 @@ function chatAgent<
                 locals.set(chatDeferKey, new Set());
                 locals.set(chatCompactionStateKey, undefined);
                 locals.set(chatSteeringQueueKey, []);
+                locals.set(chatPendingBackgroundKey, []);
                 locals.set(chatResponsePartsKey, []);
                 // NOTE: chatBackgroundQueueKey is NOT reset here — messages injected
                 // by deferred work from the previous turn's onTurnComplete need to
@@ -8125,6 +8227,8 @@ function chatAgent<
                     );
                     accumulatedUIMessages = [...hydrated] as TUIMessage[];
                     accumulatedMessages = await toModelMessages(hydrated);
+                    laneCompacted = false;
+                    laneInjections = [];
                     locals.set(chatCurrentUIMessagesKey, accumulatedUIMessages);
                   }
 
@@ -8162,6 +8266,8 @@ function chatAgent<
                       locals.set(chatOverrideMessagesKey, undefined);
                       accumulatedUIMessages = [...actionOverride] as TUIMessage[];
                       accumulatedMessages = await toModelMessages(actionOverride);
+                      laneCompacted = false;
+                      laneInjections = [];
                       locals.set(chatCurrentUIMessagesKey, accumulatedUIMessages);
 
                       actionChangedHistory = true;
@@ -8294,6 +8400,8 @@ function chatAgent<
 
                     accumulatedUIMessages = merged;
                     accumulatedMessages = await toModelMessages(merged);
+                    laneCompacted = false;
+                    laneInjections = [];
                     locals.set(chatCurrentUIMessagesKey, accumulatedUIMessages);
 
                     // Track new messages for onTurnComplete.newUIMessages.
@@ -8343,6 +8451,8 @@ function chatAgent<
                         accumulatedUIMessages.pop();
                       }
                       accumulatedMessages = await toModelMessages(accumulatedUIMessages);
+                      laneCompacted = false;
+                      laneInjections = [];
                     } else if (cleanedUIMessages.length > 0) {
                       // Submit-message (and the special-cased
                       // handover-prepare → submit-message rewrite earlier in
@@ -8396,6 +8506,8 @@ function chatAgent<
                             "chat.agent: replaced message not found at the model lane tail; reconverting the lane"
                           );
                           accumulatedMessages = await toModelMessages(accumulatedUIMessages);
+                          laneCompacted = false;
+                          laneInjections = [];
                         }
                       } else {
                         const incomingModelMessages = await toModelMessages(cleanedUIMessages);
@@ -8605,6 +8717,8 @@ function chatAgent<
                           locals.set(chatOverrideMessagesKey, undefined);
                           accumulatedUIMessages = [...turnStartOverride] as TUIMessage[];
                           accumulatedMessages = await toModelMessages(turnStartOverride);
+                          laneCompacted = false;
+                          laneInjections = [];
                           locals.set(chatCurrentUIMessagesKey, accumulatedUIMessages);
                         }
                       },
@@ -8673,7 +8787,12 @@ function chatAgent<
                     const lastAccumulated = accumulatedMessages[accumulatedMessages.length - 1];
                     const bgQueue = locals.get(chatBackgroundQueueKey);
                     if (bgQueue && bgQueue.length > 0 && lastAccumulated?.role !== "tool") {
-                      accumulatedMessages.push(...bgQueue.splice(0));
+                      const injected = bgQueue.splice(0);
+                      accumulatedMessages.push(...injected);
+                      laneInjections.push({
+                        afterId: accumulatedUIMessages.at(-1)?.id ?? "",
+                        messages: injected,
+                      });
                     }
 
                     if (isHeadStartFinalTurn) {
@@ -8866,6 +8985,8 @@ function chatAgent<
                     accumulatedMessages = await toModelMessages(
                       runOverride.filter((m) => !pendingIds.has(m.id))
                     );
+                    laneCompacted = false;
+                    laneInjections = [];
                     locals.set(chatCurrentUIMessagesKey, accumulatedUIMessages);
                   }
 
@@ -8891,6 +9012,8 @@ function chatAgent<
                     accumulatedMessages = taskCompactionConfig?.compactModelMessages
                       ? await taskCompactionConfig.compactModelMessages(compactEvent)
                       : modelOnlyOverride;
+                    laneCompacted = true;
+                    laneInjections = [];
 
                     // Apply UI messages: callback or default (preserve all)
                     if (taskCompactionConfig?.compactUIMessages) {
@@ -8909,9 +9032,10 @@ function chatAgent<
                   // before the response is appended so the order stays
                   // steer-then-answer. Outside the `capturedResponseMessage`
                   // branches below, so a turn that captured no response is covered.
-                  const steerTailThisTurn = reconcilePendingSteer({
-                    turnNew: turnNewModelMessages,
-                  }).reduce((n, e) => n + e.model.length, 0);
+                  const steerTailThisTurn =
+                    reconcilePendingSteer({
+                      turnNew: turnNewModelMessages,
+                    }).reduce((n, e) => n + e.model.length, 0) + reconcilePendingBackground();
 
                   // Append the assistant's response (partial or complete) to the accumulator.
                   // The onFinish callback fires even on abort/stop, so partial responses
@@ -8983,6 +9107,8 @@ function chatAgent<
                             "chat.agent: replaced response not found at the model lane tail; reconverting the lane"
                           );
                           accumulatedMessages = await toModelMessages(accumulatedUIMessages);
+                          laneCompacted = false;
+                          laneInjections = [];
                         }
                       } else {
                         accumulatedMessages.push(...responseModelMessages);
@@ -9102,6 +9228,9 @@ function chatAgent<
                                     },
                                   ];
 
+                              laneCompacted = true;
+                              laneInjections = [];
+
                               // UI messages: callback or default (preserve all)
                               if (outerCompaction.compactUIMessages) {
                                 accumulatedUIMessages = (await outerCompaction.compactUIMessages(
@@ -9206,6 +9335,8 @@ function chatAgent<
                           locals.set(chatOverrideMessagesKey, undefined);
                           accumulatedUIMessages = [...override] as TUIMessage[];
                           accumulatedMessages = await toModelMessages(override);
+                          laneCompacted = false;
+                          laneInjections = [];
                           locals.set(chatCurrentUIMessagesKey, accumulatedUIMessages);
                           // Update event so onTurnComplete sees compacted messages
                           turnCompleteEvent.messages = accumulatedMessages;
@@ -9265,6 +9396,8 @@ function chatAgent<
                           locals.set(chatOverrideMessagesKey, undefined);
                           accumulatedUIMessages = [...turnCompleteOverride] as TUIMessage[];
                           accumulatedMessages = await toModelMessages(turnCompleteOverride);
+                          laneCompacted = false;
+                          laneInjections = [];
                           locals.set(chatCurrentUIMessagesKey, accumulatedUIMessages);
                         }
                       },
@@ -9599,6 +9732,7 @@ function chatAgent<
             let erroredNewModelMessages: ModelMessage[] = [];
 
             const reconciledSteer = reconcilePendingSteer();
+            const backgroundTailThisTurn = reconcilePendingBackground();
 
             if (!responseCommitted) {
               try {
@@ -9634,13 +9768,16 @@ function chatAgent<
                       accumulatedMessages,
                       erroredUIMessages[partialIdx]!,
                       partialResponse!,
-                      reconciledSteer.reduce((n, e) => n + e.model.length, 0)
+                      reconciledSteer.reduce((n, e) => n + e.model.length, 0) +
+                        backgroundTailThisTurn
                     );
                     if (!ok) {
                       logger.warn(
                         "chat.agent: replaced partial not found at the model lane tail; reconverting the lane"
                       );
                       accumulatedMessages = await toModelMessages(erroredUIMessagesWithPartial);
+                      laneCompacted = false;
+                      laneInjections = [];
                     }
                   }
                   accumulatedUIMessages = erroredUIMessagesWithPartial;

--- a/packages/trigger-sdk/src/v3/transcriptStorage.ts
+++ b/packages/trigger-sdk/src/v3/transcriptStorage.ts
@@ -1,5 +1,5 @@
 import type { TaskRunContext, TranscriptSnapshotEntry } from "@trigger.dev/core/v3";
-import type { UIMessage } from "ai";
+import type { ModelMessage, UIMessage } from "ai";
 import { readChatSnapshot, writeChatSnapshot } from "./chatSnapshotIo.js";
 
 /**
@@ -260,23 +260,12 @@ export function snapshotTranscriptStorage(): TranscriptStorage<unknown> {
         ? { entries: snapshot.messages, state: snapshot.state }
         : emptyTranscriptState<TUIMessage>();
 
-      let entries = full.entries;
-      if (opts?.before !== undefined) {
-        const idx = entries.findIndex((e) => e.id === opts.before);
-        if (idx !== -1) entries = entries.slice(0, idx);
-      }
-      let nextCursor: string | undefined;
-      if (opts?.limit !== undefined && entries.length > opts.limit) {
-        entries = entries.slice(entries.length - opts.limit);
-        nextCursor = entries[0]?.id;
-      }
       return {
-        messages: entries.map((e) => e.message),
+        ...pageEntries(full.entries, opts),
         state: full.state,
         cursors: snapshot
           ? { lastOutEventId: snapshot.lastOutEventId, lastInEventId: snapshot.lastInEventId }
           : undefined,
-        nextCursor,
       };
     },
 
@@ -295,3 +284,195 @@ export function snapshotTranscriptStorage(): TranscriptStorage<unknown> {
 
 /** The storage `chat.agent` uses when none is configured: {@link snapshotTranscriptStorage}. */
 export const defaultStorage: TranscriptStorage<unknown> = snapshotTranscriptStorage();
+
+function pageEntries<TUIMessage extends UIMessage>(
+  all: TranscriptSnapshotEntry<TUIMessage>[],
+  opts: TranscriptLoadOptions | undefined
+): { messages: TUIMessage[]; nextCursor: string | undefined } {
+  let entries = all;
+  if (opts?.before !== undefined) {
+    const idx = entries.findIndex((e) => e.id === opts.before);
+    if (idx !== -1) entries = entries.slice(0, idx);
+  }
+  let nextCursor: string | undefined;
+  if (opts?.limit !== undefined && entries.length > opts.limit) {
+    entries = entries.slice(entries.length - opts.limit);
+    nextCursor = entries[0]?.id;
+  }
+  return { messages: entries.map((e) => e.message), nextCursor };
+}
+
+export type MemoryTranscriptStorage = TranscriptStorage<unknown> & {
+  /** The stored transcript for a chat, or `undefined` when nothing has been saved. */
+  transcript(chatId: string): (TranscriptState & { cursors?: TranscriptCursors }) | undefined;
+  /** Every changeset `save` received, in order. */
+  readonly changesets: Array<{
+    ctx: TranscriptStorageContext<unknown>;
+    changeset: TranscriptChangeset;
+  }>;
+};
+
+/**
+ * A storage that keeps every transcript in process memory. The reference
+ * implementation for the conformance tests, and a way to inspect exactly
+ * what the runtime hands a storage.
+ */
+export function memoryTranscriptStorage(): MemoryTranscriptStorage {
+  const transcripts = new Map<string, TranscriptState & { cursors?: TranscriptCursors }>();
+  const changesets: MemoryTranscriptStorage["changesets"] = [];
+
+  return {
+    changesets,
+    transcript(chatId) {
+      return transcripts.get(chatId);
+    },
+    async load<TUIMessage extends UIMessage = UIMessage>(
+      scope: TranscriptScope<unknown>,
+      opts?: TranscriptLoadOptions
+    ): Promise<TranscriptLoadResult<TUIMessage>> {
+      const stored = transcripts.get(scope.chatId);
+      if (!stored) return { messages: [], state: null, cursors: undefined, nextCursor: undefined };
+      return {
+        ...pageEntries(stored.entries as TranscriptSnapshotEntry<TUIMessage>[], opts),
+        state: stored.state,
+        cursors: stored.cursors,
+      };
+    },
+    async save(ctx, changeset) {
+      changesets.push({ ctx, changeset });
+      const prev = transcripts.get(ctx.chatId);
+      const next = reduceTranscriptChanges(prev ?? emptyTranscriptState(), changeset.changes);
+      transcripts.set(ctx.chatId, { ...next, cursors: changeset.cursors ?? prev?.cursors });
+    },
+  };
+}
+
+type ModelLaneInjection = { afterId: string; messages: ModelMessage[] };
+
+/**
+ * What the runtime keeps in the storage's `state` slot: the parts of the
+ * model's context that cannot be rebuilt from the transcript. Opaque to a
+ * storage; only the runtime reads it.
+ *
+ * `compaction` is the whole model lane after a compaction, valid for the
+ * transcript prefix ending at `throughId` whose fingerprint matches, so a
+ * rollback or edit of that prefix makes it unusable and the next save
+ * clears it. `injections` are conversational messages `chat.inject` added,
+ * anchored after the transcript message they followed.
+ */
+export type TranscriptRuntimeState = {
+  v: 1;
+  compaction?: { modelMessages: ModelMessage[]; throughId: string; fingerprint: string };
+  injections?: ModelLaneInjection[];
+  /** `chat.inject` messages queued but not yet drained into a turn when the save happened. */
+  queued?: ModelMessage[];
+};
+
+export function parseTranscriptRuntimeState(value: unknown): TranscriptRuntimeState | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  if (record.v !== 1) return undefined;
+  const out: TranscriptRuntimeState = { v: 1 };
+  const compaction = record.compaction as Record<string, unknown> | undefined;
+  if (
+    compaction &&
+    typeof compaction === "object" &&
+    Array.isArray(compaction.modelMessages) &&
+    typeof compaction.throughId === "string" &&
+    typeof compaction.fingerprint === "string"
+  ) {
+    out.compaction = {
+      modelMessages: compaction.modelMessages as ModelMessage[],
+      throughId: compaction.throughId,
+      fingerprint: compaction.fingerprint,
+    };
+  }
+  if (Array.isArray(record.injections)) {
+    out.injections = (record.injections as unknown[]).flatMap((entry) => {
+      const inj = entry as Record<string, unknown> | null;
+      return inj && typeof inj.afterId === "string" && Array.isArray(inj.messages)
+        ? [{ afterId: inj.afterId, messages: inj.messages as ModelMessage[] }]
+        : [];
+    });
+  }
+  if (Array.isArray(record.queued) && record.queued.length > 0) {
+    out.queued = record.queued as ModelMessage[];
+  }
+  return out;
+}
+
+/**
+ * A 32-bit FNV-1a hash over the fingerprints of the messages up to and
+ * including `throughId`, in order. Cheap enough to compute on every save
+ * because the per-message fingerprints already exist in the shadow.
+ */
+export function prefixFingerprint(shadow: TranscriptShadow, throughId: string): string {
+  let hash = 0x811c9dc5;
+  if (throughId === "") return hash.toString(16).padStart(8, "0");
+  const mix = (s: string) => {
+    for (let i = 0; i < s.length; i++) {
+      hash ^= s.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+  };
+  for (const id of shadow.ids) {
+    mix(id);
+    mix(" ");
+    mix(shadow.fingerprints.get(id) ?? "");
+    mix("");
+    if (id === throughId) return hash.toString(16).padStart(8, "0");
+  }
+  return "";
+}
+
+/**
+ * Rebuild the model lane for a transcript at boot. Uses the persisted
+ * compacted lane when the transcript prefix it covers is unchanged, then
+ * converts the rest of the transcript, re-inserting persisted injections
+ * after the messages they followed.
+ */
+export async function restoreModelLane<TUIMessage extends UIMessage>(
+  messages: TUIMessage[],
+  state: TranscriptRuntimeState | undefined,
+  convert: (messages: TUIMessage[]) => Promise<ModelMessage[]>
+): Promise<{ messages: ModelMessage[]; compacted: boolean; injections: ModelLaneInjection[] }> {
+  const lane: ModelMessage[] = [];
+  let start = 0;
+  let compacted = false;
+
+  if (state?.compaction) {
+    const throughId = state.compaction.throughId;
+    const idx = throughId === "" ? -1 : messages.findIndex((m) => m.id === throughId);
+    if (
+      (idx !== -1 || throughId === "") &&
+      prefixFingerprint(createTranscriptShadow(messages), throughId) ===
+        state.compaction.fingerprint
+    ) {
+      lane.push(...state.compaction.modelMessages);
+      start = idx + 1;
+      compacted = true;
+    }
+  }
+
+  const anchored = (state?.injections ?? [])
+    .map((inj) => ({
+      inj,
+      idx: inj.afterId === "" ? -1 : messages.findIndex((m) => m.id === inj.afterId),
+    }))
+    .filter(({ inj, idx }) => (inj.afterId === "" ? start === 0 : idx >= start))
+    .sort((a, b) => a.idx - b.idx);
+
+  let cursor = start;
+  for (const { inj, idx } of anchored) {
+    if (idx + 1 > cursor) {
+      lane.push(...(await convert(messages.slice(cursor, idx + 1))));
+      cursor = idx + 1;
+    }
+    lane.push(...inj.messages);
+  }
+  if (cursor < messages.length) {
+    lane.push(...(await convert(messages.slice(cursor))));
+  }
+
+  return { messages: lane, compacted, injections: anchored.map(({ inj }) => inj) };
+}

--- a/packages/trigger-sdk/test/transcript-changesets.test.ts
+++ b/packages/trigger-sdk/test/transcript-changesets.test.ts
@@ -1,0 +1,550 @@
+import { mockChatAgent } from "../src/v3/test/index.js";
+
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import type { ModelMessage, UIMessage } from "ai";
+import { simulateReadableStream, stepCountIs, streamText, tool } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { __setTranscriptStorageForTests, chat } from "../src/v3/ai.js";
+import {
+  createTranscriptShadow,
+  memoryTranscriptStorage,
+  prefixFingerprint,
+  restoreModelLane,
+  type MemoryTranscriptStorage,
+  type TranscriptChange,
+  type TranscriptRuntimeState,
+} from "../src/v3/transcriptStorage.js";
+
+const usage = {
+  inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+  outputTokens: { total: 10, text: 10, reasoning: undefined },
+};
+
+function userMessage(text: string, id: string): UIMessage {
+  return { id, role: "user", parts: [{ type: "text", text }] };
+}
+
+function textChunks(text: string): LanguageModelV3StreamPart[] {
+  return [
+    { type: "text-start", id: "t1" },
+    { type: "text-delta", id: "t1", delta: text },
+    { type: "text-end", id: "t1" },
+    { type: "finish", finishReason: { unified: "stop", raw: "stop" }, usage },
+  ];
+}
+
+function promptText(prompt: unknown): string {
+  return JSON.stringify(prompt);
+}
+
+function recordingModel(prompts: unknown[], reply = "ack") {
+  return new MockLanguageModelV3({
+    doStream: async ({ prompt }) => {
+      prompts.push(prompt);
+      return { stream: simulateReadableStream({ chunks: textChunks(reply) }) };
+    },
+  });
+}
+
+async function waitFor(check: () => boolean, label: string, timeoutMs = 8_000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (check()) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error(`waitFor timed out: ${label}`);
+}
+
+const ops = (changes: TranscriptChange[]) => changes.map((c) => c.op);
+const putIds = (changes: TranscriptChange[]) =>
+  changes.flatMap((c) => (c.op === "put" ? [c.message.id] : []));
+const stateOf = (changes: TranscriptChange[]) =>
+  changes.find((c) => c.op === "state")?.value as TranscriptRuntimeState | null | undefined;
+
+let storage: MemoryTranscriptStorage;
+
+beforeEach(() => {
+  storage = memoryTranscriptStorage();
+  __setTranscriptStorageForTests(storage);
+});
+
+afterEach(() => {
+  __setTranscriptStorageForTests(undefined);
+});
+
+describe("chat.agent transcript changesets", () => {
+  it("saves a turn as puts for the new user and assistant messages with cursors", async () => {
+    const prompts: unknown[] = [];
+    const agent = chat.agent({
+      id: "changeset-turn",
+      run: async ({ messages, signal }) =>
+        streamText({ model: recordingModel(prompts), messages, abortSignal: signal }),
+    });
+    const harness = mockChatAgent(agent, { chatId: "changeset-turn" });
+    try {
+      await harness.sendMessage(userMessage("hello", "u1"));
+      await waitFor(() => storage.changesets.length === 1, "first save");
+
+      const { ctx, changeset } = storage.changesets[0]!;
+      expect(ctx.chatId).toBe("changeset-turn");
+      expect(ctx.trigger).toBe("submit-message");
+      expect(ctx.turn).toBe(0);
+      expect(changeset.reason).toBe("turn-complete");
+      expect(ops(changeset.changes)).toEqual(["put", "put"]);
+      expect(putIds(changeset.changes)[0]).toBe("u1");
+      expect(changeset.cursors?.lastOutEventId).toBeDefined();
+
+      await harness.sendMessage(userMessage("again", "u2"));
+      await waitFor(() => storage.changesets.length === 2, "second save");
+      expect(ops(storage.changesets[1]!.changeset.changes)).toEqual(["put", "put"]);
+      expect(putIds(storage.changesets[1]!.changeset.changes)[0]).toBe("u2");
+      expect(storage.transcript("changeset-turn")!.entries.map((e) => e.message.role)).toEqual([
+        "user",
+        "assistant",
+        "user",
+        "assistant",
+      ]);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("saves a stopped response with final: false and a completed one as final", async () => {
+    const chatId = "changeset-stopped";
+    const words = ["one", "two", "three", "four", "five", "six"];
+    const slow = new MockLanguageModelV3({
+      doStream: async () => ({
+        stream: simulateReadableStream({
+          chunks: [
+            { type: "text-start", id: "t1" },
+            ...words.map((w) => ({ type: "text-delta" as const, id: "t1", delta: `${w} ` })),
+            { type: "text-end", id: "t1" },
+            { type: "finish", finishReason: { unified: "stop", raw: "stop" }, usage },
+          ] satisfies LanguageModelV3StreamPart[],
+          initialDelayInMs: 0,
+          chunkDelayInMs: 300,
+        }),
+      }),
+    });
+    const agent = chat.agent({
+      id: "changeset-stopped",
+      run: async ({ messages, signal }) =>
+        streamText({ model: slow, messages, abortSignal: signal }),
+    });
+    const harness = mockChatAgent(agent, { chatId });
+    try {
+      void harness.sendMessage(userMessage("go", "u1"));
+      await waitFor(
+        () =>
+          (harness.allChunks as { type?: string }[]).filter((c) => c.type === "text-delta")
+            .length >= 1,
+        "first delta"
+      );
+      await harness.sendStop();
+      await waitFor(() => storage.changesets.length === 1, "stopped turn save");
+
+      const puts = storage.changesets[0]!.changeset.changes.filter((c) => c.op === "put");
+      expect(puts).toHaveLength(2);
+      expect(puts[0]).toMatchObject({ op: "put", message: { id: "u1" } });
+      expect(puts[0]).not.toHaveProperty("final");
+      expect(puts[1]).toMatchObject({ op: "put", message: { role: "assistant" }, final: false });
+      expect(storage.transcript(chatId)!.entries.map((e) => e.final)).toEqual([true, false]);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("persists a conversational injection drained at a step boundary and restores it at boot", async () => {
+    const chatId = "changeset-inject-step";
+    let call = 0;
+    const model = new MockLanguageModelV3({
+      doStream: async ({ prompt }) => {
+        call += 1;
+        if (call === 1) {
+          return {
+            stream: simulateReadableStream({
+              chunks: [
+                { type: "tool-input-start", id: "c1", toolName: "lookup" },
+                { type: "tool-input-delta", id: "c1", delta: "{}" },
+                { type: "tool-input-end", id: "c1" },
+                { type: "tool-call", toolCallId: "c1", toolName: "lookup", input: "{}" },
+                {
+                  type: "finish",
+                  finishReason: { unified: "tool-calls", raw: "tool-calls" },
+                  usage,
+                },
+              ] satisfies LanguageModelV3StreamPart[],
+            }),
+          };
+        }
+        stepPrompts.push(prompt);
+        return { stream: simulateReadableStream({ chunks: textChunks("done") }) };
+      },
+    });
+    const stepPrompts: unknown[] = [];
+    const makeAgent = () =>
+      chat.agent({
+        id: "changeset-inject-step",
+        tools: {
+          lookup: tool({
+            description: "look something up",
+            inputSchema: z.object({}),
+            execute: async () => {
+              chat.inject([{ role: "user", content: "[note] drained at the step boundary" }]);
+              return { ok: true };
+            },
+          }),
+        },
+        run: async ({ messages, tools, signal }) =>
+          streamText({
+            ...chat.toStreamTextOptions({ tools }),
+            model,
+            messages,
+            abortSignal: signal,
+            stopWhen: stepCountIs(5),
+          }),
+      });
+
+    const first = mockChatAgent(makeAgent(), { chatId });
+    try {
+      await first.sendMessage(userMessage("look it up", "u1"));
+      await waitFor(() => storage.changesets.length === 1, "turn save");
+
+      expect(promptText(stepPrompts[0])).toContain("[note] drained at the step boundary");
+      const state = stateOf(storage.changesets[0]!.changeset.changes);
+      expect(state?.injections).toHaveLength(1);
+      expect(state!.injections![0]!.afterId).toBe("u1");
+    } finally {
+      await first.close();
+    }
+
+    const second = mockChatAgent(makeAgent(), {
+      chatId,
+      continuation: true,
+      previousRunId: "run_1",
+    });
+    try {
+      call = 1;
+      await second.sendMessage(userMessage("again", "u2"));
+      await waitFor(() => stepPrompts.length === 2, "continuation turn");
+      expect(promptText(stepPrompts[1])).toContain("[note] drained at the step boundary");
+    } finally {
+      await second.close();
+    }
+  });
+
+  it("carries an injection that was still queued when the run ended into the continuation", async () => {
+    const chatId = "changeset-inject-queued";
+    let injectedOnce = false;
+    const makeAgent = (prompts: unknown[]) =>
+      chat.agent({
+        id: "changeset-inject-queued",
+        onTurnComplete: async () => {
+          if (injectedOnce) return;
+          injectedOnce = true;
+          chat.inject([{ role: "user", content: "[note] queued at exit" } as ModelMessage]);
+          chat.endRun();
+        },
+        run: async ({ messages, signal }) =>
+          streamText({ model: recordingModel(prompts), messages, abortSignal: signal }),
+      });
+
+    const firstPrompts: unknown[] = [];
+    const first = mockChatAgent(makeAgent(firstPrompts), { chatId });
+    try {
+      await first.sendMessage(userMessage("one", "u1"));
+      await waitFor(() => storage.changesets.length === 1, "turn save");
+      const state = stateOf(storage.changesets[0]!.changeset.changes);
+      expect(state?.queued).toHaveLength(1);
+      expect(state?.injections).toBeUndefined();
+    } finally {
+      await first.close();
+    }
+
+    const secondPrompts: unknown[] = [];
+    const second = mockChatAgent(makeAgent(secondPrompts), {
+      chatId,
+      continuation: true,
+      previousRunId: "run_1",
+    });
+    try {
+      await second.sendMessage(userMessage("two", "u2"));
+      await waitFor(() => storage.changesets.length === 2, "continuation save");
+      expect(promptText(secondPrompts[0])).toContain("[note] queued at exit");
+      const state = stateOf(storage.changesets[1]!.changeset.changes);
+      expect(state?.queued).toBeUndefined();
+      expect(state?.injections).toHaveLength(1);
+    } finally {
+      await second.close();
+    }
+  });
+
+  it("puts a steering message the drain consumed into the turn's changeset", async () => {
+    const send = { fn: async () => {} };
+    let call = 0;
+    const model = new MockLanguageModelV3({
+      doStream: async () => {
+        call += 1;
+        if (call === 1) {
+          await send.fn();
+          return {
+            stream: simulateReadableStream({
+              chunks: [
+                { type: "tool-input-start", id: "c1", toolName: "lookup" },
+                { type: "tool-input-delta", id: "c1", delta: "{}" },
+                { type: "tool-input-end", id: "c1" },
+                { type: "tool-call", toolCallId: "c1", toolName: "lookup", input: "{}" },
+                {
+                  type: "finish",
+                  finishReason: { unified: "tool-calls", raw: "tool-calls" },
+                  usage,
+                },
+              ] satisfies LanguageModelV3StreamPart[],
+            }),
+          };
+        }
+        return { stream: simulateReadableStream({ chunks: textChunks("done") }) };
+      },
+    });
+
+    const agent = chat.agent({
+      id: "changeset-steer",
+      tools: {
+        lookup: tool({
+          description: "look something up",
+          inputSchema: z.object({}),
+          execute: async () => ({ ok: true }),
+        }),
+      },
+      pendingMessages: { shouldInject: ({ steps }) => steps.length > 0 },
+      run: async ({ messages, tools, signal }) =>
+        streamText({
+          ...chat.toStreamTextOptions({ tools }),
+          model,
+          messages,
+          abortSignal: signal,
+          stopWhen: stepCountIs(5),
+        }),
+    });
+    const harness = mockChatAgent(agent, { chatId: "changeset-steer" });
+    send.fn = async () => {
+      await harness.sendPendingMessage(userMessage("only the platform one", "steer-1"));
+    };
+    try {
+      await harness.sendMessage(userMessage("summarise every project", "u1"));
+      await waitFor(() => storage.changesets.length === 1, "save");
+
+      const ids = putIds(storage.changesets[0]!.changeset.changes);
+      expect(ids).toContain("steer-1");
+      expect(ids.indexOf("steer-1")).toBeGreaterThan(ids.indexOf("u1"));
+      expect(storage.transcript("changeset-steer")!.entries.map((e) => e.id)).toEqual(ids);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("persists a compaction as state and boots a continuation from the summary", async () => {
+    const chatId = "changeset-compaction";
+    let compactions = 0;
+    const makeAgent = (prompts: unknown[]) =>
+      chat.agent({
+        id: "changeset-compaction",
+        compaction: {
+          shouldCompact: ({ source }) => source === "outer" && compactions === 0,
+          summarize: async () => {
+            compactions += 1;
+            return "SUMMARY-OF-EVERYTHING";
+          },
+        },
+        run: async ({ messages, signal }) =>
+          streamText({ model: recordingModel(prompts), messages, abortSignal: signal }),
+      });
+
+    const firstPrompts: unknown[] = [];
+    const first = mockChatAgent(makeAgent(firstPrompts), { chatId });
+    try {
+      await first.sendMessage(userMessage("the early message", "u1"));
+      await waitFor(() => storage.changesets.length === 1, "turn 1 save");
+      expect(compactions).toBe(1);
+
+      const state = stateOf(storage.changesets[0]!.changeset.changes);
+      expect(state?.compaction).toBeDefined();
+      expect(state!.compaction!.throughId).toBe(
+        putIds(storage.changesets[0]!.changeset.changes).at(-1)
+      );
+      expect(JSON.stringify(state!.compaction!.modelMessages)).toContain("SUMMARY-OF-EVERYTHING");
+      expect(JSON.stringify(state!.compaction!.modelMessages)).not.toContain("the early message");
+
+      await first.sendMessage(userMessage("a follow-up", "u2"));
+      await waitFor(() => storage.changesets.length === 2, "turn 2 save");
+      expect(promptText(firstPrompts[1])).toContain("SUMMARY-OF-EVERYTHING");
+      expect(promptText(firstPrompts[1])).not.toContain("the early message");
+      expect(stateOf(storage.changesets[1]!.changeset.changes)?.compaction).toBeDefined();
+    } finally {
+      await first.close();
+    }
+
+    expect(storage.transcript(chatId)!.entries.map((e) => e.id)).toHaveLength(4);
+    expect(storage.transcript(chatId)!.state).not.toBeNull();
+
+    const secondPrompts: unknown[] = [];
+    const second = mockChatAgent(makeAgent(secondPrompts), {
+      chatId,
+      continuation: true,
+      previousRunId: "run_first",
+    });
+    try {
+      await second.sendMessage(userMessage("after the continuation", "u3"));
+      await waitFor(() => secondPrompts.length === 1, "continuation turn");
+
+      const prompt = promptText(secondPrompts[0]);
+      expect(prompt).toContain("SUMMARY-OF-EVERYTHING");
+      expect(prompt).toContain("a follow-up");
+      expect(prompt).toContain("after the continuation");
+      expect(prompt).not.toContain("the early message");
+      expect(compactions).toBe(1);
+    } finally {
+      await second.close();
+    }
+  });
+
+  it("clears the compaction state in the same changeset as a rollback", async () => {
+    const chatId = "changeset-rollback";
+    let compactions = 0;
+    const prompts: unknown[] = [];
+    const agent = chat.agent({
+      id: "changeset-rollback",
+      actionSchema: z.discriminatedUnion("type", [z.object({ type: z.literal("undo") })]),
+      compaction: {
+        shouldCompact: ({ source }) => source === "outer" && compactions === 0,
+        summarize: async () => {
+          compactions += 1;
+          return "SUMMARY";
+        },
+      },
+      onAction: async ({ action }) => {
+        if (action.type === "undo") chat.history.slice(0, -2);
+      },
+      run: async ({ messages, signal }) =>
+        streamText({ model: recordingModel(prompts), messages, abortSignal: signal }),
+    });
+    const harness = mockChatAgent(agent, { chatId });
+    try {
+      await harness.sendMessage(userMessage("one", "u1"));
+      await harness.sendMessage(userMessage("two", "u2"));
+      await waitFor(() => storage.changesets.length === 2, "two turns");
+      expect(stateOf(storage.changesets[1]!.changeset.changes)?.compaction).toBeDefined();
+
+      await harness.sendAction({ type: "undo" });
+      await waitFor(() => storage.changesets.length === 3, "action save");
+
+      const { ctx, changeset } = storage.changesets[2]!;
+      expect(ctx.trigger).toBe("action");
+      expect(changeset.reason).toBe("action");
+      expect(ops(changeset.changes)).toEqual(["truncateAfter", "state"]);
+      expect(stateOf(changeset.changes)).toBeNull();
+      expect(storage.transcript(chatId)!.entries.map((e) => e.id)).toHaveLength(2);
+      expect(storage.transcript(chatId)!.state).toBeNull();
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("persists conversational injections anchored to the transcript and restores them at boot", async () => {
+    const chatId = "changeset-inject";
+    const makeAgent = (prompts: unknown[]) =>
+      chat.agent({
+        id: "changeset-inject",
+        onTurnComplete: async ({ turn }) => {
+          if (turn === 0) {
+            chat.inject([{ role: "user", content: "[note] inventory is low" } as ModelMessage]);
+          }
+        },
+        run: async ({ messages, signal }) =>
+          streamText({ model: recordingModel(prompts), messages, abortSignal: signal }),
+      });
+
+    const firstPrompts: unknown[] = [];
+    const first = mockChatAgent(makeAgent(firstPrompts), { chatId });
+    try {
+      await first.sendMessage(userMessage("one", "u1"));
+      await first.sendMessage(userMessage("two", "u2"));
+      await waitFor(() => storage.changesets.length === 2, "two turns");
+
+      expect(promptText(firstPrompts[1])).toContain("[note] inventory is low");
+      const state = stateOf(storage.changesets[1]!.changeset.changes);
+      expect(state?.injections).toHaveLength(1);
+      expect(state!.injections![0]!.afterId).toBe("u2");
+      expect(state?.queued).toBeUndefined();
+      const queuedAtTurn0 = stateOf(storage.changesets[0]!.changeset.changes);
+      expect(queuedAtTurn0?.queued).toHaveLength(1);
+      expect(queuedAtTurn0?.injections).toBeUndefined();
+    } finally {
+      await first.close();
+    }
+
+    const secondPrompts: unknown[] = [];
+    const second = mockChatAgent(makeAgent(secondPrompts), {
+      chatId,
+      continuation: true,
+      previousRunId: "run_first",
+    });
+    try {
+      await second.sendMessage(userMessage("three", "u3"));
+      await waitFor(() => secondPrompts.length === 1, "continuation turn");
+      const prompt = secondPrompts[0] as { role: string; content: unknown }[];
+      const text = promptText(prompt);
+      expect(text).toContain("[note] inventory is low");
+      const noteIdx = prompt.findIndex((m) => promptText(m).includes("[note] inventory is low"));
+      const u2Idx = prompt.findIndex((m) => promptText(m).includes('"two"'));
+      const u3Idx = prompt.findIndex((m) => promptText(m).includes('"three"'));
+      expect(noteIdx).toBeGreaterThan(u2Idx);
+      expect(noteIdx).toBeLessThan(u3Idx);
+    } finally {
+      await second.close();
+    }
+  });
+});
+
+function assistantMessage(id: string): UIMessage {
+  return { id, role: "assistant", parts: [{ type: "text", text: "hello" }] };
+}
+
+describe("restoreModelLane", () => {
+  it("restores a compacted lane that covers an emptied transcript", async () => {
+    const summary = { role: "assistant" as const, content: "[Conversation summary] all of it" };
+    const fingerprint = prefixFingerprint(createTranscriptShadow([]), "");
+    const restored = await restoreModelLane(
+      [userMessage("two", "u-2")],
+      { v: 1, compaction: { modelMessages: [summary], throughId: "", fingerprint } },
+      async (messages) => messages.map((m) => ({ role: m.role, content: m.id }) as never)
+    );
+    expect(restored.compacted).toBe(true);
+    expect(restored.messages).toEqual([summary, { role: "user", content: "u-2" }]);
+  });
+
+  it("ignores a compacted lane whose covered prefix changed", async () => {
+    const shadow = createTranscriptShadow([userMessage("one", "u-1"), assistantMessage("a-1")]);
+    const state = {
+      v: 1 as const,
+      compaction: {
+        modelMessages: [{ role: "assistant" as const, content: "summary" }],
+        throughId: "a-1",
+        fingerprint: prefixFingerprint(shadow, "a-1"),
+      },
+    };
+    const edited = {
+      ...assistantMessage("a-1"),
+      parts: [{ type: "text" as const, text: "edited" }],
+    };
+    const restored = await restoreModelLane(
+      [userMessage("one", "u-1"), edited, userMessage("two", "u-2")],
+      state,
+      async (messages) => messages.map((m) => ({ role: m.role, content: m.id }) as never)
+    );
+    expect(restored.compacted).toBe(false);
+    expect(restored.messages.map((m) => m.content)).toEqual(["u-1", "a-1", "u-2"]);
+  });
+});


### PR DESCRIPTION
## Summary

Makes a compaction summary and `chat.inject` context survive a continuation run, for every storage including the default.

Until now the model lane after a compaction lived only in the running worker. When the next run booted it rebuilt the lane from the transcript, so every continuation re-read the whole conversation and summarised it again. The same applied to conversational messages added with `chat.inject`: they lived for the worker's life and vanished on a continuation.

## Design

The runtime records what it cannot rebuild from the transcript in the storage's `state` slot: after a compaction, the compacted model lane together with the transcript id it covers and a fingerprint of that prefix; for injections, the messages anchored to the transcript message they followed. At boot the compacted lane is used when the covered prefix is unchanged, otherwise the lane is converted from the transcript as before, and injections are re-inserted after their anchors.

A rollback or edit that reconverts the lane clears the state in the same changeset as the `truncateAfter`, so a storage never holds a summary for a transcript it no longer matches. A mid-turn steering message reaches the storage as a `put` in that turn's changeset.

An in-memory storage that logs the changesets it receives, and a test-only override for the storage the runtime persists through, let the tests assert the exact changesets for a turn, a steer, a compaction, a rollback and an injection.
