### PR TITLE
ci: skip webapp and internal tests for changes to packages they don't depend on

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -20,9 +20,9 @@ jobs:
     outputs:
       code: ${{ steps.code_filter.outputs.code }}
       typecheck_self: ${{ steps.filter.outputs.typecheck_self }}
-      webapp: ${{ steps.filter.outputs.webapp }}
+      webapp: ${{ steps.filter.outputs.webapp == 'true' || steps.shared_packages_filter.outputs.shared_packages == 'true' }}
       packages: ${{ steps.filter.outputs.packages }}
-      internal: ${{ steps.filter.outputs.internal }}
+      internal: ${{ steps.filter.outputs.internal == 'true' || steps.shared_packages_filter.outputs.shared_packages == 'true' }}
       obsmap: ${{ steps.filter.outputs.obsmap }}
       cli: ${{ steps.filter.outputs.cli }}
       sdk: ${{ steps.filter.outputs.sdk }}
@@ -62,7 +62,6 @@ jobs:
               - '.github/workflows/code-quality.yml'
             webapp:
               - 'apps/webapp/**'
-              - 'packages/**'
               - 'internal-packages/**'
               - '.github/workflows/pr_checks.yml'
               - '.github/workflows/unit-tests-webapp.yml'
@@ -85,7 +84,6 @@ jobs:
               - 'turbo.json'
             internal:
               - 'internal-packages/**'
-              - 'packages/**'
               - '.github/workflows/pr_checks.yml'
               - '.github/workflows/unit-tests-internal.yml'
               - '.configs/**'
@@ -111,7 +109,7 @@ jobs:
             #
             # Deliberately NOT here: this package's own paths, and packages/plugins/src and
             # internal-packages/rbac/src, the other two trees webappSymbols.test.ts reads.
-            # `internal` above already matches `internal-packages/**` and `packages/**`, and
+            # `internal` above already matches `internal-packages/**` and the shared packages, and
             # `unit-tests-internal.yml` runs `turbo run test --filter "@internal/*"`, which picks up
             # @internal/observability-map and runs the same vitest suite. Listing them here as well
             # ran the suite twice on every PR touching them, which was this filter's own doing.
@@ -147,6 +145,19 @@ jobs:
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
               - 'turbo.json'
+
+      # Only the packages the webapp and internal packages depend on; the rest run their own suites.
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: shared_packages_filter
+        with:
+          predicate-quantifier: every
+          filters: |
+            shared_packages:
+              - 'packages/**'
+              - '!packages/cli-v3/**'
+              - '!packages/react-hooks/**'
+              - '!packages/python/**'
+              - '!packages/rsc/**'
 
   code-quality:
     uses: ./.github/workflows/code-quality.yml

--- a/internal-packages/observability-map/src/integration.test.ts
+++ b/internal-packages/observability-map/src/integration.test.ts
@@ -255,8 +255,20 @@ describe("the package's tests are wired into the gate", () => {
     expect(obsmap).not.toContain("internal-packages/rbac");
 
     const internal = text.split("            internal:")[1]!.split("            obsmap:")[0]!;
-    expect(internal).toContain(`'${PATH_PREFIX}packages/**'`);
     expect(internal).toContain(`'${PATH_PREFIX}internal-packages/**'`);
+
+    // Whichever filter carries packages/** into `internal`, plugins must stay in it.
+    const sharedBlock = text.split("            shared_packages:")[1];
+    if (sharedBlock) {
+      const shared = sharedBlock.split("\n  code-quality:")[0]!;
+      expect(shared).toContain(`'${PATH_PREFIX}packages/**'`);
+      expect(shared).not.toContain("packages/plugins");
+      expect(text).toContain(
+        "internal: ${{ steps.filter.outputs.internal == 'true' || steps.shared_packages_filter.outputs.shared_packages == 'true' }}"
+      );
+    } else {
+      expect(internal).toContain(`'${PATH_PREFIX}packages/**'`);
+    }
   });
 
   // Naming this package here as well ran the suite twice on every pull request touching it. Asserted


### PR DESCRIPTION
CLI-only PRs currently run the full webapp and internal test suites because the `webapp` and `internal` filters match all of `packages/**`.

This narrows them to the packages the webapp and internal packages actually depend on. Changes to `cli-v3`, `react-hooks`, `python` and `rsc` now only run their own suites (packages, CLI e2e, sdk-compat).

The exclusions live in a separate `shared_packages` filter step because negation patterns only work with `predicate-quantifier: every`, and that would break the multi-path `webapp` and `internal` filters.