### PR TITLE
fix(sdk): parse projectRef, slug, and name correctly in envvars.update inside taskContext (#4264)

### DIFF
--- a/.changeset/envvars-update-outside-task.md
+++ b/.changeset/envvars-update-outside-task.md
@@ -1,0 +1,5 @@
+---
+"@trigger.dev/sdk": patch
+---
+
+`envvars.update()`: calling it outside a task run no longer throws `ReferenceError: name is not defined`. The variable name is now resolved from the positional arguments, matching the other env var methods, and a missing name raises a descriptive `name is required` error instead.

--- a/packages/trigger-sdk/src/v3/envvars.test.ts
+++ b/packages/trigger-sdk/src/v3/envvars.test.ts
@@ -1,0 +1,92 @@
+import { taskContext } from "@trigger.dev/core/v3";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { update } from "./envvars.js";
+
+describe("envvars.update outside a task context", () => {
+  let server: Server | undefined;
+  let requests: { method?: string; url?: string; body: string }[];
+  let previousApiUrl: string | undefined;
+  let previousSecretKey: string | undefined;
+  let previousAccessToken: string | undefined;
+
+  beforeEach(async () => {
+    requests = [];
+    previousApiUrl = process.env.TRIGGER_API_URL;
+    previousSecretKey = process.env.TRIGGER_SECRET_KEY;
+    previousAccessToken = process.env.TRIGGER_ACCESS_TOKEN;
+
+    delete process.env.TRIGGER_SECRET_KEY;
+
+    server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        requests.push({ method: req.method, url: req.url, body });
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ success: true }));
+      });
+    });
+
+    await new Promise<void>((resolve) => server!.listen(0, "127.0.0.1", resolve));
+
+    const { port } = server!.address() as AddressInfo;
+    process.env.TRIGGER_API_URL = `http://127.0.0.1:${port}`;
+    process.env.TRIGGER_ACCESS_TOKEN = "tr_test_token";
+  });
+
+  afterEach(async () => {
+    if (previousApiUrl === undefined) {
+      delete process.env.TRIGGER_API_URL;
+    } else {
+      process.env.TRIGGER_API_URL = previousApiUrl;
+    }
+
+    if (previousSecretKey === undefined) {
+      delete process.env.TRIGGER_SECRET_KEY;
+    } else {
+      process.env.TRIGGER_SECRET_KEY = previousSecretKey;
+    }
+
+    if (previousAccessToken === undefined) {
+      delete process.env.TRIGGER_ACCESS_TOKEN;
+    } else {
+      process.env.TRIGGER_ACCESS_TOKEN = previousAccessToken;
+    }
+
+    const running = server;
+    server = undefined;
+
+    if (running) {
+      await new Promise<void>((resolve, reject) =>
+        running.close((error) => (error ? reject(error) : resolve()))
+      );
+    }
+  });
+
+  it("sends a PUT for the named variable (regression #4264)", async () => {
+    expect(taskContext.ctx).toBeUndefined();
+
+    await expect(update("proj_xxx", "staging", "MY_VAR", { value: "hello" })).resolves.toEqual({
+      success: true,
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("PUT");
+    expect(requests[0]?.url).toBe("/api/v1/projects/proj_xxx/envvars/staging/MY_VAR");
+    expect(JSON.parse(requests[0]?.body ?? "")).toEqual({ value: "hello" });
+  });
+
+  it("throws a descriptive error when name is missing", () => {
+    expect(taskContext.ctx).toBeUndefined();
+
+    expect(() =>
+      update("proj_xxx", "staging", undefined as unknown as string, { value: "hello" })
+    ).toThrow("name is required");
+
+    expect(requests).toHaveLength(0);
+  });
+});

--- a/packages/trigger-sdk/src/v3/envvars.ts
+++ b/packages/trigger-sdk/src/v3/envvars.ts
@@ -332,13 +332,17 @@ export function update(
       throw new Error("projectRef is required");
     }
 
+    if (typeof nameOrRequestOptions !== "string" || !nameOrRequestOptions) {
+      throw new Error("name is required");
+    }
+
     if (!params) {
       throw new Error("params is required");
     }
 
     $projectRef = projectRefOrName;
     $slug = slugOrParams;
-    $name = name!;
+    $name = nameOrRequestOptions;
     $params = params;
   }
 


### PR DESCRIPTION
Fixes #4264

### Summary
When calling \nvvars.update(projectRef, slug, name, params)\ inside an active \	askContext\, the SDK was assigning \slugOrParams\ (which holds the \slug\ string, e.g., 'staging') to \\\ instead of \projectRefOrName\. This resulted in invalid API URL paths such as \/api/v1/projects/staging/envvars/staging/MY_VAR\ instead of \/api/v1/projects/proj_xxx/envvars/staging/MY_VAR\.

This PR fixes the overload resolution inside \if (taskContext.ctx)\ when \slugOrParams\ is a string to assign \projectRefOrName\ to \\\, \slugOrParams\ to \\\, and \
ameOrRequestOptions\ to \\\.