### PR TITLE
fix(cli): keep docker login output out of build logs

### DIFF
--- a/.changeset/dry-mirrors-shake.md
+++ b/.changeset/dry-mirrors-shake.md
@@ -1,0 +1,5 @@
+---
+"trigger.dev": patch
+---
+
+Build logs no longer include docker's registry login output, most notably the credential-storage warning on failed builds.

--- a/packages/cli-v3/src/deploy/buildImage.ts
+++ b/packages/cli-v3/src/deploy/buildImage.ts
@@ -514,8 +514,12 @@ async function localBuildImage(options: SelfHostedBuildImageOptions): Promise<Bu
     loginProcess.process?.stdin?.write(credentials.password);
     loginProcess.process?.stdin?.end();
 
+    // Login output (incl. docker's credential-storage warning) stays out of the build
+    // logs; it is fully visible at debug level and returned when the login itself fails.
+    const loginLogs: string[] = [];
+
     for await (const line of loginProcess) {
-      errors.push(line);
+      loginLogs.push(line);
       logger.debug(line);
     }
 
@@ -523,10 +527,12 @@ async function localBuildImage(options: SelfHostedBuildImageOptions): Promise<Bu
       return {
         ok: false as const,
         error: `Failed to login to registry: ${cloudRegistryHost}`,
-        logs: extractLogs(errors),
+        logs: extractLogs(loginLogs),
       };
     }
 
+    // `errors` is the shared build log buffer; keep a marker there so failure logs show auth ran
+    errors.push(`Logged in to ${cloudRegistryHost}`);
     options.onLog?.(`Successfully logged in to the remote registry`);
   }
 


### PR DESCRIPTION
On self-hosted and local builds, the registry login step's output landed in the shared build log buffer, so every build log carried docker's `WARNING! Your credentials are stored unencrypted` block. The warning is misleading in our context: the credentials are per-project, short-lived deploy tokens on an ephemeral builder machine.

Login output now goes to debug logging only; a single `Logged in to <registry>` marker is pushed into the build log on success (so failure logs still show auth ran), and a failed login still returns its full output.