### PR TITLE
fix(replication): recover leadership after a failed leader-lock extend

### DIFF
--- a/.server-changes/replication-leader-lock-recovery.md
+++ b/.server-changes/replication-leader-lock-recovery.md
@@ -1,0 +1,6 @@
+---
+area: webapp
+type: fix
+---
+
+Runs replication no longer logs "Cannot extend an already-expired lock" forever after a Redis restart or outage. The leader now re-acquires its lock or steps down once and re-elects, so replication to ClickHouse resumes on its own instead of waiting for a webapp restart.

--- a/internal-packages/replication/src/client.test.ts
+++ b/internal-packages/replication/src/client.test.ts
@@ -1,3 +1,4 @@
+import { Redis } from "@internal/redis";
 import { postgresAndRedisTest } from "@internal/testcontainers";
 import { LogicalReplicationClient } from "./client.js";
 import { setTimeout } from "timers/promises";
@@ -463,6 +464,365 @@ describe("Replication Client", () => {
       expect(becameLeader).toBe(true);
 
       await b.shutdown();
+    }
+  );
+
+  postgresAndRedisTest(
+    "a failed leader-lock extend re-acquires or steps down instead of looping forever",
+    async ({ postgresContainer, prisma, redisOptions }) => {
+      await prisma.$executeRawUnsafe(`ALTER TABLE public."TaskRun" REPLICA IDENTITY FULL;`);
+
+      const slotName = "lock_recovery_slot";
+      // Same key prefix the client derives, so raw reads and writes here hit
+      // the very key Redlock is holding.
+      const lockKey = `logical-replication-client:${slotName}`;
+      const redis = new Redis({
+        ...redisOptions,
+        keyPrefix: `${redisOptions.keyPrefix}logical-replication-client:`,
+      });
+
+      const client = new LogicalReplicationClient({
+        name: "lock-recovery",
+        slotName,
+        publicationName: "lock_recovery_pub",
+        redisOptions,
+        table: "TaskRun",
+        pgConfig: { connectionString: postgresContainer.getConnectionUri() },
+        resubscribeOnFailure: true,
+        resubscribeMinDelayMs: 200,
+        resubscribeMaxDelayMs: 400,
+        leaderLockTimeoutMs: 2000,
+        leaderLockExtendIntervalMs: 300,
+        leaderLockAcquireAdditionalTimeMs: 200,
+        leaderLockRetryIntervalMs: 100,
+      });
+      const elections: boolean[] = [];
+      const lockErrors: string[] = [];
+      client.events.on("leaderElection", (won) => elections.push(won));
+      client.events.on("error", (error) => {
+        // Only the lock-related failures matter here; the client may surface
+        // unrelated connection noise on stop/resubscribe.
+        const message = String((error as Error)?.message ?? error);
+        if (/already-expired|unable to achieve a quorum|extend/i.test(message)) {
+          lockErrors.push(message);
+        }
+      });
+
+      try {
+        await client.subscribe();
+        expect(elections).toEqual([true]);
+        expect(await redis.exists(lockKey)).toBe(1);
+
+        // 1. The lock disappears underneath us (Redis restarted, key expired) and
+        //    nobody else wants it. The next extend fails; the client must take the
+        //    lock again and keep streaming — no election flip, no error spam.
+        await redis.del(lockKey);
+        await setTimeout(1200); // several heartbeat ticks
+        expect(await redis.exists(lockKey)).toBe(1);
+        expect(elections).toEqual([true]);
+        expect(lockErrors).toHaveLength(0);
+        expect(client.isStopped).toBe(false);
+
+        // 2. Redis stops answering while the key is still ours (a network blip,
+        //    a restart with persistence). Deny the lock scripts so every extend
+        //    and re-acquire fails, but leave the key in place. The client must
+        //    keep streaming under the still-valid TTL, then reclaim the SAME
+        //    lock once Redis answers again — no election flip, no error, no
+        //    stream restart. (ACL rule changes apply to connected clients.)
+        const valueBefore = await redis.get(lockKey);
+        await redis.call("ACL", "SETUSER", "default", "-eval", "-evalsha");
+        try {
+          await setTimeout(700); // 2-3 failed heartbeat ticks, well inside the 2s TTL
+          expect(elections).toEqual([true]);
+          expect(lockErrors).toHaveLength(0);
+          expect(client.isStopped).toBe(false);
+        } finally {
+          await redis.call("ACL", "SETUSER", "default", "+eval", "+evalsha");
+        }
+        await setTimeout(900);
+        expect(await redis.get(lockKey)).toBe(valueBefore);
+        expect(elections).toEqual([true]);
+        expect(lockErrors).toHaveLength(0);
+        expect(client.isStopped).toBe(false);
+
+        // 3. Someone else holds the lock when our extend fails. We must step down
+        //    exactly once, then win it back when they let go — the pre-fix client
+        //    logged "Cannot extend an already-expired lock" every tick forever.
+        await redis.set(lockKey, "someone-else", "PX", 1500);
+        await setTimeout(1200);
+        expect(elections).toContain(false);
+        // Exactly one surfaced failure for the step-down, not one per tick.
+        expect(lockErrors).toHaveLength(1);
+
+        let regained = false;
+        for (let i = 0; i < 40; i++) {
+          if (elections.filter((won) => won).length >= 2) {
+            regained = true;
+            break;
+          }
+          await setTimeout(250);
+        }
+        expect(regained).toBe(true);
+        // Regaining leadership must not have kept emitting extend failures.
+        expect(lockErrors).toHaveLength(1);
+        expect(await redis.exists(lockKey)).toBe(1);
+      } finally {
+        await client.shutdown();
+        await redis.quit();
+      }
+    }
+  );
+
+  postgresAndRedisTest(
+    "a client without resubscribe steps down and stops instead of streaming without the lock",
+    async ({ postgresContainer, prisma, redisOptions }) => {
+      await prisma.$executeRawUnsafe(`ALTER TABLE public."TaskRun" REPLICA IDENTITY FULL;`);
+
+      const slotName = "lock_recovery_noresub_slot";
+      const lockKey = `logical-replication-client:${slotName}`;
+      const redis = new Redis({
+        ...redisOptions,
+        keyPrefix: `${redisOptions.keyPrefix}logical-replication-client:`,
+      });
+
+      const client = new LogicalReplicationClient({
+        name: "lock-recovery-noresub",
+        slotName,
+        publicationName: "lock_recovery_noresub_pub",
+        redisOptions,
+        table: "TaskRun",
+        pgConfig: { connectionString: postgresContainer.getConnectionUri() },
+        leaderLockTimeoutMs: 2000,
+        leaderLockExtendIntervalMs: 300,
+        leaderLockAcquireAdditionalTimeMs: 200,
+        leaderLockRetryIntervalMs: 100,
+      });
+      const elections: boolean[] = [];
+      const lockErrors: string[] = [];
+      client.events.on("leaderElection", (won) => elections.push(won));
+      client.events.on("error", (error) => {
+        const message = String((error as Error)?.message ?? error);
+        if (/already-expired|unable to achieve a quorum|extend/i.test(message)) {
+          lockErrors.push(message);
+        }
+      });
+
+      try {
+        await client.subscribe();
+        expect(elections).toEqual([true]);
+
+        // Someone else takes the key. With nothing to resubscribe, the pre-fix
+        // client announced the loss and then kept streaming the slot, lockless,
+        // until the process died.
+        await redis.set(lockKey, "someone-else", "PX", 1500);
+        for (let i = 0; i < 30 && !elections.includes(false); i++) {
+          await setTimeout(100);
+        }
+        await setTimeout(500); // let the pg client finish ending
+        expect(elections).toEqual([true, false]);
+        expect(lockErrors).toHaveLength(1);
+        expect(client.isStopped).toBe(true);
+        const backends = await prisma.$queryRaw<{ count: bigint }[]>`
+          SELECT count(*) AS count FROM pg_stat_activity WHERE application_name = 'lock-recovery-noresub'
+        `;
+        expect(Number(backends[0].count)).toBe(0);
+
+        // The other holder is long gone; nothing on this client contends again.
+        await setTimeout(2000);
+        expect(elections).toEqual([true, false]);
+        expect(lockErrors).toHaveLength(1);
+        expect(client.isStopped).toBe(true);
+        expect(await redis.exists(lockKey)).toBe(0);
+      } finally {
+        await client.shutdown();
+        await redis.quit();
+      }
+    }
+  );
+
+  postgresAndRedisTest(
+    "an extend rejection that lands after the lock was replaced starts no recovery",
+    async ({ postgresContainer, prisma, redisOptions }) => {
+      await prisma.$executeRawUnsafe(`ALTER TABLE public."TaskRun" REPLICA IDENTITY FULL;`);
+
+      const slotName = "lock_recovery_stale_slot";
+      const lockKey = `logical-replication-client:${slotName}`;
+      const redis = new Redis({
+        ...redisOptions,
+        keyPrefix: `${redisOptions.keyPrefix}logical-replication-client:`,
+      });
+
+      const client = new LogicalReplicationClient({
+        name: "lock-recovery-stale",
+        slotName,
+        publicationName: "lock_recovery_stale_pub",
+        redisOptions,
+        table: "TaskRun",
+        pgConfig: { connectionString: postgresContainer.getConnectionUri() },
+        resubscribeOnFailure: true,
+        resubscribeMinDelayMs: 200,
+        resubscribeMaxDelayMs: 400,
+        leaderLockTimeoutMs: 2000,
+        leaderLockExtendIntervalMs: 300,
+        leaderLockAcquireAdditionalTimeMs: 200,
+        leaderLockRetryIntervalMs: 100,
+      });
+      const elections: boolean[] = [];
+      const lockErrors: string[] = [];
+      client.events.on("leaderElection", (won) => elections.push(won));
+      client.events.on("error", (error) => {
+        const message = String((error as Error)?.message ?? error);
+        if (/already-expired|unable to achieve a quorum|extend/i.test(message)) {
+          lockErrors.push(message);
+        }
+      });
+
+      const redlock = client["redlock"];
+      const realExtend = redlock.extend.bind(redlock);
+      let openGate: () => void = () => {};
+      const gate = new Promise<void>((resolve) => (openGate = resolve));
+      let extendSpy: ReturnType<typeof vi.spyOn> | undefined;
+      let acquireSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+      try {
+        await client.subscribe();
+        expect(elections).toEqual([true]);
+
+        // Park the first extend after the takeover below; every later one runs
+        // for real. This is the tick a slow Redis leaves in flight while the next
+        // tick already fails, recovers, and moves on.
+        let parked = false;
+        extendSpy = vi
+          .spyOn(redlock, "extend")
+          .mockImplementation(async (...args: Parameters<typeof realExtend>) => {
+            if (!parked) {
+              parked = true;
+              await gate;
+            }
+            return realExtend(...args);
+          });
+        acquireSpy = vi.spyOn(redlock, "acquire");
+
+        // Someone else takes the key: the next real extend fails, the client steps
+        // down once, and wins the slot back once the other holder expires.
+        await redis.set(lockKey, "someone-else", "PX", 1500);
+        let regained = false;
+        for (let i = 0; i < 60; i++) {
+          if (elections.filter((won) => won).length >= 2) {
+            regained = true;
+            break;
+          }
+          await setTimeout(100);
+        }
+        expect(regained).toBe(true);
+        expect(elections.filter((won) => !won)).toHaveLength(1);
+        expect(lockErrors).toHaveLength(1);
+        // Re-election fires before the new stream is up; wait until it is, so the
+        // stale rejection below meets a running client, not one still subscribing.
+        for (let i = 0; i < 40 && client.isStopped; i++) {
+          await setTimeout(100);
+        }
+        expect(client.isStopped).toBe(false);
+
+        // Now the parked extend rejects. Its lock was dropped at the step-down and
+        // replaced at re-election, so it must not start a recovery: no acquire, no
+        // second announcement, no error.
+        const acquiresBefore = acquireSpy.mock.calls.length;
+        openGate();
+        await setTimeout(600);
+        expect(acquireSpy.mock.calls.length).toBe(acquiresBefore);
+        expect(elections.filter((won) => !won)).toHaveLength(1);
+        expect(lockErrors).toHaveLength(1);
+        expect(client.isStopped).toBe(false);
+        expect(await redis.exists(lockKey)).toBe(1);
+      } finally {
+        openGate();
+        extendSpy?.mockRestore();
+        acquireSpy?.mockRestore();
+        await client.shutdown();
+        await redis.quit();
+      }
+    }
+  );
+
+  postgresAndRedisTest(
+    "shutdown during leader-lock recovery releases the re-acquired lock and stays quiet",
+    async ({ postgresContainer, prisma, redisOptions }) => {
+      await prisma.$executeRawUnsafe(`ALTER TABLE public."TaskRun" REPLICA IDENTITY FULL;`);
+
+      const slotName = "lock_recovery_shutdown_slot";
+      const lockKey = `logical-replication-client:${slotName}`;
+      const redis = new Redis({
+        ...redisOptions,
+        keyPrefix: `${redisOptions.keyPrefix}logical-replication-client:`,
+      });
+
+      const client = new LogicalReplicationClient({
+        name: "lock-recovery-shutdown",
+        slotName,
+        publicationName: "lock_recovery_shutdown_pub",
+        redisOptions,
+        table: "TaskRun",
+        pgConfig: { connectionString: postgresContainer.getConnectionUri() },
+        resubscribeOnFailure: true,
+        resubscribeMinDelayMs: 200,
+        resubscribeMaxDelayMs: 400,
+        leaderLockTimeoutMs: 2000,
+        leaderLockExtendIntervalMs: 300,
+        leaderLockAcquireAdditionalTimeMs: 200,
+        leaderLockRetryIntervalMs: 100,
+      });
+      const elections: boolean[] = [];
+      const lockErrors: string[] = [];
+      client.events.on("leaderElection", (won) => elections.push(won));
+      client.events.on("error", (error) => {
+        const message = String((error as Error)?.message ?? error);
+        if (/already-expired|unable to achieve a quorum|extend/i.test(message)) {
+          lockErrors.push(message);
+        }
+      });
+
+      const redlock = client["redlock"];
+      const realAcquire = redlock.acquire.bind(redlock);
+      let openGate: () => void = () => {};
+      const gate = new Promise<void>((resolve) => (openGate = resolve));
+      let acquireSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+      try {
+        await client.subscribe();
+        expect(elections).toEqual([true]);
+
+        // Hold the recovery's re-acquire open so shutdown() can land while it is
+        // in flight — the window a Redis that answers slowly opens in production.
+        acquireSpy = vi
+          .spyOn(redlock, "acquire")
+          .mockImplementation(async (...args: Parameters<typeof realAcquire>) => {
+            await gate;
+            return realAcquire(...args);
+          });
+
+        // The key vanishes → the next extend fails → recovery calls acquire and parks on the gate.
+        await redis.del(lockKey);
+        for (let i = 0; i < 30 && acquireSpy.mock.calls.length === 0; i++) {
+          await setTimeout(100);
+        }
+        expect(acquireSpy.mock.calls.length).toBeGreaterThan(0);
+
+        await client.shutdown();
+        openGate();
+        await setTimeout(600); // > resubscribeMaxDelayMs: a wrongly scheduled resubscribe would have fired
+
+        // stop() owns the teardown: the recovered lock is released, and there is
+        // no lost-leadership announcement, error, or resubscribe after shutdown.
+        expect(await redis.exists(lockKey)).toBe(0);
+        expect(elections).toEqual([true]);
+        expect(lockErrors).toHaveLength(0);
+        expect(client.isStopped).toBe(true);
+      } finally {
+        acquireSpy?.mockRestore();
+        await client.shutdown();
+        await redis.quit();
+      }
     }
   );
 });

--- a/internal-packages/replication/src/client.ts
+++ b/internal-packages/replication/src/client.ts
@@ -4,7 +4,7 @@ import { Logger } from "@trigger.dev/core/logger";
 import { tryCatch } from "@trigger.dev/core/utils";
 import EventEmitter from "node:events";
 import { type ClientConfig, type Connection, Client } from "pg";
-import Redlock, { type Lock } from "redlock";
+import Redlock, { Lock } from "redlock";
 import { LogicalReplicationClientError, PublicationMisconfiguredError } from "./errors.js";
 import {
   type PgoutputMessage,
@@ -121,6 +121,10 @@ export class LogicalReplicationClient {
   private leaderLockAcquireAdditionalTimeMs: number;
   private leaderLockRetryIntervalMs: number;
   private leaderLockHeartbeatTimer: NodeJS.Timeout | null = null;
+  private leaderLockRecovering: boolean = false;
+  // Redlock's own estimate of when the key we last confirmed in Redis expires.
+  // Until then nobody else can take the lock, whatever our Lock object says.
+  private leaderLockHeldUntil: number = 0;
   private ackIntervalSeconds: number;
   private lastAckTimestamp: number = 0;
   private ackIntervalTimer: NodeJS.Timeout | null = null;
@@ -917,6 +921,7 @@ export class LogicalReplicationClient {
           [`logical-replication-client:${this.options.slotName}`],
           this.leaderLockTimeoutMs
         );
+        this.leaderLockHeldUntil = this.leaderLock.expiration;
 
         this.logger.debug("Acquired leader lock", {
           name: this.options.name,
@@ -984,10 +989,12 @@ export class LogicalReplicationClient {
     }
     if (!this.leaderLock) return;
     this.leaderLockHeartbeatTimer = setInterval(async () => {
-      if (!this.leaderLock) return;
+      const lock = this.leaderLock;
+      if (!lock) return;
       if (this._isStopped) return;
       try {
-        this.leaderLock = await this.leaderLock.extend(this.leaderLockTimeoutMs);
+        this.leaderLock = await lock.extend(this.leaderLockTimeoutMs);
+        this.leaderLockHeldUntil = this.leaderLock.expiration;
         this.logger.debug("Extended leader lock", {
           name: this.options.name,
           slotName: this.options.slotName,
@@ -996,18 +1003,147 @@ export class LogicalReplicationClient {
           lockExtendIntervalMs: this.leaderLockExtendIntervalMs,
         });
       } catch (err) {
-        this.logger.error("Failed to extend leader lock", {
-          name: this.options.name,
-          slotName: this.options.slotName,
-          publicationName: this.options.publicationName,
-          error: err,
-          lockTimeoutMs: this.leaderLockTimeoutMs,
-          lockExtendIntervalMs: this.leaderLockExtendIntervalMs,
-        });
-        // Optionally emit an error or handle loss of leadership
-        this.events.emit("error", err instanceof Error ? err : new Error(String(err)));
+        await this.#handleLeaderLockExtendFailure(lock, err);
       }
     }, this.leaderLockExtendIntervalMs);
+  }
+
+  /**
+   * Redlock never repairs a Lock whose extend failed. While the object's local
+   * `expiration` is still ahead every tick just retries the extend; once it
+   * passes (a Redis outage longer than the TTL, a pod reschedule) every tick
+   * throws "Cannot extend an already-expired lock." locally, without asking
+   * Redis again — and kept doing so every interval until the process restarted
+   * (triggerdotdev/trigger.dev#3428).
+   *
+   * The Lock object's state says nothing certain about the key in Redis, so
+   * recover from what Redis actually holds, cheapest first:
+   *  1. Nobody holds the key (it expired, or Redis lost it): take it again.
+   *  2. The key is still ours (the extend landed but its reply was lost, or
+   *     local and server expiry disagree): rebuild the Lock around the live
+   *     key and extend it as usual.
+   *  3. Someone else holds it: we are no longer the leader. Drop the dead
+   *     lock, announce `leaderElection(false)` once, tear the stream down like
+   *     every other failure path, and let the resubscribe path contend for the
+   *     slot with backoff.
+   *  4. Redis is unreachable: as long as the key we last confirmed is inside
+   *     its TTL nobody else can take it, so keep streaming and retry on the
+   *     next tick. Only when that window closes without an answer do we step
+   *     down as in 3. This is what lets a rotation-length Redis outage pass
+   *     without interrupting replication.
+   */
+  async #handleLeaderLockExtendFailure(lock: Lock, err: unknown) {
+    const context = {
+      name: this.options.name,
+      slotName: this.options.slotName,
+      publicationName: this.options.publicationName,
+      lockTimeoutMs: this.leaderLockTimeoutMs,
+      lockExtendIntervalMs: this.leaderLockExtendIntervalMs,
+    };
+
+    if (this._isStopped || this._intentionalStop) return;
+    // A rejection from an extend that was still in flight when a recovery or a
+    // teardown replaced or dropped this lock says nothing about the current one.
+    if (this.leaderLock !== lock) return;
+    // A slow Redis can let the next tick fire while we are still recovering.
+    if (this.leaderLockRecovering) return;
+    this.leaderLockRecovering = true;
+
+    try {
+      await this.#recoverLeaderLock(err, context);
+    } finally {
+      this.leaderLockRecovering = false;
+    }
+  }
+
+  async #recoverLeaderLock(err: unknown, context: Record<string, unknown>) {
+    const dead = this.leaderLock;
+    const resource = `logical-replication-client:${this.options.slotName}`;
+
+    // 1. Free key → take it again.
+    const [reacquireError, reacquired] = await tryCatch(
+      this.redlock.acquire([resource], this.leaderLockTimeoutMs)
+    );
+
+    // 2. Key still ours → rebuild the Lock and extend it. The placeholder
+    //    expiration only exists to get past Redlock's local "already expired"
+    //    check; the extend script itself verifies the value in Redis.
+    let holder: string | null = null;
+    let holderError: unknown = undefined;
+    let reclaimError: unknown = undefined;
+    let recovered = reacquired;
+    if (!recovered) {
+      [holderError, holder] = await tryCatch(this.redis.get(resource));
+      if (dead && holder !== null && holder === dead.value) {
+        const live = new Lock(
+          this.redlock,
+          dead.resources,
+          dead.value,
+          dead.attempts,
+          Date.now() + this.leaderLockTimeoutMs
+        );
+        [reclaimError, recovered] = await tryCatch(live.extend(this.leaderLockTimeoutMs));
+      }
+    }
+
+    if (this._isStopped || this._intentionalStop) {
+      // stop() landed while we were talking to Redis and owns the teardown: no
+      // leadership to announce lost, nothing to resubscribe. Just don't leave a
+      // lock behind that nobody heartbeats.
+      if (recovered) await tryCatch(recovered.release());
+      return;
+    }
+
+    if (recovered) {
+      this.leaderLock = recovered;
+      this.leaderLockHeldUntil = recovered.expiration;
+      this.logger.warn("Leader lock extend failed; recovered without losing leadership", {
+        ...context,
+        error: err,
+        how: reacquired ? "re-acquired" : "still-held",
+      });
+      return;
+    }
+
+    // 4. No answer from Redis and nobody else visibly holds the key: stay
+    //    leader while the last confirmed TTL still shields the key.
+    const heldByOther = holder !== null && (!dead || holder !== dead.value);
+    const validForMs = this.leaderLockHeldUntil - Date.now();
+    if (!heldByOther && validForMs > 0) {
+      this.logger.warn("Leader lock extend failed; retrying while the lock is still valid", {
+        ...context,
+        error: err,
+        reacquireError,
+        holderError,
+        reclaimError,
+        validForMs,
+      });
+      return;
+    }
+
+    // 3. Leadership is lost. The lock is dead (expired or held by someone
+    //    else); releasing it would only throw. Drop the reference so the
+    //    teardown below doesn't try.
+    this.leaderLock = null;
+    this.leaderLockHeldUntil = 0;
+
+    this.logger.error("Leader lock lost", {
+      ...context,
+      error: err,
+      reacquireError,
+      holderError,
+      reclaimError,
+      holder: holder ?? undefined,
+      willResubscribe: this.resubscribeOnFailure,
+    });
+    this.events.emit("error", err instanceof Error ? err : new Error(String(err)));
+    this.events.emit("leaderElection", false);
+
+    // A non-leader must not keep streaming. Tear the attempt down now (which
+    // also stops this heartbeat), then contend for the slot with the normal
+    // acquire/backoff machinery.
+    await this.#cleanupAttempt();
+    this.#scheduleResubscribe("leader-lock-lost");
   }
 
   #startAckInterval() {


### PR DESCRIPTION
Closes #3428

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/triggerdotdev/trigger.dev/blob/main/CONTRIBUTING.md)
- [x] The PR title follows the convention.
- [x] I ran and tested the code works

---

## Problem

`LogicalReplicationClient` renews its Redis leader lock every `leaderLockExtendIntervalMs`. Redlock never repairs a `Lock` whose `extend` failed: while the object's local `expiration` is still ahead each heartbeat tick retries the extend, but once it passes (a Redis outage longer than the TTL, a pod reschedule) `Redlock.extend` throws `Cannot extend an already-expired lock.` locally, without asking Redis again. The heartbeat catch only logged and emitted `error`, so nothing reset state: the process stayed "leader" in its own eyes, kept the slot, and logged `Failed to extend leader lock` + `Replication client error` every interval until it was restarted. That is the loop described in #3428.

We hit it on a self-hosted v4 deployment whose single Redis pod is rescheduled roughly daily by node rotation (3–47 s of downtime each time).

## Fix

On extend failure, `#recoverLeaderLock` recovers from what Redis actually holds, cheapest first:

1. **Nobody holds the key** (expired, or Redis lost it): take it again. Leadership continues, one `warn` line.
2. **The key is still ours** (the extend landed but its reply was lost, or local and server expiry disagree): rebuild the `Lock` around the live key and extend it as usual.
3. **Someone else holds it**: drop the dead lock, emit `error` + `leaderElection(false)` exactly once, tear the attempt down with `#cleanupAttempt()` like every other failure path (a non-leader must not keep streaming), and hand off to the existing `#scheduleResubscribe` path, which contends for the slot with the normal acquire/backoff machinery.
4. **Redis is unreachable**: while the key we last confirmed (`leaderLockHeldUntil`) is inside its TTL nobody else can take it, so keep streaming and retry next tick. Only when that window closes without an answer do we step down as in 3. This lets a Redis restart of a few seconds pass without interrupting replication.

Two guards keep it single-shot. A `leaderLockRecovering` flag stops a slow Redis from stacking recoveries across ticks. Each tick hands the handler the `Lock` it tried to extend, and a rejection that lands after a recovery or teardown has already replaced or dropped that lock is ignored, so a straggling extend can never start a second recovery or announce a second step-down. If `stop()`/`shutdown()` lands while a recovery is still talking to Redis, the recovery releases whatever it re-acquired and exits quietly.

Scope: one commit in `internal-packages/replication/src/client.ts` plus tests. No API, env, or dependency changes. The lock TTL/extend interval stay configurable through the existing `RUN_REPLICATION_LEADER_LOCK_*` env vars.

### Cost / benefit

This touches leader election for Postgres → ClickHouse replication, so the failure modes worth weighing are: (a) two pods streaming the same slot, and (b) a pod streaming with no lock. Neither is newly possible. Case 1 and 2 only ever re-take or extend a key that is free or already carries our own value, and Redlock's scripts enforce that atomically. Case 3 tears the stream down before resubscribing. Case 4 keeps streaming only while our last confirmed TTL still excludes every other contender, which is the same guarantee the heartbeat relied on before. The pre-fix behavior, by contrast, kept the slot open indefinitely with no lock at all. The benefit is that a self-hosted deployment recovers from a Redis restart on its own instead of needing a pod restart.

### Open question for maintainers

We kept recovery in-process rather than exiting the process (option (b) in #3428), because on a single-replica self-host an exit turns every Redis blip into a full replication outage, and here the leader was still the only candidate. If you would also like an exit strategy, it could sit behind an env flag next to the knobs proposed in #3613. Happy to add it in this PR or a follow-up, whichever you prefer.

---

## Testing

All against real Postgres + Redis containers via `postgresAndRedisTest` in `internal-packages/replication/src/client.test.ts`:

- `a failed leader-lock extend re-acquires or steps down instead of looping forever`
  - key deleted → re-acquired within a few ticks, `leaderElection` stays `[true]`, no lock error events;
  - lock scripts denied via `ACL SETUSER default -eval -evalsha` for several ticks with the key intact (Redis "unreachable") → no election flip, no error, and the same lock value once Redis answers again;
  - key set to another holder with a short PX → exactly one `leaderElection(false)` and one lock error, then re-election once the other holder expires, with no further errors.
- `a client without resubscribe steps down and stops instead of streaming without the lock` → one `leaderElection(false)`, one error, `isStopped` true, zero pg backends for the client, nothing contends again.
- `an extend rejection that lands after the lock was replaced starts no recovery` → parks the first `redlock.extend` across a step-down and re-election, then releases it: no `redlock.acquire` call, no second announcement, no error.
- `shutdown during leader-lock recovery releases the re-acquired lock and stays quiet` → gates the recovery's `redlock.acquire`, calls `shutdown()` mid-recovery, opens the gate: key left free, no election flip, no error, no resubscribe.

Removing either guard makes its test fail (checked by mutation). Full `client.test.ts` (11 tests) passes locally on this branch rebased onto `main`; `pnpm run typecheck` for the package, `oxfmt --check`, and `oxlint` are clean.

---

## Changelog

`.server-changes/replication-leader-lock-recovery.md` (webapp, fix): runs replication no longer logs "Cannot extend an already-expired lock" forever after a Redis restart or outage; the leader re-acquires its lock or steps down once and re-elects.

---

## Screenshots

N/A (server-side only).

💯
