### PR TITLE
fix(batch): clear idempotency keys pointing at dead runs in batchTrigger

### DIFF
--- a/.server-changes/batch-idempotency-dead-runs.md
+++ b/.server-changes/batch-idempotency-dead-runs.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Fix `batchTrigger` returning a stale failed run when its idempotency key points at a run that crashed, timed out, or otherwise failed. The key is now cleared and a fresh run triggered, matching single-`trigger` behaviour

--- a/apps/webapp/app/v3/services/batchTriggerV3.server.ts
+++ b/apps/webapp/app/v3/services/batchTriggerV3.server.ts
@@ -27,7 +27,11 @@ import { mintBatchFriendlyId } from "~/v3/runOpsMigration/mintBatchFriendlyId.se
 import { batchTriggerWorker } from "../batchTriggerWorker.server";
 import { guardQueueSizeLimitsForEnv } from "../queueSizeLimits.server";
 import { downloadPacketFromObjectStore, uploadPacketToObjectStore } from "../objectStore.server";
-import { isFinalAttemptStatus, isFinalRunStatus } from "../taskStatus";
+import {
+  isFinalAttemptStatus,
+  isFinalRunStatus,
+  shouldIdempotencyKeyBeCleared,
+} from "../taskStatus";
 import { startActiveSpan } from "../tracer.server";
 import { BaseService, ServiceValidationError } from "./baseService.server";
 import { OutOfEntitlementError, TriggerTaskService } from "./triggerTask.server";
@@ -439,8 +443,10 @@ export class BatchTriggerV3Service extends BaseService {
       )
     ).flat();
 
-    // Build the run IDs in order: reuse an unexpired cached id, else mint a new id (and record any
-    // expired cached id so its idempotency key can be cleared below).
+    // Build the run IDs in order: reuse a still-valid cached id, else mint a new id (and record the
+    // superseded cached id so its idempotency key can be cleared below). "Still valid" means both
+    // that the key has not timed out and that the run it points at has not reached a clearable
+    // terminal state.
     const expiredRunIds = new Set<string>();
 
     const runs = await Promise.all(
@@ -450,7 +456,16 @@ export class BatchTriggerV3Service extends BaseService {
         );
 
         if (cachedRun) {
-          if (cachedRun.idempotencyKeyExpiresAt && cachedRun.idempotencyKeyExpiresAt < new Date()) {
+          // Reuse the cached id only if the key is still live AND the run it points at is still
+          // usable. A run that reached a clearable terminal state (failed statuses + EXPIRED) is
+          // treated exactly like an expired key: clear it and mint a fresh run, matching the
+          // single-trigger path in `IdempotencyKeyConcern.handleExistingRun`. Sharing the branch
+          // matters - it is what adds the run to `expiredRunIds`, so the stale key cannot survive
+          // to the next batch.
+          const keyTimeExpired =
+            !!cachedRun.idempotencyKeyExpiresAt && cachedRun.idempotencyKeyExpiresAt < new Date();
+
+          if (keyTimeExpired || shouldIdempotencyKeyBeCleared(cachedRun.status)) {
             expiredRunIds.add(cachedRun.friendlyId);
 
             return {

--- a/internal-packages/run-store/src/PostgresRunStore.findRunsByIdempotencyKeys.test.ts
+++ b/internal-packages/run-store/src/PostgresRunStore.findRunsByIdempotencyKeys.test.ts
@@ -1,5 +1,5 @@
 import { postgresTest } from "@internal/testcontainers";
-import type { PrismaClient } from "@trigger.dev/database";
+import type { PrismaClient, TaskRunStatus } from "@trigger.dev/database";
 import { describe, expect } from "vitest";
 import { PostgresRunStore } from "./PostgresRunStore.js";
 
@@ -38,6 +38,7 @@ async function createRun(
     taskIdentifier: string;
     idempotencyKey: string;
     idempotencyKeyExpiresAt?: Date;
+    status?: TaskRunStatus;
   }
 ) {
   await prisma.taskRun.create({
@@ -46,6 +47,7 @@ async function createRun(
       taskIdentifier: params.taskIdentifier,
       idempotencyKey: params.idempotencyKey,
       idempotencyKeyExpiresAt: params.idempotencyKeyExpiresAt ?? null,
+      ...(params.status ? { status: params.status } : {}),
       payload: "{}",
       payloadType: "application/json",
       runtimeEnvironmentId: params.runtimeEnvironmentId,
@@ -103,6 +105,42 @@ describe("PostgresRunStore.findRunsByIdempotencyKeys", () => {
       expiresAt.toISOString()
     );
     expect(byKey.get("idem-2")?.idempotencyKeyExpiresAt).toBeNull();
+  });
+
+  // Regression for #4819: the batch trigger path decides whether a cached match is still reusable
+  // by feeding this row's status to `shouldIdempotencyKeyBeCleared`. Before the fix the query did
+  // not select `status` at all, so a key pointing at a dead run was returned as cached forever.
+  postgresTest("returns the run status so callers can reject dead runs", async ({ prisma }) => {
+    const { project, environment } = await seedEnvironment(prisma);
+    const store = new PostgresRunStore({ prisma, readOnlyPrisma: prisma });
+
+    await createRun(prisma, {
+      runtimeEnvironmentId: environment.id,
+      projectId: project.id,
+      friendlyId: "run_dead",
+      taskIdentifier: "task-a",
+      idempotencyKey: "idem-dead",
+      status: "CRASHED",
+    });
+    await createRun(prisma, {
+      runtimeEnvironmentId: environment.id,
+      projectId: project.id,
+      friendlyId: "run_live",
+      taskIdentifier: "task-a",
+      idempotencyKey: "idem-live",
+      status: "EXECUTING",
+    });
+
+    const rows = await store.findRunsByIdempotencyKeys({
+      runtimeEnvironmentId: environment.id,
+      taskIdentifier: "task-a",
+      idempotencyKeys: ["idem-dead", "idem-live"],
+    });
+
+    const byKey = new Map(rows.map((r) => [r.idempotencyKey, r]));
+    expect(rows).toHaveLength(2);
+    expect(byKey.get("idem-dead")?.status).toBe("CRASHED");
+    expect(byKey.get("idem-live")?.status).toBe("EXECUTING");
   });
 
   postgresTest("short-circuits on an empty key list without querying", async ({ prisma }) => {

--- a/internal-packages/run-store/src/PostgresRunStore.ts
+++ b/internal-packages/run-store/src/PostgresRunStore.ts
@@ -1861,7 +1861,7 @@ export class PostgresRunStore implements RunStore {
     const branches = args.idempotencyKeys.map((key) => {
       const base = params.length;
       params.push(args.runtimeEnvironmentId, args.taskIdentifier, key);
-      return `SELECT "id", "createdAt", "friendlyId", "idempotencyKey", "idempotencyKeyExpiresAt" FROM "TaskRun" WHERE "runtimeEnvironmentId" = $${base + 1} AND "taskIdentifier" = $${base + 2} AND "idempotencyKey" = $${base + 3}`;
+      return `SELECT "id", "createdAt", "friendlyId", "idempotencyKey", "idempotencyKeyExpiresAt", "status" FROM "TaskRun" WHERE "runtimeEnvironmentId" = $${base + 1} AND "taskIdentifier" = $${base + 2} AND "idempotencyKey" = $${base + 3}`;
     });
     return prisma.$queryRawUnsafe<IdempotencyKeyRunMatch[]>(
       branches.join(" UNION ALL "),

--- a/internal-packages/run-store/src/runOpsStore.shardMap.test.ts
+++ b/internal-packages/run-store/src/runOpsStore.shardMap.test.ts
@@ -622,6 +622,7 @@ describe("RoutingRunStore findRunsByIdempotencyKeys tiebreak", () => {
     friendlyId: `run_${id}`,
     idempotencyKey: "k",
     idempotencyKeyExpiresAt: null,
+    status: "PENDING",
   });
 
   it("keeps NEW-wins across the gen-1 pair even when legacy is older", async () => {

--- a/internal-packages/run-store/src/types.ts
+++ b/internal-packages/run-store/src/types.ts
@@ -28,6 +28,10 @@ export type IdempotencyKeyRunMatch = {
   friendlyId: string;
   idempotencyKey: string | null;
   idempotencyKeyExpiresAt: Date | null;
+  /** Callers decide whether a cached match is still reusable: a run that reached a clearable
+   *  terminal state must not be handed back as cached. Policy lives in the webapp
+   *  (`shouldIdempotencyKeyBeCleared`); the store just returns the column. */
+  status: TaskRunStatus;
 };
 
 export type CreateRunSnapshotInput = {


### PR DESCRIPTION
Fixes #4819. Reported by @Jaimin2687.

## The bug

The single-trigger path clears an idempotency key when the run it points at reached a clearable terminal state — `IdempotencyKeyConcern.handleExistingRun` guards on `shouldIdempotencyKeyBeCleared(existingRun.status)`. The batch path (`batchTriggerV3.server.ts:453`) only tested time expiry:

```ts
if (cachedRun.idempotencyKeyExpiresAt && cachedRun.idempotencyKeyExpiresAt < new Date()) { ... }
return { id: cachedRun.friendlyId, isCached: true, ... };  // dead run returned here
```

So `batchTrigger` with a key pointing at a CRASHED / TIMED_OUT / SYSTEM_FAILURE run returned that run as `isCached: true`, and kept returning it on every retry.

## Why it isn't a one-line check

The batch path had no status to test. `findRunsByIdempotencyKeys` selected five columns and `status` was not one of them (`PostgresRunStore.ts:1864`), and `IdempotencyKeyRunMatch` agreed. Dropping `shouldIdempotencyKeyBeCleared(cachedRun.status)` in would not have compiled. Hence three files:

1. **`internal-packages/run-store/src/types.ts`** — `IdempotencyKeyRunMatch` gains `status: TaskRunStatus`.
2. **`internal-packages/run-store/src/PostgresRunStore.ts`** — the lookup selects `"status"`. `delegatingRunStore.ts:439` and `runOpsStore.ts:781` both just forward, so no change there.
3. **`apps/webapp/app/v3/services/batchTriggerV3.server.ts`** — the guard becomes `keyTimeExpired || shouldIdempotencyKeyBeCleared(cachedRun.status)`.

Two deliberate choices:

- **Same branch as time expiry, not a separate one.** That branch is what adds the run to `expiredRunIds`, which drives the `clearIdempotencyKey` call below. A separate branch would mint a fresh run but leave the stale key in place, and the next batch would hit it again.
- **Policy stays in the webapp.** `shouldIdempotencyKeyBeCleared` lives in `v3/taskStatus.ts` and stays there; the run store just returns one more column. The tradeoff is that the store now carries a field only one caller uses, which seemed better than pushing status policy down into the store.

## Notes

- Added a `.server-changes/` entry rather than a changeset: the webapp change is user-facing, and `@internal/run-store` is `private: true`, so per `CHANGESETS.md` no changeset applies.
- Also gave `status` to the `IdempotencyKeyRunMatch` fixture in `runOpsStore.shardMap.test.ts` so it stays faithful to the type (those rows are cast, so it was not a compile break).

## Verification — honest status

- **Static, against this branch:** `TaskRun.status` is a real non-null column (`TaskRunStatus @default(PENDING)`), so the added SELECT is valid; `shouldIdempotencyKeyBeCleared` is `isFailedRunStatus(status) || status === "EXPIRED"`, i.e. exactly the six clearable statuses, matching single-trigger; `shouldIdempotencyKeyBeCleared` was already reachable from `../taskStatus`, which `batchTriggerV3.server.ts` already imports from.
- **Not run locally:** the added store-level regression test (`PostgresRunStore.findRunsByIdempotencyKeys.test.ts` — asserts a CRASHED and an EXECUTING row come back with their statuses) needs the repo's testcontainers/Docker harness, and I could not install the workspace in this environment. It should run in CI, and I'll fix anything that falls out.

Context: a bot opened #4912 for this issue off my analysis in #4819; it was auto-closed by CI within seconds. This is the same fix reworked and submitted properly, with the changeset/server-changes distinction handled and the fixture updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
