### PR TITLE
fix(supervisor): authorize the dequeue route and reject absent tokens in enforce mode

### DIFF
--- a/apps/supervisor/src/workloadServer/index.ts
+++ b/apps/supervisor/src/workloadServer/index.ts
@@ -197,7 +197,7 @@ export class WorkloadServer extends EventEmitter<WorkloadServerEvents> {
    * Verify the deployment token from the workload deployment-id header and return the verified
    * environment_id to forward upstream. The env id is only forwarded in enforce mode: in log mode
    * we still verify + record metrics but attach no header (so the platform never scopes). Only
-   * enforce fails a request, and only for a present-but-invalid token; absent and legacy ids pass.
+   * enforce fails a request, and only for an absent or invalid token; legacy bare ids pass.
    *
    * `claims` are returned on any valid token, for local use only - never to scope the platform,
    * which is why environmentId stays gated on enforce.
@@ -213,7 +213,7 @@ export class WorkloadServer extends EventEmitter<WorkloadServerEvents> {
 
     const result = await verifyDeploymentIdHeader(this.deploymentIdFromRequest(req), "http");
 
-    if (result.outcome === "jwt_invalid" && workloadTokenEnforced) {
+    if (workloadTokenEnforced && (result.outcome === "jwt_invalid" || result.outcome === "token_absent")) {
       return { ok: false };
     }
 
@@ -735,6 +735,11 @@ export class WorkloadServer extends EventEmitter<WorkloadServerEvents> {
             "GET",
             async () => {
               const { req, reply, params } = ctx;
+              const auth = await this.authorizeWorkloadRequest(req);
+              if (!auth.ok) {
+                reply.empty(401);
+                return;
+              }
               const dequeueResponse = await this.workerClient.dequeueFromVersion(
                 params.deploymentId,
                 1,


### PR DESCRIPTION
## Summary

The supervisor's workload server is the trust boundary between tenant task code and the run data plane: runners connect to it to dequeue and start run attempts, and it serves the run payload plus the environment's env vars. While auditing a self-hosted (k8s/docker) deployment, three gaps line up so that anything network-adjacent to the workload server can pull runs and their secrets from other deployments without any credentials:

1. `WORKLOAD_TOKEN_ENFORCEMENT` defaults to disabled, and the helm chart doesn't expose an override — so stock self-hosted deployments ship with no workload-token requirement at all.
2. Even with `WORKLOAD_TOKEN_ENFORCEMENT=enforce`, a request with **no token header at all** passes: `authorizeWorkloadRequest` only rejected `jwt_invalid` (a present-but-invalid token); `token_absent` was accepted, so simply omitting the header bypassed enforcement entirely.
3. The dequeue route (`GET /api/v1/workload-actions/deployments/:deploymentId/dequeue`) never called `authorizeWorkloadRequest` at all — unguarded in every mode.

With those three in place, an unauthenticated `attempts/start` or `dequeue` (knowing only run + snapshot friendly IDs) returns the run payload and the environment's env vars. From a PoC harness against a stock-config supervisor with a stubbed worker client:

```
[poc] A(default): HTTP 200 body.envVars={"SECRET_API_KEY":"prod-secret-value"}
[poc] A(default): forwarded environmentId=undefined (undefined = unscoped)
[poc] A(enforce): HTTP 200 forwarded environmentId=undefined — absent header BYPASSES enforcement
[poc] B: HTTP 200 forwarded=true (no deployment token supplied)
```

Because the request was never verified, the supervisor forwards no environment id upstream, so the platform serves the env vars unscoped rather than scoped to the caller's environment.

## What this PR changes

Two changes in `apps/supervisor/src/workloadServer/index.ts` — the code-level guard only:

- The dequeue route now calls `authorizeWorkloadRequest` and answers `401` when it fails, like the other workload-action routes.
- In enforce mode, `token_absent` is rejected alongside `jwt_invalid`. Enforce mode means the operator has explicitly opted in, so failing requests with no token header is what "enforce" promises. The doc comment on `authorizeWorkloadRequest` is updated to match.

Behavior in the default (unenforced) mode is unchanged — this PR does not turn enforcement on.

## Deliberately not changed (flagging for maintainers)

The remaining exposure is a deployment-default / product-policy question rather than a code bug, so I didn't change it unilaterally:

- Enforcement still defaults to disabled, and the helm chart / docker compose still don't expose a convenient opt-in. Flipping the default (or adding a chart value) is a compatibility decision for pre-token runners that maintainers should make.
- Legacy bare deployment ids (`legacy_bare`, a bare friendlyId from a pre-upgrade runner) still pass in enforce mode, for the same upgrade-compatibility reason.
- The webapp's created-at gate backstop (rejecting tokens minted before a cutoff) is likewise a policy default that is currently off.

Happy to follow up with a helm value for `WORKLOAD_TOKEN_ENFORCEMENT` if you want one.

## Testing

- PoC (vitest against the real `WorkloadServer` with a stubbed worker client, no real credentials) shows both routes answering 200 with env vars before the fix, and 401 in enforce mode after it; the default-mode path is unchanged.
- `oxlint` on the changed file: clean.
