### PR TITLE
fix(sdk): use nameOrRequestOptions in envvars.update outside a task

### DIFF
--- a/.changeset/fix-envvars-update-name.md
+++ b/.changeset/fix-envvars-update-name.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+`envvars.update(projectRef, slug, name, params)` no longer throws `ReferenceError: name is not defined` when called from a Node script outside a task run.

--- a/packages/trigger-sdk/src/v3/envvars.test.ts
+++ b/packages/trigger-sdk/src/v3/envvars.test.ts
@@ -1,0 +1,84 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { apiClientManager, taskContext } from "@trigger.dev/core/v3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { update } from "./envvars.js";
+
+type ReceivedRequest = {
+  method: string;
+  url: string;
+  authorization?: string;
+  body: unknown;
+};
+
+describe("envvars.update outside a task", () => {
+  let server: Server;
+  let baseUrl: string;
+  let requests: ReceivedRequest[];
+
+  beforeEach(async () => {
+    requests = [];
+    apiClientManager.disable();
+    taskContext.disable();
+    server = createServer((request, response) => {
+      void handleRequest(request, response, requests);
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address() as AddressInfo;
+        baseUrl = `http://127.0.0.1:${address.port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    apiClientManager.disable();
+    taskContext.disable();
+  });
+
+  it("PUTs the 4-arg form to /projects/{ref}/envvars/{slug}/{name}", async () => {
+    const key = "tr_dev_sk_0123456789abcdefghijklmn";
+    await apiClientManager.runWithConfig({ baseURL: baseUrl, accessToken: key }, () =>
+      update("proj_x", "dev", "FOO", { value: "bar" })
+    );
+
+    expect(requests).toEqual([
+      {
+        method: "PUT",
+        url: "/api/v1/projects/proj_x/envvars/dev/FOO",
+        authorization: `Bearer ${key}`,
+        body: { value: "bar" },
+      },
+    ]);
+  });
+
+  it("throws name is required when the 4-arg name is missing", () => {
+    expect(() => update("proj_x", "dev", undefined as unknown as string, { value: "bar" })).toThrow(
+      "name is required"
+    );
+    expect(requests).toEqual([]);
+  });
+});
+
+async function handleRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  requests: ReceivedRequest[]
+) {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.from(chunk));
+  }
+  const rawBody = Buffer.concat(chunks).toString();
+  requests.push({
+    method: request.method ?? "",
+    url: request.url ?? "",
+    authorization: request.headers.authorization,
+    body: rawBody ? JSON.parse(rawBody) : undefined,
+  });
+
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end(JSON.stringify({ success: true }));
+}

--- a/packages/trigger-sdk/src/v3/envvars.ts
+++ b/packages/trigger-sdk/src/v3/envvars.ts
@@ -332,13 +332,17 @@ export function update(
       throw new Error("projectRef is required");
     }
 
+    if (typeof nameOrRequestOptions !== "string") {
+      throw new Error("name is required");
+    }
+
     if (!params) {
       throw new Error("params is required");
     }
 
     $projectRef = projectRefOrName;
     $slug = slugOrParams;
-    $name = name!;
+    $name = nameOrRequestOptions;
     $params = params;
   }
 


### PR DESCRIPTION
Fixes #4264

`envvars.update(projectRef, slug, name, params)` from a plain Node script throws `ReferenceError: name is not defined` before any HTTP call. Repro on 0a23814a0:

```
cd packages/trigger-sdk
../../node_modules/.bin/tsx --eval 'import { update } from "./src/v3/envvars.ts"; update("proj_x","dev","FOO",{value:"bar"})'
```

Cause: the implementation parameter is `nameOrRequestOptions`, but the non-task branch assigned `$name` from a bare `name` binding at envvars.ts:341. Typecheck passes because `lib.dom` declares a global `name`. Node has none.

Fix: the non-task branch checks `typeof nameOrRequestOptions === "string"` (same shape as the slug/params checks next to it) and assigns that.

Not touched: the in-task 4-arg branch. With `taskContext` project `proj_ctx` / env `prod`, the same call PUTs `http://x/api/v1/projects/dev/envvars/dev/FOO` because that branch sets `$projectRef = slugOrParams`. Separate bug, left for a follow-up.

Test: `packages/trigger-sdk/src/v3/envvars.test.ts` uses a local HTTP server like `auth.test.ts` and asserts the PUT path `/api/v1/projects/proj_x/envvars/dev/FOO` and body `{value:"bar"}`. Without the assignment change both tests fail with the ReferenceError above. With it, `pnpm run test ./src/v3/envvars.test.ts --run` reports 2 passed. `oxlint` and `oxfmt --check` on the two changed files are clean.
